### PR TITLE
Upgrade to urql v4 under the hood

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -20,16 +20,15 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.4.0",
-    "@urql/core": "^3.0.1",
-    "@urql/exchange-multipart-fetch": "^1.0.1",
-    "cross-fetch": "^3.0.6",
+    "@urql/core": "^4.0.10",
+    "cross-fetch": "^3.1.5",
     "gql-query-builder": "^3.7.2",
     "graphql": "~16.6.0",
-    "graphql-ws": "^5.5.5",
-    "isomorphic-ws": "^4.0.1",
+    "graphql-ws": "^5.13.1",
+    "isomorphic-ws": "^5.0.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
-    "ws": "^8.11.0"
+    "ws": "^8.13.0"
   },
   "devDependencies": {
     "@types/lodash.clonedeep": "^4.5.6",

--- a/packages/api-client-core/spec/support.spec.ts
+++ b/packages/api-client-core/spec/support.spec.ts
@@ -16,6 +16,8 @@ describe("support utilities", () => {
           {
             operation: null as any,
             data: { foo: { bar: "baz" } },
+            stale: false,
+            hasNext: false,
           },
           ["foo", "bar"]
         )
@@ -29,6 +31,8 @@ describe("support utilities", () => {
             operation: null as any,
             data: null,
             error: new CombinedError({ networkError: new Error("foobar") }),
+            stale: false,
+            hasNext: false,
           },
 
           ["foo", "bar"]
@@ -43,6 +47,8 @@ describe("support utilities", () => {
             operation: null as any,
             data: null,
             error: new CombinedError({ networkError: new Error("foobar") }),
+            stale: false,
+            hasNext: false,
           },
 
           ["foo", "bar"]
@@ -60,6 +66,8 @@ describe("support utilities", () => {
             data: null,
             // @ts-expect-error an array of network errors doesn't match urql's types, but we've observed it at runtime
             error: new CombinedError({ networkError: [new Error("foo"), new Error("foo")] }),
+            stale: false,
+            hasNext: false,
           },
 
           ["foo", "bar"]
@@ -77,6 +85,8 @@ describe("support utilities", () => {
             operation: null as any,
             data: null,
             error: new CombinedError({ graphQLErrors: [new Error("foo")] }),
+            stale: false,
+            hasNext: false,
           },
 
           ["foo", "bar"]
@@ -91,6 +101,8 @@ describe("support utilities", () => {
             operation: null as any,
             data: null,
             error: new CombinedError({ graphQLErrors: [new Error("foo"), "bar"] }),
+            stale: false,
+            hasNext: false,
           },
 
           ["foo", "bar"]
@@ -108,6 +120,8 @@ describe("support utilities", () => {
             operation: null as any,
             data: null,
             error: new CombinedError({ graphQLErrors: [new GraphQLError("inner graphql error")] }),
+            stale: false,
+            hasNext: false,
           },
 
           ["foo", "bar"]
@@ -122,6 +136,8 @@ describe("support utilities", () => {
             operation: null as any,
             data: null,
             error: new CombinedError({ response: { whatever: true } }),
+            stale: false,
+            hasNext: false,
           },
 
           ["foo", "bar"]
@@ -138,6 +154,8 @@ describe("support utilities", () => {
             operation: null as any,
             data: null,
             error: new CombinedError({ graphQLErrors: [new GraphQLError("inner graphql error")] }),
+            stale: false,
+            hasNext: false,
           },
           ["foo", "bar"]
         )
@@ -150,6 +168,8 @@ describe("support utilities", () => {
           operation: null as any,
           data: undefined,
           error: undefined,
+          stale: false,
+          hasNext: false,
         },
         ["foo", "bar"]
       );
@@ -194,6 +214,8 @@ describe("support utilities", () => {
           {
             operation: null as any,
             data: { createWidget: { success: true, errors: null, widget: { bar: "baz" } } },
+            stale: false,
+            hasNext: false,
           },
           ["createWidget"]
         )
@@ -212,6 +234,8 @@ describe("support utilities", () => {
                 widget: null,
               },
             },
+            stale: false,
+            hasNext: false,
           },
 
           ["createWidget"]
@@ -231,6 +255,8 @@ describe("support utilities", () => {
                 widget: null,
               },
             },
+            stale: false,
+            hasNext: false,
           },
 
           ["createWidget"]
@@ -266,6 +292,8 @@ describe("support utilities", () => {
                 widget: null,
               },
             },
+            stale: false,
+            hasNext: false,
           },
           ["createWidget"]
         );
@@ -302,6 +330,8 @@ describe("support utilities", () => {
                 widget: null,
               },
             },
+            stale: false,
+            hasNext: false,
           },
           ["createWidget"]
         );

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -19,9 +19,9 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.13.10",
+    "@gadgetinc/api-client-core": "^0.13.14",
     "deep-equal": "^2.2.0",
-    "urql": "^3.0.3"
+    "urql": "^4.0.4"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",
@@ -30,7 +30,7 @@
     "@types/lodash": "^4.14.191",
     "@types/react": "^18.2.9",
     "@types/react-dom": "^18.2.4",
-    "@urql/core": "^3.0.1",
+    "@urql/core": "^4.0.10",
     "conditional-type-checks": "^1.0.6",
     "graphql": "16.5.0",
     "lodash": "^4.17.21",

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -121,6 +121,8 @@ describe("useAction", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -173,6 +175,8 @@ describe("useAction", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -216,6 +220,8 @@ describe("useAction", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -254,6 +260,8 @@ describe("useAction", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -289,6 +297,8 @@ describe("useAction", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -336,6 +346,8 @@ describe("useAction", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -364,6 +376,8 @@ describe("useAction", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {

--- a/packages/react/spec/useBulkAction.spec.ts
+++ b/packages/react/spec/useBulkAction.spec.ts
@@ -84,6 +84,8 @@ describe("useBulkAction", () => {
           ],
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -132,6 +134,8 @@ describe("useBulkAction", () => {
           widgets: null,
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -169,6 +173,8 @@ describe("useBulkAction", () => {
           ],
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {

--- a/packages/react/spec/useFindBy.spec.ts
+++ b/packages/react/spec/useFindBy.spec.ts
@@ -58,6 +58,8 @@ describe("useFindBy", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data!.id).toEqual("123");
@@ -87,6 +89,8 @@ describe("useFindBy", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data).toBeFalsy();
@@ -115,6 +119,8 @@ describe("useFindBy", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     const data = result.current[0].data;

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -57,6 +57,8 @@ describe("useFindMany", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data![0].id).toEqual("123");
@@ -96,6 +98,8 @@ describe("useFindMany", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data![0].id).toEqual("123");
@@ -130,6 +134,8 @@ describe("useFindMany", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data![0].id).toEqual("def");
@@ -161,6 +167,8 @@ describe("useFindMany", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data!.length).toEqual(0);
@@ -192,6 +200,8 @@ describe("useFindMany", () => {
           },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     const beforeObject = result.current[0];

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -51,6 +51,8 @@ describe("useFindOne", () => {
           email: "test@test.com",
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data!.id).toEqual("123");
@@ -72,6 +74,8 @@ describe("useFindOne", () => {
       data: {
         user: null,
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data).toBeFalsy();
@@ -98,6 +102,8 @@ describe("useFindOne", () => {
           email: "test@test.com",
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     const beforeObject = result.current[0];

--- a/packages/react/spec/useGet.spec.ts
+++ b/packages/react/spec/useGet.spec.ts
@@ -50,6 +50,8 @@ describe("useGet", () => {
           id: "123",
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data!.id).toEqual("123");
@@ -70,6 +72,8 @@ describe("useGet", () => {
       data: {
         currentSession: null,
       },
+      stale: false,
+      hasNext: false,
     });
 
     expect(result.current[0].data).toBe(null);
@@ -88,6 +92,8 @@ describe("useGet", () => {
           id: "123",
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     const beforeObject = result.current[0];

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -52,6 +52,8 @@ describe("useGlobalAction", () => {
           result: { flipped: true },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -92,6 +94,8 @@ describe("useGlobalAction", () => {
           ],
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {
@@ -122,6 +126,8 @@ describe("useGlobalAction", () => {
           result: { flipped: true },
         },
       },
+      stale: false,
+      hasNext: false,
     });
 
     await act(async () => {

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -119,7 +119,7 @@ export const useAction = <
           ...context,
           additionalTypenames: [...(context?.additionalTypenames ?? []), capitalizeIdentifier(action.modelApiIdentifier)],
         });
-        return processResult({ fetching: false, stale: false, ...result }, action);
+        return processResult({ fetching: false, ...result }, action);
       },
       [action, runMutation]
     ),

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -79,7 +79,7 @@ export const useBulkAction = <
           ...context,
           additionalTypenames: [...(context?.additionalTypenames ?? []), capitalizeIdentifier(action.modelApiIdentifier)],
         });
-        return processResult({ fetching: false, stale: false, ...result }, action);
+        return processResult({ fetching: false, ...result }, action);
       },
       [action, runMutation]
     ),

--- a/packages/react/src/useGlobalAction.ts
+++ b/packages/react/src/useGlobalAction.ts
@@ -43,7 +43,7 @@ export const useGlobalAction = <F extends GlobalActionFunction<any>>(
     useCallback(
       async (variables, context) => {
         const result = await runMutation(variables, context);
-        return processResult({ fetching: false, stale: false, ...result }, action);
+        return processResult({ fetching: false, ...result }, action);
       },
       [action, runMutation]
     ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,13 +88,10 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@urql/core':
-        specifier: ^3.0.1
-        version: 3.0.1(graphql@16.6.0)
-      '@urql/exchange-multipart-fetch':
-        specifier: ^1.0.1
-        version: 1.0.1(graphql@16.6.0)
+        specifier: ^4.0.10
+        version: 4.0.10(graphql@16.6.0)
       cross-fetch:
-        specifier: ^3.0.6
+        specifier: ^3.1.5
         version: 3.1.5
       gql-query-builder:
         specifier: ^3.7.2
@@ -103,11 +100,11 @@ importers:
         specifier: ~16.6.0
         version: 16.6.0
       graphql-ws:
-        specifier: ^5.5.5
-        version: 5.8.2(graphql@16.6.0)
+        specifier: ^5.13.1
+        version: 5.13.1(graphql@16.6.0)
       isomorphic-ws:
-        specifier: ^4.0.1
-        version: 4.0.1(ws@8.11.0)
+        specifier: ^5.0.0
+        version: 5.0.0(ws@8.13.0)
       lodash.clonedeep:
         specifier: ^4.5.0
         version: 4.5.0
@@ -115,8 +112,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
       ws:
-        specifier: ^8.11.0
-        version: 8.11.0
+        specifier: ^8.13.0
+        version: 8.13.0
     devDependencies:
       '@types/lodash.clonedeep':
         specifier: ^4.5.6
@@ -183,8 +180,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       urql:
-        specifier: ^3.0.3
-        version: 3.0.3(graphql@16.5.0)(react@18.2.0)
+        specifier: ^4.0.4
+        version: 4.0.4(graphql@16.5.0)(react@18.2.0)
     devDependencies:
       '@testing-library/react':
         specifier: ^13.4.0
@@ -202,8 +199,8 @@ importers:
         specifier: ^18.2.4
         version: 18.2.4
       '@urql/core':
-        specifier: ^3.0.1
-        version: 3.0.3(graphql@16.5.0)
+        specifier: ^4.0.10
+        version: 4.0.10(graphql@16.5.0)
       conditional-type-checks:
         specifier: ^1.0.6
         version: 1.0.6
@@ -279,6 +276,27 @@ importers:
         version: 18.2.0(react@18.2.0)
 
 packages:
+
+  /@0no-co/graphql.web@1.0.4(graphql@16.5.0):
+    resolution: {integrity: sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+    dependencies:
+      graphql: 16.5.0
+
+  /@0no-co/graphql.web@1.0.4(graphql@16.6.0):
+    resolution: {integrity: sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+    dependencies:
+      graphql: 16.6.0
+    dev: false
 
   /@ampproject/remapping@2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
@@ -938,21 +956,6 @@ packages:
       - '@volar/vue-typescript'
       - typescript
     dev: true
-
-  /@graphql-typed-document-node/core@3.1.1(graphql@16.5.0):
-    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 16.5.0
-
-  /@graphql-typed-document-node/core@3.1.1(graphql@16.6.0):
-    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 16.6.0
-    dev: false
 
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
@@ -1831,45 +1834,21 @@ packages:
       eslint-visitor-keys: 3.4.0
     dev: true
 
-  /@urql/core@3.0.1(graphql@16.6.0):
-    resolution: {integrity: sha512-VMnAx1JsV32XjuCQVHHeq2BAn39XBSr6qEJd3xSE3Gwrc2NGndTZeFd6loZKmYF9XTHmvj8YbY2BFfHW7nGbmg==}
-    peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  /@urql/core@4.0.10(graphql@16.5.0):
+    resolution: {integrity: sha512-Vs3nOSAnYftqOCg034Ostp/uSqWlQg5ryLIzcOrm8+O43s4M+Ew4GQAuemIH7ZDB8dek6h61zzWI3ujd8FH3NA==}
     dependencies:
-      '@graphql-typed-document-node/core': 3.1.1(graphql@16.6.0)
-      graphql: 16.6.0
+      '@0no-co/graphql.web': 1.0.4(graphql@16.5.0)
       wonka: 6.3.2
-    dev: false
+    transitivePeerDependencies:
+      - graphql
 
-  /@urql/core@3.0.3(graphql@16.5.0):
-    resolution: {integrity: sha512-raQP51ERNtg5BvlN8x8mHVRvk4K0ugWQ69n53BdkjKpXVV5kuWp7trnwriGv1fQKa8HuiGNSCfyslUucc0OVQg==}
-    peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  /@urql/core@4.0.10(graphql@16.6.0):
+    resolution: {integrity: sha512-Vs3nOSAnYftqOCg034Ostp/uSqWlQg5ryLIzcOrm8+O43s4M+Ew4GQAuemIH7ZDB8dek6h61zzWI3ujd8FH3NA==}
     dependencies:
-      '@graphql-typed-document-node/core': 3.1.1(graphql@16.5.0)
-      graphql: 16.5.0
+      '@0no-co/graphql.web': 1.0.4(graphql@16.6.0)
       wonka: 6.3.2
-
-  /@urql/core@3.0.3(graphql@16.6.0):
-    resolution: {integrity: sha512-raQP51ERNtg5BvlN8x8mHVRvk4K0ugWQ69n53BdkjKpXVV5kuWp7trnwriGv1fQKa8HuiGNSCfyslUucc0OVQg==}
-    peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      '@graphql-typed-document-node/core': 3.1.1(graphql@16.6.0)
-      graphql: 16.6.0
-      wonka: 6.3.2
-    dev: false
-
-  /@urql/exchange-multipart-fetch@1.0.1(graphql@16.6.0):
-    resolution: {integrity: sha512-fjxRrKR/D9Rs52L8wJMvqsGQBC/mjFcg/VdkSkU5IXmqCb5KmicXl2208hoCnaBl/QLA6NDpCNnG3zjDniMOTg==}
-    deprecated: This package is now obsolete and `@urql/core` now supports GraphQL Multipart Requests (File Uploads) natively.
-    peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      '@urql/core': 3.0.3(graphql@16.6.0)
-      extract-files: 11.0.0
-      graphql: 16.6.0
-      wonka: 6.3.2
+    transitivePeerDependencies:
+      - graphql
     dev: false
 
   /@vitejs/plugin-react-swc@3.3.0(vite@4.2.2):
@@ -3148,11 +3127,6 @@ packages:
       jest-util: 29.3.1
     dev: true
 
-  /extract-files@11.0.0:
-    resolution: {integrity: sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dev: false
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -3492,8 +3466,8 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /graphql-ws@5.8.2(graphql@16.6.0):
-    resolution: {integrity: sha512-hYo8kTGzxePFJtMGC7Y4cbypwifMphIJJ7n4TDcVUAfviRwQBnmZAbfZlC+XFwWDUaR7raEDQPxWctpccmE0JQ==}
+  /graphql-ws@5.13.1(graphql@16.6.0):
+    resolution: {integrity: sha512-eiX7ES/ZQr0q7hSM5UBOEIFfaAUmAY9/CSDyAnsETuybByU7l/v46drRg9DQoTvVABEHp3QnrvwgTRMhqy7zxQ==}
     engines: {node: '>=10'}
     peerDependencies:
       graphql: '>=0.11 <=16'
@@ -3842,12 +3816,12 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /isomorphic-ws@4.0.1(ws@8.11.0):
-    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+  /isomorphic-ws@5.0.0(ws@8.13.0):
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
       ws: '*'
     dependencies:
-      ws: 8.11.0
+      ws: 8.13.0
     dev: false
 
   /istanbul-lib-coverage@3.2.0:
@@ -4440,7 +4414,7 @@ packages:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
-      ws: 8.11.0
+      ws: 8.13.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -5842,16 +5816,16 @@ packages:
       requires-port: 1.0.0
     dev: true
 
-  /urql@3.0.3(graphql@16.5.0)(react@18.2.0):
-    resolution: {integrity: sha512-aVUAMRLdc5AOk239DxgXt6ZxTl/fEmjr7oyU5OGo8uvpqu42FkeJErzd2qBzhAQ3DyusoZIbqbBLPlnKo/yy2A==}
+  /urql@4.0.4(graphql@16.5.0)(react@18.2.0):
+    resolution: {integrity: sha512-C5P4BMnAsk+rbytCWglit5ijXbIKXsa9wofSGPbuMyJKsDdL+9GfipS362Nff/Caag+eYOK5W+sox8fwEILT6Q==}
     peerDependencies:
-      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
       react: '>= 16.8.0'
     dependencies:
-      '@urql/core': 3.0.3(graphql@16.5.0)
-      graphql: 16.5.0
+      '@urql/core': 4.0.10(graphql@16.5.0)
       react: 18.2.0
       wonka: 6.3.2
+    transitivePeerDependencies:
+      - graphql
     dev: false
 
   /util-deprecate@1.0.2:
@@ -6071,12 +6045,12 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /ws@8.11.0:
-    resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
+  /ws@8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true


### PR DESCRIPTION
This upgrades us to urql v4 for all generated api client packages.

 - removes the deprecated exchanges that are built into the client now to get rid of that pesky message
 - adds the new mandatory properties to the `OperationResult` type

More comments inline

Gadget side test PR here: https://github.com/gadget-inc/gadget/pull/6756 (it works!)