### PR TITLE
Add support for a `.touch()` operation to mark a GadgetRecord as changed without actually changing any field values

### DIFF
--- a/packages/api-client-core/spec/GadgetRecord.spec.ts
+++ b/packages/api-client-core/spec/GadgetRecord.spec.ts
@@ -335,6 +335,37 @@ describe("GadgetRecord", () => {
     expect(product.newField).toEqual("foo");
   });
 
+  test("should allow touching, which marks the record as changed without changing field values", () => {
+    const product = new GadgetRecord<SampleBaseRecord>(productBaseRecord);
+    expect(product.changed()).toBe(false);
+    product.touch();
+    expect(product.changed()).toBe(true);
+    expect(product.changed(ChangeTracking.SinceLastPersisted)).toBe(true);
+    expect(product.changed(ChangeTracking.SinceLoaded)).toBe(true);
+    expect(product.changes()).toEqual({});
+    expect(product.toChangedJSON()).toEqual({});
+  });
+
+  test("reverting changes clears touched status", () => {
+    const product = new GadgetRecord<SampleBaseRecord>(productBaseRecord);
+    expect(product.changed()).toBe(false);
+    product.touch();
+    expect(product.changed()).toBe(true);
+    product.revertChanges();
+    expect(product.changed()).toBe(false);
+  });
+
+  test("should allow touching and changing fields together", () => {
+    const product = new GadgetRecord<SampleBaseRecord>(productBaseRecord);
+    expect(product.changed()).toBe(false);
+    product.name = "A new name";
+    expect(product.changed()).toBe(true);
+    product.touch();
+    expect(product.changed()).toBe(true);
+    product.revertChanges();
+    expect(product.changed()).toBe(false);
+  });
+
   test("arrays and objects stored in the instantiated and persisted fields should be independent of each other and active fields", () => {
     const nestedObject = { foo: "bar", subArray: [1, 2, 3] };
     const anArray = [1, 2, 3];


### PR DESCRIPTION
I'm working on a feature Gadget side to only persist Session records if the sandbox changes them in any way. This will result in us generating a lot less sessions, as most requests to the sandbox don't even look at the session let alone change it, but, we currently still provision and persist session for each of those requests. Instead, I want the sandbox to look at the session state and only report it as requiring persistence if it was in fact changed. This works, but, if you want to mark a session as needing persistence from userland (say for our tests, or because you want to track a particular user's session through an important flow), you would now need to add a bogus field and change it just to get the thing persisted. 

Instead, we should add a function for marking a record as changed, without actually changing anything on it. Rails has this built in as the `touch` function -- I think we can just copy that here! 