### PR TITLE
Add release workflow to automatically publish npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+on:
+  push:
+#    branches:
+#      - main
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: ./.github/actions/setup-test-env
+      - name: Build all packages
+        shell: nix develop -c bash -eo pipefail -l {0}
+        run: yarn build
+      - name: Publish @gadgetinc/api-client-core
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/api-client-core/package.json
+          dry-run: true
+      - name: Publish @gadgetinc/react
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/react/package.json
+          dry-run: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
   push:
-#    branches:
-#      - main
+    branches:
+      - main
 jobs:
   test:
     uses: ./.github/workflows/test.yml
@@ -20,10 +20,8 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/api-client-core/package.json
-          dry-run: true
       - name: Publish @gadgetinc/react
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/react/package.json
-          dry-run: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,10 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/api-client-core/package.json
+          access: public
       - name: Publish @gadgetinc/react
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/react/package.json
+          access: public

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: "Test"
 on:
   push:
+  workflow_call:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Contributing.md
+++ b/Contributing.md
@@ -18,7 +18,9 @@ It can be annoying to work with these packages via `yarn link` sometimes, so we 
 
 # Releasing
 
-Right now we release through yarn. Run
+Releasing is done automatically via [our release workflow](.github/workflows/release.yml). Any commits to the main branch that changes one of our `packages/**/package.json` versions will automatically be published.
+
+If you need to release manually for some reason you can do the following
 
 ```
 yarn workspace @gadgetinc/api-client-core publish --access=public --no-git-tag-version


### PR DESCRIPTION
Added a `release.yml` workflow to automatically publish our packages. It uses [this action](https://github.com/JS-DevTools/npm-publish) under the hood which only publishes a package if it's `package.json`'s `version` changes.

I made the `release.yml` workflow re-use the `test.yml` workflow so we don't have to duplicate our test steps. The `release.yml` is only set to run on the main branch.

I know I initially wanted to have this be a manual action but I changed my mind... go fast and break things right!?