### PR TITLE
fix(frontends): Prevent flash of unloaded content

### DIFF
--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -47,7 +47,7 @@ const InnerGadgetProvider = memo(
       isAuthenticated: false,
       isEmbedded: false,
       canAuth: false,
-      loading: false,
+      loading: true,
       appBridge,
       isRootFrameRequest: false,
     });


### PR DESCRIPTION
We initialize the GadgetProvider 'loading' parameter to 'false', and then immediately start a load. This results in a microsecond where the 'isAuthorized' logic will report false (because it is not loading and not true), which we use to show a different UI when an embedded app is accessed outside of a shopify embed.

This results is a flash of the message 'This application is only viewable in the shopify admin' when first loading a page inside the shopify admin.
