### PR TITLE
Linting fix for InternalModelManager

### DIFF
--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -150,7 +150,7 @@ describe("InternalModelManager", () => {
       const result = internalBulkCreateMutation("widget", "widgets");
 
       expect(result).toMatch(
-        /mutation InternalBulkCreateWidgets\(\$records: \[InternalWidgetInput\]\!\) {\s*gadgetMeta {\s*hydrations\(modelName: "widget"\)\s*}\s*internal {\s*bulkCreateWidgets\(widgets: \$records\) {\s*success\s*errors {\s*... InternalErrorsDetails\s*}\s*widgets\s*}\s*}\s*}/
+        /mutation InternalBulkCreateWidgets\(\$records: \[InternalWidgetInput\]!\) {\s*gadgetMeta {\s*hydrations\(modelName: "widget"\)\s*}\s*internal {\s*bulkCreateWidgets\(widgets: \$records\) {\s*success\s*errors {\s*... InternalErrorsDetails\s*}\s*widgets\s*}\s*}\s*}/
       );
     });
 

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -4,13 +4,13 @@ import type { GadgetRecord, RecordShape } from "./GadgetRecord";
 import { GadgetRecordList } from "./GadgetRecordList";
 import type { GadgetTransaction } from "./GadgetTransaction";
 import {
+  GadgetClientError,
   assert,
   assertMutationSuccess,
   assertNullableOperationSuccess,
   assertOperationSuccess,
   camelize,
   capitalize,
-  GadgetClientError,
   hydrateConnection,
   hydrateRecord,
   hydrateRecordArray,

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -4,13 +4,13 @@ import type { GadgetRecord, RecordShape } from "./GadgetRecord";
 import { GadgetRecordList } from "./GadgetRecordList";
 import type { GadgetTransaction } from "./GadgetTransaction";
 import {
-  GadgetClientError,
   assert,
   assertMutationSuccess,
   assertNullableOperationSuccess,
   assertOperationSuccess,
   camelize,
   capitalize,
+  GadgetClientError,
   hydrateConnection,
   hydrateRecord,
   hydrateRecordArray,


### PR DESCRIPTION
I had a pr [here](https://github.com/gadget-inc/js-clients/pull/189) that passed all tests including lint, and the pr was merged. But no release was generated because the lint test apparently [failed](https://github.com/gadget-inc/js-clients/actions/runs/4919851054). Strange 😞 

Running yarn lint fix in a new branch showed some changes, hopefully this is the real prettier version.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
