### PR TITLE
Add a flag to let developers know that they're viewing a page request

### DIFF
--- a/packages/react-shopify-app-bridge/README.md
+++ b/packages/react-shopify-app-bridge/README.md
@@ -96,7 +96,7 @@ export default function App() {
 
 // An example component that uses the Gadget React hooks to work with data in the Shopify backend
 function ProductManager() {
-  const { loading, appBridge } = useGadget();
+  const { loading, appBridge, isRootFrameRequest, isAuthenticated } = useGadget();
   const [, deleteProduct] = useAction(api.shopifyProduct.delete);
   const [{ data, fetching, error }, refresh] = useFindMany(api.shopifyProduct);
 
@@ -119,7 +119,9 @@ function ProductManager() {
   return (
     <>
       {loading && <span>Loading...</span>}
-      {!loading &&
+      {/* A user is viewing this page from a direct link so show them the home page! */}
+      {!loading && isRootFrameRequest && <div>Welcome to my cool app's webpage!</div>}
+      {!loading && isAuthenticated &&
         data.map((product) => (
           <button
             onClick={(event) => {

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -22,6 +22,7 @@ type GadgetProviderProps = {
   gadgetAppUrl: string;
   originalQueryParams?: URLSearchParams;
   api: AnyClient;
+  isRootFrameRequest: boolean;
 };
 
 const GetCurrentSessionQuery = `
@@ -39,94 +40,98 @@ const GetCurrentSessionQuery = `
 `;
 
 // inner component that exists in order to ask for the app bridge
-const InnerGadgetProvider = memo(({ children, forceRedirect, isEmbedded, gadgetAppUrl, originalQueryParams, api }: GadgetProviderProps) => {
-  const appBridge = useContext(AppBridgeContext);
+const InnerGadgetProvider = memo(
+  ({ children, forceRedirect, isEmbedded, gadgetAppUrl, originalQueryParams, api, isRootFrameRequest }: GadgetProviderProps) => {
+    const appBridge = useContext(AppBridgeContext);
 
-  const [context, setContext] = useState<GadgetAuthContextValue>({
-    isAuthenticated: false,
-    isEmbedded: false,
-    canAuth: false,
-    loading: false,
-    appBridge,
-  });
-
-  useEffect(() => {
-    if (!appBridge) return;
-    // setup the api client to always query using the custom shopify auth implementation
-    api.connection.setAuthenticationMode({
-      custom: {
-        processFetch: async (_input, init) => {
-          const headers = new Headers(init.headers);
-          headers.append("Authorization", `ShopifySessionToken ${await getSessionToken(appBridge)}`);
-          init.headers ??= {};
-          headers.forEach(function (value, key) {
-            (init.headers as Record<string, string>)[key] = value;
-          });
-        },
-        processTransactionConnectionParams(_params) {
-          throw new Error("client side transactions yet not supported in Shopify Gadget provider");
-        },
-      },
+    const [context, setContext] = useState<GadgetAuthContextValue>({
+      isAuthenticated: false,
+      isEmbedded: false,
+      canAuth: false,
+      loading: false,
+      appBridge,
+      isRootFrameRequest: false,
     });
-  }, [api.connection, appBridge]);
 
-  let runningShopifyAuth = false;
-  let isAuthenticated = false;
+    useEffect(() => {
+      if (!appBridge) return;
+      // setup the api client to always query using the custom shopify auth implementation
+      api.connection.setAuthenticationMode({
+        custom: {
+          processFetch: async (_input, init) => {
+            const headers = new Headers(init.headers);
+            headers.append("Authorization", `ShopifySessionToken ${await getSessionToken(appBridge)}`);
+            init.headers ??= {};
+            headers.forEach(function (value, key) {
+              (init.headers as Record<string, string>)[key] = value;
+            });
+          },
+          processTransactionConnectionParams(_params) {
+            throw new Error("client side transactions yet not supported in Shopify Gadget provider");
+          },
+        },
+      });
+    }, [api.connection, appBridge]);
 
-  // always run one session fetch to the gadget backend on boot to discover if this app is installed
-  const [{ data: currentSessionData, fetching: sessionFetching, error }] = useQuery({
-    query: GetCurrentSessionQuery,
-  });
+    let runningShopifyAuth = false;
+    let isAuthenticated = false;
 
-  if (currentSessionData) {
-    if (currentSessionData.currentSession) {
-      if (!currentSessionData.currentSession.shop) {
-        runningShopifyAuth = true;
-      } else {
-        // we need to re-authenticate because we're missing scopes so let's force redirect
-        if (currentSessionData.shopifyConnection?.requiresReauthentication) {
+    // always run one session fetch to the gadget backend on boot to discover if this app is installed
+    const [{ data: currentSessionData, fetching: sessionFetching, error }] = useQuery({
+      query: GetCurrentSessionQuery,
+    });
+
+    if (currentSessionData) {
+      if (currentSessionData.currentSession) {
+        if (!currentSessionData.currentSession.shop) {
           runningShopifyAuth = true;
         } else {
-          isAuthenticated = true;
+          // we need to re-authenticate because we're missing scopes so let's force redirect
+          if (currentSessionData.shopifyConnection?.requiresReauthentication) {
+            runningShopifyAuth = true;
+          } else {
+            isAuthenticated = true;
+          }
         }
+      } else {
+        console.warn(
+          "Unexpected response from Gadget backend trying to bootstrap session -- no session returned for valid Shopify Session Token. Is the Gadget Connection configured properly?"
+        );
       }
-    } else {
-      console.warn(
-        "Unexpected response from Gadget backend trying to bootstrap session -- no session returned for valid Shopify Session Token. Is the Gadget Connection configured properly?"
-      );
     }
+
+    // redirect to Gadget to initiate the oauth process if we need to.
+    useEffect(() => {
+      if (!runningShopifyAuth || isRootFrameRequest) return;
+      // redirect to gadget app root pages url with oauth params
+      const redirectURL = new URL(gadgetAppUrl);
+      redirectURL.search = originalQueryParams?.toString() ?? "";
+      const redirectURLWithOAuthParams = redirectURL.toString();
+
+      if (isEmbedded && appBridge) {
+        Redirect.create(appBridge).dispatch(Redirect.Action.REMOTE, redirectURLWithOAuthParams);
+      } else {
+        window.location.assign(redirectURLWithOAuthParams);
+      }
+    }, [appBridge, gadgetAppUrl, isEmbedded, originalQueryParams, runningShopifyAuth]);
+
+    const loading = (forceRedirect || runningShopifyAuth || sessionFetching) && !isRootFrameRequest;
+
+    useEffect(() => {
+      return setContext({
+        isAuthenticated,
+        isEmbedded,
+        canAuth: !!appBridge,
+        loading,
+        appBridge,
+        error,
+        isRootFrameRequest,
+      });
+    }, [loading, isEmbedded, appBridge, isAuthenticated, error]);
+
+    return <GadgetAuthContext.Provider value={context}>{children}</GadgetAuthContext.Provider>;
   }
-
-  // redirect to Gadget to initiate the oauth process if we need to.
-  useEffect(() => {
-    if (!runningShopifyAuth) return;
-    // redirect to gadget app root pages url with oauth params
-    const redirectURL = new URL(gadgetAppUrl);
-    redirectURL.search = originalQueryParams?.toString() ?? "";
-    const redirectURLWithOAuthParams = redirectURL.toString();
-
-    if (isEmbedded && appBridge) {
-      Redirect.create(appBridge).dispatch(Redirect.Action.REMOTE, redirectURLWithOAuthParams);
-    } else {
-      window.location.assign(redirectURLWithOAuthParams);
-    }
-  }, [appBridge, gadgetAppUrl, isEmbedded, originalQueryParams, runningShopifyAuth]);
-
-  const loading = forceRedirect || runningShopifyAuth || sessionFetching;
-
-  useEffect(() => {
-    return setContext({
-      isAuthenticated,
-      isEmbedded,
-      canAuth: !!appBridge,
-      loading,
-      appBridge,
-      error,
-    });
-  }, [loading, isEmbedded, appBridge, isAuthenticated, error]);
-
-  return <GadgetAuthContext.Provider value={context}>{children}</GadgetAuthContext.Provider>;
-});
+);
 
 type ProviderLocation = {
   query?: URLSearchParams;
@@ -162,6 +167,9 @@ export const Provider = ({
   const isEmbedded = typeof window !== "undefined" ? window.top !== window.self : false;
   const inDestinationContext = isEmbedded == ((type ?? AppType.Embedded) == AppType.Embedded);
 
+  // We need to inform developers if the component is being rendered in a non embedded context when it should be AND we're not in an interstitial installation state. This is determined for now by the absence of both hmac and shop. This will generally occur when someone visits the app url while not in the Shopify admin.
+  const isRootFrameRequest = !query?.has("hmac") && !query?.has("shop") && (type ?? AppType.Embedded) == AppType.Embedded;
+
   const forceRedirect = isReady && !isUndefined(host) && !inDestinationContext;
 
   const gadgetAppUrl = new URL(api.connection.options.endpoint).origin;
@@ -181,6 +189,7 @@ export const Provider = ({
         gadgetAppUrl={gadgetAppUrl}
         api={api}
         originalQueryParams={originalQueryParams}
+        isRootFrameRequest={isRootFrameRequest}
       >
         {children}
       </InnerGadgetProvider>

--- a/packages/react-shopify-app-bridge/src/context.ts
+++ b/packages/react-shopify-app-bridge/src/context.ts
@@ -17,6 +17,8 @@ export type GadgetAuthContextValue = {
   canAuth: boolean;
   /** Is this browser window authenticated and ready to make requests to the Gadget backend */
   isAuthenticated: boolean;
+  /** Is the app being rendered outside of a Shopify admin flow, this only applies if type is set to AppType.Embedded. e.g. navigating to this page through a link */
+  isRootFrameRequest: boolean;
 };
 
 export const GadgetAuthContext = createContext<GadgetAuthContextValue>({
@@ -25,6 +27,7 @@ export const GadgetAuthContext = createContext<GadgetAuthContextValue>({
   isAuthenticated: false,
   canAuth: false,
   appBridge: null,
+  isRootFrameRequest: false,
 });
 
 export const useGadget = () => useContext<GadgetAuthContextValue>(GadgetAuthContext);


### PR DESCRIPTION
I'm not entirely sure what to call this flag but it is there to indicate that the page has rendered because a user has visited the page directly via something like a link instead of the shopify admin (if the app is set as embedded). This is so that developers can add their own behavior i.e. redirect to app listing, ask for shop url to install on, or show some splash page.