### PR TITLE
Use query builder for internal find many query

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -1,0 +1,133 @@
+import { internalFindFirstQuery, internalFindManyQuery } from "../src";
+
+describe("InternalModelManager", () => {
+  describe("internalFindManyQuery", () => {
+    test("should build a find many query with no options", () => {
+      expect(internalFindManyQuery("widget", undefined)).toMatchInlineSnapshot(`
+        Object {
+          "query": "query InternalFindManyWidget ($after: String, $before: String, $first: Int, $last: Int) { internal  { listWidget (after: $after, before: $before, first: $first, last: $last) { pageInfo { hasNextPage, hasPreviousPage, startCursor, endCursor }, edges { cursor, node } } } }",
+          "variables": Object {
+            "after": undefined,
+            "before": undefined,
+            "first": undefined,
+            "last": undefined,
+          },
+        }
+      `);
+    });
+
+    test("should build a find many query with sort", () => {
+      expect(internalFindManyQuery("widget", { sort: [{ id: "Ascending" }] })).toMatchInlineSnapshot(`
+        Object {
+          "query": "query InternalFindManyWidget ($sort: [WidgetSort!], $after: String, $before: String, $first: Int, $last: Int) { internal  { listWidget (sort: $sort, after: $after, before: $before, first: $first, last: $last) { pageInfo { hasNextPage, hasPreviousPage, startCursor, endCursor }, edges { cursor, node } } } }",
+          "variables": Object {
+            "after": undefined,
+            "before": undefined,
+            "first": undefined,
+            "last": undefined,
+            "sort": Array [
+              Object {
+                "id": "Ascending",
+              },
+            ],
+          },
+        }
+      `);
+    });
+
+    test("should build a find many query with search", () => {
+      expect(internalFindManyQuery("widget", { search: "term" })).toMatchInlineSnapshot(`
+        Object {
+          "query": "query InternalFindManyWidget ($search: String, $after: String, $before: String, $first: Int, $last: Int) { internal  { listWidget (search: $search, after: $after, before: $before, first: $first, last: $last) { pageInfo { hasNextPage, hasPreviousPage, startCursor, endCursor }, edges { cursor, node } } } }",
+          "variables": Object {
+            "after": undefined,
+            "before": undefined,
+            "first": undefined,
+            "last": undefined,
+            "search": "term",
+          },
+        }
+      `);
+    });
+
+    test("should build a find many query with filter", () => {
+      expect(internalFindManyQuery("widget", { filter: [{ id: { equals: "1" } }] })).toMatchInlineSnapshot(`
+        Object {
+          "query": "query InternalFindManyWidget ($filter: [WidgetFilter!], $after: String, $before: String, $first: Int, $last: Int) { internal  { listWidget (filter: $filter, after: $after, before: $before, first: $first, last: $last) { pageInfo { hasNextPage, hasPreviousPage, startCursor, endCursor }, edges { cursor, node } } } }",
+          "variables": Object {
+            "after": undefined,
+            "before": undefined,
+            "filter": Array [
+              Object {
+                "id": Object {
+                  "equals": "1",
+                },
+              },
+            ],
+            "first": undefined,
+            "last": undefined,
+          },
+        }
+      `);
+    });
+  });
+
+  describe("internalFindFirstQuery", () => {
+    test("should build a find first query with no options", () => {
+      expect(internalFindFirstQuery("widget", undefined)).toMatchInlineSnapshot(`
+        Object {
+          "query": "query InternalFindFirstWidget ($first: Int) { internal  { listWidget (first: $first) { edges { node } } } }",
+          "variables": Object {
+            "first": 1,
+          },
+        }
+      `);
+    });
+
+    test("should build a find first query with sort", () => {
+      expect(internalFindFirstQuery("widget", { sort: [{ id: "Ascending" }] })).toMatchInlineSnapshot(`
+        Object {
+          "query": "query InternalFindFirstWidget ($sort: [WidgetSort!], $first: Int) { internal  { listWidget (sort: $sort, first: $first) { edges { node } } } }",
+          "variables": Object {
+            "first": 1,
+            "sort": Array [
+              Object {
+                "id": "Ascending",
+              },
+            ],
+          },
+        }
+      `);
+    });
+
+    test("should build a find first query with search", () => {
+      expect(internalFindFirstQuery("widget", { search: "term" })).toMatchInlineSnapshot(`
+        Object {
+          "query": "query InternalFindFirstWidget ($search: String, $first: Int) { internal  { listWidget (search: $search, first: $first) { edges { node } } } }",
+          "variables": Object {
+            "first": 1,
+            "search": "term",
+          },
+        }
+      `);
+    });
+
+    test("should build a find first query with filter", () => {
+      expect(internalFindFirstQuery("widget", { filter: [{ id: { equals: "1" } }] })).toMatchInlineSnapshot(`
+        Object {
+          "query": "query InternalFindFirstWidget ($filter: [WidgetFilter!], $first: Int) { internal  { listWidget (filter: $filter, first: $first) { edges { node } } } }",
+          "variables": Object {
+            "filter": Array [
+              Object {
+                "id": Object {
+                  "equals": "1",
+                },
+              },
+            ],
+            "first": 1,
+          },
+        }
+      `);
+    });
+  });
+});

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -1,3 +1,4 @@
+import { query } from "gql-query-builder";
 import { GadgetConnection } from "./GadgetConnection";
 import { GadgetRecord, RecordShape } from "./GadgetRecord";
 import { GadgetRecordList } from "./GadgetRecordList";
@@ -44,61 +45,78 @@ export const internalFindOneQuery = (apiIdentifier: string) => {
     `;
 };
 
-export const internalFindManyQuery = (apiIdentifier: string, isFirstQuery = false) => {
+export const internalFindFirstQuery = (apiIdentifier: string, options?: RecordData) => {
   const capitalizedApiIdentifier = capitalize(apiIdentifier);
-  const namePrefix = isFirstQuery ? "InternalFindFirst" : "InternalFindMany";
-  return `
-    query ${namePrefix}${capitalizedApiIdentifier}(
-      ${
-        isFirstQuery
-          ? ""
-          : `
-      $after: String
-      $before: String
-      $first: Int
-      $last: Int`
-      }
-      $search: String
-      $sort: [${capitalizedApiIdentifier}Sort!]
-      $filter: [${capitalizedApiIdentifier}Filter!]
-    ) {
-      ${internalHydrationPlan(apiIdentifier)}
-      internal {
-        list${capitalizedApiIdentifier}(
-          ${
-            isFirstQuery
-              ? `
-          first: 1`
-              : `
-          after: $after
-          before: $before
-          first: $first
-          last: $last
-          `
-          }    
-          search: $search
-          sort: $sort
-          filter: $filter
-        ) {
-          edges {
-            ${isFirstQuery ? "" : "cursor"}
-            node
-          }
-          ${
-            isFirstQuery
-              ? ""
-              : `
-          pageInfo {
-            hasNextPage
-            hasPreviousPage
-            startCursor
-            endCursor
-          }`
-          }
-        }
-      }
-    }
-    `;
+
+  const defaultVariables = {
+    ...(options?.search && { search: { value: options?.search, type: "String", required: false } }),
+    ...(options?.sort && { sort: { value: options?.sort, type: `${capitalizedApiIdentifier}Sort!`, list: true } }),
+    ...(options?.filter && { filter: { value: options?.filter, type: `${capitalizedApiIdentifier}Filter!`, list: true } }),
+  };
+
+  return query(
+    [
+      {
+        operation: "internal",
+        fields: [
+          {
+            operation: `list${capitalizedApiIdentifier}`,
+            fields: [
+              {
+                edges: ["node"],
+              },
+            ],
+            variables: {
+              ...defaultVariables,
+              first: { value: 1, type: "Int" },
+            },
+          },
+        ],
+      },
+    ],
+    null,
+    { operationName: `InternalFindFirst${capitalizedApiIdentifier}` }
+  );
+};
+
+export const internalFindManyQuery = (apiIdentifier: string, options?: RecordData) => {
+  const capitalizedApiIdentifier = capitalize(apiIdentifier);
+
+  const defaultVariables = {
+    ...(options?.search && { search: { value: options?.search, type: "String", required: false } }),
+    ...(options?.sort && { sort: { value: options?.sort, type: `${capitalizedApiIdentifier}Sort!`, list: true } }),
+    ...(options?.filter && { filter: { value: options?.filter, type: `${capitalizedApiIdentifier}Filter!`, list: true } }),
+  };
+
+  return query(
+    [
+      {
+        operation: "internal",
+        fields: [
+          {
+            operation: `list${capitalizedApiIdentifier}`,
+            fields: [
+              {
+                pageInfo: ["hasNextPage", "hasPreviousPage", "startCursor", "endCursor"],
+              },
+              {
+                edges: ["cursor", "node"],
+              },
+            ],
+            variables: {
+              ...defaultVariables,
+              after: { value: options?.after, type: "String" },
+              before: { value: options?.before, type: "String" },
+              first: { value: options?.first, type: "Int" },
+              last: { value: options?.last, type: "Int" },
+            },
+          },
+        ],
+      },
+    ],
+    null,
+    { operationName: `InternalFindMany${capitalizedApiIdentifier}` }
+  );
 };
 
 export const internalCreateMutation = (apiIdentifier: string) => {
@@ -207,9 +225,8 @@ export class InternalModelManager {
   }
 
   async findMany(options?: RecordData, throwOnEmptyData?: boolean, isFirstQuery = false): Promise<GadgetRecordList<any>> {
-    const response = await this.connection.currentClient
-      .query(internalFindManyQuery(this.apiIdentifier, isFirstQuery), options)
-      .toPromise();
+    const plan = isFirstQuery ? internalFindFirstQuery(this.apiIdentifier, options) : internalFindManyQuery(this.apiIdentifier, options);
+    const response = await this.connection.currentClient.query(plan.query, plan.variables).toPromise();
 
     let connection;
     if (throwOnEmptyData === false) {


### PR DESCRIPTION
Implements conditional arguments for `search`, `sort` and `filter` for the internal find many query. The internal version of https://github.com/gadget-inc/js-clients/pull/31.

In order to make this easier I have converted this to also use the graphql query builder that is used by the `operationBuilder` to generate the query rather than using a hardcoded string. I have also broken out into 2 methods for the `findFirst` case and the default `findMany` as the queries were sufficiently different (no pagination options, no page info, no cursor and different operation name). This meant I could remove a bunch conditional logic within the query itself. 

I have added a bunch of tests similar to those in `operationBuilder.spec` for the generated queries. 