### PR TITLE
Bump api-client-core dep in react to ^0.4

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,7 +18,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.3.0",
+    "@gadgetinc/api-client-core": "^0.4",
     "deep-equal": "^2.0.5",
     "urql": "^2.0.5"
   },

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -48,7 +48,8 @@ import { useStructuralMemo } from "./useStructuralMemo";
  */
 export const useAction = <
   GivenOptions extends OptionsType, // currently necessary for Options to be a narrow type (e.g., `true` instead of `boolean`)
-  F extends ActionFunction<GivenOptions, any, any, any, any>,
+  SchemaT,
+  F extends ActionFunction<GivenOptions, any, any, SchemaT, any>,
   Options extends F["optionsType"]
 >(
   action: F,

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -42,7 +42,8 @@ import { useStructuralMemo } from "./useStructuralMemo";
  */
 export const useBulkAction = <
   GivenOptions extends OptionsType, // currently necessary for Options to be a narrow type (e.g., `true` instead of `boolean`)
-  F extends BulkActionFunction<GivenOptions, any, any, any, any>,
+  SchemaT,
+  F extends BulkActionFunction<GivenOptions, any, any, SchemaT, any>,
   Options extends F["optionsType"]
 >(
   action: F,

--- a/packages/react/src/useFindBy.ts
+++ b/packages/react/src/useFindBy.ts
@@ -38,7 +38,8 @@ import { useStructuralMemo } from "./useStructuralMemo";
  */
 export const useFindBy = <
   GivenOptions extends OptionsType, // currently necessary for Options to be a narrow type (e.g., `true` instead of `boolean`)
-  F extends FindOneFunction<GivenOptions, any, any, any>,
+  SchemaT,
+  F extends FindOneFunction<GivenOptions, any, SchemaT, any>,
   Options extends F["optionsType"] & Omit<UseQueryArgs, "query" | "variables">
 >(
   finder: F,

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -19,6 +19,7 @@ import { useStructuralMemo } from "./useStructuralMemo";
  * @param options options for filtering and searching records, and selecting the fields in each record of the result
  *
  * @example
+ *
  * ```
  * export function Users() {
  *   const [result, refresh] = useFindMany(Client.user, {
@@ -37,7 +38,8 @@ import { useStructuralMemo } from "./useStructuralMemo";
  */
 export const useFindMany = <
   GivenOptions extends OptionsType, // currently necessary for Options to be a narrow type (e.g., `true` instead of `boolean`)
-  F extends FindManyFunction<GivenOptions, any, any, any>,
+  SchemaT,
+  F extends FindManyFunction<GivenOptions, any, SchemaT, any>,
   Options extends F["optionsType"] & Omit<UseQueryArgs, "query" | "variables">
 >(
   manager: { findMany: F },

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -30,7 +30,8 @@ import { useStructuralMemo } from "./useStructuralMemo";
  */
 export const useFindOne = <
   GivenOptions extends OptionsType, // currently necessary for Options to be a narrow type (e.g., `true` instead of `boolean`)
-  F extends FindOneFunction<GivenOptions, any, any, any>,
+  SchemaT,
+  F extends FindOneFunction<GivenOptions, any, SchemaT, any>,
   Options extends F["optionsType"] & Omit<UseQueryArgs, "query" | "variables">
 >(
   manager: { findOne: F },

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -29,7 +29,8 @@ import { useStructuralMemo } from "./useStructuralMemo";
  */
 export const useGet = <
   GivenOptions extends OptionsType, // currently necessary for Options to be a narrow type (e.g., `true` instead of `boolean`)
-  F extends GetFunction<GivenOptions, any, any, any>,
+  SchemaT,
+  F extends GetFunction<GivenOptions, any, SchemaT, any>,
   Options extends F["optionsType"]
 >(
   manager: { get: F },


### PR DESCRIPTION
The new version of `api-client-core` includes improvements to the `Select` type, which makes the result types for all of our hooks be properly typed when selecting an array/nullable type. This unfortunate led to TS complaining about:

> Type instantiation is excessively deep and possibly infinite

on the return types. Adding an additional generic parameter for the schema seems to have resolved this issue. I can't explain why, unfortunately.

One question: should we consider a different version specifier for now, that is a little more loose? I was thinking `~0.3` (>=0.3, <1) instead of `^0.3` (>= 0.3, <0.4).