### PR TITLE
Add a `currentChanges` to `GadgetRecord`

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/spec/GadgetRecord.spec.ts
+++ b/packages/api-client-core/spec/GadgetRecord.spec.ts
@@ -138,6 +138,23 @@ describe("GadgetRecord", () => {
     });
   });
 
+  it("should allow you to ask for CURRENT values of changed props on the entire object", () => {
+    const product = new GadgetRecord<SampleBaseRecord>(productBaseRecord);
+    expectNoChanges(product, "name", "body", "count");
+
+    product.name = "A newer name";
+    product.count = 123;
+
+    expect(product.changed("name")).toEqual(true);
+    expect(product.changed("count")).toEqual(true);
+    expect(product.changed("body")).toEqual(false);
+    expect(product.changed()).toEqual(true);
+    expect(product.toChangedJSON()).toEqual({
+      name: "A newer name",
+      count: 123,
+    });
+  });
+
   it("should allow dirty tracking on array fields", () => {
     const product = new GadgetRecord<SampleBaseRecord>({ ...productBaseRecord, anArray: [1, 2, 3] });
     expectNoChanges(product, "anArray");

--- a/packages/api-client-core/src/GadgetRecord.ts
+++ b/packages/api-client-core/src/GadgetRecord.ts
@@ -113,6 +113,21 @@ export class GadgetRecordImplementation<Shape extends RecordShape> {
     }
   }
 
+  /** Returns all current values for fields that have changed */
+  toChangedJSON(tracking = ChangeTracking.SinceLoaded): { [prop: string]: any } {
+    const diffFields = tracking == ChangeTracking.SinceLoaded ? this.__gadget.instantiatedFields : this.__gadget.persistedFields;
+    const current = {} as Record<string, any>;
+
+    for (let index = 0; index < this.__gadget.fieldKeys.length; index++) {
+      const key = this.__gadget.fieldKeys[index];
+      if (!isEqual(diffFields[key], this.__gadget.fields[key])) {
+        current[key] = this.__gadget.fields[key];
+      }
+    }
+
+    return current;
+  }
+
   /** Returns `true` if any field has changed on this record. */
   changed(): boolean;
   changed(tracking: ChangeTracking): boolean;

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.9.0",
+    "@gadgetinc/api-client-core": "^0.10.0",
     "@shopify/app-bridge-utils": "^3.1.1",
     "crypto-js": "^4.1.1",
     "lodash": "^4.17.21"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.9.0",
+    "@gadgetinc/api-client-core": "^0.10.0",
     "deep-equal": "^2.0.5",
     "urql": "^3.0.1"
   },


### PR DESCRIPTION
- Improved GadgetRecord performance, by greatly minimizing the number of object-to-array conversions, and avoiding generating all changes just to see if there is one change.
- Added `currentChanges` method to get the current value of changed fields, rather than both current AND previous values in a nested object.
- Added a new test for this feature.