### PR TITLE
hotfix: Return a GadgetRecordList from the useFindMany hook

### DIFF
--- a/packages/api-client-core/src/GadgetRecordList.ts
+++ b/packages/api-client-core/src/GadgetRecordList.ts
@@ -19,11 +19,11 @@ export class GadgetRecordList<Shape extends RecordShape> extends Array<GadgetRec
   /** Internal method used to create a list. Should not be used by applications. */
   static boot<Shape extends RecordShape>(
     modelManager: AnyModelManager | InternalModelManager,
-    nodes: GadgetRecord<Shape>[],
+    records: GadgetRecord<Shape>[],
     pagination: PaginationConfig
   ) {
     const list = new GadgetRecordList<Shape>();
-    list.push(...nodes);
+    list.push(...records);
     list.modelManager = modelManager;
     list.pagination = pagination;
     Object.freeze(list);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -210,7 +210,7 @@ See [the `refetch` function](#the-refetch-function) docs for more information on
 
 `useFindMany` returns two values: a result object with the `data`, `fetching`, and `error` keys for use in your React component's output, and a [`refetch` function](#the-refetch-function) to trigger a refresh of the hook's data.
 
-- `data: GadgetRecord[] | null`: The resulting page of records fetched from the backend for your model, once they've arrived
+- `data: GadgetRecordList | null`: The resulting page of records fetched from the backend for your model, once they've arrived
 - `fetching: boolean`: A boolean describing if the hook is currently making a request to the backend.
 - `error: Error | null`: An error from the client or server side, if encountered during the request. See the [Errors](#errors-from-the-returned-error-object) section.
 
@@ -298,9 +298,13 @@ const [{ data, fetching, error }, _refetch] = useFindMany(api.widget, {
   after: "some-cursor-value",
 });
 
+// data is a GadgetRecordList object, which has extra properties for inquiring about the pagination state
 // the current page's start and end cursor are available for use to then make later requests for different pages
-data.endCursor; // used for forward pagination, pass to the `after:` variable
-data.startCursor; // used for backwards pagination, pass to the `before:` variable
+data.endCursor; // => string, used for forward pagination, pass to the `after:` variable
+data.startCursor; // => string, used for backwards pagination, pass to the `before:` variable
+// data also reports if there are more pages for fetching
+data.hasNextPage; // => boolean, true if there is another page to fetch after the `endCursor`
+data.hasPreviousPage; // => boolean, true if there is another page to fetch before the `startCursor`
 ```
 
 An easy way to do pagination is using React state, or for a better user experience, using the URL with whatever router system works for your application. We use React state to demonstrate pagination in this example:

--- a/packages/react/spec/testWrapper.tsx
+++ b/packages/react/spec/testWrapper.tsx
@@ -70,6 +70,7 @@ const newMockOperationFn = () => {
         ...response,
       });
       subjects[key].complete();
+      delete subjects[key];
     });
   };
 

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -1,4 +1,4 @@
-import { GadgetRecord } from "@gadgetinc/api-client-core";
+import { GadgetRecordList } from "@gadgetinc/api-client-core";
 import { renderHook } from "@testing-library/react";
 import { assert, IsExact } from "conditional-type-checks";
 import { useFindMany } from "../src/useFindMany";
@@ -12,7 +12,7 @@ describe("useFindMany", () => {
     const [{ data, fetching, error }, refresh] = useFindMany(relatedProductsApi.user, { select: { id: true, email: true } });
 
     assert<IsExact<typeof fetching, boolean>>(true);
-    assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>[]>>(true);
+    assert<IsExact<typeof data, undefined | GadgetRecordList<{ id: string; email: string | null }>>>(true);
     assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
     if (data) {
@@ -61,8 +61,82 @@ describe("useFindMany", () => {
     expect(result.current[0].data![0].id).toEqual("123");
     expect(result.current[0].data![1].id).toEqual("124");
     expect(result.current[0].data!.length).toEqual(2);
+    expect(result.current[0].data!.hasNextPage).toEqual(false);
+    expect(result.current[0].data!.hasPreviousPage).toEqual(false);
+    expect(result.current[0].data!.startCursor).toEqual("123");
+    expect(result.current[0].data!.endCursor).toEqual("abc");
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("can find a list of records and query for the next page", async () => {
+    const { result, rerender } = renderHook((after?: string) => useFindMany(relatedProductsApi.user, { first: 2, after }), {
+      wrapper: TestWrapper,
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockClient.executeQuery).toBeCalledTimes(1);
+
+    mockClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [
+            { cursor: "123", node: { id: "123", email: "test@test.com" } },
+            { cursor: "abc", node: { id: "124", email: "test@test.com" } },
+          ],
+          pageInfo: {
+            startCursor: "123",
+            endCursor: "abc",
+            hasNextPage: true,
+            hasPreviousPage: false,
+          },
+        },
+      },
+    });
+
+    expect(result.current[0].data![0].id).toEqual("123");
+    expect(result.current[0].data![1].id).toEqual("124");
+    expect(result.current[0].data!.length).toEqual(2);
+    expect(result.current[0].data!.endCursor).toEqual("abc");
+    expect(result.current[0].data!.hasNextPage).toEqual(true);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    // rerun the hook with the after cursor to simulate being called
+    rerender(result.current[0].data!.endCursor);
+
+    await Promise.resolve();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockClient.executeQuery).toBeCalledTimes(2);
+
+    mockClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [
+            { cursor: "def", node: { id: "def", email: "test@test.com" } },
+            { cursor: "hij", node: { id: "hij", email: "test@test.com" } },
+          ],
+          pageInfo: {
+            startCursor: "def",
+            endCursor: "hij",
+            hasNextPage: false,
+            hasPreviousPage: true,
+          },
+        },
+      },
+    });
+
+    expect(result.current[0].data![0].id).toEqual("def");
+    expect(result.current[0].data![1].id).toEqual("hij");
+    expect(result.current[0].data!.hasNextPage).toEqual(false);
+    expect(result.current[0].data!.hasPreviousPage).toEqual(true);
+    expect(result.current[0].data!.startCursor).toEqual("def");
+    expect(result.current[0].data!.endCursor).toEqual("hij");
   });
 
   test("can find an empty list of records", async () => {

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -1,8 +1,9 @@
 import {
+  AnyModelManager,
   DefaultSelection,
   FindManyFunction,
   findManyOperation,
-  GadgetRecord,
+  GadgetRecordList,
   get,
   getQueryArgs,
   hydrateConnection,
@@ -49,7 +50,7 @@ export const useFindMany = <
   manager: { findMany: F },
   options?: LimitToKnownKeys<Options, F["optionsType"]> & Omit<UseQueryArgs, "query" | "variables">
 ): ReadHookResult<
-  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>[]
+  GadgetRecordList<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>
 > => {
   const memoizedOptions = useStructuralMemo(options);
   const plan = useMemo(() => {
@@ -68,7 +69,8 @@ export const useFindMany = <
   if (data) {
     const connection = get(result.data, dataPath);
     if (connection) {
-      data = hydrateConnection(result, connection);
+      const records = hydrateConnection(result, connection);
+      data = GadgetRecordList.boot(manager as unknown as AnyModelManager, records, connection);
     }
   }
 


### PR DESCRIPTION
It's important that react hook users are able to inquire about the pageInfo returned by a connection, so they can paginate forwards or backwards and know if those pages exist! We tried to make this possible previously but failed by accident -- we were still returning a plain old array of records instead of the extended-array GadgetRecordList object. This updates us to definitely return that fancier object to match the docs that already describe using it, and adds a test that actually exercises those bits to prove it is working.
