### PR TITLE
Add option to specify initial browser session token

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/src/ClientOptions.ts
+++ b/packages/api-client-core/src/ClientOptions.ts
@@ -10,6 +10,15 @@ export interface ClientOptions {
 
 /** Options to configure a specific browser-based authentication mode */
 export interface BrowserSessionAuthenticationModeOptions {
+  /**
+   * The initial token to set for browser authentication.
+   * This is useful when your session is initialized by some external authentication system, like OAuth.
+   */
+  initialToken?: string;
+
+  /**
+   * Configures how the authentication token is persisted. See `BrowserSessionStorageType`.
+   */
   storageType: BrowserSessionStorageType;
 }
 

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -10,6 +10,7 @@ import {
   Sink,
 } from "graphql-ws";
 import WebSocket from "isomorphic-ws";
+import { isObject } from "lodash";
 import { getCurrentSpan } from ".";
 import type { AuthenticationModeOptions, BrowserSessionAuthenticationModeOptions } from "./ClientOptions";
 import { BrowserSessionStorageType } from "./ClientOptions";
@@ -114,13 +115,21 @@ export class GadgetConnection {
 
   enableSessionMode(options?: true | BrowserSessionAuthenticationModeOptions) {
     this.authenticationMode = AuthenticationMode.BrowserSession;
+
+    let sessionTokenStore;
     if (!options || typeof options == "boolean" || options.storageType == BrowserSessionStorageType.Durable) {
-      this.sessionTokenStore = window.localStorage;
+      sessionTokenStore = window.localStorage;
     } else if (options.storageType == BrowserSessionStorageType.Session) {
-      this.sessionTokenStore = window.sessionStorage;
+      sessionTokenStore = window.sessionStorage;
     } else {
-      this.sessionTokenStore = new InMemoryStorage();
+      sessionTokenStore = new InMemoryStorage();
     }
+
+    if (isObject(options) && "initialToken" in options && options.initialToken) {
+      sessionTokenStore.setItem(sessionStorageKey, options.initialToken);
+    }
+
+    this.sessionTokenStore = sessionTokenStore;
     this.resetClients();
   }
 


### PR DESCRIPTION
This will allow us to manage browser session tokens our self for the public app oauth flow.

fixes ggt-1457