### PR TITLE
Don't use `localStorage` for auth if it isn't available

### DIFF
--- a/packages/api-client-core/spec/GadgetConnection.browser.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnection.browser.spec.ts
@@ -1,0 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
+import { GadgetConnectionSharedSuite } from "./GadgetConnection-suite";
+
+describe("GadgetConnection in the browser", () => {
+  GadgetConnectionSharedSuite("    __typename\n");
+});

--- a/packages/api-client-core/spec/GadgetConnection.browser.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnection.browser.spec.ts
@@ -1,8 +1,58 @@
 /**
  * @jest-environment jsdom
  */
+import { AuthenticationMode, BrowserSessionStorageType, GadgetConnection, InMemoryStorage } from "../src";
 import { GadgetConnectionSharedSuite } from "./GadgetConnection-suite";
+import { withWindowMissingSupport } from "./helpers";
 
 describe("GadgetConnection in the browser", () => {
   GadgetConnectionSharedSuite("    __typename\n");
+
+  describe("browser session authentication with varying support for localStorage", () => {
+    it("should default to the durable authentication mode browserSession: true", () => {
+      const connection = new GadgetConnection({ endpoint: "https://someapp.gadget.app", authenticationMode: { browserSession: true } });
+      expect(connection.authenticationMode).toEqual(AuthenticationMode.BrowserSession);
+      expect((connection as any).sessionTokenStore).toBe(window.localStorage);
+    });
+
+    it("should use localStorage when available for the durable authentication mode", () => {
+      const connection = new GadgetConnection({
+        endpoint: "https://someapp.gadget.app",
+        authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Durable } },
+      });
+      expect(connection.authenticationMode).toEqual(AuthenticationMode.BrowserSession);
+      expect((connection as any).sessionTokenStore).toBe(window.localStorage);
+    });
+
+    it("should use sessionStorage when available for the session authentication mode", () => {
+      const connection = new GadgetConnection({
+        endpoint: "https://someapp.gadget.app",
+        authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Session } },
+      });
+      expect(connection.authenticationMode).toEqual(AuthenticationMode.BrowserSession);
+      expect((connection as any).sessionTokenStore).toBe(window.sessionStorage);
+    });
+
+    it("should use temporary storage when localStorage is not available for the durable authentication mode", () => {
+      withWindowMissingSupport("localStorage", () => {
+        const connection = new GadgetConnection({
+          endpoint: "https://someapp.gadget.app",
+          authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Durable } },
+        });
+        expect(connection.authenticationMode).toEqual(AuthenticationMode.BrowserSession);
+        expect((connection as any).sessionTokenStore).toBeInstanceOf(InMemoryStorage);
+      });
+    });
+
+    it("should use temporary storage when localStorage is not available for the session authentication mode", () => {
+      withWindowMissingSupport("sessionStorage", () => {
+        const connection = new GadgetConnection({
+          endpoint: "https://someapp.gadget.app",
+          authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Session } },
+        });
+        expect(connection.authenticationMode).toEqual(AuthenticationMode.BrowserSession);
+        expect((connection as any).sessionTokenStore).toBeInstanceOf(InMemoryStorage);
+      });
+    });
+  });
 });

--- a/packages/api-client-core/spec/GadgetConnection.node.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnection.node.spec.ts
@@ -1,0 +1,25 @@
+import { AuthenticationMode, BrowserSessionStorageType, GadgetConnection, InMemoryStorage } from "../src";
+import { GadgetConnectionSharedSuite } from "./GadgetConnection-suite";
+
+describe("GadgetConnection in node", () => {
+  GadgetConnectionSharedSuite();
+
+  describe("browser session authentication in node", () => {
+    it("should default to temporary storage with mode browserSession: true", () => {
+      const connection = new GadgetConnection({ endpoint: "https://someapp.gadget.app", authenticationMode: { browserSession: true } });
+      expect(connection.authenticationMode).toEqual(AuthenticationMode.BrowserSession);
+      // node doesn't have localstorage, must use an in-memory store
+      expect((connection as any).sessionTokenStore).toBeInstanceOf(InMemoryStorage);
+    });
+
+    it("should use temporary storage for the durable authentication mode", () => {
+      const connection = new GadgetConnection({
+        endpoint: "https://someapp.gadget.app",
+        authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Durable } },
+      });
+      expect(connection.authenticationMode).toEqual(AuthenticationMode.BrowserSession);
+      // node doesn't have localstorage, must use an in-memory store
+      expect((connection as any).sessionTokenStore).toBeInstanceOf(InMemoryStorage);
+    });
+  });
+});

--- a/packages/api-client-core/spec/helpers.ts
+++ b/packages/api-client-core/spec/helpers.ts
@@ -1,0 +1,11 @@
+export const withWindowMissingSupport = (key: keyof typeof window, run: () => void) => {
+  const old = window[key];
+  try {
+    delete window[key];
+    return run();
+  } finally {
+    (window as any)[key] = old;
+  }
+};
+
+export const base64 = (str: string) => Buffer.from(str).toString("base64");

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -15,7 +15,7 @@ import type { AuthenticationModeOptions, BrowserSessionAuthenticationModeOptions
 import { BrowserSessionStorageType } from "./ClientOptions";
 import { GadgetTransaction, TransactionRolledBack } from "./GadgetTransaction";
 import { BrowserStorage, InMemoryStorage } from "./InMemoryStorage";
-import { GadgetUnexpectedCloseError, isCloseEvent, traceFunction } from "./support";
+import { GadgetUnexpectedCloseError, isCloseEvent, storageAvailable, traceFunction } from "./support";
 
 export type TransactionRun<T> = (transaction: GadgetTransaction) => Promise<T>;
 export interface GadgetSubscriptionClientOptions extends Partial<SubscriptionClientOptions> {
@@ -133,10 +133,11 @@ export class GadgetConnection {
   enableSessionMode(options?: true | BrowserSessionAuthenticationModeOptions) {
     this.authenticationMode = AuthenticationMode.BrowserSession;
 
+    const desiredMode = !options || typeof options == "boolean" ? BrowserSessionStorageType.Durable : options.storageType;
     let sessionTokenStore;
-    if (!options || typeof options == "boolean" || options.storageType == BrowserSessionStorageType.Durable) {
+    if (desiredMode == BrowserSessionStorageType.Durable && storageAvailable("localStorage")) {
       sessionTokenStore = window.localStorage;
-    } else if (options.storageType == BrowserSessionStorageType.Session) {
+    } else if (desiredMode == BrowserSessionStorageType.Session && storageAvailable("sessionStorage")) {
       sessionTokenStore = window.sessionStorage;
     } else {
       sessionTokenStore = new InMemoryStorage();

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -383,3 +383,18 @@ export const getQueryArgs = <Plan extends QueryPlan, Options extends QueryOption
   pause: options?.pause,
   requestPolicy: options?.requestPolicy,
 });
+
+// Gadget Storage Test Key that minifies well
+const key = "gstk";
+
+/** Detect if the window object and window.localStorage or window.sessionStorage objects are functional */
+export const storageAvailable = (type: "localStorage" | "sessionStorage") => {
+  try {
+    const storage = window[type];
+    storage.setItem(key, key);
+    storage.removeItem(key);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
All our docs tell folks to construct their API client with no explicit `authenticationMode` for simplicity, and so that we can make an educated decision about what authentication mode to use internally based on the environment. In Node, we use anonymous authentication, and in the browser, we try to use a cookie-like authentication that works cross-domain with localStorage. 

`localStorage` however errors in some browsers if you try to touch in when the browser window is incognito, or it just doesn't work in private browsing in safari. Sad. This breaks apps trying to get through Shopify's review process, as Shopify requires that you can log in/out of the app in incognito. We support this just fine, you just have to (before this change) ensure you do `new Client({authenticationMode: { anonymous: true }})` or similar, which our docs don't tell you to do rn.

So, I think our default authentication mode for browser contexts that don't have localStorage shouldn't just be "shit the bed", it should fall back to the temporary storage. For Shopify apps, this temporary auth method gets replaced by the provider later, so what you pass doesn't even matter, it just gets replaced. For this reason, I think falling back to something is a fine default.