### PR TITLE
Update peer dependencies for react-shopify-app-bridge

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -25,7 +25,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@gadgetinc/react": "^0.4.4",
+    "@gadgetinc/react": "^0.5.0",
     "@shopify/app-bridge-react": "^2.0.25",
     "@types/crypto-js": "^4.1.1",
     "@types/jest": "^26.0.24",
@@ -40,8 +40,8 @@
     "ts-jest": "^28.0.3"
   },
   "peerDependencies": {
-    "@gadgetinc/react": "^0.4.4",
-    "@shopify/app-bridge-react": "^2.0.25",
+    "@gadgetinc/react": "^0.5.0",
+    "@shopify/app-bridge-react": "^2.0.0 || ^3.0.0",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,7 +993,7 @@
     "@gadgetinc/api-client-core" "0.6.8"
 
 "@gadgetinc/api-client-core@0.6.8":
-  version "0.6.9"
+  version "0.7.0"
   dependencies:
     "@opentelemetry/api" "^1.0.4"
     "@urql/core" "^2.1.5"


### PR DESCRIPTION
Shopify released v3 of their app bridge and we should support the new version. I did some basic testing with faker and didn't see any compatibility issues. We should add some tests for this at some point