### PR TITLE
Better handle connected states

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -57,6 +57,7 @@ export const connectionOpen = async (subscriptionClient: SubscriptionClient) => 
 
     unsubscribes.push(subscriptionClient.on("connected", wrappedResolve));
     unsubscribes.push(subscriptionClient.on("closed", wrappedReject));
+    unsubscribes.push(subscriptionClient.on("error", wrappedReject));
   }).finally(clearListeners);
 };
 


### PR DESCRIPTION
Previously, there was a chance that if the connection was established very quickly, we may have missed the "connected" event from the websocket before we created the listener in `connectionOpen`. This would result in a false timeout from our own `setTimeout`, which always rejects.

To handle this scenario, we ensure a connected listener is given in the construction of the subscription client that tracks the status.

**TODO:**
- [ ] Verify this scenario can occur, and try to reproduce it