### PR TITLE
Make InvalidRecordErrors capture structured data about the record and model which was invalid

### DIFF
--- a/packages/api-client-core/spec/InvalidRecordError.spec.ts
+++ b/packages/api-client-core/spec/InvalidRecordError.spec.ts
@@ -1,0 +1,78 @@
+import { InvalidRecordError } from "../src";
+
+describe("InvalidRecordError", () => {
+  test("it should compute a message with no validation errors", () => {
+    const error = new InvalidRecordError(null, []);
+    expect(error.message).toMatchInlineSnapshot(`"GGT_INVALID_RECORD: Record is invalid and can't be saved. ."`);
+    expect(error.code).toEqual("GGT_INVALID_RECORD");
+    expect(error.causedByClient).toBeTruthy();
+  });
+
+  test("it should compute a message with two validation errors", () => {
+    const error = new InvalidRecordError(null, [
+      {
+        apiIdentifier: "name",
+        message: "is not unique",
+      },
+      {
+        apiIdentifier: "title",
+        message: "is required",
+      },
+    ]);
+    expect(error.message).toMatchInlineSnapshot(
+      `"GGT_INVALID_RECORD: Record is invalid and can't be saved. name is not unique, title is required."`
+    );
+  });
+
+  test("it should compute a message with 4 validation errors", () => {
+    const error = new InvalidRecordError(null, [
+      {
+        apiIdentifier: "name",
+        message: "is not unique",
+      },
+      {
+        apiIdentifier: "title",
+        message: "is required",
+      },
+      {
+        apiIdentifier: "body",
+        message: "is required",
+      },
+      {
+        apiIdentifier: "body",
+        message: "must be longer than 15 characters",
+      },
+    ]);
+    expect(error.message).toMatchInlineSnapshot(
+      `"GGT_INVALID_RECORD: Record is invalid and can't be saved. name is not unique, title is required, body is required, and 1 more error needs to be corrected."`
+    );
+  });
+
+  test("it should compute a message with many validation errors", () => {
+    const error = new InvalidRecordError(null, [
+      {
+        apiIdentifier: "name",
+        message: "is not unique",
+      },
+      {
+        apiIdentifier: "title",
+        message: "is required",
+      },
+      {
+        apiIdentifier: "body",
+        message: "is required",
+      },
+      {
+        apiIdentifier: "body",
+        message: "must be longer than 15 characters",
+      },
+      {
+        apiIdentifier: "publishDate",
+        message: "is required",
+      },
+    ]);
+    expect(error.message).toMatchInlineSnapshot(
+      `"GGT_INVALID_RECORD: Record is invalid and can't be saved. name is not unique, title is required, body is required, and 2 more errors need to be corrected."`
+    );
+  });
+});

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -23,6 +23,10 @@ fragment InternalErrorsDetails on ExecutionError {
       apiIdentifier
       message
     }
+    model {
+      apiIdentifier
+    }
+    record
   }
 }
 `;


### PR DESCRIPTION
The object already captures what was invalid about which fields, but in some contexts Gadget side, we can provide more details about the record which failed validation etc.

Corresponds to gadget-inc/gadget#4006
