### PR TITLE
Create token key by host and shopify api key

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react-shopify-app-bridge/src/utils.ts
+++ b/packages/react-shopify-app-bridge/src/utils.ts
@@ -1,0 +1,1 @@
+export const getTokenKey = (host: string, appApiKey: string) => `${appApiKey}/${host}`;


### PR DESCRIPTION
We need to be able to support the same host on multiple apps so we'll need to keep tokens by both the shopify api key as well as host.

closes GGT-1734