### PR TITLE
[hooks] Return a Gadget-owned error wrapper object with easy access to validation errors from GraphQL responses

### DIFF
--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -95,6 +95,9 @@ export class GadgetNonUniqueDataError extends Error {
   code = "GGT_NON_UNIQUE_DATA";
 }
 
+/** All the errors a Gadget operation can throw */
+export type GadgetError = GadgetOperationError | GadgetInternalError | InvalidRecordError | GadgetNonUniqueDataError;
+
 export function assert<T>(value: T | undefined | null, message?: string): T {
   if (!value) {
     throw new Error("assertion error" + (message ? `: ${message}` : ""));

--- a/packages/react/spec/ErrorWrapper.spec.ts
+++ b/packages/react/spec/ErrorWrapper.spec.ts
@@ -1,0 +1,81 @@
+import { CombinedError } from "@urql/core";
+import { ErrorWrapper } from "../src/utils";
+
+describe("ErrorWrapper", () => {
+  test("errorDataIfAbsent should return an error wrapper if data isn't found at a datapath", () => {
+    const error = ErrorWrapper.errorIfDataAbsent(
+      {
+        data: {
+          foo: {},
+        },
+        fetching: false,
+        stale: false,
+      },
+      ["foo", "bar"]
+    );
+
+    expect(error).toBeTruthy();
+    expect(error!.message).toMatchInlineSnapshot(
+      `"[GraphQL] Internal Error: Gadget API didn't return expected data. Nothing found in response at foo.bar"`
+    );
+  });
+
+  test("errorDataIfAbsent should return null if data is found at a datapath", () => {
+    const error = ErrorWrapper.errorIfDataAbsent(
+      {
+        data: {
+          foo: {
+            bar: true,
+          },
+        },
+        fetching: false,
+        stale: false,
+      },
+      ["foo", "bar"]
+    );
+
+    expect(error).toBeFalsy();
+  });
+
+  test("forMaybeCombinedError should return a wrapper which reports all of urqls errors", () => {
+    const error = ErrorWrapper.forMaybeCombinedError(
+      new CombinedError({
+        graphQLErrors: ["some server side graphql error"],
+        response: { statusCode: 500 },
+      })
+    );
+
+    expect(error!.response).toBeTruthy();
+    expect(error!.executionErrors).toHaveLength(1);
+    expect(error!.networkError).toBeUndefined();
+    expect(error!.message).toMatchInlineSnapshot(`"[GraphQL] some server side graphql error"`);
+  });
+
+  test("forErrorsResponse should return a wrapper which reports server errors", () => {
+    const error = ErrorWrapper.forErrorsResponse([{ code: "GGT_UNKNOWN", message: "Unknown server error occurred" }], { response: true });
+
+    expect(error.response).toBeTruthy();
+    expect(error.executionErrors).toHaveLength(1);
+    expect(error.networkError).toBeUndefined();
+    expect(error.message).toMatchInlineSnapshot(`"[GraphQL] GGT_UNKNOWN: Unknown server error occurred"`);
+  });
+
+  test("forErrorsResponse should return a wrapper which reports validation errors", () => {
+    const error = ErrorWrapper.forErrorsResponse(
+      [
+        {
+          code: "GGT_INVALID_RECORD",
+          message: "widget record is invalid and can't be saved. name is not unique.",
+          validationErrors: [{ apiIdentifier: "name", message: "is not unique" }],
+        },
+      ],
+      { response: true }
+    );
+
+    expect(error.response).toBeTruthy();
+    expect(error.executionErrors).toHaveLength(1);
+    expect(error.networkError).toBeUndefined();
+    expect(error.message).toMatchInlineSnapshot(`"[GraphQL] widget record is invalid and can't be saved. name is not unique."`);
+    expect(error.validationErrors).toMatchInlineSnapshot(`null`);
+  });
+});

--- a/packages/react/spec/useAction.spec.ts
+++ b/packages/react/spec/useAction.spec.ts
@@ -1,7 +1,7 @@
 import { GadgetRecord } from "@gadgetinc/api-client-core";
-import { CombinedError } from "@urql/core";
 import { assert, IsExact } from "conditional-type-checks";
 import { useAction } from "../src";
+import { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
 
 // these functions are typechecked but never run to avoid actually making API calls
@@ -31,7 +31,7 @@ const TestUseActionReturnsTypedDataWithExplicitSelection = () => {
 
   assert<IsExact<typeof fetching, boolean>>(true);
   assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>>>(true);
-  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
   // data is accessible via dot access
   if (data) {

--- a/packages/react/spec/useBulkAction.spec.ts
+++ b/packages/react/spec/useBulkAction.spec.ts
@@ -1,7 +1,7 @@
 import { GadgetRecord } from "@gadgetinc/api-client-core";
-import { CombinedError } from "@urql/core";
 import { assert, IsExact } from "conditional-type-checks";
 import { useBulkAction } from "../src";
+import { ErrorWrapper } from "../src/utils";
 import { bulkExampleApi } from "./apis";
 
 // these functions are typechecked but never run to avoid actually making API calls
@@ -28,7 +28,7 @@ const _TestUseBulkActionReturnsTypedDataWithExplicitSelection = () => {
 
   assert<IsExact<typeof fetching, boolean>>(true);
   assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; name: string | null }>[]>>(true);
-  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
   if (data) {
     data[0].id;

--- a/packages/react/spec/useFindBy.spec.ts
+++ b/packages/react/spec/useFindBy.spec.ts
@@ -1,7 +1,7 @@
 import { GadgetRecord } from "@gadgetinc/api-client-core";
-import { CombinedError } from "@urql/core";
 import { assert, IsExact } from "conditional-type-checks";
 import { useFindBy } from "../src";
+import { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
 
 // these functions are typechecked but never run to avoid actually making API calls
@@ -12,7 +12,7 @@ const TestFindByReturnsTypedDataWithExplicitSelection = () => {
 
   assert<IsExact<typeof fetching, boolean>>(true);
   assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>>>(true);
-  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
   // data is accessible via dot access
   if (data) {

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -1,7 +1,7 @@
 import { GadgetRecord } from "@gadgetinc/api-client-core";
-import { CombinedError } from "@urql/core";
 import { assert, IsExact } from "conditional-type-checks";
 import { useFindMany } from "../src/useFindMany";
+import { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
 
 // all these functions are typechecked but never run to avoid actually making API calls
@@ -10,7 +10,7 @@ const TestFindManyReturnsTypedDataWithExplicitSelection = () => {
 
   assert<IsExact<typeof fetching, boolean>>(true);
   assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>[]>>(true);
-  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
   if (data) {
     data[0].id;

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -1,7 +1,7 @@
 import { GadgetRecord } from "@gadgetinc/api-client-core";
-import { CombinedError } from "@urql/core";
 import { assert, IsExact } from "conditional-type-checks";
 import { useFindOne } from "../src";
+import { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
 
 // these functions are typechecked but never run to avoid actually making API calls
@@ -10,7 +10,7 @@ const TestFindOneReturnsTypedDataWithExplicitSelection = () => {
 
   assert<IsExact<typeof fetching, boolean>>(true);
   assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>>>(true);
-  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
   // data is accessible via dot access
   if (data) {

--- a/packages/react/spec/useGet.spec.ts
+++ b/packages/react/spec/useGet.spec.ts
@@ -1,7 +1,7 @@
 import { GadgetRecord } from "@gadgetinc/api-client-core";
-import { CombinedError } from "@urql/core";
 import { assert, Has, IsExact } from "conditional-type-checks";
 import { useGet } from "../src/useGet";
+import { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
 
 // these functions are typechecked but never run to avoid actually making API calls
@@ -10,7 +10,7 @@ const TestGetReturnsTypedDataWithExplicitSelection = () => {
 
   assert<IsExact<typeof fetching, boolean>>(true);
   assert<Has<typeof data, undefined | GadgetRecord<{ id: string; state: any }>>>(true);
-  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
   // data is accessible via dot access
   if (data) {

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -1,6 +1,6 @@
-import { CombinedError } from "@urql/core";
 import { assert, IsExact } from "conditional-type-checks";
 import { useGlobalAction } from "../src";
+import { ErrorWrapper } from "../src/utils";
 import { bulkExampleApi } from "./apis";
 
 // these functions are typechecked but never run to avoid actually making API calls
@@ -9,7 +9,7 @@ const TestUseGlobalActionCanRunGlobalActionsWithVariables = () => {
 
   assert<IsExact<typeof fetching, boolean>>(true);
   assert<IsExact<typeof data, any>>(true);
-  assert<IsExact<typeof error, CombinedError | undefined>>(true);
+  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
   // can call with variables
   void mutate({ why: "foobar" });

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -10,9 +10,10 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useMutation, UseMutationResponse } from "urql";
+import { useMutation } from "urql";
 import { OptionsType } from "./OptionsType";
 import { useStructuralMemo } from "./useStructuralMemo";
+import { ActionHookResult, ErrorWrapper } from "./utils";
 
 /**
  * React hook to run a Gadget model bulk action.
@@ -49,7 +50,7 @@ export const useBulkAction = <
 >(
   action: F,
   options?: LimitToKnownKeys<Options, F["optionsType"]>
-): UseMutationResponse<
+): ActionHookResult<
   GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>[],
   Exclude<F["variablesType"], null | undefined>
 > => {
@@ -88,6 +89,7 @@ export const useBulkAction = <
   return [
     {
       ...result,
+      error: ErrorWrapper.forMaybeCombinedError(result.error),
       data,
     },
     (variables, context) => {

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -4,16 +4,16 @@ import {
   findManyOperation,
   GadgetRecord,
   get,
-  getNonNullableError,
   getQueryArgs,
   hydrateConnection,
   LimitToKnownKeys,
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { CombinedError, useQuery, UseQueryArgs, UseQueryResponse } from "urql";
+import { useQuery, UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
 import { useStructuralMemo } from "./useStructuralMemo";
+import { ErrorWrapper, ReadHookResult } from "./utils";
 
 /**
  * React hook to fetch many Gadget records using the `findMany` method of a given manager.
@@ -47,7 +47,7 @@ export const useFindMany = <
 >(
   manager: { findMany: F },
   options?: LimitToKnownKeys<Options, F["optionsType"]> & Omit<UseQueryArgs, "query" | "variables">
-): UseQueryResponse<
+): ReadHookResult<
   GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>[]
 > => {
   const memoizedOptions = useStructuralMemo(options);
@@ -71,13 +71,7 @@ export const useFindMany = <
     }
   }
 
-  const nonNullableError = getNonNullableError(result, dataPath);
-  let error = result.error;
-  if (!error && nonNullableError) {
-    error = new CombinedError({
-      graphQLErrors: [nonNullableError],
-    });
-  }
+  const error = ErrorWrapper.errorIfDataAbsent(result, dataPath);
 
   return [{ ...result, data, error }, refresh];
 };

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -9,9 +9,10 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryResponse } from "urql";
+import { useQuery } from "urql";
 import { OptionsType } from "./OptionsType";
 import { useStructuralMemo } from "./useStructuralMemo";
+import { ErrorWrapper, ReadHookResult } from "./utils";
 
 /**
  * React hook to fetch a Gadget record using the `get` method of a given "singleton" manager.
@@ -44,7 +45,7 @@ export const useGet = <
 >(
   manager: { get: F },
   options?: LimitToKnownKeys<Options, F["optionsType"]>
-): UseQueryResponse<
+): ReadHookResult<
   GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>
 > => {
   const memoizedOptions = useStructuralMemo(options);
@@ -68,6 +69,7 @@ export const useGet = <
   return [
     {
       ...result,
+      error: ErrorWrapper.forMaybeCombinedError(result.error),
       data,
     },
     refresh,

--- a/packages/react/src/useMaybeFindFirst.ts
+++ b/packages/react/src/useMaybeFindFirst.ts
@@ -10,9 +10,10 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryArgs, UseQueryResponse } from "urql";
+import { useQuery, UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
 import { useStructuralMemo } from "./useStructuralMemo";
+import { ErrorWrapper, ReadHookResult } from "./utils";
 
 /**
  * React hook to fetch many Gadget records using the `maybeFindFirst` method of a given manager.
@@ -46,7 +47,7 @@ export const useMaybeFindFirst = <
 >(
   manager: { findFirst: F },
   options?: LimitToKnownKeys<Options, F["optionsType"]> & Omit<UseQueryArgs, "query" | "variables">
-): UseQueryResponse<null | GadgetRecord<
+): ReadHookResult<null | GadgetRecord<
   Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>
 >> => {
   const firstOptions = { ...options, first: 1 };
@@ -73,5 +74,12 @@ export const useMaybeFindFirst = <
     }
   }
 
-  return [{ ...result, data }, refresh];
+  return [
+    {
+      ...result,
+      error: ErrorWrapper.forMaybeCombinedError(result.error),
+      data,
+    },
+    refresh,
+  ];
 };

--- a/packages/react/src/useMaybeFindOne.ts
+++ b/packages/react/src/useMaybeFindOne.ts
@@ -10,9 +10,10 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryArgs, UseQueryResponse } from "urql";
+import { useQuery, UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
 import { useStructuralMemo } from "./useStructuralMemo";
+import { ErrorWrapper, ReadHookResult } from "./utils";
 
 /**
  * React hook to fetch a Gadget record using the `maybeFindOne` method of a given manager.
@@ -47,7 +48,7 @@ export const useMaybeFindOne = <
   manager: { findOne: F },
   id: string,
   options?: LimitToKnownKeys<Options, F["optionsType"] & Omit<UseQueryArgs, "query" | "variables">>
-): UseQueryResponse<null | GadgetRecord<
+): ReadHookResult<null | GadgetRecord<
   Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>
 >> => {
   const memoizedOptions = useStructuralMemo(options);
@@ -72,6 +73,7 @@ export const useMaybeFindOne = <
   return [
     {
       ...result,
+      error: ErrorWrapper.forMaybeCombinedError(result.error),
       data,
     },
     refresh,

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,0 +1,179 @@
+import { GadgetError, gadgetErrorFor, getNonNullableError, InvalidFieldError, InvalidRecordError } from "@gadgetinc/api-client-core";
+import type { CombinedError, OperationResult } from "@urql/core";
+import { GraphQLError } from "graphql";
+import { AnyVariables, Operation, OperationContext, UseQueryState } from "urql";
+
+/**
+ * The inner result object returned from a query result
+ **/
+export interface ReadHookState<Data = any, Variables = Record<string, any>> {
+  fetching: boolean;
+  stale: boolean;
+  data?: Data;
+  error?: ErrorWrapper;
+  extensions?: Record<string, any>;
+  operation?: Operation<Data, Variables>;
+}
+
+/**
+ * The return value of a `useGet`, `useFindMany`, `useFindOne` etc hook.
+ * Includes the data result object and a refetch function.
+ **/
+export declare type ReadHookResult<Data = any, Variables extends AnyVariables = AnyVariables> = [
+  ReadHookState<Data, Variables>,
+  (opts?: Partial<OperationContext>) => void
+];
+
+/**
+ * The inner result object returned from a mutation result
+ */
+export interface ActionHookState<Data = any, Variables = Record<string, any>> {
+  fetching: boolean;
+  stale: boolean;
+  data?: Data;
+  error?: ErrorWrapper;
+  extensions?: Record<string, any>;
+  operation?: Operation<Data, Variables>;
+}
+
+/**
+ * The return value of a `useAction`, `useGlobalAction`, `useBulkAction` etc hook.
+ * Includes the data result object and a function for running the mutation.
+ **/
+export declare type ActionHookResult<Data = any, Variables extends AnyVariables = AnyVariables> = [
+  ActionHookState<Data, Variables>,
+  (variables: Variables, context?: Partial<OperationContext>) => Promise<OperationResult<Data, Variables>>
+];
+
+const generateErrorMessage = (networkErr?: Error, graphQlErrs?: GraphQLError[]) => {
+  let error = "";
+  if (networkErr !== undefined) {
+    error = `[Network] ${networkErr.message}`;
+  } else if (graphQlErrs !== undefined) {
+    graphQlErrs.forEach((err) => {
+      error += `[GraphQL] ${err.message}\n`;
+    });
+  } else {
+    error = "Unknown error";
+  }
+
+  return error.trim();
+};
+
+const rehydrateGraphQlError = (error: any): GraphQLError => {
+  if (typeof error === "string") {
+    return new GraphQLError(error);
+  } else if (error?.message) {
+    return new GraphQLError(error.message, error.nodes, error.source, error.positions, error.path, error, error.extensions || {});
+  } else {
+    return error;
+  }
+};
+
+/**
+ * An error returned by any of the Gadget react hooks.
+ * Always has a message, but can be inspected to retrieve more detailed errors from either the network, the raw GraphQL layer, or Gadget specific errors like validation errors.
+ * Not intended for creating outside of Gadget-owned code.
+ **/
+export class ErrorWrapper extends Error {
+  /** @private */
+  static forClientSideError(error: Error, response?: any) {
+    return new ErrorWrapper({
+      executionErrors: [error],
+      response,
+    });
+  }
+  /** @private */
+  static forErrorsResponse(errors: Record<string, any>[], response?: any) {
+    return new ErrorWrapper({
+      executionErrors: errors.map(gadgetErrorFor),
+      response,
+    });
+  }
+  /** @private */
+  static forMaybeCombinedError(error?: CombinedError | null) {
+    if (!error) return undefined;
+    return new ErrorWrapper({
+      networkError: error.networkError,
+      executionErrors: error.graphQLErrors,
+      response: error.response,
+    });
+  }
+  /** @private */
+  static errorIfDataAbsent(result: UseQueryState<any>, dataPath: string[]) {
+    const nonNullableError = getNonNullableError(result, dataPath);
+    let error = ErrorWrapper.forMaybeCombinedError(result.error);
+    if (!error && nonNullableError) {
+      error = ErrorWrapper.forClientSideError(nonNullableError);
+    }
+    return error;
+  }
+
+  /** Error message for this error. Derived from the other errors this wraps. */
+  public message: string;
+  /**
+   * A list of errors encountered by the backend when processing a request. Populated if the client successfully communicated with the backend, but the backend was unable to process the request and rejected it with an error.
+   * Includes GraphQL syntax errors, missing or invalid argument errors, data validation errors, or unexpected errors encountered when running backend logic.
+   **/
+  public executionErrors: (GraphQLError | GadgetError)[];
+  /**
+   * An error encountered when trying to communicate with the backend from the client. Includes things like connection timeouts, connection interrupts, or no internet connection errors
+   **/
+  public networkError?: Error;
+
+  /**
+   * A list of errors encountered by the backend when processing a request. Populated if the client successfully communicated with the backend, but the backend was unable to process the request and rejected it with an error.
+   * Includes GraphQL syntax errors, missing or invalid argument errors, data validation errors, or unexpected errors encountered when running backend logic.
+   *
+   * This property allows this object to match the interface of urql's `CombinedError` object.
+   *
+   * @deprecated use `executionErrors` instead for a list of the errors that the GraphQL backend API returned *and* client side errors from unexpected responses.
+   **/
+  public graphQLErrors: GraphQLError[];
+
+  /**
+   * The response from the server, if any was retrieved.
+   */
+  public response?: any;
+
+  constructor({
+    networkError,
+    executionErrors,
+    response,
+  }: {
+    networkError?: Error;
+    executionErrors?: Array<string | Partial<GraphQLError> | Error>;
+    validationErrors?: InvalidFieldError[];
+    response?: any;
+  }) {
+    const normalizedExecutionErrors = (executionErrors || []).map(rehydrateGraphQlError);
+    const message = generateErrorMessage(networkError, normalizedExecutionErrors);
+
+    super(message);
+
+    this.message = message;
+    this.executionErrors = normalizedExecutionErrors;
+    this.graphQLErrors = normalizedExecutionErrors;
+    this.networkError = networkError;
+    this.response = response;
+  }
+
+  /** Class name of this error -- always `ErrorWrapper` */
+  get name() {
+    return "ErrorWrapper";
+  }
+
+  toString() {
+    return this.message;
+  }
+
+  /**
+   * A list of errors the backend reported for specific fields being invalid for the records touched by an action. Is a shortcut for accessing the validation errors of a `GadgetInvalidRecordError` if that's what is in the `executionErrors`.
+   **/
+  public get validationErrors(): InvalidFieldError[] | null {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const firstInvalidRecordError = this.executionErrors.find((err) => err instanceof InvalidRecordError) as InvalidRecordError | undefined;
+
+    return firstInvalidRecordError?.validationErrors ?? null;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,21 +1007,6 @@
     lodash.isequal "^4.5.0"
     ws "^8.2.2"
 
-"@gadgetinc/api-client-core@^0.7.0":
-  version "0.8.0"
-  dependencies:
-    "@opentelemetry/api" "^1.0.4"
-    "@urql/core" "^3.0.1"
-    "@urql/exchange-multipart-fetch" "^1.0.0"
-    cross-fetch "^3.0.6"
-    gql-query-builder "^3.6.0"
-    graphql "^15.5.0"
-    graphql-ws "^5.5.5"
-    isomorphic-ws "^4.0.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    ws "^8.2.2"
-
 "@gadgetinc/eslint-config@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@gadgetinc/eslint-config/-/eslint-config-0.4.0.tgz#bc831659717affcee7bc59556e7ee8ea8646bc37"
@@ -1049,13 +1034,11 @@
     prettier-plugin-organize-imports "^1.0.4"
 
 "@gadgetinc/react@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@gadgetinc/react/-/react-0.5.0.tgz#7b3f3371786cec017e846d4c9b5e1c3a899f4845"
-  integrity sha512-ag16uEHCm6+yDPeZ2gH43LkMzx9Wdf11k65Zpno/uBi26TuT/ZrcpG511qGNNufCmxLAu2q/xXwXvRc3EvSGCA==
+  version "0.6.0"
   dependencies:
-    "@gadgetinc/api-client-core" "^0.7.0"
+    "@gadgetinc/api-client-core" "^0.8.0"
     deep-equal "^2.0.5"
-    urql "^2.0.5"
+    urql "^3.0.1"
 
 "@graphql-typed-document-node/core@^3.1.1":
   version "3.1.1"
@@ -1754,14 +1737,6 @@
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     wonka "^6.0.0"
-
-"@urql/core@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-2.6.1.tgz#c10ee972c5e81df6d7bf1e778ef1b5d30e2906e5"
-  integrity sha512-gYrEHy3tViJhwIhauK6MIf2Qp09QTsgNHZRd0n71rS+hF6gdwjspf1oKljl4m25+272cJF7fPjBUGmjaiEr7Kg==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.1.1"
-    wonka "^4.0.14"
 
 "@urql/exchange-multipart-fetch@^1.0.0":
   version "1.0.0"
@@ -5779,14 +5754,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urql@^2.0.5:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-2.2.3.tgz#84c6ad962d771235106f24de56b5dc6bd85a2c3a"
-  integrity sha512-XMkSYJKW9s4ZlbSuxcUz3fTBIykOn0sGileRXQeyZpaRBXJPVz5saSY05k7jdefNxShZtTI+/nr7PYUWQertfg==
-  dependencies:
-    "@urql/core" "^2.6.1"
-    wonka "^4.0.14"
-
 urql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/urql/-/urql-3.0.1.tgz#e937e2c4e08c0e6f2af6a2277d8cad2b156a4a0e"
@@ -5960,11 +5927,6 @@ which@^2.0.1, which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-wonka@^4.0.14:
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.15.tgz#9aa42046efa424565ab8f8f451fcca955bf80b89"
-  integrity sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==
 
 wonka@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
When a Gadget backend rejects an action because the supplied params are invalid, it returns an error in the format like:
```
{
  success: false,
  errors: {
    message: "GGT_INVALID_RECORD: Record is invalid. 2 error needs to be corrected",
    validationErrors: [
       { field: "title", message: "is too short" },
       { field: "body", message: "is required" }
    ]
}
```

The point of all that is to always return a top level error message regardless of what kind of error happened (be it like a backend error where all we have is a message) and then provide structured error details if we do have them (the by-field error messages).

This data is really useful for driving form validations where you want to show a user which fields are broken. They need to correct those fields before they can move on, so we need to make this data from the GraphQL response available in React land really easily. Before this change, the way you would get at it is like so:

```typescript
const [{data, fetching, error}, mutate] = useAction(api.widget.create);
const validationErrors = error?.graphQLErrors.?[0]?.originalError.validationErrors // any
```

which sucks IMO. The type of the `error` object returned before this change is an `urql` `CombinedError` object which wraps all the errors that can occur client side, like network errors and GraphQL execution errors. I think we should return our own type that works like this:

```typescript
const [{data, fetching, error}, mutate] = useAction(api.widget.create);
const validationErrors = error.validationErrors // FieldErrorMessage[] | undefined
```

This does just that! We introduce a new class called `ErrorWrapper` which is the `error` in all our React hook results, and give it nicer types for having these validation errors on them. `ErrorWrapper` was also a nice place to DRY up some of the repeated error handling logic across the hooks.
