### PR TITLE
Add a configurable ws timeout

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Set the WS connection timeout - the time we wait for the `onConnect` callback to run at 10s. (2x the previous value).

And allow users of the client to pass a different timeout in to avoid needing to change the client when we update this value in the future.