### PR TITLE
Add support for an anonymous authentication mode

### DIFF
--- a/packages/api-client-core/spec/GadgetConnection.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnection.spec.ts
@@ -1,0 +1,16 @@
+import { AuthenticationMode, GadgetConnection } from "../src/GadgetConnection";
+
+describe("GadgetConnection", () => {
+  // this object is integration tested within Gadget itself
+
+  it("should require an endpoint to be set", () => {
+    expect(() => new GadgetConnection({} as any)).toThrowErrorMatchingInlineSnapshot(
+      `"Must provide an \`endpoint\` option for a GadgetConnection to connect to"`
+    );
+  });
+
+  it("should default to the anonymous authentication mode if no authentication mode is passed", () => {
+    const connection = new GadgetConnection({ endpoint: "http://someapp.gadget.host" });
+    expect(connection.authenticationMode).toEqual(AuthenticationMode.Anonymous);
+  });
+});

--- a/packages/api-client-core/src/ClientOptions.ts
+++ b/packages/api-client-core/src/ClientOptions.ts
@@ -41,6 +41,9 @@ export interface AuthenticationModeOptions {
   // This allows a web user to log in and keep their sessiontheir cookie (containing their credentials) will be sent.
   browserSession?: boolean | BrowserSessionAuthenticationModeOptions;
 
+  // Use no authentication at all, and get access only to the data that the Unauthenticated backend role has access to.
+  anonymous?: true;
+
   // @private Use an internal platform auth token for authentication
   // This is used to communicate within Gadget itself and shouldn't be used to connect to Gadget from other systems
   internalAuthToken?: string;


### PR DESCRIPTION
When building some next.js examples, I noticed that it was kind of annoying to have to pick an authentication mode for the server side of the system that I know doesn't make any API calls just to get the same code running on the client side of the system which will make API calls. I think we should have a null / anonymous authentication mode for the client that these contexts can use, and so that folks who are running on a shopify storefront for example don't need to needlessly copy paste API keys into their storefront to make things work. 