### PR TITLE
Adds a specific error for timeouts opening a websocket connection to …

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -15,7 +15,13 @@ import type { AuthenticationModeOptions, BrowserSessionAuthenticationModeOptions
 import { BrowserSessionStorageType } from "./ClientOptions";
 import { GadgetTransaction, TransactionRolledBack } from "./GadgetTransaction";
 import { BrowserStorage, InMemoryStorage } from "./InMemoryStorage";
-import { GadgetUnexpectedCloseError, isCloseEvent, storageAvailable, traceFunction } from "./support";
+import {
+  GadgetUnexpectedCloseError,
+  GadgetWebsocketConnectionTimeoutError,
+  isCloseEvent,
+  storageAvailable,
+  traceFunction,
+} from "./support";
 
 export type TransactionRun<T> = (transaction: GadgetTransaction) => Promise<T>;
 export interface GadgetSubscriptionClientOptions extends Partial<SubscriptionClientOptions> {
@@ -394,7 +400,7 @@ export class GadgetConnection {
     return await new Promise<SubscriptionClient>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.disposeClient(subscriptionClient);
-        wrappedReject(new Error("Timeout opening websocket connection to Gadget API"));
+        wrappedReject(new GadgetWebsocketConnectionTimeoutError("Timeout opening websocket connection to Gadget API"));
       }, globalTimeout);
 
       const retryOnClose = (event: unknown) => {

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -66,6 +66,19 @@ export class GadgetUnexpectedCloseError extends Error {
 }
 
 /**
+ * A client error when the client times out waiting for the Gadget API to open websocket connection.
+ */
+export class GadgetWebsocketConnectionTimeoutError extends Error {
+  code = "GGT_WEBSOCKET_CONNECTION_TIMEOUT";
+  name = "WebsocketConnectionTimeoutError";
+
+  /** @private */
+  statusCode = 500;
+  /** @private */
+  causedByClient = false;
+}
+
+/**
  * A Gadget API error representing a backend validation error on the input data for an action. Thrown when any of the validations configured on a model fail for the given input data. Has a `validationErrors` property describing which fields failed validation, with messages for each.
  **/
 export class InvalidRecordError extends Error {
@@ -137,7 +150,8 @@ export type GadgetError =
   | InvalidRecordError
   | GadgetNonUniqueDataError
   | GadgetNotFoundError
-  | GadgetUnexpectedCloseError;
+  | GadgetUnexpectedCloseError
+  | GadgetWebsocketConnectionTimeoutError;
 
 export function assert<T>(value: T | undefined | null, message?: string): T {
   if (!value) {

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.12.1",
+    "@gadgetinc/api-client-core": "^0.13.0",
     "@shopify/app-bridge-utils": "^3.1.1",
     "crypto-js": "^4.1.1",
     "lodash": "^4.17.21"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.12.1",
+    "@gadgetinc/api-client-core": "^0.13.0",
     "deep-equal": "^2.2.0",
     "urql": "^3.0.3"
   },


### PR DESCRIPTION
Adds a dedicated error for timeouts opening a websocket connection to the gadget API, and marks these errors as not caused by the client.

## PR Checklist

- [x] Important or complicated code is tested
- [x] Any user facing changes are documented in the Gadget-side changelog
- [x] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [x] Versions within this monorepo are matching and there's a valid upgrade path
