### PR TITLE
Export everything from GadgetFunctions in api-client-core

### DIFF
--- a/packages/api-client-core/src/index.ts
+++ b/packages/api-client-core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./ClientOptions";
 export * from "./DataHydrator";
 export * from "./FieldSelection";
 export * from "./GadgetConnection";
+export * from "./GadgetFunctions";
 export * from "./GadgetRecord";
 export * from "./GadgetRecordList";
 export * from "./GadgetTransaction";


### PR DESCRIPTION
I forgot to do this in https://github.com/gadget-inc/js-clients/pull/3. I planned on moving these from my react branch to `api-client-core`. I'll keep my copy in the react client for now, and come back later to remove it.