### PR TITLE
Fix empty `findFirst` cases

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -104,7 +104,7 @@ export const getNonUniqueDataError = (modelApiIdentifier: string, fieldName: str
     `More than one record found for ${modelApiIdentifier}.${fieldName} = ${fieldValue}. Please confirm your unique validation is not reporting an error.`
   );
 
-export const getNonNullableError = (response: Result & { fetching: boolean }, dataPath: string[], throwOnEmptyData = true) => {
+export const getNonNullableError = (response: Result & { fetching: boolean }, dataPath: string[], throwOnEmptyData = false) => {
   if (response.fetching) {
     return;
   }
@@ -120,7 +120,7 @@ export const getNonNullableError = (response: Result & { fetching: boolean }, da
   }
 };
 
-export const assertOperationSuccess = (response: OperationResult<any>, dataPath: string[], throwOnEmptyData = true) => {
+export const assertOperationSuccess = (response: OperationResult<any>, dataPath: string[], throwOnEmptyData = false) => {
   if (response.error) {
     if (response.error instanceof CombinedError && (response.error.networkError as any as Error[])?.length) {
       response.error.message = (response.error.networkError as any as Error[]).map((error) => "[Network] " + error.message).join("\n");

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react/src/useFindFirst.ts
+++ b/packages/react/src/useFindFirst.ts
@@ -74,7 +74,7 @@ export const useFindFirst = <
     }
   }
 
-  const nonNullableError = getNonNullableError(result, dataPath);
+  const nonNullableError = getNonNullableError(result, dataPath, true);
   let error = result.error;
   if (!error && nonNullableError) {
     error = new CombinedError({


### PR DESCRIPTION
Supports [sc-1556]

Adds logic to properly address empty `findFirst` empty results. The base `findMany` runner and internal method now account for 3 possible expected behaviours:
1. For `findMany`, where results of empty array are possible.
2. For `findFirst`, where results of empty array throw an error.
3. For `maybeFindFirst`, where results of an empty array are returned as `null`, with no error thrown.