### PR TITLE
GGT-2034 - New provider for react library

### DIFF
--- a/packages/react/spec/testWrapper.tsx
+++ b/packages/react/spec/testWrapper.tsx
@@ -3,9 +3,10 @@ import { find, findLast } from "lodash";
 import React, { ReactNode } from "react";
 import { act } from "react-dom/test-utils";
 import type { Client, GraphQLRequest, OperationContext, OperationResult } from "urql";
-import { makeErrorResult, Provider } from "urql";
+import { makeErrorResult } from "urql";
 import type { Subject } from "wonka";
 import { makeSubject } from "wonka";
+import { GadgetProvider as Provider } from "../src/GadgetProvider";
 
 export type MockOperationFn = jest.Mock & {
   subjects: Record<string, Subject<OperationResult>>;

--- a/packages/react/spec/useGadgetMutation.spec.ts
+++ b/packages/react/spec/useGadgetMutation.spec.ts
@@ -1,0 +1,15 @@
+/* eslint-disable jest/no-try-expect */
+import { renderHook } from "@testing-library/react";
+import { useGadgetMutation } from "../src/useGadgetMutation";
+import { noProviderErrorMessage } from "../src/utils";
+
+describe("useGadgetMutation", () => {
+  test("throw error when no provider included", () => {
+    try {
+      renderHook(() => useGadgetMutation("{__typename}"));
+    } catch (error: any) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe(noProviderErrorMessage);
+    }
+  });
+});

--- a/packages/react/spec/useGadgetQuery.spec.ts
+++ b/packages/react/spec/useGadgetQuery.spec.ts
@@ -1,0 +1,15 @@
+/* eslint-disable jest/no-try-expect */
+import { renderHook } from "@testing-library/react";
+import { useGadgetQuery } from "../src/useGadgetQuery";
+import { noProviderErrorMessage } from "../src/utils";
+
+describe("useGadgetQuery", () => {
+  test("throw error when no provider included", () => {
+    try {
+      renderHook(() => useGadgetQuery({ query: "{__typename}" }));
+    } catch (error: any) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe(noProviderErrorMessage);
+    }
+  });
+});

--- a/packages/react/src/GadgetProvider.tsx
+++ b/packages/react/src/GadgetProvider.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Client, Provider } from "urql";
 
-export const GadgetContext = React.createContext<Client | null>(null);
+export const GadgetContext = React.createContext<Client | undefined>(undefined);
 export const GadgetProvider: React.FC<React.PropsWithChildren<{ value: Client }>> = ({ children, value }) => {
   return (
     <GadgetContext.Provider value={value}>

--- a/packages/react/src/GadgetProvider.tsx
+++ b/packages/react/src/GadgetProvider.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Client, Provider } from "urql";
+
+export const GadgetContext = React.createContext<Client | null>(null);
+export const GadgetProvider: React.FC<React.PropsWithChildren<{ value: Client }>> = ({ children, value }) => {
+  return (
+    <GadgetContext.Provider value={value}>
+      <Provider value={value}>{children}</Provider>
+    </GadgetContext.Provider>
+  );
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
-export { Consumer, Context, useMutation, useQuery } from "urql";
+export { Consumer, Context } from "urql";
 export { GadgetProvider as Provider } from "./GadgetProvider";
 export * from "./useAction";
 export * from "./useBulkAction";
@@ -6,6 +6,8 @@ export * from "./useFindBy";
 export * from "./useFindFirst";
 export * from "./useFindMany";
 export * from "./useFindOne";
+export { useGadgetMutation as useMutation } from "./useGadgetMutation";
+export { useGadgetQuery as useQuery } from "./useGadgetQuery";
 export * from "./useGet";
 export * from "./useGlobalAction";
 export * from "./useMaybeFindFirst";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,5 @@
-export { Consumer, Context, Provider, useMutation, useQuery } from "urql";
+export { Consumer, Context, useMutation, useQuery } from "urql";
+export { GadgetProvider as Provider } from "./GadgetProvider";
 export * from "./useAction";
 export * from "./useBulkAction";
 export * from "./useFindBy";

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -9,11 +9,12 @@ import {
   LimitToKnownKeys,
   Select,
 } from "@gadgetinc/api-client-core";
-import { useCallback, useMemo } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { useMutation, UseMutationState } from "urql";
+import { GadgetContext } from "./GadgetProvider";
 import { OptionsType } from "./OptionsType";
 import { useStructuralMemo } from "./useStructuralMemo";
-import { ActionHookResult, ActionHookState, ErrorWrapper } from "./utils";
+import { ActionHookResult, ActionHookState, ErrorWrapper, noProviderErrorMessage } from "./utils";
 
 /**
  * React hook to run a Gadget model action. `useAction` must be passed an action function from an instance of your generated API client library, like `api.user.create` or `api.blogPost.publish`. `useAction` doesn't actually run the action when invoked, but instead returns an action function as the second result for running the action in response to an event.
@@ -59,6 +60,8 @@ export const useAction = <
   GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>,
   Exclude<F["variablesType"], null | undefined>
 > => {
+  if (!useContext(GadgetContext)) throw new Error(noProviderErrorMessage);
+
   const memoizedOptions = useStructuralMemo(options);
   const plan = useMemo(() => {
     return actionOperation(

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -10,9 +10,10 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useCallback, useContext, useMemo } from "react";
-import { useMutation, UseMutationState } from "urql";
+import { UseMutationState } from "urql";
 import { GadgetContext } from "./GadgetProvider";
 import { OptionsType } from "./OptionsType";
+import { useGadgetMutation } from "./useGadgetMutation";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ActionHookResult, ActionHookState, ErrorWrapper, noProviderErrorMessage } from "./utils";
 
@@ -75,7 +76,7 @@ export const useAction = <
     );
   }, [action, memoizedOptions]);
 
-  const [result, runMutation] = useMutation<
+  const [result, runMutation] = useGadgetMutation<
     GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>,
     F["variablesType"]
   >(plan.query);

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -10,8 +10,9 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useCallback, useMemo } from "react";
-import { useMutation, UseMutationState } from "urql";
+import { UseMutationState } from "urql";
 import { OptionsType } from "./OptionsType";
+import { useGadgetMutation } from "./useGadgetMutation";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ActionHookResult, ErrorWrapper } from "./utils";
 
@@ -67,7 +68,7 @@ export const useBulkAction = <
     );
   }, [action, memoizedOptions]);
 
-  const [result, runMutation] = useMutation<
+  const [result, runMutation] = useGadgetMutation<
     GadgetRecord<
       Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>
     >[],

--- a/packages/react/src/useFindBy.ts
+++ b/packages/react/src/useFindBy.ts
@@ -12,8 +12,9 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryArgs } from "urql";
+import { UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
+import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ErrorWrapper, ReadHookResult } from "./utils";
 
@@ -64,7 +65,7 @@ export const useFindBy = <
     );
   }, [finder, value, memoizedOptions]);
 
-  const [result, refresh] = useQuery(getQueryArgs(plan, options));
+  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, options));
 
   const dataPath = [finder.operationName];
   let records = [];

--- a/packages/react/src/useFindFirst.ts
+++ b/packages/react/src/useFindFirst.ts
@@ -10,8 +10,9 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryArgs } from "urql";
+import { UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
+import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ErrorWrapper, ReadHookResult } from "./utils";
 
@@ -61,7 +62,7 @@ export const useFindFirst = <
     );
   }, [manager, memoizedOptions]);
 
-  const [result, refresh] = useQuery(getQueryArgs(plan, firstOptions));
+  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, firstOptions));
 
   const dataPath = [manager.findFirst.operationName];
   let data = result.data;

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -10,8 +10,9 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryArgs } from "urql";
+import { UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
+import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ErrorWrapper, ReadHookResult } from "./utils";
 
@@ -60,7 +61,7 @@ export const useFindMany = <
     );
   }, [manager, memoizedOptions]);
 
-  const [result, refresh] = useQuery(getQueryArgs(plan, options));
+  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, options));
 
   const dataPath = [manager.findMany.operationName];
   let data = result.data;

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -10,8 +10,9 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryArgs } from "urql";
+import { UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
+import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ErrorWrapper, ReadHookResult } from "./utils";
 
@@ -62,7 +63,7 @@ export const useFindOne = <
     );
   }, [manager, id, memoizedOptions]);
 
-  const [result, refresh] = useQuery(getQueryArgs(plan, options));
+  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, options));
 
   const dataPath = [manager.findOne.operationName];
   let data = result.data && get(result.data, dataPath);

--- a/packages/react/src/useGadgetMutation.ts
+++ b/packages/react/src/useGadgetMutation.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+import { useMutation } from "urql";
+import { GadgetContext } from "./GadgetProvider";
+import { noProviderErrorMessage } from "./utils";
+
+export const useGadgetMutation: typeof useMutation = (query) => {
+  if (!useContext(GadgetContext)) throw new Error(noProviderErrorMessage);
+  return useMutation(query);
+};

--- a/packages/react/src/useGadgetQuery.ts
+++ b/packages/react/src/useGadgetQuery.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+import { useQuery } from "urql";
+import { GadgetContext } from "./GadgetProvider";
+import { noProviderErrorMessage } from "./utils";
+
+export const useGadgetQuery: typeof useQuery = (args) => {
+  if (!useContext(GadgetContext)) throw new Error(noProviderErrorMessage);
+  return useQuery(args);
+};

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -9,8 +9,8 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery } from "urql";
 import { OptionsType } from "./OptionsType";
+import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ErrorWrapper, ReadHookResult } from "./utils";
 
@@ -60,7 +60,7 @@ export const useGet = <
     );
   }, [manager, memoizedOptions]);
 
-  const [result, refresh] = useQuery({ query: plan.query, variables: plan.variables });
+  const [result, refresh] = useGadgetQuery({ query: plan.query, variables: plan.variables });
 
   let data = null;
   const rawRecord = result.data && get(result.data, [manager.get.operationName]);

--- a/packages/react/src/useGlobalAction.ts
+++ b/packages/react/src/useGlobalAction.ts
@@ -1,6 +1,7 @@
 import { get, GlobalActionFunction, globalActionOperation } from "@gadgetinc/api-client-core";
 import { useCallback, useMemo } from "react";
-import { useMutation, UseMutationState } from "urql";
+import { UseMutationState } from "urql";
+import { useGadgetMutation } from "./useGadgetMutation";
 import { ActionHookResult, ErrorWrapper } from "./utils";
 
 /**
@@ -31,7 +32,7 @@ export const useGlobalAction = <F extends GlobalActionFunction<any>>(
     return globalActionOperation(action.operationName, action.variables, action.namespace);
   }, [action]);
 
-  const [result, runMutation] = useMutation<any, F["variablesType"]>(plan.query);
+  const [result, runMutation] = useGadgetMutation<any, F["variablesType"]>(plan.query);
 
   return [
     processResult(result, action),

--- a/packages/react/src/useMaybeFindFirst.ts
+++ b/packages/react/src/useMaybeFindFirst.ts
@@ -10,8 +10,9 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryArgs } from "urql";
+import { UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
+import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ErrorWrapper, ReadHookResult } from "./utils";
 
@@ -61,7 +62,7 @@ export const useMaybeFindFirst = <
     );
   }, [manager, memoizedOptions]);
 
-  const [result, refresh] = useQuery(getQueryArgs(plan, firstOptions));
+  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, firstOptions));
 
   const dataPath = [manager.findFirst.operationName];
   let data = result.data ?? null;

--- a/packages/react/src/useMaybeFindOne.ts
+++ b/packages/react/src/useMaybeFindOne.ts
@@ -10,8 +10,9 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
-import { useQuery, UseQueryArgs } from "urql";
+import { UseQueryArgs } from "urql";
 import { OptionsType } from "./OptionsType";
+import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import { ErrorWrapper, ReadHookResult } from "./utils";
 
@@ -62,7 +63,7 @@ export const useMaybeFindOne = <
     );
   }, [manager, id, memoizedOptions]);
 
-  const [result, refresh] = useQuery(getQueryArgs(plan, options));
+  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, options));
 
   let data = result.data ?? null;
   if (data) {

--- a/packages/react/src/useStructuralMemo.ts
+++ b/packages/react/src/useStructuralMemo.ts
@@ -1,10 +1,14 @@
 import deepEqual from "deep-equal";
-import { useRef } from "react";
+import { useContext, useRef } from "react";
+import { GadgetContext } from "./GadgetProvider";
+import { noProviderErrorMessage } from "./utils";
 
 /**
  * Memoize and ensure a stable identity on a given value as long as it remains the same, structurally.
  */
 export const useStructuralMemo = <T>(value: T): T | undefined => {
+  if (!useContext(GadgetContext)) throw new Error(noProviderErrorMessage);
+
   const ref = useRef<T>();
   if (value) {
     if (ref.current === undefined || !deepEqual(value, ref.current)) {

--- a/packages/react/src/useStructuralMemo.ts
+++ b/packages/react/src/useStructuralMemo.ts
@@ -1,14 +1,10 @@
 import deepEqual from "deep-equal";
-import { useContext, useRef } from "react";
-import { GadgetContext } from "./GadgetProvider";
-import { noProviderErrorMessage } from "./utils";
+import { useRef } from "react";
 
 /**
  * Memoize and ensure a stable identity on a given value as long as it remains the same, structurally.
  */
 export const useStructuralMemo = <T>(value: T): T | undefined => {
-  if (!useContext(GadgetContext)) throw new Error(noProviderErrorMessage);
-
   const ref = useRef<T>();
   if (value) {
     if (ref.current === undefined || !deepEqual(value, ref.current)) {

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -45,6 +45,8 @@ export declare type ActionHookResult<Data = any, Variables extends AnyVariables 
   (variables: Variables, context?: Partial<OperationContext>) => Promise<ActionHookState<Data, Variables>>
 ];
 
+export const noProviderErrorMessage = `Could not find a client in the conext of Provider. Please ensure you wrap the root component in a <Provider>`;
+
 const generateErrorMessage = (networkErr?: Error, graphQlErrs?: GraphQLError[]) => {
   let error = "";
   if (networkErr !== undefined) {


### PR DESCRIPTION
Problems:
- No proper error if the user doesn't include the provider.
- urql will create a client that points to `/graphql` if the provider is not included.
- urql has no parameter to get the url of the client.

Solution:
- Create a provider that wrap the urql provider, then check to see if that provider's context has a client in it.