### PR TITLE
Minor versions of react and react-shopify-app-bridge packages

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -37,7 +37,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@gadgetinc/react": "^0.10.0",
+    "@gadgetinc/react": "^0.11.0",
     "@shopify/app-bridge-react": "^2.0.0 || ^3.0.0",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
We released `0.13.0` of `api-client-core` and updated it in Gagdet's userland deps. This means new clients are generated with `^0.13.0` dependency and no longer resolves to the same version listed under `react` and `react-shopify-app-bridge` (`^0.12.0`). Since we're `<1.0.0`, semver `^0.12.0` only matches the patch version and not the minor version.

Tested locally by installing the current version of client and `react-shopify-app-bridge` which results in the error. Then building a local version with `0.13.0` as the dependency and the error goes away. I updated minor versions for these since `api-client-core` was updated a minor version as well.

closes GGT-3639

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
