### PR TITLE
Wrap `useAction` promise results

### DIFF
--- a/packages/react/spec/testWrapper.tsx
+++ b/packages/react/spec/testWrapper.tsx
@@ -61,7 +61,7 @@ const newMockOperationFn = () => {
   fn.subjects = subjects;
   fn.pushResponse = (key, response) => {
     if (!subjects[key]) {
-      throw new Error(`No mock client subject started for key ${key}`);
+      throw new Error(`No mock client subject started for key ${key}, options are ${Object.keys(subjects).join(", ")}`);
     }
     act(() => {
       subjects[key].next({

--- a/packages/react/spec/useAction.spec.ts
+++ b/packages/react/spec/useAction.spec.ts
@@ -56,7 +56,7 @@ describe("useAction", () => {
   test("returns no data, not fetching, and no error when the component is first mounted", () => {
     const { result } = renderHook(() => useAction(relatedProductsApi.user.update), { wrapper: TestWrapper });
 
-    expect(result.current[0].data).toBe(null);
+    expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].error).toBeFalsy();
   });

--- a/packages/react/spec/useAction.spec.ts
+++ b/packages/react/spec/useAction.spec.ts
@@ -88,7 +88,11 @@ describe("useAction", () => {
     });
 
     await act(async () => {
-      await mutationPromise;
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data!.id).toEqual("123");
+      expect(promiseResult.data!.email).toEqual("test@test.com");
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeFalsy();
     });
 
     expect(result.current[0].data!.id).toEqual("123");
@@ -136,7 +140,10 @@ describe("useAction", () => {
     });
 
     await act(async () => {
-      await mutationPromise;
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeTruthy();
+      expect(promiseResult.data).toBeFalsy();
     });
 
     expect(result.current[0].fetching).toBe(false);

--- a/packages/react/spec/useBulkAction.spec.ts
+++ b/packages/react/spec/useBulkAction.spec.ts
@@ -1,48 +1,148 @@
 import { GadgetRecord } from "@gadgetinc/api-client-core";
+import { renderHook } from "@testing-library/react";
 import { assert, IsExact } from "conditional-type-checks";
+import { act } from "react-dom/test-utils";
 import { useBulkAction } from "../src";
 import { ErrorWrapper } from "../src/utils";
 import { bulkExampleApi } from "./apis";
+import { mockClient, TestWrapper } from "./testWrapper";
 
-// these functions are typechecked but never run to avoid actually making API calls
-const _TestUseBulkActionCanRunActionsWithVariables = () => {
-  const [_, mutate] = useBulkAction(bulkExampleApi.widget.bulkFlipDown);
+describe("useBulkAction", () => {
+  // these functions are typechecked but never run to avoid actually making API calls
+  const _TestUseBulkActionCanRunActionsWithVariables = () => {
+    const [_, mutate] = useBulkAction(bulkExampleApi.widget.bulkFlipDown);
 
-  // can call with variables
-  void mutate({ ids: ["123", "124"] });
+    // can call with variables
+    void mutate({ ids: ["123", "124"] });
 
-  // @ts-expect-error can't call with no arguments
-  void mutate();
+    // @ts-expect-error can't call with no arguments
+    void mutate();
 
-  // @ts-expect-error can't call with no ids
-  void mutate({});
+    // @ts-expect-error can't call with no ids
+    void mutate({});
 
-  // @ts-expect-error can't call with variables that don't belong to the model
-  void mutate({ foo: "123" });
-};
+    // @ts-expect-error can't call with variables that don't belong to the model
+    void mutate({ foo: "123" });
+  };
 
-const _TestUseBulkActionReturnsTypedDataWithExplicitSelection = () => {
-  const [{ data, fetching, error }, _mutate] = useBulkAction(bulkExampleApi.widget.bulkFlipDown, {
-    select: { id: true, name: true },
+  const _TestUseBulkActionReturnsTypedDataWithExplicitSelection = () => {
+    const [{ data, fetching, error }, _mutate] = useBulkAction(bulkExampleApi.widget.bulkFlipDown, {
+      select: { id: true, name: true },
+    });
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+    assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; name: string | null }>[]>>(true);
+    assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+
+    if (data) {
+      data[0].id;
+      data[0].name;
+    }
+  };
+
+  const _TestUseActionReturnsTypedDataWithNoSelection = () => {
+    const [{ data }] = useBulkAction(bulkExampleApi.widget.bulkFlipDown);
+
+    if (data) {
+      data[0].id;
+      data[0].name;
+    }
+  };
+
+  test("returns no data, not fetching, and no error when the component is first mounted", () => {
+    const { result } = renderHook(() => useBulkAction(bulkExampleApi.widget.bulkFlipDown), { wrapper: TestWrapper });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
   });
 
-  assert<IsExact<typeof fetching, boolean>>(true);
-  assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; name: string | null }>[]>>(true);
-  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+  test("returns no data, fetching=true, and no error when the mutation is run, and then the successful data if the mutation succeeds", async () => {
+    const { result } = renderHook(() => useBulkAction(bulkExampleApi.widget.bulkFlipDown), { wrapper: TestWrapper });
 
-  if (data) {
-    data[0].id;
-    data[0].name;
-  }
-};
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ ids: ["123", "124"] });
+    });
 
-const _TestUseActionReturnsTypedDataWithNoSelection = () => {
-  const [{ data }] = useBulkAction(bulkExampleApi.widget.bulkFlipDown);
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
 
-  if (data) {
-    data[0].id;
-    data[0].name;
-  }
-};
+    expect(mockClient.executeMutation).toBeCalledTimes(1);
 
-test("true", () => undefined);
+    mockClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
+      data: {
+        bulkFlipDownWidgets: {
+          success: true,
+          widgets: [
+            {
+              id: "123",
+            },
+            { id: "124" },
+          ],
+        },
+      },
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data!.length).toEqual(2);
+      expect(promiseResult.data![0].id).toEqual("123");
+      expect(promiseResult.data![1].id).toEqual("124");
+    });
+
+    expect(result.current[0].data!.length).toEqual(2);
+    expect(result.current[0].data![0].id).toEqual("123");
+    expect(result.current[0].data![1].id).toEqual("124");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("returns an error when the mutation is run and the server responds with success: false", async () => {
+    const { result } = renderHook(
+      () => {
+        return useBulkAction(bulkExampleApi.widget.bulkFlipDown);
+      },
+      { wrapper: TestWrapper }
+    );
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ ids: ["123", "124"] });
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockClient.executeMutation).toBeCalledTimes(1);
+
+    mockClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
+      data: {
+        bulkFlipDownWidgets: {
+          success: false,
+          errors: [
+            {
+              message: "Something went wrong in the backend",
+              code: "GGT_UNKNOWN",
+            },
+          ],
+          widgets: null,
+        },
+      },
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeTruthy();
+      expect(promiseResult.data).toBeFalsy();
+    });
+
+    expect(result.current[0].fetching).toBe(false);
+    const error = result.current[0].error;
+    expect(error).toBeTruthy();
+    expect(result.current[0].data).toBeFalsy();
+  });
+});

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -1,21 +1,103 @@
+import { renderHook } from "@testing-library/react";
 import { assert, IsExact } from "conditional-type-checks";
+import { act } from "react-dom/test-utils";
 import { useGlobalAction } from "../src";
 import { ErrorWrapper } from "../src/utils";
 import { bulkExampleApi } from "./apis";
+import { mockClient, TestWrapper } from "./testWrapper";
 
-// these functions are typechecked but never run to avoid actually making API calls
-const TestUseGlobalActionCanRunGlobalActionsWithVariables = () => {
-  const [{ data, fetching, error }, mutate] = useGlobalAction(bulkExampleApi.flipAll);
+describe("useGlobalAction", () => {
+  // these functions are typechecked but never run to avoid actually making API calls
+  const TestUseGlobalActionCanRunGlobalActionsWithVariables = () => {
+    const [{ data, fetching, error }, mutate] = useGlobalAction(bulkExampleApi.flipAll);
 
-  assert<IsExact<typeof fetching, boolean>>(true);
-  assert<IsExact<typeof data, any>>(true);
-  assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+    assert<IsExact<typeof fetching, boolean>>(true);
+    assert<IsExact<typeof data, any>>(true);
+    assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
-  // can call with variables
-  void mutate({ why: "foobar" });
+    // can call with variables
+    void mutate({ why: "foobar" });
 
-  // @ts-expect-error can't call with variables that don't belong to the model
-  void mutate({ foo: "123" });
-};
+    // @ts-expect-error can't call with variables that don't belong to the model
+    void mutate({ foo: "123" });
+  };
 
-test("true", () => undefined);
+  test("returns no data, not fetching, and no error when the component is first mounted", () => {
+    const { result } = renderHook(() => useGlobalAction(bulkExampleApi.flipAll), { wrapper: TestWrapper });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("returns no data, fetching=true, and no error when the mutation is run, and then the successful data if the mutation succeeds", async () => {
+    const { result } = renderHook(() => useGlobalAction(bulkExampleApi.flipAll), { wrapper: TestWrapper });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ why: "foobar" });
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockClient.executeMutation).toBeCalledTimes(1);
+
+    mockClient.executeMutation.pushResponse("flipAll", {
+      data: {
+        flipAll: {
+          success: true,
+        },
+      },
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeFalsy();
+    });
+
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("returns an error when the mutation is run and the server responds with success: false", async () => {
+    const { result } = renderHook(() => useGlobalAction(bulkExampleApi.flipAll), { wrapper: TestWrapper });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ why: "foobar" });
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockClient.executeMutation).toBeCalledTimes(1);
+
+    mockClient.executeMutation.pushResponse("flipAll", {
+      data: {
+        flipAll: {
+          success: false,
+          errors: [
+            {
+              message: "Something went wrong in the backend",
+              code: "GGT_UNKNOWN",
+            },
+          ],
+        },
+      },
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeTruthy();
+    });
+
+    expect(result.current[0].fetching).toBe(false);
+    const error = result.current[0].error;
+    expect(error).toBeTruthy();
+  });
+});

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -9,8 +9,8 @@ import {
   LimitToKnownKeys,
   Select,
 } from "@gadgetinc/api-client-core";
-import { useMemo } from "react";
-import { useMutation } from "urql";
+import { useCallback, useMemo } from "react";
+import { useMutation, UseMutationState } from "urql";
 import { OptionsType } from "./OptionsType";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ActionHookResult, ErrorWrapper } from "./utils";
@@ -74,8 +74,27 @@ export const useBulkAction = <
     F["variablesType"]
   >(plan.query);
 
+  return [
+    processResult(result, action),
+    useCallback(
+      async (variables, context) => {
+        // Adding the model's additional typename ensures document cache will properly refresh, regardless of whether __typename was
+        // selected (and sometimes we can't even select it, like delete actions!)
+        const result = await runMutation(variables, {
+          ...context,
+          additionalTypenames: [...(context?.additionalTypenames ?? []), capitalize(action.modelApiIdentifier)],
+        });
+        return processResult({ fetching: false, stale: false, ...result }, action);
+      },
+      [action, runMutation]
+    ),
+  ];
+};
+
+const processResult = (result: UseMutationState<any, any>, action: BulkActionFunction<any, any, any, any, any>) => {
+  const error = ErrorWrapper.forMaybeCombinedError(result.error);
   let data = result.data;
-  if (data) {
+  if (data && !error) {
     // TODO deal with deletion better than checking selectionType
     if (action.defaultSelection != null) {
       const dataPath = [action.operationName, action.modelSelectionField];
@@ -85,20 +104,5 @@ export const useBulkAction = <
       data = hydrateRecordArray(result, get(result.data, dataPath));
     }
   }
-
-  return [
-    {
-      ...result,
-      error: ErrorWrapper.forMaybeCombinedError(result.error),
-      data,
-    },
-    (variables, context) => {
-      // Adding the model's additional typename ensures document cache will properly refresh, regardless of whether __typename was
-      // selected (and sometimes we can't even select it, like delete actions!)
-      return runMutation(variables, {
-        ...context,
-        additionalTypenames: [...(context?.additionalTypenames ?? []), capitalize(action.modelApiIdentifier)],
-      });
-    },
-  ];
+  return { ...result, error, data };
 };

--- a/packages/react/src/useGlobalAction.ts
+++ b/packages/react/src/useGlobalAction.ts
@@ -47,10 +47,9 @@ export const useGlobalAction = <F extends GlobalActionFunction<any>>(
 
 const processResult = (result: UseMutationState<any, any>, action: GlobalActionFunction<any>) => {
   let error = ErrorWrapper.forMaybeCombinedError(result.error);
-  let data = result.data;
-  if (data) {
+  let data = undefined;
+  if (result.data) {
     data = get(result.data, [action.operationName]);
-
     if (data) {
       const errors = data.errors;
       if (errors && errors[0]) {

--- a/packages/react/src/useGlobalAction.ts
+++ b/packages/react/src/useGlobalAction.ts
@@ -1,6 +1,6 @@
 import { get, GlobalActionFunction, globalActionOperation } from "@gadgetinc/api-client-core";
-import { useMemo } from "react";
-import { useMutation } from "urql";
+import { useCallback, useMemo } from "react";
+import { useMutation, UseMutationState } from "urql";
 import { ActionHookResult, ErrorWrapper } from "./utils";
 
 /**
@@ -33,6 +33,19 @@ export const useGlobalAction = <F extends GlobalActionFunction<any>>(
 
   const [result, runMutation] = useMutation<any, F["variablesType"]>(plan.query);
 
+  return [
+    processResult(result, action),
+    useCallback(
+      async (variables, context) => {
+        const result = await runMutation(variables, context);
+        return processResult({ fetching: false, stale: false, ...result }, action);
+      },
+      [action, runMutation]
+    ),
+  ];
+};
+
+const processResult = (result: UseMutationState<any, any>, action: GlobalActionFunction<any>) => {
   let error = ErrorWrapper.forMaybeCombinedError(result.error);
   let data = result.data;
   if (data) {
@@ -45,13 +58,5 @@ export const useGlobalAction = <F extends GlobalActionFunction<any>>(
       }
     }
   }
-
-  return [
-    {
-      ...result,
-      error,
-      data,
-    },
-    runMutation,
-  ];
+  return { ...result, error, data };
 };

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,5 +1,5 @@
 import { GadgetError, gadgetErrorFor, getNonNullableError, InvalidFieldError, InvalidRecordError } from "@gadgetinc/api-client-core";
-import type { CombinedError, OperationResult } from "@urql/core";
+import type { CombinedError } from "@urql/core";
 import { GraphQLError } from "graphql";
 import { AnyVariables, Operation, OperationContext, UseQueryState } from "urql";
 
@@ -42,7 +42,7 @@ export interface ActionHookState<Data = any, Variables = Record<string, any>> {
  **/
 export declare type ActionHookResult<Data = any, Variables extends AnyVariables = AnyVariables> = [
   ActionHookState<Data, Variables>,
-  (variables: Variables, context?: Partial<OperationContext>) => Promise<OperationResult<Data, Variables>>
+  (variables: Variables, context?: Partial<OperationContext>) => Promise<ActionHookState<Data, Variables>>
 ];
 
 const generateErrorMessage = (networkErr?: Error, graphQlErrs?: GraphQLError[]) => {


### PR DESCRIPTION
We wrap urql's `useMutation` hook to return a fancy hydrated value with our own error class and our own hydrated data. This worked for the `const [result] = useAction` bit, but wasn't applied to the `const [_, run] = useAction(); const result = await run()` part.

This fixes that woop woop!