### PR TITLE
Bump minor version of api-client-core

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -18,10 +18,10 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.6.9",
+    "lodash": "^4.17.21",
+    "@gadgetinc/api-client-core": "^0.7.0",
     "@shopify/app-bridge-utils": "^3.1.1",
-    "crypto-js": "^4.1.1",
-    "lodash": "^4.17.21"
+    "crypto-js": "^4.1.1"
   },
   "devDependencies": {
     "@gadgetinc/react": "^0.4.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,7 +18,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.6.9",
+    "@gadgetinc/api-client-core": "^0.7.0",
     "deep-equal": "^2.0.5",
     "urql": "^2.0.5"
   },


### PR DESCRIPTION
Need to deploy the api-client-core changes so that the shopify react package can use the new custom auth.