### PR TITLE
Exclude the `__typename` field from GadgetRecord.toJSON()

### DIFF
--- a/packages/api-client-core/spec/GadgetRecord.spec.ts
+++ b/packages/api-client-core/spec/GadgetRecord.spec.ts
@@ -1,3 +1,4 @@
+import { omit } from "lodash";
 import { ChangeTracking, GadgetRecord } from "../src/GadgetRecord";
 interface SampleBaseRecord {
   id?: string;
@@ -42,6 +43,7 @@ describe("GadgetRecord", () => {
   let productBaseRecord: SampleBaseRecord;
   beforeAll(() => {
     productBaseRecord = {
+      __typename: "Product",
       id: "123",
       name: "A cool product",
       body: "A description of why it's cool",
@@ -51,7 +53,7 @@ describe("GadgetRecord", () => {
   it("should respond toJSON, which returns the inner __gadget.fields properties", () => {
     const product = new GadgetRecord<SampleBaseRecord>(productBaseRecord);
     expect(product.toJSON()).toEqual({
-      ...productBaseRecord,
+      ...omit(productBaseRecord, "__typename"),
     });
   });
 
@@ -402,5 +404,23 @@ describe("GadgetRecord", () => {
     expect(product.getField("changed")).toEqual(false);
     product.setField("changed", true);
     expect(product.getField("changed")).toEqual(true);
+  });
+
+  test("the typename should be accessible on the object if passed when constructing", () => {
+    const product = new GadgetRecord<SampleBaseRecord>(productBaseRecord);
+    expect(product.typename).toEqual("Product");
+  });
+
+  test("the typename should be undefined on the object if not passed when constructing", () => {
+    const product = new GadgetRecord<SampleBaseRecord>({});
+    expect(product.typename).toBeUndefined();
+  });
+
+  test("the typename should not be included in the toJSON output", () => {
+    let instance = new GadgetRecord<{ __typename: "foo" }>({ __typename: "foo" });
+    expect(instance.toJSON()).toEqual({});
+
+    instance = new GadgetRecord<{ __typename: "foo"; bar: number }>({ __typename: "foo", bar: 1 });
+    expect(instance.toJSON()).toEqual({ bar: 1 });
   });
 });

--- a/packages/api-client-core/src/GadgetRecord.ts
+++ b/packages/api-client-core/src/GadgetRecord.ts
@@ -22,11 +22,16 @@ export class GadgetRecordImplementation<Shape extends RecordShape> {
   };
 
   private empty = false;
+  __typename?: string;
 
-  constructor(data: Shape) {
-    this.__gadget.instantiatedFields = cloneDeep(data);
-    this.__gadget.persistedFields = cloneDeep(data);
-    Object.assign(this.__gadget.fields, data);
+  constructor(data?: Shape | null) {
+    if (data) {
+      const { __typename, ...fields } = data;
+      this.__typename = __typename;
+      this.__gadget.instantiatedFields = cloneDeep(fields);
+      this.__gadget.persistedFields = cloneDeep(fields);
+      Object.assign(this.__gadget.fields, fields);
+    }
 
     if (!data || Object.keys(data).length === 0) {
       this.empty = true;
@@ -75,6 +80,10 @@ export class GadgetRecordImplementation<Shape extends RecordShape> {
   /** Checks if the original constructor data was empty or not */
   isEmpty(): boolean {
     return this.empty;
+  }
+
+  get typename(): string | undefined {
+    return this.__typename;
   }
 
   /** Returns the value of the field for the given `apiIdentifier`. These properties may also be accessed on this record directly. This method can be used if your model field `apiIdentifier` conflicts with the `GadgetRecord` helper functions. */


### PR DESCRIPTION
Riley noticed a discord user trying to pass `record.toJSON()` back as an input to a different action call. This didn't work out of the box because the `.toJSON()` includes all the fields that came back from loading the record, including `__typename`. When sending this back at the GraphQL API, the `__typename` attribute causes GraphQL to get mad as you are passing fields which don't exist as input fields.