### PR TITLE
Fix requiresReauthentication check for missing shop records

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.7.0",
+    "@gadgetinc/api-client-core": "^0.7.3",
     "@shopify/app-bridge-utils": "^3.1.1",
     "crypto-js": "^4.1.1",
     "lodash": "^4.17.21"

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -82,21 +82,15 @@ const InnerGadgetProvider = memo(
     });
 
     if (currentSessionData) {
+      runningShopifyAuth = currentSessionData.shopifyConnection?.requiresReauthentication;
+
       if (currentSessionData.currentSession) {
         if (!currentSessionData.currentSession.shop) {
           runningShopifyAuth = true;
         } else {
-          // we need to re-authenticate because we're missing scopes so let's force redirect
-          if (currentSessionData.shopifyConnection?.requiresReauthentication) {
-            runningShopifyAuth = true;
-          } else {
-            isAuthenticated = true;
-          }
+          // we may be missing scopes, if so, we aren't fully authenticated
+          isAuthenticated = !currentSessionData.shopifyConnection?.requiresReauthentication;
         }
-      } else {
-        console.warn(
-          "Unexpected response from Gadget backend trying to bootstrap session -- no session returned for valid Shopify Session Token. Is the Gadget Connection configured properly?"
-        );
       }
     }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.7.0",
+    "@gadgetinc/api-client-core": "^0.7.3",
     "deep-equal": "^2.0.5",
     "urql": "^2.0.5"
   },


### PR DESCRIPTION
The Provider makes a query 
```graphql
query GetSessionForShopifyApp {
    currentSession {
      id
      shop {
        id
      }
    }
    shopifyConnection {
      requiresReauthentication
    }
  }
```

To determine if the scopes are up to date and the session is valid. 


If the `Shop` record was removed on the Gadget back-end, but the app remained embedded. The app provider would hit a situation where it can't find a Session since we first need the Shop record to validate the Session JWT token. 

We fix this by no longer assuming `currentSession` is present (it wont be if the shop record is missing), and instead just look at the `requiresReauthentication` value on its own.

This goes along with  a change to the GraphQL API here https://github.com/gadget-inc/gadget/pull/4001
