### PR TITLE
delete many mutation

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/spec/support.spec.ts
+++ b/packages/api-client-core/spec/support.spec.ts
@@ -1,0 +1,127 @@
+import { CombinedError } from "@urql/core";
+import { GraphQLError } from "graphql";
+import { assertOperationSuccess } from "../src";
+
+describe("support utilities", () => {
+  describe("assertOperationSuccess", () => {
+    test("returns the result at the datapath if the operation was successful", () => {
+      expect(
+        assertOperationSuccess(
+          {
+            operation: null as any,
+            data: { foo: { bar: "baz" } },
+          },
+          ["foo", "bar"]
+        )
+      ).toEqual("baz");
+    });
+
+    test("throws the operation error if there's a network error on the operation", () => {
+      expect(() =>
+        assertOperationSuccess(
+          {
+            operation: null as any,
+            data: null,
+            error: new CombinedError({ networkError: new Error("foobar") }),
+          },
+
+          ["foo", "bar"]
+        )
+      ).toThrowErrorMatchingInlineSnapshot(`"[Network] foobar"`);
+    });
+
+    test("throws an actual error object and not a string so that the user gets a stack message", () => {
+      try {
+        assertOperationSuccess(
+          {
+            operation: null as any,
+            data: null,
+            error: new CombinedError({ networkError: new Error("foobar") }),
+          },
+
+          ["foo", "bar"]
+        );
+      } catch (error: any) {
+        // eslint-disable-next-line jest/no-try-expect
+        expect(error).toBeInstanceOf(Error);
+      }
+    });
+
+    test("throws the operation error if there's multiple network errors on the operation", () => {
+      expect(() =>
+        assertOperationSuccess(
+          {
+            operation: null as any,
+            data: null,
+            // @ts-expect-error an array of network errors doesn't match urql's types, but we've observed it at runtime
+            error: new CombinedError({ networkError: [new Error("foo"), new Error("foo")] }),
+          },
+
+          ["foo", "bar"]
+        )
+      ).toThrowErrorMatchingInlineSnapshot(`
+        "[Network] foo
+        [Network] foo"
+      `);
+    });
+
+    test("throws the operation error if there's a error on the operation", () => {
+      expect(() =>
+        assertOperationSuccess(
+          {
+            operation: null as any,
+            data: null,
+            error: new CombinedError({ graphQLErrors: [new Error("foo")] }),
+          },
+
+          ["foo", "bar"]
+        )
+      ).toThrowErrorMatchingInlineSnapshot(`"[GraphQL] foo"`);
+    });
+
+    test("throws the operation error if there's multiple errors on the operation", () => {
+      expect(() =>
+        assertOperationSuccess(
+          {
+            operation: null as any,
+            data: null,
+            error: new CombinedError({ graphQLErrors: [new Error("foo"), "bar"] }),
+          },
+
+          ["foo", "bar"]
+        )
+      ).toThrowErrorMatchingInlineSnapshot(`
+        "[GraphQL] foo
+        [GraphQL] bar"
+      `);
+    });
+
+    test("throws the operation error if there's a graphql error on the operation", () => {
+      expect(() =>
+        assertOperationSuccess(
+          {
+            operation: null as any,
+            data: null,
+            error: new CombinedError({ graphQLErrors: [new GraphQLError("inner graphql error")] }),
+          },
+
+          ["foo", "bar"]
+        )
+      ).toThrowErrorMatchingInlineSnapshot(`"[GraphQL] inner graphql error"`);
+    });
+
+    test("throws the operation error if there's no error on the operation but urql still throws a CombinedError", () => {
+      expect(() =>
+        assertOperationSuccess(
+          {
+            operation: null as any,
+            data: null,
+            error: new CombinedError({ response: { whatever: true } }),
+          },
+
+          ["foo", "bar"]
+        )
+      ).toThrowErrorMatchingInlineSnapshot(`""`);
+    });
+  });
+});

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -1,4 +1,4 @@
-import { OperationResult } from "@urql/core";
+import { CombinedError, OperationResult } from "@urql/core";
 import { DataHydrator } from "./DataHydrator";
 import { GadgetRecord } from "./GadgetRecord";
 
@@ -100,7 +100,10 @@ export const filterTypeName = (modelApiIdentifier: string) => `${camelize(modelA
 
 export const assertOperationSuccess = (response: OperationResult<any>, dataPath: string[]) => {
   if (response.error) {
-    throw response.error.message;
+    if (response.error instanceof CombinedError && (response.error.networkError as any as Error[])?.length) {
+      response.error.message = (response.error.networkError as any as Error[]).map((error) => "[Network] " + error.message).join("\n");
+    }
+    throw response.error;
   }
 
   const result = get(response.data, dataPath);

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -22,7 +22,7 @@ export class GadgetClientError extends Error {}
  **/
 export class GadgetOperationError extends Error {
   constructor(message: string, readonly errorCode: string) {
-    super(message);
+    super(errorCode + ": " + message);
   }
 }
 
@@ -151,8 +151,8 @@ export const getHydrator = (response: Result) => {
 };
 
 export const hydrateRecord = <Shape = any>(response: Result, record: any): Shape => {
-  let hydrator;
-  if ((hydrator = getHydrator(response))) {
+  const hydrator = getHydrator(response);
+  if (hydrator) {
     record = hydrator.apply(record);
   }
   return new GadgetRecord<Shape>(record);


### PR DESCRIPTION
- v0.4.4
- Throw real error objects from inside our success assertion helpers so they have stacks for the user to trace
- Add support for the internal deleteMany mutation to InternalModelManager
