### PR TITLE
[react] Typed default selection support

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -13,6 +13,9 @@ runs:
           experimental-features = nix-command flakes
     - run: nix flake check
       shell: bash
+    - name: Add Gadget yarn registry
+      shell: nix develop -c bash -eo pipefail -l {0}
+      run: npm config set @gadget-client:registry https://registry.gadget.dev/npm
     - name: Install dependencies with yarn install
       shell: nix develop -c bash -eo pipefail -l {0}
       run: yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,25 +5,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.4
-    - uses: ./.github/actions/setup-test-env
-    - name: Test
-      shell: nix develop -c bash -eo pipefail -l {0}
-      run: yarn test
+      - uses: actions/checkout@v2.3.4
+      - uses: ./.github/actions/setup-test-env
+      - name: Build all packages (so they can require each other)
+        shell: nix develop -c bash -eo pipefail -l {0}
+        run: yarn build
+      - name: Test
+        shell: nix develop -c bash -eo pipefail -l {0}
+        run: yarn test
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.4
-    - uses: ./.github/actions/setup-test-env
-    - name: Lint
-      shell: nix develop -c bash -eo pipefail -l {0}
-      run: yarn lint
-
-  build-js:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2.3.4
-    - uses: ./.github/actions/setup-test-env
-    - name: Lint
-      shell: nix develop -c bash -eo pipefail -l {0}
-      run: yarn build
+      - uses: actions/checkout@v2.3.4
+      - uses: ./.github/actions/setup-test-env
+      - name: Lint
+        shell: nix develop -c bash -eo pipefail -l {0}
+        run: yarn lint

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "jest-junit": "^12.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
-    "typescript": "4.4.3"
+    "typescript": "4.4.3",
+    "@gadget-client/bulk-actions-example": "^1.45.0",
+    "@gadget-client/related-products-example": "1.213.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,10 @@
     "@babel/preset-typescript": "^7.15.0",
     "@types/deep-equal": "^1.0.1",
     "@types/react": "^17.0.27",
-    "@types/react-dom": "^17.0.9"
+    "@types/react-dom": "^17.0.9",
+    "conditional-type-checks": "^1.0.5",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/react/spec/apis.ts
+++ b/packages/react/spec/apis.ts
@@ -1,0 +1,5 @@
+import { Client as BulkClient } from "@gadget-client/bulk-actions-example";
+import { Client } from "@gadget-client/related-products-example";
+
+export const relatedProductsApi = new Client();
+export const bulkExampleApi = new BulkClient();

--- a/packages/react/spec/useAction.spec.ts
+++ b/packages/react/spec/useAction.spec.ts
@@ -1,0 +1,52 @@
+import { GadgetRecord } from "@gadgetinc/api-client-core";
+import { CombinedError } from "@urql/core";
+import { assert, IsExact } from "conditional-type-checks";
+import { useAction } from "../src";
+import { relatedProductsApi } from "./apis";
+
+// these functions are typechecked but never run to avoid actually making API calls
+const TestUseActionCanRunActionsWithVariables = () => {
+  const [_, mutate] = useAction(relatedProductsApi.user.update);
+
+  // hook return value includes the urql mutation function
+  void mutate();
+
+  // can call with variables
+  void mutate({ id: "123", user: { email: "foo@bar.com" } });
+
+  // can call with no model variables
+  void mutate({ id: "123" });
+
+  // @ts-expect-error can't call with no id
+  void mutate({});
+
+  // @ts-expect-error can't call with variables that don't belong to the model
+  void mutate({ foo: "123" });
+};
+
+const TestUseActionReturnsTypedDataWithExplicitSelection = () => {
+  const [{ data, fetching, error }, mutate] = useAction(relatedProductsApi.user.update, {
+    select: { id: true, email: true },
+  });
+
+  assert<IsExact<typeof fetching, boolean>>(true);
+  assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>>>(true);
+  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+
+  // data is accessible via dot access
+  if (data) {
+    data.id;
+    data.email;
+  }
+};
+
+const TestUseActionReturnsTypedDataWithNoSelection = () => {
+  const [{ data }] = useAction(relatedProductsApi.user.update);
+
+  if (data) {
+    data.id;
+    data.email;
+  }
+};
+
+test("true", () => undefined);

--- a/packages/react/spec/useBulkAction.spec.ts
+++ b/packages/react/spec/useBulkAction.spec.ts
@@ -1,0 +1,48 @@
+import { GadgetRecord } from "@gadgetinc/api-client-core";
+import { CombinedError } from "@urql/core";
+import { assert, IsExact } from "conditional-type-checks";
+import { useBulkAction } from "../src";
+import { bulkExampleApi } from "./apis";
+
+// these functions are typechecked but never run to avoid actually making API calls
+const TestUseBulkActionCanRunActionsWithVariables = () => {
+  const [_, mutate] = useBulkAction(bulkExampleApi.widget.bulkFlipDown);
+
+  // hook return value includes the urql mutation function
+  void mutate();
+
+  // can call with variables
+  void mutate({ ids: ["123", "124"] });
+
+  // @ts-expect-error can't call with no ids
+  void mutate({});
+
+  // @ts-expect-error can't call with variables that don't belong to the model
+  void mutate({ foo: "123" });
+};
+
+const TestUseBulkActionReturnsTypedDataWithExplicitSelection = () => {
+  const [{ data, fetching, error }, mutate] = useBulkAction(bulkExampleApi.widget.bulkFlipDown, {
+    select: { id: true, name: true },
+  });
+
+  assert<IsExact<typeof fetching, boolean>>(true);
+  assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; name: string | null }>[]>>(true);
+  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+
+  if (data) {
+    data[0].id;
+    data[0].name;
+  }
+};
+
+const TestUseActionReturnsTypedDataWithNoSelection = () => {
+  const [{ data }] = useBulkAction(bulkExampleApi.widget.bulkFlipDown);
+
+  if (data) {
+    data[0].id;
+    data[0].name;
+  }
+};
+
+test("true", () => undefined);

--- a/packages/react/spec/useFindBy.spec.ts
+++ b/packages/react/spec/useFindBy.spec.ts
@@ -1,0 +1,36 @@
+import { GadgetRecord } from "@gadgetinc/api-client-core";
+import { CombinedError } from "@urql/core";
+import { assert, IsExact } from "conditional-type-checks";
+import { useFindBy } from "../src";
+import { relatedProductsApi } from "./apis";
+
+// these functions are typechecked but never run to avoid actually making API calls
+const TestFindByReturnsTypedDataWithExplicitSelection = () => {
+  const [{ data, fetching, error }, refresh] = useFindBy(relatedProductsApi.user.findByEmail, "hello@gadget.dev", {
+    select: { id: true, email: true },
+  });
+
+  assert<IsExact<typeof fetching, boolean>>(true);
+  assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>>>(true);
+  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+
+  // data is accessible via dot access
+  if (data) {
+    data.id;
+    data.email;
+  }
+
+  // hook return value includes the urql refresh function
+  refresh();
+};
+
+const TestFindByReturnsTypedDataWithNoSelection = () => {
+  const [{ data }] = useFindBy(relatedProductsApi.user.findByEmail, "hello@gadget.dev");
+
+  if (data) {
+    data.id;
+    data.email;
+  }
+};
+
+test("true", () => undefined);

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -1,0 +1,32 @@
+import { GadgetRecord } from "@gadgetinc/api-client-core";
+import { CombinedError } from "@urql/core";
+import { assert, IsExact } from "conditional-type-checks";
+import { useFindMany } from "../src/useFindMany";
+import { relatedProductsApi } from "./apis";
+
+// all these functions are typechecked but never run to avoid actually making API calls
+const TestFindManyReturnsTypedDataWithExplicitSelection = () => {
+  const [{ data, fetching, error }, refresh] = useFindMany(relatedProductsApi.user, { select: { id: true, email: true } });
+
+  assert<IsExact<typeof fetching, boolean>>(true);
+  assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>[]>>(true);
+  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+
+  if (data) {
+    data[0].id;
+    data[0].email;
+  }
+
+  refresh();
+};
+
+const TestFindManyReturnsTypedDataWithNoSelection = () => {
+  const [{ data }] = useFindMany(relatedProductsApi.user);
+
+  if (data) {
+    data[0].id;
+    data[0].email;
+  }
+};
+
+test("true", () => undefined);

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -1,0 +1,34 @@
+import { GadgetRecord } from "@gadgetinc/api-client-core";
+import { CombinedError } from "@urql/core";
+import { assert, IsExact } from "conditional-type-checks";
+import { useFindOne } from "../src";
+import { relatedProductsApi } from "./apis";
+
+// these functions are typechecked but never run to avoid actually making API calls
+const TestFindOneReturnsTypedDataWithExplicitSelection = () => {
+  const [{ data, fetching, error }, refresh] = useFindOne(relatedProductsApi.user, "10", { select: { id: true, email: true } });
+
+  assert<IsExact<typeof fetching, boolean>>(true);
+  assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>>>(true);
+  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+
+  // data is accessible via dot access
+  if (data) {
+    data.id;
+    data.email;
+  }
+
+  // hook return value includes the urql refresh function
+  refresh();
+};
+
+const TestFindOneReturnsTypedDataWithNoSelection = () => {
+  const [{ data }] = useFindOne(relatedProductsApi.user, "10");
+
+  if (data) {
+    data.id;
+    data.email;
+  }
+};
+
+test("true", () => undefined);

--- a/packages/react/spec/useGet.spec.ts
+++ b/packages/react/spec/useGet.spec.ts
@@ -1,0 +1,34 @@
+import { GadgetRecord } from "@gadgetinc/api-client-core";
+import { CombinedError } from "@urql/core";
+import { assert, Has, IsExact } from "conditional-type-checks";
+import { useGet } from "../src/useGet";
+import { relatedProductsApi } from "./apis";
+
+// these functions are typechecked but never run to avoid actually making API calls
+const TestGetReturnsTypedDataWithExplicitSelection = () => {
+  const [{ data, fetching, error }, refresh] = useGet(relatedProductsApi.currentSession, { select: { id: true, state: true } });
+
+  assert<IsExact<typeof fetching, boolean>>(true);
+  assert<Has<typeof data, undefined | GadgetRecord<{ id: string; state: any }>>>(true);
+  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+
+  // data is accessible via dot access
+  if (data) {
+    data.id;
+    data.state;
+  }
+
+  // hook return value includes the urql refresh function
+  refresh();
+};
+
+const TestGetReturnsTypedDataWithNoSelection = () => {
+  const [{ data }] = useGet(relatedProductsApi.currentSession);
+
+  if (data) {
+    data.id;
+    data.state;
+  }
+};
+
+test("true", () => undefined);

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -1,0 +1,21 @@
+import { CombinedError } from "@urql/core";
+import { assert, IsExact } from "conditional-type-checks";
+import { useGlobalAction } from "../src";
+import { bulkExampleApi } from "./apis";
+
+// these functions are typechecked but never run to avoid actually making API calls
+const TestUseGlobalActionCanRunGlobalActionsWithVariables = () => {
+  const [{ data, fetching, error }, mutate] = useGlobalAction(bulkExampleApi.flipAll);
+
+  assert<IsExact<typeof fetching, boolean>>(true);
+  assert<IsExact<typeof data, any>>(true);
+  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+
+  // can call with variables
+  void mutate({ why: "foobar" });
+
+  // @ts-expect-error can't call with variables that don't belong to the model
+  void mutate({ foo: "123" });
+};
+
+test("true", () => undefined);

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -2,6 +2,7 @@ import {
   ActionFunction,
   actionOperation,
   capitalize,
+  DefaultSelection,
   gadgetErrorFor,
   GadgetRecord,
   get,
@@ -55,7 +56,7 @@ export const useAction = <
   action: F,
   options?: LimitToKnownKeys<Options, F["optionsType"]>
 ): UseMutationResponse<
-  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, Options["select"]>>,
+  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>,
   Exclude<F["variablesType"], null | undefined>
 > => {
   const memoizedOptions = useStructuralMemo(options);
@@ -72,7 +73,7 @@ export const useAction = <
   }, [action, memoizedOptions]);
 
   const [result, runMutation] = useMutation<
-    GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, Options["select"]>>,
+    GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>,
     F["variablesType"]
   >(plan.query);
 

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -2,6 +2,7 @@ import {
   actionOperation,
   BulkActionFunction,
   capitalize,
+  DefaultSelection,
   GadgetRecord,
   get,
   hydrateRecordArray,
@@ -49,7 +50,7 @@ export const useBulkAction = <
   action: F,
   options?: LimitToKnownKeys<Options, F["optionsType"]>
 ): UseMutationResponse<
-  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, Options["select"]>>[],
+  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>[],
   Exclude<F["variablesType"], null | undefined>
 > => {
   const memoizedOptions = useStructuralMemo(options);
@@ -66,7 +67,9 @@ export const useBulkAction = <
   }, [action, memoizedOptions]);
 
   const [result, runMutation] = useMutation<
-    GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, Options["select"]>>[],
+    GadgetRecord<
+      Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>
+    >[],
     F["variablesType"]
   >(plan.query);
 

--- a/packages/react/src/useFindBy.ts
+++ b/packages/react/src/useFindBy.ts
@@ -1,4 +1,5 @@
 import {
+  DefaultSelection,
   findOneByFieldOperation,
   FindOneFunction,
   GadgetNonUniqueDataError,
@@ -45,7 +46,9 @@ export const useFindBy = <
   finder: F,
   value: string,
   options?: LimitToKnownKeys<Options, F["optionsType"]> & Omit<UseQueryArgs, "query" | "variables">
-): UseQueryResponse<GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, Options["select"]>>> => {
+): UseQueryResponse<
+  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>
+> => {
   const memoizedOptions = useStructuralMemo(options);
   const plan = useMemo(() => {
     return findOneByFieldOperation(

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -1,4 +1,5 @@
 import {
+  DefaultSelection,
   FindManyFunction,
   findManyOperation,
   GadgetRecord,
@@ -44,7 +45,9 @@ export const useFindMany = <
 >(
   manager: { findMany: F },
   options?: LimitToKnownKeys<Options, F["optionsType"]> & Omit<UseQueryArgs, "query" | "variables">
-): UseQueryResponse<GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, Options["select"]>>[]> => {
+): UseQueryResponse<
+  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>[]
+> => {
   const memoizedOptions = useStructuralMemo(options);
   const plan = useMemo(() => {
     return findManyOperation(

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -1,4 +1,13 @@
-import { FindOneFunction, findOneOperation, GadgetRecord, get, hydrateRecord, LimitToKnownKeys, Select } from "@gadgetinc/api-client-core";
+import {
+  DefaultSelection,
+  FindOneFunction,
+  findOneOperation,
+  GadgetRecord,
+  get,
+  hydrateRecord,
+  LimitToKnownKeys,
+  Select,
+} from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
 import { useQuery, UseQueryArgs, UseQueryResponse } from "urql";
 import { OptionsType } from "./OptionsType";
@@ -37,7 +46,9 @@ export const useFindOne = <
   manager: { findOne: F },
   id: string,
   options?: LimitToKnownKeys<Options, F["optionsType"] & Omit<UseQueryArgs, "query" | "variables">>
-): UseQueryResponse<GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, Options["select"]>>> => {
+): UseQueryResponse<
+  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>
+> => {
   const memoizedOptions = useStructuralMemo(options);
   const plan = useMemo(() => {
     return findOneOperation(

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -1,4 +1,13 @@
-import { findOneOperation, GadgetRecord, get, GetFunction, hydrateRecord, LimitToKnownKeys, Select } from "@gadgetinc/api-client-core";
+import {
+  DefaultSelection,
+  findOneOperation,
+  GadgetRecord,
+  get,
+  GetFunction,
+  hydrateRecord,
+  LimitToKnownKeys,
+  Select,
+} from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
 import { useQuery, UseQueryResponse } from "urql";
 import { OptionsType } from "./OptionsType";
@@ -35,7 +44,9 @@ export const useGet = <
 >(
   manager: { get: F },
   options?: LimitToKnownKeys<Options, F["optionsType"]>
-): UseQueryResponse<GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, Options["select"]>>> => {
+): UseQueryResponse<
+  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>
+> => {
   const memoizedOptions = useStructuralMemo(options);
   const plan = useMemo(() => {
     return findOneOperation(

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,6 +943,20 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@gadget-client/bulk-actions-example@^1.45.0":
+  version "1.45.0"
+  resolved "https://registry.gadget.dev/npm/_/tarball/1356/1537/207#3b1b286aabac1094a2fe6acb58421a34214b9f72"
+  integrity sha1-OxsoaqusEJSi/mrLWEIaNCFLn3I=
+  dependencies:
+    "@gadgetinc/api-client-core" "^0.4.2"
+
+"@gadget-client/related-products-example@1.213.0":
+  version "1.213.0"
+  resolved "https://registry.gadget.dev/npm/_/tarball/1268/1361/201#839ff6e8daaef27b9479db01e41d39463a25c58a"
+  integrity sha1-g5/26Nqu8nuUedsB5B05RjolxYo=
+  dependencies:
+    "@gadgetinc/api-client-core" "^0.4.2"
+
 "@gadgetinc/eslint-config@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@gadgetinc/eslint-config/-/eslint-config-0.4.0.tgz#bc831659717affcee7bc59556e7ee8ea8646bc37"
@@ -3952,7 +3966,7 @@ log-symbols@^3.0.0:
   dependencies:
     chalk "^2.4.2"
 
-loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4494,6 +4508,15 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
 react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -4503,6 +4526,14 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-pkg-up@^3.0.0:
   version "3.0.0"
@@ -4692,6 +4723,14 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"


### PR DESCRIPTION
When working on some example apps I went to use a plain ole `useFindMany(api.widget)` without passing a `select` option and found there to be no typed return value! The implementation supports this just fine, but we needed one little extra step to default the `select` option at type time as well as at runtime. This adds that, as well as a bunch of type-time tests that assert it works. To type test in this package I added some example clients that we yarn install from production Gadget apps which feels a little weird but I think buys us a lot of confidence so I think we aught to do it. 