### PR TITLE
Use the location passed in through the custom router if it exists

### DIFF
--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -147,7 +147,26 @@ export const Provider = ({
     history: History;
   };
 }) => {
-  const [location, setLocation] = useState<ProviderLocation | null>(null);
+  const [_location, setLocation] = useState<ProviderLocation | null>(null);
+  const routerParamLocation = router?.location
+    ? typeof router.location === "string"
+      ? router.location
+      : `${router.location.pathname}${router.location.search}`
+    : "";
+  const location = useMemo(() => {
+    if (router) {
+      const url = typeof router.location === "string" ? new URL(router.location) : router.location;
+
+      return {
+        query: new URLSearchParams(url),
+        asPath: `${url.pathname}${url.search}`,
+      };
+    }
+
+    return _location;
+    // don't subscribe to router as the pointer is likely to change on every render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routerParamLocation, _location]);
   const isReady = !!location;
   const { query } = location ?? {};
   const host = query?.get("host") ?? undefined;


### PR DESCRIPTION
If a custom router is passed to the `Provider` we should use that to determine any query params in the URL (for things like host). This will work better for technologies like Next that may have a SSR component and have a custom router.