### PR TITLE
Add api-client-core resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "ts-node": "^10.7.0",
     "typescript": "4.4.3",
     "zx": "^6.0.3"
+  },
+  "resolutions": {
+    "@gadgetinc/api-client-core": "*"
   }
 }


### PR DESCRIPTION
This will solve the problem I had [releasing v.0.5.2](https://github.com/gadget-inc/js-clients/actions/runs/2036689687).

**Problem**

Our `@gadgetinc/react` tests use `@gadget-client/bulk-actions-example` and `@gadget-client/related-products-example` which are generated clients from gadget. The generated clients depend on `@gadgetinc/api-client-core` and pin their dependency version - in this case they were pinned to v0.5.1.

`@gadgetinc/react` also depends on `@gadgetinc/api-client-core`, but it's only pinned to v0.5, so yarn installed `@gadgetincapi-client-core@0.5.1` for the generated clients but let `@gadgetinc/react` use the new monorepo version v0.5.2.

This caused `@gadgetinc/react` and our generated clients to use different `@gadgetinc/api-core-client` versions which causes TypeScript to complain - previously discussed [here](https://github.com/gadget-inc/js-clients/pull/21).

**Solution**

Adding the following yarn resolution _seems to_ make sure that there's only ever one version of `@gadgetinc/api-client-core` is used (the monorepo one).

```json
"resolutions": {
  "@gadgetinc/api-client-core": "*"
}
```

This isn't the greatest fix because of how difficult it is to explain, but it does have the added benefit of always testing our generated clients with the monorepo version of `@gadgetinc/api-client-core`.

This was discussed with @airhorns and @thegedge.