### PR TITLE
Update bulk-actions-example client package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "node --max-old-space-size=4096 --stack-trace-limit=1000 node_modules/.bin/jest"
   },
   "devDependencies": {
-    "@gadget-client/bulk-actions-example": "^1.45.0",
+    "@gadget-client/bulk-actions-example": "^1.65.0",
     "@gadget-client/related-products-example": "^1.213.0",
     "@gadgetinc/eslint-config": "^0.4.0",
     "@gadgetinc/prettier-config": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,10 +982,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gadget-client/bulk-actions-example@^1.45.0":
-  version "1.63.0"
-  resolved "https://registry.gadget.dev/npm/_/tarball/1356/1537/397#053e4a2101178ecc3d572d9fbf8cf93a64314f83"
-  integrity sha1-BT5KIQEXjsw9Vy2fv4z5OmQxT4M=
+"@gadget-client/bulk-actions-example@^1.65.0":
+  version "1.65.0"
+  resolved "https://registry.gadget.dev/npm/_/tarball/2162/3149/415#9931629627f27dd27ecc2231ca0c7236d104d2a5"
+  integrity sha1-mTFilifyfdJ+zCIxygxyNtEE0qU=
   dependencies:
     "@gadgetinc/api-client-core" "0.5.1"
 


### PR DESCRIPTION
I had accidentally hard deleted this package from the production Gadget platform, so this repo's CI started failing trying to download it and install it. My bad! Recreated the app within Gadget, and then removed and reinstalled the client here, now we should be back in business.
