### PR TITLE
Release v12.1 with fix to GadgetProvider loading default value

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Releasing a new version of the react GadgetProvider which is initially set loading = true