### PR TITLE
Add return explicit return type to `toJSON`

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -38,6 +38,7 @@
     "conditional-type-checks": "^1.0.6",
     "gql-tag": "^1.0.1",
     "nock": "^13.2.9",
+    "type-fest": "^3.3.0",
     "typescript": "4.7.4"
   }
 }

--- a/packages/api-client-core/src/GadgetRecord.ts
+++ b/packages/api-client-core/src/GadgetRecord.ts
@@ -1,5 +1,6 @@
 import cloneDeep from "lodash.clonedeep";
 import isEqual from "lodash.isequal";
+import type { Jsonify } from "type-fest";
 import { toPrimitiveObject } from "./support";
 
 export enum ChangeTracking {
@@ -171,7 +172,7 @@ export class GadgetRecordImplementation<Shape extends RecordShape> {
   }
 
   /** Returns a JSON representation of all fields on this record. */
-  toJSON() {
+  toJSON(): Jsonify<Shape> {
     return toPrimitiveObject({ ...this.__gadget.fields });
   }
 }

--- a/packages/api-client-core/src/GadgetRecordList.ts
+++ b/packages/api-client-core/src/GadgetRecordList.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-throw-literal */
 /* eslint-disable @typescript-eslint/require-await */
+import type { Jsonify } from "type-fest";
 import { GadgetRecord, RecordShape } from "./GadgetRecord";
 import type { InternalModelManager } from "./InternalModelManager";
 import type { AnyModelManager } from "./ModelManager";
@@ -41,7 +42,7 @@ export class GadgetRecordList<Shape extends RecordShape> extends Array<GadgetRec
     return this[0];
   }
 
-  toJSON() {
+  toJSON(): Jsonify<Shape>[] {
     return this.map((record) => record.toJSON());
   }
 

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -127,7 +127,7 @@ export const internalCreateMutation = (apiIdentifier: string) => {
   const capitalizedApiIdentifier = capitalize(apiIdentifier);
   return `
     ${internalErrorsDetails}
-    
+
     mutation InternalCreate${capitalizedApiIdentifier}($record: Internal${capitalizedApiIdentifier}Input) {
       ${internalHydrationPlan(apiIdentifier)}
       internal {
@@ -147,7 +147,7 @@ export const internalUpdateMutation = (apiIdentifier: string) => {
   const capitalizedApiIdentifier = capitalize(apiIdentifier);
   return `
     ${internalErrorsDetails}
-    
+
     mutation InternalUpdate${capitalizedApiIdentifier}($id: GadgetID!, $record: Internal${capitalizedApiIdentifier}Input) {
       ${internalHydrationPlan(apiIdentifier)}
       internal {
@@ -167,7 +167,7 @@ export const internalDeleteMutation = (apiIdentifier: string) => {
   const capitalizedApiIdentifier = capitalize(apiIdentifier);
   return `
     ${internalErrorsDetails}
-    
+
     mutation InternalDelete${capitalizedApiIdentifier}($id: GadgetID!) {
       ${internalHydrationPlan(apiIdentifier)}
       internal {
@@ -186,7 +186,7 @@ export const internalDeleteManyMutation = (apiIdentifier: string) => {
   const capitalizedApiIdentifier = capitalize(apiIdentifier);
   return `
     ${internalErrorsDetails}
-    
+
     mutation InternalDeleteMany${capitalizedApiIdentifier}(
       $search: String
       $filter: [${capitalizedApiIdentifier}Filter!]
@@ -220,7 +220,7 @@ export class InternalModelManager {
     const response = await this.connection.currentClient.query(internalFindOneQuery(this.apiIdentifier), { id }).toPromise();
     const assertSuccess = throwOnEmptyData ? assertOperationSuccess : assertNullableOperationSuccess;
     const result = assertSuccess(response, ["internal", this.apiIdentifier]);
-    return await hydrateRecord(response, result);
+    return hydrateRecord(response, result);
   }
 
   async maybeFindOne(id: string): Promise<GadgetRecord<RecordData> | null> {
@@ -268,7 +268,7 @@ export class InternalModelManager {
         })
         .toPromise();
       const result = assertMutationSuccess(response, ["internal", `create${this.capitalizedApiIdentifier}`]);
-      return await hydrateRecord(response, result[this.apiIdentifier]);
+      return hydrateRecord(response, result[this.apiIdentifier]);
     });
   }
 
@@ -283,7 +283,7 @@ export class InternalModelManager {
         .toPromise();
       const result = assertMutationSuccess(response, ["internal", `update${this.capitalizedApiIdentifier}`]);
 
-      return await hydrateRecord(response, result[this.apiIdentifier]);
+      return hydrateRecord(response, result[this.apiIdentifier]);
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5274,6 +5274,11 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-fest@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.3.0.tgz#3378c9664eecfd1eb4f0522b13cb0630bc1ec044"
+  integrity sha512-gezeeOIZyQLGW5uuCeEnXF1aXmtt2afKspXz3YqoOcZ3l/YMJq1pujvgT+cz/Nw1O/7q/kSav5fihJHsC/AOUg==
+
 typescript@4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"


### PR DESCRIPTION
This adds an explicit return type to our `toJSON` methods instead of the inferred `any` type.

## PR Checklist

- [x] Important or complicated code is tested
- [x] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [x] Versions within this monorepo are matching and there's a valid upgrade path
