### PR TITLE
Bump other packages to include updated api-client-core version

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.7.0",
+    "@gadgetinc/api-client-core": "^0.7.1",
     "@shopify/app-bridge-utils": "^3.1.1",
     "crypto-js": "^4.1.1",
     "lodash": "^4.17.21"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.7.0",
+    "@gadgetinc/api-client-core": "^0.7.1",
     "deep-equal": "^2.0.5",
     "urql": "^2.0.5"
   },


### PR DESCRIPTION
We need to bump package versions to update dep for `api-client-core`