### PR TITLE
Don't override `initialToken` on ws connect

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -310,7 +310,12 @@ export class GadgetConnection {
         connected: (socket, payload) => {
           // If we're using session token authorization, we don't use request headers to exchange the session token, we use graphql-ws' ConnectionAck payload to persist the token. When the subscription client first starts, the server will send us session token identifying this client, and we persist it to the session token store
           if (this.authenticationMode == AuthenticationMode.BrowserSession && payload?.sessionToken) {
-            this.sessionTokenStore!.setItem(sessionStorageKey, payload.sessionToken as string);
+            const initialToken = isObject(this.options.authenticationMode?.browserSession)
+              ? this.options.authenticationMode?.browserSession.initialToken
+              : null;
+            if (!initialToken) {
+              this.sessionTokenStore!.setItem(sessionStorageKey, payload.sessionToken as string);
+            }
           }
           this.subscriptionClientOptions?.on?.connected?.(socket, payload);
           overrides?.on?.connected?.(socket, payload);


### PR DESCRIPTION
I was wondering why auth wasn't working with the `initialToken` option, and then I realized it was being clobbered by the existing setup that sets it when the websocket connection is opened :woman_facepalming: 