### PR TITLE
Update storage token to be keyed by endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ TODO
 packages/*/dist
 .idea
 packages/sample-app
+*.orig

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "node --max-old-space-size=4096 --stack-trace-limit=1000 node_modules/.bin/jest"
   },
   "devDependencies": {
-    "@gadget-client/bulk-actions-test": "^1.100.0",
+    "@gadget-client/bulk-actions-test": "^1.101.0",
     "@gadget-client/related-products-example": "^1.783.0",
     "@gadgetinc/eslint-config": "^0.4.0",
     "@gadgetinc/prettier-config": "*",

--- a/packages/api-client-core/spec/GadgetConnectionBrowser.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnectionBrowser.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import gql from "gql-tag";
+import nock from "nock";
+import { BrowserSessionStorageType } from "../src";
+import { GadgetConnection } from "../src/GadgetConnection";
+
+nock.disableNetConnect();
+
+describe("GadgetConnection in browser", () => {
+  // this object is integration tested within Gadget itself also
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    expect(nock.pendingMocks()).toEqual([]);
+    // ensure local storage data doesn't leak between tests
+    window.localStorage.clear();
+  });
+
+  it("should store a x-set-authorization header and reuse it for subsequent requests", async () => {
+    nock("https://someapp.gadget.app")
+      .post("/api/graphql")
+      .reply(
+        200,
+        function () {
+          expect(this.req.headers["authorization"]).toBeUndefined();
+          return {
+            data: {
+              meta: {
+                appName: "some app",
+              },
+            },
+          };
+        },
+        {
+          "x-set-authorization": "Session token-123",
+        }
+      )
+      .post("/api/graphql")
+      .reply(
+        200,
+        function () {
+          expect(this.req.headers["authorization"]).toEqual(["Session token-123"]);
+          return {
+            data: {
+              currentSession: {
+                id: 1,
+              },
+            },
+          };
+        },
+        {
+          "x-set-authorization": "Session token-123",
+        }
+      );
+
+    const connection = new GadgetConnection({
+      endpoint: "https://someapp.gadget.app/api/graphql",
+      authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Durable } },
+    });
+
+    const firstResult = await connection.currentClient
+      .query(
+        gql`
+          {
+            meta {
+              appName
+            }
+          }
+        `,
+        {}
+      )
+      .toPromise();
+
+    expect(firstResult.data).toEqual({ meta: { appName: "some app" } });
+
+    const secondResult = await connection.currentClient
+      .query(
+        gql`
+          {
+            currentSession {
+              id
+            }
+          }
+        `,
+        {}
+      )
+      .toPromise();
+
+    expect(secondResult.data).toEqual({ currentSession: { id: 1 } });
+  });
+
+  it("should not re-use session tokens across apps", async () => {
+    nock("https://someapp.gadget.app")
+      .post("/api/graphql")
+      .reply(
+        200,
+        function () {
+          expect(this.req.headers["authorization"]).toBeUndefined();
+          return {
+            data: {
+              meta: {
+                appName: "some app",
+              },
+            },
+          };
+        },
+        {
+          "x-set-authorization": "Session token-123",
+        }
+      );
+    nock("https://anotherapp.gadget.app")
+      .post("/api/graphql")
+      .reply(
+        200,
+        function () {
+          expect(this.req.headers["authorization"]).toBeUndefined();
+          return {
+            data: {
+              meta: {
+                appName: "another app",
+              },
+            },
+          };
+        },
+        {
+          "x-set-authorization": "Session token-456",
+        }
+      );
+
+    let connection = new GadgetConnection({
+      endpoint: "https://someapp.gadget.app/api/graphql",
+      authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Durable } },
+    });
+
+    const firstResult = await connection.currentClient
+      .query(
+        gql`
+          {
+            meta {
+              appName
+            }
+          }
+        `,
+        {}
+      )
+      .toPromise();
+
+    expect(firstResult.data).toEqual({ meta: { appName: "some app" } });
+
+    connection = new GadgetConnection({
+      endpoint: "https://anotherapp.gadget.app/api/graphql",
+      authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Durable } },
+    });
+
+    const secondResult = await connection.currentClient
+      .query(
+        gql`
+          {
+            meta {
+              appName
+            }
+          }
+        `,
+        {}
+      )
+      .toPromise();
+
+    expect(secondResult.data).toEqual({ meta: { appName: "another app" } });
+  });
+});

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -100,6 +100,10 @@ export class GadgetConnection {
     this.baseClient = this.newBaseClient();
   }
 
+  private get sessionStorageKey() {
+    return `${sessionStorageKey}-${this.endpoint}`;
+  }
+
   get currentClient() {
     return this.currentTransaction?.client || this.baseClient;
   }
@@ -143,7 +147,7 @@ export class GadgetConnection {
     }
 
     if (options !== null && typeof options === "object" && "initialToken" in options && options.initialToken) {
-      sessionTokenStore.setItem(sessionStorageKey, options.initialToken);
+      sessionTokenStore.setItem(this.sessionStorageKey, options.initialToken);
     }
 
     this.sessionTokenStore = sessionTokenStore;
@@ -257,7 +261,7 @@ export class GadgetConnection {
       const headerValue = response.headers.get("x-set-authorization");
       const sessionToken = headerValue?.startsWith("Session ") ? headerValue.replace("Session ", "") : null;
       if (sessionToken) {
-        this.sessionTokenStore!.setItem(sessionStorageKey, sessionToken);
+        this.sessionTokenStore!.setItem(this.sessionStorageKey, sessionToken);
       }
     }
 
@@ -313,7 +317,7 @@ export class GadgetConnection {
     } else if (this.authenticationMode == AuthenticationMode.InternalAuthToken) {
       connectionParams.auth.token = this.options.authenticationMode!.internalAuthToken!;
     } else if (this.authenticationMode == AuthenticationMode.BrowserSession) {
-      connectionParams.auth.sessionToken = this.sessionTokenStore!.getItem(sessionStorageKey);
+      connectionParams.auth.sessionToken = this.sessionTokenStore!.getItem(this.sessionStorageKey);
     } else if (this.authenticationMode == AuthenticationMode.Custom) {
       this.options.authenticationMode?.custom?.processTransactionConnectionParams(connectionParams);
     }
@@ -343,7 +347,7 @@ export class GadgetConnection {
             const browserSession = this.options.authenticationMode?.browserSession;
             const initialToken = browserSession !== null && typeof browserSession === "object" ? browserSession.initialToken : null;
             if (!initialToken) {
-              this.sessionTokenStore!.setItem(sessionStorageKey, payload.sessionToken as string);
+              this.sessionTokenStore!.setItem(this.sessionStorageKey, payload.sessionToken as string);
             }
           }
           this.subscriptionClientOptions?.on?.connected?.(socket, payload);
@@ -363,7 +367,7 @@ export class GadgetConnection {
     } else if (this.authenticationMode == AuthenticationMode.APIKey) {
       headers.authorization = `Bearer ${this.options.authenticationMode?.apiKey}`;
     } else if (this.authenticationMode == AuthenticationMode.BrowserSession) {
-      const val = this.sessionTokenStore!.getItem(sessionStorageKey);
+      const val = this.sessionTokenStore!.getItem(this.sessionStorageKey);
       if (val) {
         headers.authorization = `Session ${val}`;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,12 +1351,12 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gadget-client/bulk-actions-test@^1.100.0":
-  version "1.100.0"
-  resolved "https://registry.gadget.dev/npm/_/tarball/6681/12076/2373#8b0a175087af466d58ac0e15ada4dd12c2436f2b"
-  integrity sha1-iwoXUIevRm1YrA4VraTdEsJDbys=
+"@gadget-client/bulk-actions-test@^1.101.0":
+  version "1.101.0"
+  resolved "https://registry.gadget.dev/npm/_/tarball/6681/12076/2621#f2e72156c15aa4ca82a85be3431798798626c1ee"
+  integrity sha1-8uchVsFapMqCqFvjQxeYeYYmwe4=
   dependencies:
-    "@gadgetinc/api-client-core" "0.10.1"
+    "@gadgetinc/api-client-core" "0.11.0"
 
 "@gadget-client/related-products-example@^1.783.0":
   version "1.783.0"
@@ -1364,6 +1364,21 @@
   integrity sha1-/d+6TiAfTTBHjHoD3jDKFBhdaH0=
   dependencies:
     "@gadgetinc/api-client-core" "0.9.0"
+
+"@gadgetinc/api-client-core@0.11.0":
+  version "0.10.1"
+  dependencies:
+    "@opentelemetry/api" "^1.0.4"
+    "@urql/core" "^3.0.1"
+    "@urql/exchange-multipart-fetch" "^1.0.1"
+    cross-fetch "^3.0.6"
+    gql-query-builder "^3.6.0"
+    graphql "^16.5.0"
+    graphql-ws "^5.5.5"
+    isomorphic-ws "^4.0.1"
+    lodash.clonedeep "^4.5.0"
+    lodash.isequal "^4.5.0"
+    ws "^8.2.2"
 
 "@gadgetinc/api-client-core@0.9.0":
   version "0.10.1"


### PR DESCRIPTION
We noticed that session tokens are stored at the static `token` key and this ends up being re-used across different Gadget apps if you're building multiple embedded apps

closes GGT-2915

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
