### PR TITLE
Added inlineSources: true to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "noImplicitAny": true,
     "sourceMap": true,
+    "inlineSources": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
**What**

This fixes our source map issues when someone uses our react client with create-react-app v5.

```shell
Failed to parse source map from 'node_modules/@gadgetinc/api-client-core/src/AnyClient.ts' file:
Error: ENOENT: no such file or directory, open 'node_modules/@gadgetinc/api-client-core/src/AnyClient.ts'

Failed to parse source map from 'node_modules/@gadgetinc/react/src/index.ts' file:
Error: ENOENT: no such file or directory, open 'node_modules/@gadgetinc/react/src/index.ts'
```

**Why**

Because we want a seamless out-of-the-box experience with creact-react-app.

**How**

Webpack can't find the original source code that our source maps are pointing to, so we have 2 options:

1. Include the `src` directory in our bundle
2. Set `inlineSources: true` in our tsconfig.json

I went with option 2 because it's what [@opentelemtry-js](https://github.com/open-telemetry/opentelemetry-js/blob/main/tsconfig.base.json) does...

**Note**

Our `gql-query-builder` dependency has the same source map issue so our users are still going to get warnings. I'm going to start working on a PR for them after this.