### PR TITLE
Updating react-shopify-app-bridge oauth url to be app specific

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -98,7 +98,7 @@ const InnerGadgetProvider = memo(
     useEffect(() => {
       if (!runningShopifyAuth || isRootFrameRequest) return;
       // redirect to gadget app root pages url with oauth params
-      const redirectURL = new URL(gadgetAppUrl);
+      const redirectURL = new URL("/api/connections/auth/shopify", gadgetAppUrl);
       redirectURL.search = originalQueryParams?.toString() ?? "";
       const redirectURLWithOAuthParams = redirectURL.toString();
 


### PR DESCRIPTION
We're updating Gadget's Shopify OAuth URLs to be app specific e.g. https://sample.gadget.app/api/connections/auth/shopify vs https://app.gadget.dev/connections/auth/shopify/callback. This PR updates `react-shopify-app-bridge` to use the new app specific route instead of the root domain.

This shouldn't be merged before https://github.com/gadget-inc/gadget/pull/3558

closes GGT-1744.