### PR TITLE
bump @gadgetinc/react version

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
We didn't update `@gadgetinc/react` package version after merging #112 