### PR TITLE
Update gql-query-builder to v3.6.0

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -22,7 +22,7 @@
     "@urql/core": "^2.1.5",
     "@urql/exchange-multipart-fetch": "^0.1.13",
     "cross-fetch": "^3.0.6",
-    "gql-query-builder": "^3.5.5",
+    "gql-query-builder": "^3.6.0",
     "graphql": "^15.5.0",
     "graphql-ws": "^5.5.5",
     "isomorphic-ws": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,10 +3110,10 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-gql-query-builder@^3.5.5:
-  version "3.5.9"
-  resolved "https://registry.yarnpkg.com/gql-query-builder/-/gql-query-builder-3.5.9.tgz#8efe866ef684e1ddd727c3260a42e9bdb042d622"
-  integrity sha512-J6EoDabBbY/gDvFCQ5713YibgUOUmmhzf+5Av5zLOtB4s6O/pr3wOIc1fOpHc/e6LnYc90Z7d4YQ3NjItOC6UA==
+gql-query-builder@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/gql-query-builder/-/gql-query-builder-3.6.0.tgz#e4f17cc26478259b9ac55e5505f3a6239a64e9c6"
+  integrity sha512-++OiouUz5OQDgNVY/rmfNfud/uTZUQV961b9Zp9IBq5B+PIJb2Y3iq3iaZchAtjg5h31x646zZYT18BlgQQAjQ==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.9:
   version "4.2.9"


### PR DESCRIPTION
The source map fix for gql-query-builder [was merged](https://github.com/atulmy/gql-query-builder/pull/69) 🎉

Let's update to the newest version.