### PR TITLE
React shopify deps

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^14.18.26",
     "conditional-type-checks": "^1.0.6",
     "gql-tag": "^1.0.1",
-    "jest": "^27.5.1",
+    "jest": "^28.0.8",
     "nock": "^13.2.9",
     "typescript": "4.7.4"
   }

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@gadgetinc/react": "^0.5.0",
+    "@gadgetinc/react": "^0.7.2",
     "@shopify/app-bridge-react": "^2.0.25",
     "@types/crypto-js": "^4.1.1",
     "@types/jest": "^26.0.24",
@@ -40,7 +40,7 @@
     "ts-jest": "^28.0.8"
   },
   "peerDependencies": {
-    "@gadgetinc/react": "^0.6.0",
+    "@gadgetinc/react": "^0.7.2",
     "@shopify/app-bridge-react": "^2.0.0 || ^3.0.0",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -1,12 +1,11 @@
 import { AnyClient } from "@gadgetinc/api-client-core";
-import { Provider as GadgetUrqlProvider } from "@gadgetinc/react";
+import { Provider as GadgetUrqlProvider, useQuery } from "@gadgetinc/react";
 import { Provider as AppBridgeProvider } from "@shopify/app-bridge-react";
 import { AppBridgeContext } from "@shopify/app-bridge-react/context";
 import { getSessionToken } from "@shopify/app-bridge-utils";
 import { Redirect } from "@shopify/app-bridge/actions";
 import { isUndefined } from "lodash";
 import React, { memo, useContext, useEffect, useMemo, useState } from "react";
-import { useQuery } from "urql";
 import { GadgetAuthContext, GadgetAuthContextValue } from "./index";
 
 export enum AppType {


### PR DESCRIPTION
Bump the peer dependency versions for `@gadgetinc/react` in `@gadgetinc/react-shopify-app-bridge`. Also update to use `useQuery` from `@gadgetinc/react` instead of `urql`. Won't bump the version for now and can wait for the version bump when we merge [PR#45](https://github.com/gadget-inc/js-clients/pull/45)