### PR TITLE
chore(react): expand react peer dependency to include ^18.0.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -34,7 +34,7 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   }
 }


### PR DESCRIPTION
I haven't found any incompatibilities with this library and react 18 --
but if you try to install it on a project with react 18 you will get a
peer dependency error, I think we can support both

![image](https://user-images.githubusercontent.com/52211/168676211-c85f08fc-b87d-46c7-a4db-445cfd9c7166.png)

https://linear.app/gadget-dev/issue/GGT-1522/gadgetincreact-is-not-compatible-with-react-18