### PR TITLE
Ensure the react hooks return objects with the same identity if nothing changes on rerender

### DIFF
--- a/packages/react/spec/useAction.spec.ts
+++ b/packages/react/spec/useAction.spec.ts
@@ -159,4 +159,113 @@ describe("useAction", () => {
     `);
     expect(result.current[0].data).toBeFalsy();
   });
+
+  test("returns the same data after executing the mutation and rerendering", async () => {
+    const { result, rerender } = renderHook(() => useAction(relatedProductsApi.user.update), { wrapper: TestWrapper });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } });
+    });
+
+    expect(mockClient.executeMutation).toBeCalledTimes(1);
+
+    mockClient.executeMutation.pushResponse("updateUser", {
+      data: {
+        updateUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "test@test.com",
+          },
+        },
+      },
+    });
+
+    await act(async () => {
+      await mutationPromise;
+    });
+
+    const beforeObject = result.current[0]!;
+    expect(beforeObject).toBeTruthy();
+
+    rerender();
+
+    expect(result.current[0]).toBe(beforeObject);
+  });
+
+  test("returns a second mutation response if called a second time", async () => {
+    const { result } = renderHook(() => useAction(relatedProductsApi.user.update), { wrapper: TestWrapper });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } });
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockClient.executeMutation).toBeCalledTimes(1);
+
+    mockClient.executeMutation.pushResponse("updateUser", {
+      data: {
+        updateUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "test@test.com",
+          },
+        },
+      },
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data!.id).toEqual("123");
+      expect(promiseResult.data!.email).toEqual("test@test.com");
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeFalsy();
+    });
+
+    expect(result.current[0].data!.id).toEqual("123");
+    expect(result.current[0].data!.email).toEqual("test@test.com");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    act(() => {
+      mutationPromise = result.current[1]({ id: "456", user: { email: "another@test.com" } });
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockClient.executeMutation).toBeCalledTimes(2);
+
+    mockClient.executeMutation.pushResponse("updateUser", {
+      data: {
+        updateUser: {
+          success: true,
+          user: {
+            id: "456",
+            email: "another@test.com",
+          },
+        },
+      },
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data!.id).toEqual("456");
+      expect(promiseResult.data!.email).toEqual("another@test.com");
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeFalsy();
+    });
+
+    expect(result.current[0].data!.id).toEqual("456");
+    expect(result.current[0].data!.email).toEqual("another@test.com");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
 });

--- a/packages/react/spec/useBulkAction.spec.ts
+++ b/packages/react/spec/useBulkAction.spec.ts
@@ -145,4 +145,40 @@ describe("useBulkAction", () => {
     expect(error).toBeTruthy();
     expect(result.current[0].data).toBeFalsy();
   });
+
+  test("returns the same data on successive rerenders after a mutation", async () => {
+    const { result, rerender } = renderHook(() => useBulkAction(bulkExampleApi.widget.bulkFlipDown), { wrapper: TestWrapper });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ ids: ["123", "124"] });
+    });
+
+    expect(mockClient.executeMutation).toBeCalledTimes(1);
+
+    mockClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
+      data: {
+        bulkFlipDownWidgets: {
+          success: true,
+          widgets: [
+            {
+              id: "123",
+            },
+            { id: "124" },
+          ],
+        },
+      },
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+    });
+
+    const beforeObject = result.current[0];
+
+    // rerender
+    rerender();
+
+    expect(result.current[0]).toBe(beforeObject);
+  });
 });

--- a/packages/react/spec/useFindBy.spec.ts
+++ b/packages/react/spec/useFindBy.spec.ts
@@ -94,4 +94,33 @@ describe("useFindBy", () => {
     expect(error).toBeTruthy();
     expect(error!.message).toMatchInlineSnapshot(`"[GraphQL] user record with email=test@test.com not found"`);
   });
+
+  test("returns the same data object on rerender", async () => {
+    const { result, rerender } = renderHook(() => useFindBy(relatedProductsApi.user.findByEmail, "test@test.com"), {
+      wrapper: TestWrapper,
+    });
+
+    expect(mockClient.executeQuery).toBeCalledTimes(1);
+
+    mockClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],
+          pageInfo: {
+            startCursor: "123",
+            endCursor: "123",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+    });
+
+    const data = result.current[0].data;
+    expect(data).toBeTruthy();
+
+    rerender();
+
+    expect(result.current[0].data).toBe(data);
+  });
 });

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -166,4 +166,37 @@ describe("useFindMany", () => {
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].error).toBeFalsy();
   });
+
+  test("returns the same data object on rerender if nothing changes about the result", async () => {
+    const { result, rerender } = renderHook(() => useFindMany(relatedProductsApi.user), { wrapper: TestWrapper });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockClient.executeQuery).toBeCalledTimes(1);
+
+    mockClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [
+            { cursor: "123", node: { id: "123", email: "test@test.com" } },
+            { cursor: "abc", node: { id: "124", email: "test@test.com" } },
+          ],
+          pageInfo: {
+            startCursor: "123",
+            endCursor: "abc",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+    });
+
+    const beforeObject = result.current[0];
+
+    rerender();
+
+    expect(result.current[0]).toBe(beforeObject);
+  });
 });

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -59,7 +59,7 @@ describe("useFindOne", () => {
   });
 
   test("returns an error if the record isn't found", async () => {
-    const { result } = renderHook(() => useFindOne(relatedProductsApi.user, "123"), { wrapper: TestWrapper });
+    const { result, rerender } = renderHook(() => useFindOne(relatedProductsApi.user, "123"), { wrapper: TestWrapper });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
@@ -78,5 +78,31 @@ describe("useFindOne", () => {
     const error = result.current[0].error;
     expect(error).toBeTruthy();
     expect(error!.message).toMatchInlineSnapshot(`"[GraphQL] Internal Error: Gadget API returned no data at user"`);
+
+    // ensure the error is the same after rerendering
+    rerender();
+
+    expect(result.current[0].error).toBe(error);
+  });
+
+  test("returns the same data on rerender", async () => {
+    const { result, rerender } = renderHook(() => useFindOne(relatedProductsApi.user, "123"), { wrapper: TestWrapper });
+
+    expect(mockClient.executeQuery).toBeCalledTimes(1);
+
+    mockClient.executeQuery.pushResponse("user", {
+      data: {
+        user: {
+          id: "123",
+          email: "test@test.com",
+        },
+      },
+    });
+
+    const beforeObject = result.current[0];
+
+    rerender();
+
+    expect(result.current[0]).toBe(beforeObject);
   });
 });

--- a/packages/react/spec/useGet.spec.ts
+++ b/packages/react/spec/useGet.spec.ts
@@ -75,4 +75,24 @@ describe("useGet", () => {
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].error).toBeFalsy();
   });
+
+  test("it returns the same data on rerender", async () => {
+    const { result, rerender } = renderHook(() => useGet(relatedProductsApi.currentSession), { wrapper: TestWrapper });
+
+    expect(mockClient.executeQuery).toBeCalledTimes(1);
+
+    mockClient.executeQuery.pushResponse("currentSession", {
+      data: {
+        currentSession: {
+          id: "123",
+        },
+      },
+    });
+
+    const beforeObject = result.current[0];
+
+    rerender();
+
+    expect(result.current[0]).toBe(beforeObject);
+  });
 });

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -48,16 +48,19 @@ describe("useGlobalAction", () => {
       data: {
         flipAll: {
           success: true,
+          result: { flipped: true },
         },
       },
     });
 
     await act(async () => {
       const promiseResult = await mutationPromise;
+      expect(promiseResult.data).toEqual({ flipped: true });
       expect(promiseResult.fetching).toBe(false);
       expect(promiseResult.error).toBeFalsy();
     });
 
+    expect(result.current[0].data).toEqual({ flipped: true });
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].error).toBeFalsy();
   });
@@ -99,5 +102,35 @@ describe("useGlobalAction", () => {
     expect(result.current[0].fetching).toBe(false);
     const error = result.current[0].error;
     expect(error).toBeTruthy();
+  });
+
+  test("returns the same data after executing the mutation and rerendering", async () => {
+    const { result, rerender } = renderHook(() => useGlobalAction(bulkExampleApi.flipAll), { wrapper: TestWrapper });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ why: "foobar" });
+    });
+
+    expect(mockClient.executeMutation).toBeCalledTimes(1);
+
+    mockClient.executeMutation.pushResponse("flipAll", {
+      data: {
+        flipAll: {
+          success: true,
+          result: { flipped: true },
+        },
+      },
+    });
+
+    await act(async () => {
+      await mutationPromise;
+    });
+
+    const beforeObject = result.current[0];
+
+    rerender();
+
+    expect(result.current[0]).toBe(beforeObject);
   });
 });

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -81,8 +81,10 @@ export const useAction = <
     F["variablesType"]
   >(plan.query);
 
+  const transformedResult = useMemo(() => processResult(result, action), [result, action]);
+
   return [
-    processResult(result, action),
+    transformedResult,
     useCallback(
       async (variables, context) => {
         // Adding the model's additional typename ensures document cache will properly refresh, regardless of whether __typename was

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -75,8 +75,10 @@ export const useBulkAction = <
     F["variablesType"]
   >(plan.query);
 
+  const transformedResult = useMemo(() => processResult(result, action), [result, action]);
+
   return [
-    processResult(result, action),
+    transformedResult,
     useCallback(
       async (variables, context) => {
         // Adding the model's additional typename ensures document cache will properly refresh, regardless of whether __typename was

--- a/packages/react/src/useFindFirst.ts
+++ b/packages/react/src/useFindFirst.ts
@@ -62,19 +62,24 @@ export const useFindFirst = <
     );
   }, [manager, memoizedOptions]);
 
-  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, firstOptions));
+  const [rawResult, refresh] = useGadgetQuery(getQueryArgs(plan, firstOptions));
 
-  const dataPath = [manager.findFirst.operationName];
-  let data = result.data;
-  if (data) {
-    const connection = get(result.data, dataPath);
-    if (connection) {
-      data = hydrateConnection(result, connection)[0];
-    } else {
-      data = data[0];
+  const result = useMemo(() => {
+    const dataPath = [manager.findFirst.operationName];
+    let data = rawResult.data;
+    if (data) {
+      const connection = get(rawResult.data, dataPath);
+      if (connection) {
+        data = hydrateConnection(rawResult, connection)[0];
+      } else {
+        data = data[0];
+      }
     }
-  }
 
-  const error = ErrorWrapper.errorIfDataAbsent(result, dataPath);
-  return [{ ...result, data, error }, refresh];
+    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath);
+
+    return { ...rawResult, data, error };
+  }, [manager, rawResult]);
+
+  return [result, refresh];
 };

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -62,19 +62,23 @@ export const useFindMany = <
     );
   }, [manager, memoizedOptions]);
 
-  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, options));
+  const [rawResult, refresh] = useGadgetQuery(getQueryArgs(plan, options));
 
-  const dataPath = [manager.findMany.operationName];
-  let data = result.data;
-  if (data) {
-    const connection = get(result.data, dataPath);
-    if (connection) {
-      const records = hydrateConnection(result, connection);
-      data = GadgetRecordList.boot(manager as unknown as AnyModelManager, records, connection);
+  const result = useMemo(() => {
+    const dataPath = [manager.findMany.operationName];
+    let data = rawResult.data;
+    if (data) {
+      const connection = get(rawResult.data, dataPath);
+      if (connection) {
+        const records = hydrateConnection(rawResult, connection);
+        data = GadgetRecordList.boot(manager as unknown as AnyModelManager, records, connection);
+      }
     }
-  }
 
-  const error = ErrorWrapper.errorIfDataAbsent(result, dataPath);
+    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath);
 
-  return [{ ...result, data, error }, refresh];
+    return { ...rawResult, data, error };
+  }, [manager, rawResult]);
+
+  return [result, refresh];
 };

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -63,14 +63,18 @@ export const useFindOne = <
     );
   }, [manager, id, memoizedOptions]);
 
-  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, options));
+  const [rawResult, refresh] = useGadgetQuery(getQueryArgs(plan, options));
 
-  const dataPath = [manager.findOne.operationName];
-  let data = result.data && get(result.data, dataPath);
-  if (data) {
-    data = hydrateRecord(result, data);
-  }
-  const error = ErrorWrapper.errorIfDataAbsent(result, dataPath);
+  const result = useMemo(() => {
+    const dataPath = [manager.findOne.operationName];
+    let data = rawResult.data && get(rawResult.data, dataPath);
+    if (data) {
+      data = hydrateRecord(rawResult, data);
+    }
+    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath);
 
-  return [{ ...result, data, error }, refresh];
+    return { ...rawResult, data, error };
+  }, [rawResult, manager]);
+
+  return [result, refresh];
 };

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -60,20 +60,22 @@ export const useGet = <
     );
   }, [manager, memoizedOptions]);
 
-  const [result, refresh] = useGadgetQuery({ query: plan.query, variables: plan.variables });
+  const [rawResult, refresh] = useGadgetQuery({ query: plan.query, variables: plan.variables });
 
-  let data = null;
-  const rawRecord = result.data && get(result.data, [manager.get.operationName]);
-  if (rawRecord) {
-    data = hydrateRecord(result, rawRecord);
-  }
+  const result = useMemo(() => {
+    let data = null;
+    const rawRecord = rawResult.data && get(rawResult.data, [manager.get.operationName]);
+    if (rawRecord) {
+      data = hydrateRecord(rawResult, rawRecord);
+    }
+    const error = ErrorWrapper.forMaybeCombinedError(rawResult.error);
 
-  return [
-    {
-      ...result,
-      error: ErrorWrapper.forMaybeCombinedError(result.error),
+    return {
+      ...rawResult,
+      error,
       data,
-    },
-    refresh,
-  ];
+    };
+  }, [rawResult, manager]);
+
+  return [result, refresh];
 };

--- a/packages/react/src/useGlobalAction.ts
+++ b/packages/react/src/useGlobalAction.ts
@@ -34,8 +34,10 @@ export const useGlobalAction = <F extends GlobalActionFunction<any>>(
 
   const [result, runMutation] = useGadgetMutation<any, F["variablesType"]>(plan.query);
 
+  const transformedResult = useMemo(() => processResult(result, action), [result, action]);
+
   return [
-    processResult(result, action),
+    transformedResult,
     useCallback(
       async (variables, context) => {
         const result = await runMutation(variables, context);
@@ -53,6 +55,7 @@ const processResult = (result: UseMutationState<any, any>, action: GlobalActionF
     data = get(result.data, [action.operationName]);
     if (data) {
       const errors = data.errors;
+      data = data.result;
       if (errors && errors[0]) {
         error = ErrorWrapper.forErrorsResponse(errors);
       }

--- a/packages/react/src/useMaybeFindFirst.ts
+++ b/packages/react/src/useMaybeFindFirst.ts
@@ -62,25 +62,28 @@ export const useMaybeFindFirst = <
     );
   }, [manager, memoizedOptions]);
 
-  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, firstOptions));
+  const [rawResult, refresh] = useGadgetQuery(getQueryArgs(plan, firstOptions));
 
-  const dataPath = [manager.findFirst.operationName];
-  let data = result.data ?? null;
-  if (data) {
-    const connection = get(result.data, dataPath);
-    if (connection) {
-      data = hydrateConnection(result, connection)[0] ?? null;
-    } else {
-      data = data[0] ?? null;
+  const result = useMemo(() => {
+    const dataPath = [manager.findFirst.operationName];
+    let data = rawResult.data ?? null;
+    if (data) {
+      const connection = get(rawResult.data, dataPath);
+      if (connection) {
+        data = hydrateConnection(rawResult, connection)[0] ?? null;
+      } else {
+        data = data[0] ?? null;
+      }
     }
-  }
 
-  return [
-    {
-      ...result,
-      error: ErrorWrapper.forMaybeCombinedError(result.error),
+    const error = ErrorWrapper.forMaybeCombinedError(rawResult.error);
+
+    return {
+      ...rawResult,
+      error,
       data,
-    },
-    refresh,
-  ];
+    };
+  }, [rawResult, manager]);
+
+  return [result, refresh];
 };

--- a/packages/react/src/useMaybeFindOne.ts
+++ b/packages/react/src/useMaybeFindOne.ts
@@ -63,20 +63,21 @@ export const useMaybeFindOne = <
     );
   }, [manager, id, memoizedOptions]);
 
-  const [result, refresh] = useGadgetQuery(getQueryArgs(plan, options));
+  const [rawResult, refresh] = useGadgetQuery(getQueryArgs(plan, options));
 
-  let data = result.data ?? null;
-  if (data) {
-    const value = get(result.data, [manager.findOne.operationName]);
-    data = value && "id" in value ? hydrateRecord(result, value) : null;
-  }
-
-  return [
-    {
-      ...result,
-      error: ErrorWrapper.forMaybeCombinedError(result.error),
+  const result = useMemo(() => {
+    let data = rawResult.data ?? null;
+    if (data) {
+      const value = get(rawResult.data, [manager.findOne.operationName]);
+      data = value && "id" in value ? hydrateRecord(rawResult, value) : null;
+    }
+    const error = ErrorWrapper.forMaybeCombinedError(rawResult.error);
+    return {
+      ...rawResult,
+      error,
       data,
-    },
-    refresh,
-  ];
+    };
+  }, [rawResult, manager]);
+
+  return [result, refresh];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,7 +549,7 @@
     "@gadgetinc/api-client-core" "0.9.0"
 
 "@gadgetinc/api-client-core@0.11.0":
-  version "0.13.0"
+  version "0.13.3"
   dependencies:
     "@opentelemetry/api" "^1.4.0"
     "@urql/core" "^3.0.1"
@@ -564,22 +564,7 @@
     ws "^8.11.0"
 
 "@gadgetinc/api-client-core@0.9.0":
-  version "0.13.0"
-  dependencies:
-    "@opentelemetry/api" "^1.4.0"
-    "@urql/core" "^3.0.1"
-    "@urql/exchange-multipart-fetch" "^1.0.1"
-    cross-fetch "^3.0.6"
-    gql-query-builder "^3.7.2"
-    graphql "^16.5.0"
-    graphql-ws "^5.5.5"
-    isomorphic-ws "^4.0.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    ws "^8.11.0"
-
-"@gadgetinc/api-client-core@^0.12.0":
-  version "0.13.0"
+  version "0.13.3"
   dependencies:
     "@opentelemetry/api" "^1.4.0"
     "@urql/core" "^3.0.1"
@@ -620,12 +605,10 @@
     prettier-plugin-organize-imports "^1.0.4"
 
 "@gadgetinc/react@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@gadgetinc/react/-/react-0.10.0.tgz#08dbf4c059619bbffe6da5688cdd2a419886ed92"
-  integrity sha512-sPoy4/6X73WjcmDvjR15TjQazFilhAwgfoBEM5U7hruMJjA30Oi5YEetxLXua9ZxSJUURJU6PJgvK0HwK+24Hw==
+  version "0.11.0"
   dependencies:
-    "@gadgetinc/api-client-core" "^0.12.0"
-    deep-equal "^2.0.5"
+    "@gadgetinc/api-client-core" "^0.13.0"
+    deep-equal "^2.2.0"
     urql "^3.0.3"
 
 "@graphql-typed-document-node/core@^3.1.1":
@@ -2143,7 +2126,7 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-equal@^2.0.5, deep-equal@^2.2.0:
+deep-equal@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.0.tgz#5caeace9c781028b9ff459f33b779346637c43e6"
   integrity sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==


### PR DESCRIPTION
urql takes great care to ensure that if your component rerenders and calls `useQuery` again, but nothing about the query has changed, you get back the same object. This is so that if you use that object in a dependencies array, it's identity is stable and react won't expire memos or re-run useEffects.

Prior to this change, we didn't keep this same property. If you wrote code like this:

```javascript
const [{ data, fetching, error}] = useFindFirst(api.someModel);
const [something, setSomething] = useState(null)

useEffect(() => {
    setSomething(data)
}, [data]);
```

You'd accidentally get an infinite loop because the useEffect would trigger a rerender because it called setstate, which would rerun our react hook, which would return new data, which would be passed to the array of dependencies for use effect, which would trigger it to rerun, etc.

Instead, let's keep the same property that urql has, which is that you only get a new result object when something about the result changes.
