### PR TITLE
Make passing in the params by model api identifier optional

### DIFF
--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -1,4 +1,7 @@
 import {
+  BrowserSessionStorageType,
+  GadgetConnection,
+  InternalModelManager,
   internalBulkCreateMutation,
   internalCreateMutation,
   internalDeleteManyMutation,
@@ -9,6 +12,122 @@ import {
 } from "../src";
 
 describe("InternalModelManager", () => {
+  describe("getRecordFromData", () => {
+    let connection: GadgetConnection;
+    let internalModelManager: InternalModelManager;
+
+    beforeEach(() => {
+      connection = new GadgetConnection({
+        endpoint: "https://someapp.gadget.app",
+        authenticationMode: { browserSession: { storageType: BrowserSessionStorageType.Durable } },
+      });
+
+      internalModelManager = new InternalModelManager("someModel", connection, {
+        hasAmbiguousIdentifiers: false,
+        pluralApiIdentifier: "someModels",
+      });
+    });
+
+    test("can unwrap params nested under api identifier", () => {
+      const result = (internalModelManager as any).getRecordFromData({
+        someModel: {
+          name: "foo",
+          bar: 12,
+          _atomics: {
+            _baz: {
+              increment: 1,
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        name: "foo",
+        bar: 12,
+        _atomics: {
+          _baz: {
+            increment: 1,
+          },
+        },
+      });
+    });
+
+    test("returns params if model api identifier does not exist in params", () => {
+      const result = (internalModelManager as any).getRecordFromData({
+        name: "foo",
+        bar: 12,
+        _atomics: {
+          _baz: {
+            decrement: 1,
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        name: "foo",
+        bar: 12,
+        _atomics: {
+          _baz: {
+            decrement: 1,
+          },
+        },
+      });
+    });
+
+    test("throws if model has ambiguous api identifier and record data does not have model api identifier key", () => {
+      if (internalModelManager.options) {
+        internalModelManager.options.hasAmbiguousIdentifiers = true;
+      }
+
+      expect(internalModelManager.options?.hasAmbiguousIdentifiers).toBeTruthy();
+
+      expect(() =>
+        (internalModelManager as any).getRecordFromData(
+          {
+            name: "foo",
+            bar: 12,
+            _atomics: {
+              _baz: {
+                decrement: 1,
+              },
+            },
+          },
+          "create"
+        )
+      ).toThrow("Invalid arguments found in variables. Did you mean to use create({ someModel: { ... } })?");
+    });
+
+    test("does not throw if model has ambiguous api identifier and record data has model api identifier key", () => {
+      if (internalModelManager.options) {
+        internalModelManager.options.hasAmbiguousIdentifiers = true;
+      }
+
+      expect(internalModelManager.options?.hasAmbiguousIdentifiers).toBeTruthy();
+
+      const result = (internalModelManager as any).getRecordFromData({
+        someModel: {
+          name: "foo",
+          bar: 12,
+          _atomics: {
+            _baz: {
+              increment: 1,
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        name: "foo",
+        bar: 12,
+        _atomics: {
+          _baz: {
+            increment: 1,
+          },
+        },
+      });
+    });
+  });
+
   describe("internalFindManyQuery", () => {
     test("should build a find many query with no options", () => {
       expect(internalFindManyQuery("widget", undefined)).toMatchInlineSnapshot(`


### PR DESCRIPTION
This PR makes it optional to wrap your model params for create/update in the model api identifier. The only exception is if there is a field with the same api identifier as the model, then the params must be wrapped in the model api identifier; this is because there's no way to tell if the consumer is passing in model params or field value.

It would be nice to be able to test that the correct query/variables are called but the mutations rely on transactions via ws. This is a bit difficult to mock I think without adding some interfaces so that we can create a mock transaction, not sure if that was worth adding here.

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
