### PR TITLE
Updating react shopify app bridge dependency

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -25,7 +25,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@gadgetinc/react": "^0.7.2",
+    "@gadgetinc/react": "^0.8.2",
     "@shopify/app-bridge-react": "^2.0.25",
     "@types/crypto-js": "^4.1.1",
     "@types/jest": "^26.0.24",
@@ -39,7 +39,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@gadgetinc/react": "^0.7.2",
+    "@gadgetinc/react": "^0.8.2",
     "@shopify/app-bridge-react": "^2.0.0 || ^3.0.0",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"


### PR DESCRIPTION
We need to update the dependent version of `@gadgetinc/react` in the `@gadgetinc/react-shopify-app-bridge` package