### PR TITLE
Add support for a custom auth method which can be used to implement platform native auths from userland

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -39,7 +39,9 @@
     "@types/lodash.isequal": "^4.5.5",
     "@types/node": "^14.14.41",
     "conditional-type-checks": "^1.0.5",
+    "gql-tag": "^1.0.1",
     "jest": "^27.5.1",
+    "nock": "^13.2.8",
     "typescript": "4.4.3"
   }
 }

--- a/packages/api-client-core/spec/GadgetConnection.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnection.spec.ts
@@ -1,7 +1,20 @@
+import gql from "gql-tag";
+import nock from "nock";
+import { BrowserSessionStorageType } from "../src";
 import { AuthenticationMode, GadgetConnection } from "../src/GadgetConnection";
 
+const base64 = (str: string) => Buffer.from(str).toString("base64");
+nock.disableNetConnect();
+
 describe("GadgetConnection", () => {
-  // this object is integration tested within Gadget itself
+  // this object is integration tested within Gadget itself also
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    expect(nock.pendingMocks()).toEqual([]);
+  });
 
   it("should require an endpoint to be set", () => {
     expect(() => new GadgetConnection({} as any)).toThrowErrorMatchingInlineSnapshot(
@@ -10,7 +23,261 @@ describe("GadgetConnection", () => {
   });
 
   it("should default to the anonymous authentication mode if no authentication mode is passed", () => {
-    const connection = new GadgetConnection({ endpoint: "http://someapp.gadget.host" });
+    const connection = new GadgetConnection({ endpoint: "https://someapp.gadget.app" });
     expect(connection.authenticationMode).toEqual(AuthenticationMode.Anonymous);
+  });
+
+  describe("authorization", () => {
+    it("should allow connecting with anonymous authentication", async () => {
+      nock("https://someapp.gadget.app")
+        .post("/api/graphql", { query: "{\n  meta {\n    appName\n  }\n}\n", variables: {} })
+        .reply(200, {
+          data: {
+            meta: {
+              appName: "some app",
+            },
+          },
+        });
+
+      const connection = new GadgetConnection({
+        endpoint: "https://someapp.gadget.app/api/graphql",
+        authenticationMode: { anonymous: true },
+      });
+
+      const result = await connection.currentClient
+        .query(
+          gql`
+            {
+              meta {
+                appName
+              }
+            }
+          `
+        )
+        .toPromise();
+
+      expect(result.data).toEqual({ meta: { appName: "some app" } });
+    });
+
+    it("should allow connecting with internal auth token authentication", async () => {
+      nock("https://someapp.gadget.app")
+        .post("/api/graphql", { query: "{\n  meta {\n    appName\n  }\n}\n", variables: {} })
+        // .basicAuth({ user: "gadget", pass: "opaque-token-thing" })
+        .reply(200, function () {
+          expect(this.req.headers["authorization"]).toEqual([`Basic ${base64("gadget-internal:opaque-token-thing")}`]);
+
+          return {
+            data: {
+              meta: {
+                appName: "some app",
+              },
+            },
+          };
+        });
+
+      const connection = new GadgetConnection({
+        endpoint: "https://someapp.gadget.app/api/graphql",
+        authenticationMode: { internalAuthToken: "opaque-token-thing" },
+      });
+
+      const result = await connection.currentClient
+        .query(
+          gql`
+            {
+              meta {
+                appName
+              }
+            }
+          `
+        )
+        .toPromise();
+
+      expect(result.data).toEqual({ meta: { appName: "some app" } });
+    });
+
+    it("should allow connecting with a gadget API Key", async () => {
+      nock("https://someapp.gadget.app")
+        .post("/api/graphql", { query: "{\n  meta {\n    appName\n  }\n}\n", variables: {} })
+        .reply(200, function () {
+          expect(this.req.headers["authorization"]).toEqual([`Bearer gsk-abcde`]);
+
+          return {
+            data: {
+              meta: {
+                appName: "some app",
+              },
+            },
+          };
+        });
+
+      const connection = new GadgetConnection({
+        endpoint: "https://someapp.gadget.app/api/graphql",
+        authenticationMode: { apiKey: "gsk-abcde" },
+      });
+
+      const result = await connection.currentClient
+        .query(
+          gql`
+            {
+              meta {
+                appName
+              }
+            }
+          `
+        )
+        .toPromise();
+
+      expect(result.data).toEqual({ meta: { appName: "some app" } });
+    });
+
+    describe("session token storage", () => {
+      it("should allow connecting with no session in a session storage mode", async () => {
+        nock("https://someapp.gadget.app")
+          .post("/api/graphql", { query: "{\n  meta {\n    appName\n  }\n}\n", variables: {} })
+          .reply(
+            200,
+            {
+              data: {
+                meta: {
+                  appName: "some app",
+                },
+              },
+            },
+            {
+              "x-set-authorization": "Session token-123",
+            }
+          );
+
+        const connection = new GadgetConnection({
+          endpoint: "https://someapp.gadget.app/api/graphql",
+          authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Temporary } },
+        });
+
+        const result = await connection.currentClient
+          .query(
+            gql`
+              {
+                meta {
+                  appName
+                }
+              }
+            `
+          )
+          .toPromise();
+
+        expect(result.data).toEqual({ meta: { appName: "some app" } });
+      });
+
+      it("should allow connecting with an initial session token in session storage mode", async () => {
+        nock("https://someapp.gadget.app")
+          .post("/api/graphql", { query: "{\n  meta {\n    appName\n  }\n}\n", variables: {} })
+          .reply(
+            200,
+            function () {
+              expect(this.req.headers["authorization"]).toEqual(["Session token-123"]);
+              return {
+                data: {
+                  meta: {
+                    appName: "some app",
+                  },
+                },
+              };
+            },
+            {
+              "x-set-authorization": "Session token-123",
+            }
+          );
+
+        const connection = new GadgetConnection({
+          endpoint: "https://someapp.gadget.app/api/graphql",
+          authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Temporary, initialToken: "token-123" } },
+        });
+
+        const result = await connection.currentClient
+          .query(
+            gql`
+              {
+                meta {
+                  appName
+                }
+              }
+            `
+          )
+          .toPromise();
+
+        expect(result.data).toEqual({ meta: { appName: "some app" } });
+      });
+
+      it("should store a x-set-authorization header and reuse it for subsequent requests", async () => {
+        nock("https://someapp.gadget.app")
+          .post("/api/graphql", { query: "{\n  meta {\n    appName\n  }\n}\n", variables: {} })
+          .reply(
+            200,
+            function () {
+              expect(this.req.headers["authorization"]).toBeUndefined();
+              return {
+                data: {
+                  meta: {
+                    appName: "some app",
+                  },
+                },
+              };
+            },
+            {
+              "x-set-authorization": "Session token-123",
+            }
+          )
+          .post("/api/graphql", { query: "{\n  currentSession {\n    id\n  }\n}\n", variables: {} })
+          .reply(
+            200,
+            function () {
+              expect(this.req.headers["authorization"]).toEqual(["Session token-123"]);
+              return {
+                data: {
+                  currentSession: {
+                    id: 1,
+                  },
+                },
+              };
+            },
+            {
+              "x-set-authorization": "Session token-123",
+            }
+          );
+
+        const connection = new GadgetConnection({
+          endpoint: "https://someapp.gadget.app/api/graphql",
+          authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Temporary } },
+        });
+
+        const firstResult = await connection.currentClient
+          .query(
+            gql`
+              {
+                meta {
+                  appName
+                }
+              }
+            `
+          )
+          .toPromise();
+
+        expect(firstResult.data).toEqual({ meta: { appName: "some app" } });
+
+        const secondResult = await connection.currentClient
+          .query(
+            gql`
+              {
+                currentSession {
+                  id
+                }
+              }
+            `
+          )
+          .toPromise();
+
+        expect(secondResult.data).toEqual({ currentSession: { id: 1 } });
+      });
+    });
   });
 });

--- a/packages/api-client-core/src/ClientOptions.ts
+++ b/packages/api-client-core/src/ClientOptions.ts
@@ -47,7 +47,7 @@ export interface AuthenticationModeOptions {
   apiKey?: string;
 
   // Use a web browser's `localStorage` or `sessionStorage` to persist authentication information.
-  // This allows a web user to log in and keep their sessiontheir cookie (containing their credentials) will be sent.
+  // This allows the browser to have a persistent identity as the user navigates around and logs in and out.
   browserSession?: boolean | BrowserSessionAuthenticationModeOptions;
 
   // Use no authentication at all, and get access only to the data that the Unauthenticated backend role has access to.
@@ -56,4 +56,10 @@ export interface AuthenticationModeOptions {
   // @private Use an internal platform auth token for authentication
   // This is used to communicate within Gadget itself and shouldn't be used to connect to Gadget from other systems
   internalAuthToken?: string;
+
+  // @private Use a passed custom function for managing authentication. For some fancy integrations that the API client supports, like embedded Shopify apps, we use platform native features to authenticate with the Gadget backend.
+  custom?: {
+    processFetch(input: RequestInfo, init: RequestInit): Promise<void>;
+    processTransactionConnectionParams(params: Record<string, any>): Promise<void>;
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,7 +993,9 @@
     "@gadgetinc/api-client-core" "0.6.8"
 
 "@gadgetinc/api-client-core@0.6.8":
-  version "0.6.9"
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@gadgetinc/api-client-core/-/api-client-core-0.6.8.tgz#7c8791ac3a8c69cb5a39f6fbd7cb6a58d6f337aa"
+  integrity sha512-3WzDkg8bVisTjzTXsF+WhAsfdEMdpPISBR7KHFip80arqrGbOYfuY19NzQbjGcmadghcMbLozujQpwfViiqU6g==
   dependencies:
     "@opentelemetry/api" "^1.0.4"
     "@urql/core" "^2.1.5"
@@ -3263,6 +3265,11 @@ gql-query-builder@^3.6.0:
   resolved "https://registry.yarnpkg.com/gql-query-builder/-/gql-query-builder-3.6.0.tgz#e4f17cc26478259b9ac55e5505f3a6239a64e9c6"
   integrity sha512-++OiouUz5OQDgNVY/rmfNfud/uTZUQV961b9Zp9IBq5B+PIJb2Y3iq3iaZchAtjg5h31x646zZYT18BlgQQAjQ==
 
+gql-tag@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gql-tag/-/gql-tag-1.0.1.tgz#25294dc23986db5b950b81a8bc8debfb0acf6140"
+  integrity sha512-eVxldTiOtJJ3ySNgYbfRwyIyDDMATJ/ykojlQng5ihX1V0Xpr4C7ZXSZuWo7tg+kf+GS8lzhlbZmKSDjbYGhyA==
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
@@ -4494,6 +4501,16 @@ nock@^13.2.4:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
     lodash.set "^4.3.2"
+    propagate "^2.0.0"
+
+nock@^13.2.8:
+  version "13.2.8"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.8.tgz#e2043ccaa8e285508274575e090a7fe1e46b90f1"
+  integrity sha512-JT42FrXfQRpfyL4cnbBEJdf4nmBpVP0yoCcSBr+xkT8Q1y3pgtaCKHGAAOIFcEJ3O3t0QbVAmid0S0f2bj3Wpg==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
     propagate "^2.0.0"
 
 node-domexception@^1.0.0:


### PR DESCRIPTION
To build support for Shopify session token authentication, we need the client to be able to set arbitrary headers to send back to the Gadget backend. We don't wanna build super bespoke shopify code into a client used in a variety of non-shopify places, so this adds a hook were folks constructing the connection can create connections that pass a function that does whatever it wants to the outgoing request. Woop woop!