### PR TITLE
v0.3.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Now that #21 has been merged, specifically [this line](https://github.com/gadget-inc/js-clients/pull/21/files#diff-1f344ac391eeecc21ec0f01fb07430a47f4b80d20485c125447d54c33c4bbfc4R21), I think we should release a new version of the react package.

Since we bumped the `api-client-core`'s left most non-zero digit, I assume this means we should bump reacts as well? Let me know what you think 🤔  