### PR TITLE
Fix support for standalone mode

### DIFF
--- a/packages/react-shopify-app-bridge/spec/useGadget.spec.ts
+++ b/packages/react-shopify-app-bridge/spec/useGadget.spec.ts
@@ -4,7 +4,7 @@ import { AppType, useGadget } from "../src";
 
 // these functions are typechecked but never run to avoid actually making API calls
 const TestUseGadgetReturnsAppropriateTypes = () => {
-  const { loading, appType, isEmbedded, appBridge, canAuth, isAuthenticated } = useGadget();
+  const { loading, appType, isEmbedded, appBridge, canAuth, isAuthenticated, isRootFrameRequest } = useGadget();
 
   assert<IsExact<typeof loading, boolean>>(true);
   assert<IsExact<typeof isEmbedded, boolean>>(true);
@@ -12,6 +12,7 @@ const TestUseGadgetReturnsAppropriateTypes = () => {
   assert<IsExact<typeof isAuthenticated, boolean>>(true);
   assert<IsExact<typeof appType, AppType | undefined>>(true);
   assert<IsExact<typeof appBridge, ClientApplication<AppBridgeState> | null>>(true);
+  assert<IsExact<typeof isRootFrameRequest, boolean>>(true);
 };
 
 test("true", () => undefined);

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -22,6 +22,8 @@ type GadgetProviderProps = {
   originalQueryParams?: URLSearchParams;
   api: AnyClient;
   isRootFrameRequest: boolean;
+  isInstallRequest: boolean;
+  type: AppType;
 };
 
 const GetCurrentSessionQuery = `
@@ -40,7 +42,17 @@ const GetCurrentSessionQuery = `
 
 // inner component that exists in order to ask for the app bridge
 const InnerGadgetProvider = memo(
-  ({ children, forceRedirect, isEmbedded, gadgetAppUrl, originalQueryParams, api, isRootFrameRequest }: GadgetProviderProps) => {
+  ({
+    children,
+    forceRedirect,
+    isEmbedded,
+    gadgetAppUrl,
+    originalQueryParams,
+    api,
+    isRootFrameRequest,
+    type,
+    isInstallRequest,
+  }: GadgetProviderProps) => {
     const appBridge = useContext(AppBridgeContext);
 
     const [context, setContext] = useState<GadgetAuthContextValue>({
@@ -78,6 +90,8 @@ const InnerGadgetProvider = memo(
     // always run one session fetch to the gadget backend on boot to discover if this app is installed
     const [{ data: currentSessionData, fetching: sessionFetching, error }] = useQuery({
       query: GetCurrentSessionQuery,
+      // for now don't fetch a session's shop in standalone mode since it leverages session tokens which aren't available if standalone
+      pause: type == AppType.Standalone,
     });
 
     if (currentSessionData) {
@@ -91,6 +105,8 @@ const InnerGadgetProvider = memo(
           isAuthenticated = !currentSessionData.shopifyConnection?.requiresReauthentication;
         }
       }
+    } else if (type == AppType.Standalone && isInstallRequest) {
+      runningShopifyAuth = true;
     }
 
     // redirect to Gadget to initiate the oauth process if we need to.
@@ -151,6 +167,7 @@ export const Provider = ({
   const isReady = !!location;
   const { query } = location ?? {};
   const host = query?.get("host") ?? undefined;
+  const coalescedType = type ?? AppType.Embedded;
 
   // We store the original query params as that is what shopify uses to generate the HMAC in embedded apps
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -163,10 +180,11 @@ export const Provider = ({
   // On a browser that this policy enabled, we'll just re-run the auth process after redirecting to the embedded app.
   const isInstallRequest = query?.has("hmac") && query?.has("shop");
   const isEmbedded = typeof window !== "undefined" ? window.top !== window.self : false;
-  const inDestinationContext = isEmbedded == ((type ?? AppType.Embedded) == AppType.Embedded);
+  const inDestinationContext =
+    isEmbedded == (coalescedType == AppType.Embedded) && (coalescedType == AppType.Standalone ? !isInstallRequest : true);
 
   // We need to inform developers if the component is being rendered in a non embedded context when it should be AND we're not in an interstitial installation state. This is determined for now by the absence of both hmac and shop. This will generally occur when someone visits the app url while not in the Shopify admin.
-  const isRootFrameRequest = !query?.has("hmac") && !query?.has("shop") && (type ?? AppType.Embedded) == AppType.Embedded;
+  const isRootFrameRequest = !query?.has("hmac") && !query?.has("shop") && coalescedType == AppType.Embedded;
 
   const forceRedirect = isReady && !isUndefined(host) && !inDestinationContext;
 
@@ -188,6 +206,8 @@ export const Provider = ({
         api={api}
         originalQueryParams={originalQueryParams}
         isRootFrameRequest={isRootFrameRequest}
+        type={coalescedType}
+        isInstallRequest={!!isInstallRequest}
       >
         {children}
       </InnerGadgetProvider>
@@ -195,7 +215,7 @@ export const Provider = ({
   );
 
   // app bridge provider seems to prevent urql from sending graphql requests when it cannot communicate using postMessage when not embedded so we must skip using the app bridge provider on the very first redirect from shopify
-  if (host && (!isInstallRequest || inDestinationContext)) {
+  if (host && coalescedType != AppType.Standalone && (!isInstallRequest || inDestinationContext)) {
     app = (
       <AppBridgeProvider
         config={{


### PR DESCRIPTION
When we switched over to using Shopify Session Tokens we broke support for standalone apps that still need to go through OAuth and render some sort of UI. This PR handles the following:
- skip using app bridge altogether if running in standalone mode
- skip requesting a session's shop since that relies on Shopify Session Tokens
- redirect to OAuth endpoint if we're in standalone mode and there is an hmac and shop param

I 🎩  the following flows:
- install a standalone app
- load a standalone app
- install an embedded app
- load an already installed embedded app
- load an embedded app in a non embedded context