### PR TITLE
Change default provider's loading value to true

### DIFF
--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -47,7 +47,7 @@ const InnerGadgetProvider = memo(
       isAuthenticated: false,
       isEmbedded: false,
       canAuth: false,
-      loading: false,
+      loading: true,
       appBridge,
       isRootFrameRequest: false,
     });

--- a/packages/react-shopify-app-bridge/src/context.ts
+++ b/packages/react-shopify-app-bridge/src/context.ts
@@ -22,7 +22,7 @@ export type GadgetAuthContextValue = {
 };
 
 export const GadgetAuthContext = createContext<GadgetAuthContextValue>({
-  loading: false,
+  loading: true,
   isEmbedded: false,
   isAuthenticated: false,
   canAuth: false,


### PR DESCRIPTION
Since OAuth and any other requests that set this `loading` value are executed almost instantly, setting the default value to false will make components that rely on this value flashes in the first render.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
