### PR TITLE
Don't run specs in the built dist folders

### DIFF
--- a/packages/api-client-core/jest.config.js
+++ b/packages/api-client-core/jest.config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
@@ -137,10 +139,7 @@ module.exports = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+  testMatch: [path.join(__dirname, "spec/(*.)+(spec|test).[tj]s?(x)")],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: ["/node_modules/"],

--- a/packages/react-shopify-app-bridge/jest.config.js
+++ b/packages/react-shopify-app-bridge/jest.config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
@@ -137,10 +138,7 @@ module.exports = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+  testMatch: [path.join(__dirname, "spec/(*.)+(spec|test).[tj]s?(x)")],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: ["/node_modules/"],

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
@@ -137,10 +139,7 @@ module.exports = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+  testMatch: [path.join(__dirname, "spec/(*.)+(spec|test).[tj]s?(x)")],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: ["/node_modules/"],


### PR DESCRIPTION
Jest 29 changed the inclusion by default -- this restricts us to only run tests in our root spec folder instead of in the dist folder.