### PR TITLE
change(api-client-core): Error definitions

### DIFF
--- a/packages/api-client-core/spec/support.spec.ts
+++ b/packages/api-client-core/spec/support.spec.ts
@@ -177,7 +177,7 @@ describe("support utilities", () => {
     });
     test("returns an error if data is null", () => {
       const error = getNonNullableError({ fetching: false, data: { foo: null } }, ["foo"]);
-      expect(error?.message).toEqual("Internal Error: Gadget API returned no data at foo");
+      expect(error?.message).toEqual("Record Not Found Error: Gadget API returned no data at foo");
     });
     test("returns void if fetch is in progress", () => {
       const error = getNonNullableError({ fetching: true, data: null }, [""]);

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -77,7 +77,7 @@ describe("useFindOne", () => {
     expect(result.current[0].fetching).toBe(false);
     const error = result.current[0].error;
     expect(error).toBeTruthy();
-    expect(error!.message).toMatchInlineSnapshot(`"[GraphQL] Internal Error: Gadget API returned no data at user"`);
+    expect(error!.message).toMatchInlineSnapshot(`"[GraphQL] Record Not Found Error: Gadget API returned no data at user"`);
 
     // ensure the error is the same after rerendering
     rerender();


### PR DESCRIPTION
Changing the error definitions and added missing attributes for errors coming out of the client. We're doing this because of the errors already defined e.g. `GadgetInternalError` weren't being used in appropriate spots.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
