### PR TITLE
Restore original signature of `findOne` function

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/src/GadgetRecord.ts
+++ b/packages/api-client-core/src/GadgetRecord.ts
@@ -17,10 +17,16 @@ export class GadgetRecordImplementation<Shape extends RecordShape> {
     persistedFields: {} as any,
   };
 
+  private empty = false;
+
   constructor(data: Shape) {
     this.__gadget.instantiatedFields = cloneDeep(data);
     this.__gadget.persistedFields = cloneDeep(data);
     Object.assign(this.__gadget.fields, data);
+
+    if (!data || Object.keys(data).length === 0) {
+      this.empty = true;
+    }
 
     const handler = {
       get: (obj: any, prop: string | symbol) => {
@@ -40,6 +46,11 @@ export class GadgetRecordImplementation<Shape extends RecordShape> {
     };
 
     return new Proxy(this.__gadget.fields, handler);
+  }
+
+  /** Checks if the original constructor data was empty or not */
+  isEmpty(): boolean {
+    return this.empty;
   }
 
   /** Returns the value of the field for the given `apiIdentifier`. These properties may also be accessed on this record directly. This method can be used if your model field `apiIdentifier` conflicts with the `GadgetRecord` helper functions. */

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -194,19 +194,19 @@ export class InternalModelManager {
     this.capitalizedApiIdentifier = camelize(apiIdentifier);
   }
 
-  async findOne(id: string, throwOnEmptyData = true): Promise<GadgetRecord<Record<string, any> & ({ id: string } | { id: never })>> {
+  async findOne(id: string, throwOnEmptyData = true): Promise<GadgetRecord<RecordData>> {
     const response = await this.connection.currentClient.query(internalFindOneQuery(this.apiIdentifier), { id }).toPromise();
     const assertSuccess = throwOnEmptyData ? assertOperationSuccess : assertNullableOperationSuccess;
     const result = assertSuccess(response, ["internal", this.apiIdentifier]);
     return await hydrateRecord(response, result);
   }
 
-  async maybeFindOne(id: string): Promise<GadgetRecord<RecordShape> | null> {
+  async maybeFindOne(id: string): Promise<GadgetRecord<RecordData> | null> {
     const record = await this.findOne(id, false);
-    return record.id ? record : null;
+    return record.isEmpty() ? null : record;
   }
 
-  async findMany(options?: Record<string, any>, throwOnEmptyData?: boolean, isFirstQuery = false): Promise<GadgetRecordList<any>> {
+  async findMany(options?: RecordData, throwOnEmptyData?: boolean, isFirstQuery = false): Promise<GadgetRecordList<any>> {
     const response = await this.connection.currentClient
       .query(internalFindManyQuery(this.apiIdentifier, isFirstQuery), options)
       .toPromise();
@@ -225,12 +225,12 @@ export class InternalModelManager {
     return GadgetRecordList.boot(this, records, { options, pageInfo: connection.pageInfo });
   }
 
-  async findFirst(options?: Record<string, any>): Promise<GadgetRecord<RecordShape>> {
+  async findFirst(options?: RecordData): Promise<GadgetRecord<RecordShape>> {
     const list = await this.findMany({ ...options, first: 1, last: undefined, before: undefined, after: undefined }, true, true);
     return list[0];
   }
 
-  async maybeFindFirst(options?: Record<string, any>): Promise<GadgetRecord<RecordShape> | null> {
+  async maybeFindFirst(options?: RecordData): Promise<GadgetRecord<RecordShape> | null> {
     const list = await this.findMany({ ...options, first: 1, last: undefined, before: undefined, after: undefined }, false, true);
     return list[0] ?? null;
   }
@@ -270,7 +270,7 @@ export class InternalModelManager {
     });
   }
 
-  async deleteMany(options?: { search?: string; filter?: Record<string, any> }): Promise<void> {
+  async deleteMany(options?: { search?: string; filter?: RecordData }): Promise<void> {
     return await this.transaction(async (transaction) => {
       const response = await transaction.client.mutation(internalDeleteManyMutation(this.apiIdentifier), options).toPromise();
       assertMutationSuccess(response, ["internal", `deleteMany${this.capitalizedApiIdentifier}`]);

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -194,18 +194,16 @@ export class InternalModelManager {
     this.capitalizedApiIdentifier = camelize(apiIdentifier);
   }
 
-  async findOne(id: string, throwOnEmptyData: true): Promise<GadgetRecord<RecordShape>>;
-  async findOne(id: string, throwOnEmptyData: false): Promise<GadgetRecord<RecordShape> | null>;
-  async findOne(id: string, throwOnEmptyData = true): Promise<GadgetRecord<RecordShape> | null> {
+  async findOne(id: string, throwOnEmptyData = true): Promise<GadgetRecord<Record<string, any> & ({ id: string } | { id: never })>> {
     const response = await this.connection.currentClient.query(internalFindOneQuery(this.apiIdentifier), { id }).toPromise();
     const assertSuccess = throwOnEmptyData ? assertOperationSuccess : assertNullableOperationSuccess;
     const result = assertSuccess(response, ["internal", this.apiIdentifier]);
-    return result ? hydrateRecord<RecordShape>(response, result) : null;
+    return await hydrateRecord(response, result);
   }
 
   async maybeFindOne(id: string): Promise<GadgetRecord<RecordShape> | null> {
     const record = await this.findOne(id, false);
-    return record ?? null;
+    return record.id ? record : null;
   }
 
   async findMany(options?: Record<string, any>, throwOnEmptyData?: boolean, isFirstQuery = false): Promise<GadgetRecordList<any>> {

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -29,7 +29,7 @@ export const findOneRunner = async <Shape extends RecordShape = any>(
   const response = await modelManager.connection.currentClient.query(plan.query, plan.variables).toPromise();
   const assertSuccess = throwOnEmptyData ? assertOperationSuccess : assertNullableOperationSuccess;
   const record = assertSuccess(response, [operation]);
-  return record ? hydrateRecord<Shape>(response, record) : null;
+  return hydrateRecord<Shape>(response, record);
 };
 
 export const findOneByFieldRunner = async <Shape extends RecordShape = any>(


### PR DESCRIPTION
Unfortunately, the signature change to the `findOne` function resulted in typing issues, even with the overload designed to prevent it.

However, I've added a robust way to check if the record is empty, on the GadgetRecord class itself, so I'm no longer relying on the `id` prop.