### PR TITLE
remove filter never from select and add deep filter never to fix hand…

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^2.7.1",
     "semver": "^7.3.8",
     "ts-node": "^10.9.1",
-    "typescript": "4.7.4",
+    "typescript": "5.0.4",
     "zx": "^7.1.1"
   },
   "resolutions": {

--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -39,6 +39,6 @@
     "gql-tag": "^1.0.1",
     "nock": "^13.2.9",
     "type-fest": "^3.3.0",
-    "typescript": "4.7.4"
+    "typescript": "5.0.4"
   }
 }

--- a/packages/api-client-core/spec/TestSchema.ts
+++ b/packages/api-client-core/spec/TestSchema.ts
@@ -1,6 +1,13 @@
+export type NestedThing = {
+  bool: boolean;
+  string: string;
+  nested: NestedThing;
+};
+
 export type TestSchema = {
   num: number;
   str: string;
+  nested: NestedThing;
   obj: {
     test: "test";
     bool: boolean;
@@ -55,6 +62,7 @@ export type AvailableTestSchemaSelection = {
   optionalList?: {
     title: boolean | null | undefined;
   };
+  nested?: NestedThing;
   someConnection?: {
     edges?: {
       node?: {

--- a/packages/api-client-core/spec/select-types.spec.ts
+++ b/packages/api-client-core/spec/select-types.spec.ts
@@ -1,5 +1,5 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
-import { Select } from "../src/types";
+import { DeepFilterNever, Select } from "../src/types";
 import { TestSchema } from "./TestSchema";
 
 type _SelectingProperties = AssertTrue<IsExact<Select<TestSchema, { num: true }>, { num: number }>>;
@@ -39,6 +39,10 @@ type _SelectingCircularProperties = AssertTrue<
       };
     }
   >
+>;
+
+type _FilteredNever = AssertTrue<
+  IsExact<DeepFilterNever<{ a: { b: never }; c: string; d: { e: boolean; f: never } }>, { c: string; d: { e: boolean } }>
 >;
 
 type _optionalNestedPropertySelection = Select<TestSchema, { optionalObj: { test: true } }>;

--- a/packages/api-client-core/spec/select-types.spec.ts
+++ b/packages/api-client-core/spec/select-types.spec.ts
@@ -15,6 +15,32 @@ type _SelectingNestedProperties = AssertTrue<
   >
 >;
 
+type _SelectingCircularProperties = AssertTrue<
+  IsExact<
+    Select<
+      TestSchema,
+      {
+        num: true;
+        nested: {
+          bool: true;
+          nested: {
+            bool: true;
+          };
+        };
+      }
+    >,
+    {
+      num: number;
+      nested: {
+        bool: boolean;
+        nested: {
+          bool: boolean;
+        };
+      };
+    }
+  >
+>;
+
 type _optionalNestedPropertySelection = Select<TestSchema, { optionalObj: { test: true } }>;
 type _TestSelectingOptionalNestedProperties = AssertTrue<
   IsExact<_optionalNestedPropertySelection, { optionalObj: { test: "test" } | null }>

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -3,11 +3,11 @@ import { multipartFetchExchange } from "@urql/exchange-multipart-fetch";
 import fetchPolyfill from "cross-fetch";
 import { ExecutionResult } from "graphql";
 import {
-  Client as SubscriptionClient,
-  ClientOptions as SubscriptionClientOptions,
   CloseCode,
   createClient as createSubscriptionClient,
   Sink,
+  Client as SubscriptionClient,
+  ClientOptions as SubscriptionClientOptions,
 } from "graphql-ws";
 import WebSocket from "isomorphic-ws";
 import { getCurrentSpan } from ".";

--- a/packages/blog-example/package.json
+++ b/packages/blog-example/package.json
@@ -25,7 +25,7 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react-swc": "^3.0.0",
-    "typescript": "^4.9.3",
+    "typescript": "5.0.4",
     "vite": "^4.2.0"
   }
 }

--- a/packages/blog-example/src/main.tsx
+++ b/packages/blog-example/src/main.tsx
@@ -1,8 +1,8 @@
 import { Provider } from "@gadgetinc/react";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { api } from "./api";
 import App from "./App";
+import { api } from "./api";
 import "./styles/index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/packages/react-shopify-app-bridge/spec/useGadget.spec.ts
+++ b/packages/react-shopify-app-bridge/spec/useGadget.spec.ts
@@ -1,5 +1,5 @@
 import { AppBridgeState, ClientApplication } from "@shopify/app-bridge";
-import { assert, IsExact } from "conditional-type-checks";
+import { IsExact, assert } from "conditional-type-checks";
 import { AppType, useGadget } from "../src";
 
 // these functions are typechecked but never run to avoid actually making API calls

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -1,6 +1,6 @@
 import { AnyClient } from "@gadgetinc/api-client-core";
 import { Provider as GadgetUrqlProvider, useQuery } from "@gadgetinc/react";
-import { History, LocationOrHref, Provider as AppBridgeProvider } from "@shopify/app-bridge-react";
+import { Provider as AppBridgeProvider, History, LocationOrHref } from "@shopify/app-bridge-react";
 import { AppBridgeContext } from "@shopify/app-bridge-react/context";
 import { getSessionToken } from "@shopify/app-bridge-utils";
 import { Redirect } from "@shopify/app-bridge/actions";

--- a/packages/react-shopify-app-bridge/src/index.ts
+++ b/packages/react-shopify-app-bridge/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./context";
 export * from "./Provider";
+export * from "./context";

--- a/packages/react/spec/useFetch.spec.ts
+++ b/packages/react/spec/useFetch.spec.ts
@@ -1,10 +1,10 @@
 import { $gadgetConnection } from "@gadgetinc/api-client-core";
 import { act, renderHook } from "@testing-library/react";
-import { assert, IsExact } from "conditional-type-checks";
+import { IsExact, assert } from "conditional-type-checks";
 import { Response } from "cross-fetch";
 import { useFetch } from "../src/useFetch";
 import { ErrorWrapper } from "../src/utils";
-import { mockClient, TestWrapper } from "./testWrapper";
+import { TestWrapper, mockClient } from "./testWrapper";
 
 describe("useFetch", () => {
   // these functions are typechecked but never run to avoid actually making API calls

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -10,7 +10,7 @@ import {
   Select,
 } from "@gadgetinc/api-client-core";
 import { useCallback, useContext, useMemo } from "react";
-import { UseMutationState } from "urql";
+import { AnyVariables, UseMutationState } from "urql";
 import { GadgetContext } from "./GadgetProvider";
 import { OptionsType } from "./OptionsType";
 import { useGadgetMutation } from "./useGadgetMutation";
@@ -101,7 +101,7 @@ export const useAction = <
 };
 
 /** Processes urql's result object into the fancier Gadget result object */
-const processResult = <Data, Variables>(
+const processResult = <Data, Variables extends AnyVariables>(
   result: UseMutationState<Data, Variables>,
   action: ActionFunction<any, any, any, any, any>
 ): ActionHookState<any, any> => {

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -6,7 +6,7 @@ import { AnyVariables, Operation, OperationContext, UseQueryState } from "urql";
 /**
  * The inner result object returned from a query result
  **/
-export interface ReadHookState<Data = any, Variables = Record<string, any>> {
+export interface ReadHookState<Data = any, Variables extends AnyVariables = Record<string, any>> {
   fetching: boolean;
   stale: boolean;
   data?: Data;
@@ -27,7 +27,7 @@ export declare type ReadHookResult<Data = any, Variables extends AnyVariables = 
 /**
  * The inner result object returned from a mutation result
  */
-export interface ActionHookState<Data = any, Variables = Record<string, any>> {
+export interface ActionHookState<Data = any, Variables extends AnyVariables = Record<string, any>> {
   fetching: boolean;
   stale: boolean;
   data?: Data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,7 +666,7 @@
     "@gadgetinc/api-client-core" "0.13.3"
 
 "@gadgetinc/api-client-core@0.11.0":
-  version "0.13.4"
+  version "0.13.5"
   dependencies:
     "@opentelemetry/api" "^1.4.0"
     "@urql/core" "^3.0.1"
@@ -681,7 +681,7 @@
     ws "^8.11.0"
 
 "@gadgetinc/api-client-core@0.13.3":
-  version "0.13.4"
+  version "0.13.5"
   dependencies:
     "@opentelemetry/api" "^1.4.0"
     "@urql/core" "^3.0.1"
@@ -696,7 +696,7 @@
     ws "^8.11.0"
 
 "@gadgetinc/api-client-core@0.9.0":
-  version "0.13.4"
+  version "0.13.5"
   dependencies:
     "@opentelemetry/api" "^1.4.0"
     "@urql/core" "^3.0.1"
@@ -729,7 +729,14 @@
     eslint-plugin-react-hooks "^4.2.0"
     eslint-plugin-workspaces "^0.6.2"
 
-"@gadgetinc/prettier-config@*", "@gadgetinc/prettier-config@>=0":
+"@gadgetinc/prettier-config@*":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@gadgetinc/prettier-config/-/prettier-config-0.4.0.tgz#9fb95395b238b568c9749e61b129ea7e733ce0b5"
+  integrity sha512-a5jSbHlFjg3WojaDONSGPPvwJdToqpSAixHpLOJ55xMqnfOTRxY2Qr41lPDmLryfch0vD8v/Fnue3/pkwZKVdQ==
+  dependencies:
+    prettier-plugin-organize-imports "^3.2.1"
+
+"@gadgetinc/prettier-config@>=0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@gadgetinc/prettier-config/-/prettier-config-0.3.0.tgz#8ffc03e368ee028fc624d77c9453a3f0838bd4bf"
   integrity sha512-s58zjpPLymKIkcpoxzFdtIW6+kGYkB9HOIucS9wbApmfXS/JOHlXpgqv6cje0rOOvaXTI7SmecaXv5t8I28a8w==
@@ -4787,10 +4794,15 @@ prettier-plugin-organize-imports@^1.0.4:
   resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-1.1.1.tgz#7f1ac1a13d4d1752dc16881894dde1c10ccbf3c0"
   integrity sha512-rFA1lnek1FYkMGthm4xBKME41qUKItTovuo24bCGZu/Vu1n3gW71UPLAkIdwewwkZCe29gRVweSOPXvAdckFuw==
 
+prettier-plugin-organize-imports@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.2.tgz#91993365e017daa5d0d28d8183179834224d8dd1"
+  integrity sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==
+
 prettier@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^27.0.2:
   version "27.5.1"
@@ -5534,15 +5546,10 @@ type-fest@^3.3.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.3.0.tgz#3378c9664eecfd1eb4f0522b13cb0630bc1ec044"
   integrity sha512-gezeeOIZyQLGW5uuCeEnXF1aXmtt2afKspXz3YqoOcZ3l/YMJq1pujvgT+cz/Nw1O/7q/kSav5fihJHsC/AOUg==
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
-typescript@^4.9.3:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Added a test to verify that you can still select the nested circular props. Also to note is that with `DeepFilter` you can no longer pass in a schema that has an optional property. This is fine with Gadget schemas as these are typed as `prop: type | null` instead of `prop?: type`

We will probably want to bump a minor version for this so that this change doesn't get picked up by older client packages

cc @angelini 

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
