### PR TITLE
do not set both last and first when paging with nextPage or previousPage

### DIFF
--- a/packages/api-client-core/spec/GadgetRecordList.spec.ts
+++ b/packages/api-client-core/spec/GadgetRecordList.spec.ts
@@ -1,0 +1,119 @@
+import { GadgetConnection, GadgetRecordList, InternalModelManager } from "../src";
+
+describe("GadgetRecordList", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  const pages: { startCursor: string; endCursor: string; hasNextPage: boolean; hasPreviousPage: boolean }[] = [
+    {
+      startCursor: "start1",
+      endCursor: "end1",
+      hasNextPage: true,
+      hasPreviousPage: false,
+    },
+    {
+      startCursor: "start2",
+      endCursor: "end2",
+      hasNextPage: true,
+      hasPreviousPage: true,
+    },
+    {
+      startCursor: "start3",
+      endCursor: "end3",
+      hasNextPage: true,
+      hasPreviousPage: true,
+    },
+    {
+      startCursor: "start4",
+      endCursor: "end4",
+      hasNextPage: false,
+      hasPreviousPage: true,
+    },
+  ];
+  test("sends correct page info when paging forward", async () => {
+    let startIndex = 0;
+    const modelManager = new InternalModelManager("foo", new GadgetConnection({ endpoint: "https://fake-app.gadget.app" }));
+    let recordList = GadgetRecordList.boot(modelManager, [], { pageInfo: pages[startIndex], options: { first: 10 } });
+    jest.spyOn(modelManager, "findMany").mockImplementation(async (options) => {
+      if (!options) {
+        throw new Error("Expected options to be defined");
+      }
+
+      expect(options.after).toBe(pages[startIndex].endCursor);
+      expect(options.first).toBe(10);
+      expect(options.last).toBeUndefined();
+      return GadgetRecordList.boot(modelManager, [], { options, pageInfo: pages[++startIndex] });
+    });
+
+    recordList = await recordList.nextPage();
+    recordList = await recordList.nextPage();
+    await recordList.nextPage();
+  });
+
+  test("sends correct page info when paging backward", async () => {
+    let startIndex = 3;
+    const modelManager = new InternalModelManager("foo", new GadgetConnection({ endpoint: "https://fake-app.gadget.app" }));
+    let recordList = GadgetRecordList.boot(modelManager, [], { pageInfo: pages[startIndex], options: { last: 10 } });
+    jest.spyOn(modelManager, "findMany").mockImplementation(async (options) => {
+      if (!options) {
+        throw new Error("Expected options to be defined");
+      }
+
+      expect(options.before).toBe(pages[startIndex].startCursor);
+      expect(options.last).toBe(10);
+      expect(options.first).toBeUndefined();
+      return GadgetRecordList.boot(modelManager, [], { options, pageInfo: pages[--startIndex] });
+    });
+
+    recordList = await recordList.previousPage();
+    recordList = await recordList.previousPage();
+    await recordList.previousPage();
+  });
+
+  test("does not send both first/last when paging forward and backward", async () => {
+    let startIndex = 0;
+    const modelManager = new InternalModelManager("foo", new GadgetConnection({ endpoint: "https://fake-app.gadget.app" }));
+    let recordList = GadgetRecordList.boot(modelManager, [], { pageInfo: pages[startIndex], options: { first: 10 } });
+    jest.spyOn(modelManager, "findMany").mockImplementation(async (options) => {
+      if (!options) {
+        throw new Error("Expected options to be defined");
+      }
+
+      if (options.before || options.last) {
+        expect(options.after).toBeUndefined();
+        expect(options.first).toBeUndefined();
+      } else {
+        expect(options.before).toBeUndefined();
+        expect(options.last).toBeUndefined();
+      }
+      return GadgetRecordList.boot(modelManager, [], { options, pageInfo: pages[options.first ? ++startIndex : --startIndex] });
+    });
+
+    recordList = await recordList.nextPage();
+    recordList = await recordList.nextPage();
+    recordList = await recordList.nextPage();
+    recordList = await recordList.previousPage();
+    recordList = await recordList.previousPage();
+    recordList = await recordList.nextPage();
+    recordList = await recordList.previousPage();
+
+    await recordList.previousPage();
+  });
+
+  test("throws if paging backward is not possible", async () => {
+    const modelManager = new InternalModelManager("foo", new GadgetConnection({ endpoint: "https://fake-app.gadget.app" }));
+    const recordList = GadgetRecordList.boot(modelManager, [], { pageInfo: pages[0], options: { first: 10 } });
+
+    await expect(recordList.previousPage()).rejects.toThrow(
+      "Cannot request previous page because there isn't one, should check 'hasPreviousPage' to see if it exists"
+    );
+  });
+
+  test("throws if paging forward is not possible", async () => {
+    const modelManager = new InternalModelManager("foo", new GadgetConnection({ endpoint: "https://fake-app.gadget.app" }));
+    const recordList = GadgetRecordList.boot(modelManager, [], { pageInfo: pages[3], options: { last: 10 } });
+
+    await expect(recordList.nextPage()).rejects.toThrow(
+      "Cannot request next page because there isn't one, should check 'hasNextPage' to see if it exists"
+    );
+  });
+});

--- a/packages/api-client-core/src/GadgetRecordList.ts
+++ b/packages/api-client-core/src/GadgetRecordList.ts
@@ -64,10 +64,12 @@ export class GadgetRecordList<Shape extends RecordShape> extends Array<GadgetRec
   async nextPage() {
     if (!this.hasNextPage)
       throw new GadgetClientError("Cannot request next page because there isn't one, should check 'hasNextPage' to see if it exists");
+    // Our current implementation of paging determines paging direction based on if "first" is defined. We can pass both "before" and "after" as options but only after is respected if first is sent. One of "before" or "after" is ignored depending on whether "first" is defined.
+    const { first, last, before: _before, ...options } = this.pagination.options ?? {};
     const nextPage = this.modelManager.findMany({
-      ...this.pagination.options,
+      ...options,
       after: this.pagination.pageInfo.endCursor,
-      first: this.pagination.options?.first || this.pagination.options?.last,
+      first: first || last,
     }) as Promise<GadgetRecordList<Shape>>;
     return await nextPage;
   }
@@ -77,10 +79,12 @@ export class GadgetRecordList<Shape extends RecordShape> extends Array<GadgetRec
       throw new GadgetClientError(
         "Cannot request previous page because there isn't one, should check 'hasPreviousPage' to see if it exists"
       );
+    // Our current implementation of paging determines paging direction based on if "first" is defined. We can pass both "before" and "after" as options but only after is respected if first is sent. One of "before" or "after" is ignored depending on whether "first" is defined.
+    const { first, last, after: _after, ...options } = this.pagination.options ?? {};
     const prevPage = this.modelManager.findMany({
-      ...this.pagination.options,
+      ...options,
       before: this.pagination.pageInfo.startCursor,
-      last: this.pagination.options?.last || this.pagination.options?.first,
+      last: last || first,
     }) as Promise<GadgetRecordList<Shape>>;
     return await prevPage;
   }


### PR DESCRIPTION
Currently if using `nextPage` or `previousPage` we pass either `last` or `first` depending one which way we're paging. This causes issues if `first` or `last` was originally passed as a parameter to fetch the first result set. E.g. if we passed `first: 10` then when we page backwards we send `first: 10, last: 10`, this repeats once we page forward again since we always boot the record list with parameters it was fetched with.

The above works fine when we page backwards but always returns the same page once we try to page forward again.

Will bump version when this gets merged

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
