### PR TITLE
Include the __typename field in the default generated selections

### DIFF
--- a/packages/api-client-core/spec/FieldSelection.spec.ts
+++ b/packages/api-client-core/spec/FieldSelection.spec.ts
@@ -1,0 +1,56 @@
+import { fieldSelectionToGQLBuilderFields } from "../src";
+
+describe("fieldSelectionToGQLBuilderFields", () => {
+  it("should convert a select parameter into an output suitable for gql-query-builder", () => {
+    expect(fieldSelectionToGQLBuilderFields({ id: true, widget: { name: true, inventoryCount: false } })).toMatchInlineSnapshot(`
+      Array [
+        "id",
+        Object {
+          "widget": Array [
+            "name",
+          ],
+        },
+      ]
+    `);
+  });
+
+  it("should allow no selections", () => {
+    expect(fieldSelectionToGQLBuilderFields({})).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it("should convert deeply nested select parameters", () => {
+    expect(fieldSelectionToGQLBuilderFields({ id: true, widget: { name: true, gizmos: { edges: { node: { id: true } } } } }))
+      .toMatchInlineSnapshot(`
+      Array [
+        "id",
+        Object {
+          "widget": Array [
+            "name",
+            Object {
+              "gizmos": Array [
+                Object {
+                  "edges": Array [
+                    Object {
+                      "node": Array [
+                        "id",
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+    `);
+  });
+
+  it("should include the typename param at the root when asked", () => {
+    expect(fieldSelectionToGQLBuilderFields({ name: true, inventoryCount: false }, true)).toMatchInlineSnapshot(`
+      Array [
+        "__typename",
+        "name",
+      ]
+    `);
+  });
+});

--- a/packages/api-client-core/src/FieldSelection.ts
+++ b/packages/api-client-core/src/FieldSelection.ts
@@ -15,8 +15,9 @@ export interface FieldSelection {
  *
  * __Note__: It's important that any output objects have only one key -- `gql-query-builder` only looks at the first one. To add multiple fields with subselections, return multiple objects in the array.
  **/
-export const fieldSelectionToGQLBuilderFields = (selection: FieldSelection) => {
+export const fieldSelectionToGQLBuilderFields = (selection: FieldSelection, includeTypename = false) => {
   const fields: Fields = [];
+  if (includeTypename) fields.push("__typename");
 
   for (const [key, value] of Object.entries(selection)) {
     if (typeof value === "object" && value !== null) {

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -39,7 +39,7 @@ export const findOneOperation = (
   return query([
     {
       operation,
-      fields: fieldSelectionToGQLBuilderFields(options?.select || defaultSelection),
+      fields: fieldSelectionToGQLBuilderFields(options?.select || defaultSelection, true),
       variables,
     },
     hydrationOptions(modelApiIdentifier),
@@ -79,7 +79,7 @@ export const findManyOperation = (
           pageInfo: ["hasNextPage", "hasPreviousPage", "startCursor", "endCursor"],
         },
         {
-          edges: ["cursor", { node: fieldSelectionToGQLBuilderFields(options?.select || defaultSelection) }],
+          edges: ["cursor", { node: fieldSelectionToGQLBuilderFields(options?.select || defaultSelection, true) }],
         },
       ],
       variables: {
@@ -116,7 +116,7 @@ export const actionOperation = (
 
   const selection = options?.select || defaultSelection;
   if (selection) {
-    actionOperation.fields!.push({ [modelSelectionField]: fieldSelectionToGQLBuilderFields(selection) });
+    actionOperation.fields!.push({ [modelSelectionField]: fieldSelectionToGQLBuilderFields(selection, true) });
   }
 
   if (namespace) {


### PR DESCRIPTION
Adding `__typename`  to outgoing graphql queries allows urql's default caching mechanism to refetch operations when it knows something has changed! See https://formidable.com/open-source/urql/docs/basics/document-caching/ for more details. For folks building stuff with `@gadgetinc/react`, this is really useful to just get by default without having to configure anything. We select the `__typename` field along with `id` and whatever else the user has asked for, and then urql does fancy stuff to inspect which typenames have changed when a mutation is run and refetch any queries also touching those typenames. 

Someday we should 100% support the normalized caching thing right out of the box, but I think it is wise to stick with the simple typename based approach that urql itself defaults to for now. This is way easier change to make, and it gets us stuff like "have things that care about the current session state automatically update when the user logs in or logs out" which is great!

Annoyingly though, this solution is a bit incomplete because we don't select any nested typenames either at query time or mutation time. If you have a query that fetches a page of widgets and the first page of each widget's gizmos, and then you update a gizmo, the update query will show urql that something with the typename `Gizmo` was touched, but the initial query won't have been tagged with a dependency on that typename. The initial query's selection set would be something like:

```typescript
useFindMany(api.widget, { select: { id: true, name: true, gizmos: { edges: { node: { id: true } } } } })
```

giving a query like :

```graphql
query {
  widgets { 
    edges {
     node { 
       __typename # the new thing
       id
       name
       gizmos { 
         edges { 
            node {
              id
              # no typename selected here unless the user does it explicitly
            }
         }
      }
   }
}
```

At query compilation time, we don't yet have enough information in the client to know that any selection of `gizmos.edges.node` should always include a typename. The developer could explicitly select the `__typename` property themselves if they knew it did this, but we can't yet automatically add it for them. We do have enough information server side to do this but it is just tricky to export it and generate the right selection from it in a dense and understandable way. 

I also thought about adding typename to every selection set, but, that would end up causing a lot more cache expiry that is desirable due to types like `RichTextOutput` or whatever being used in lots of places. Yeah, a widget has a rich text and so does a gizmo, but just cause a Widget's rich text field changed doesn't mean all gizmo rich text fields changed too. The way you express that to urql is you just don't select the __typename of the rich text object at all I think.

So I say we start with this while we ponder what the next step for automatic `__typename` selection on model objects is! 