### PR TITLE
Change api-client-core to target es2019 instead of es2020

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/tsconfig.json
+++ b/packages/api-client-core/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./",
     "moduleResolution": "node",
     "module": "commonjs",
-    "target": "es2020",
+    "target": "es2019",
     "types": ["jest", "node"],
     "outDir": "./dist",
   },


### PR DESCRIPTION
We ran into some issues with NextJs minification where it cannot correctly minify code that uses null coalescing. Let's compile down to `es2919` instead where null coalesce does not exist. Will bump deps for other packages once this one is merged

before:
<img width="778" alt="Screen Shot 2022-07-29 at 12 42 30 PM" src="https://user-images.githubusercontent.com/2903015/181806646-750d5a19-f8fc-4f6a-a65a-25ebb7a2fc9d.png">

after:
<img width="1033" alt="Screen Shot 2022-07-29 at 12 41 57 PM" src="https://user-images.githubusercontent.com/2903015/181806457-764c7385-fb99-4468-b482-daaa3c3e15e1.png">

