### PR TITLE
Reauthenticate if scopes have changed

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -32,6 +32,9 @@ const GetCurrentSessionQuery = `
         id
       }
     }
+    shopifyConnection {
+      requiresReauthentication
+    }
   }
 `;
 
@@ -80,7 +83,12 @@ const InnerGadgetProvider = memo(({ children, forceRedirect, isEmbedded, gadgetA
       if (!currentSessionData.currentSession.shop) {
         runningShopifyAuth = true;
       } else {
-        isAuthenticated = true;
+        // we need to re-authenticate because we're missing scopes so let's force redirect
+        if (currentSessionData.shopifyConnection?.requiresReauthentication) {
+          runningShopifyAuth = true;
+        } else {
+          isAuthenticated = true;
+        }
       }
     } else {
       console.warn(


### PR DESCRIPTION
We recently added a `shopifyConnection` GraphQL query that allows the `Provider` to know whether or not we should re-auth with Shopify for updated scopes. This PR requests the `requiresReauthentication` field and forces a re-authentication if that returns true.

closes GGT-1850