### PR TITLE
fix(api-client-core) - GGT-2123 - Model api identifiers with underscores fail to run CRUD API

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.13.9",
+  "version": "0.14.0",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.14.0",
+  "version": "0.13.10",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -196,6 +196,217 @@ describe("InternalModelManager", () => {
           }
         `);
       });
+
+      test("should build a create record mutation", () => {
+        const result = internalCreateMutation("widget_model");
+
+        expect(result).toMatchInlineSnapshot(`
+          "
+              
+          fragment InternalErrorsDetails on ExecutionError {
+            code
+            message
+            ...on InvalidRecordError {
+              validationErrors {
+                apiIdentifier
+                message
+              }
+              model {
+                apiIdentifier
+              }
+              record
+            }
+          }
+
+
+              mutation InternalCreateWidgetModel($record: InternalWidgetModelInput) {
+                
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
+            }
+
+                internal {
+                  createWidgetModel(widget_model: $record) {
+                    success
+                    errors {
+                      ... InternalErrorsDetails
+                    }
+                    widget_model
+                  }
+                }
+              }
+            "
+        `);
+      });
+
+      test("should build a bulk create records mutation", () => {
+        const result = internalBulkCreateMutation("widget_model", "widget_models");
+
+        expect(result).toMatchInlineSnapshot(`
+          "
+              
+          fragment InternalErrorsDetails on ExecutionError {
+            code
+            message
+            ...on InvalidRecordError {
+              validationErrors {
+                apiIdentifier
+                message
+              }
+              model {
+                apiIdentifier
+              }
+              record
+            }
+          }
+
+
+              mutation InternalBulkCreateWidgetModels($records: [InternalWidgetModelInput]!) {
+                
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
+            }
+
+                internal {
+                  bulkCreateWidgetModels(widget_models: $records) {
+                    success
+                    errors {
+                      ... InternalErrorsDetails
+                    }
+                    widget_models
+                  }
+                }
+              }
+            "
+        `);
+      });
+
+      test("should build an update record mutation", () => {
+        const result = internalUpdateMutation("widget_model");
+
+        expect(result).toMatchInlineSnapshot(`
+          "
+              
+          fragment InternalErrorsDetails on ExecutionError {
+            code
+            message
+            ...on InvalidRecordError {
+              validationErrors {
+                apiIdentifier
+                message
+              }
+              model {
+                apiIdentifier
+              }
+              record
+            }
+          }
+
+
+              mutation InternalUpdateWidgetModel($id: GadgetID!, $record: InternalWidgetModelInput) {
+                
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
+            }
+
+                internal {
+                  updateWidgetModel(id: $id, widget_model: $record) {
+                    success
+                    errors {
+                      ... InternalErrorsDetails
+                    }
+                    widget_model
+                  }
+                }
+              }
+            "
+        `);
+      });
+
+      test("should build a delete record mutation", () => {
+        const result = internalDeleteMutation("widget_model");
+
+        expect(result).toMatchInlineSnapshot(`
+          "
+              
+          fragment InternalErrorsDetails on ExecutionError {
+            code
+            message
+            ...on InvalidRecordError {
+              validationErrors {
+                apiIdentifier
+                message
+              }
+              model {
+                apiIdentifier
+              }
+              record
+            }
+          }
+
+
+              mutation InternalDeleteWidgetModel($id: GadgetID!) {
+                
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
+            }
+
+                internal {
+                  deleteWidgetModel(id: $id) {
+                    success
+                    errors {
+                      ... InternalErrorsDetails
+                    }
+                  }
+                }
+              }
+            "
+        `);
+      });
+
+      test("should build a delete many records mutation", () => {
+        const result = internalDeleteManyMutation("widget_model");
+
+        expect(result).toMatchInlineSnapshot(`
+          "
+              
+          fragment InternalErrorsDetails on ExecutionError {
+            code
+            message
+            ...on InvalidRecordError {
+              validationErrors {
+                apiIdentifier
+                message
+              }
+              model {
+                apiIdentifier
+              }
+              record
+            }
+          }
+
+
+              mutation InternalDeleteManyWidgetModel(
+                $search: String
+                $filter: [WidgetModelFilter!]
+              ) {
+                
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
+            }
+
+                internal {
+                  deleteManyWidgetModel(search: $search, filter: $filter) {
+                    success
+                    errors {
+                      ... InternalErrorsDetails
+                    }
+                  }
+                }
+              }
+            "
+        `);
+      });
     });
 
     test("should build a create record mutation", () => {

--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -129,5 +129,65 @@ describe("InternalModelManager", () => {
         }
       `);
     });
+
+    describe("properly handles apiIdentifiers styled with Snake Case", () => {
+      // snake case example: "api_identifier"
+      test("should build a find first query with no options", () => {
+        expect(internalFindFirstQuery("widget_model", undefined)).toMatchInlineSnapshot(`
+          {
+            "query": "query InternalFindFirstWidgetModel ($first: Int) { internal  { listWidgetModel (first: $first) { edges { node } } } }",
+            "variables": {
+              "first": 1,
+            },
+          }
+        `);
+      });
+
+      test("should build a find first query with sort", () => {
+        expect(internalFindFirstQuery("widget_model", { sort: [{ id: "Ascending" }] })).toMatchInlineSnapshot(`
+          {
+            "query": "query InternalFindFirstWidgetModel ($sort: [WidgetModelSort!], $first: Int) { internal  { listWidgetModel (sort: $sort, first: $first) { edges { node } } } }",
+            "variables": {
+              "first": 1,
+              "sort": [
+                {
+                  "id": "Ascending",
+                },
+              ],
+            },
+          }
+        `);
+      });
+
+      test("should build a find first query with search", () => {
+        expect(internalFindFirstQuery("widget_model", { search: "term" })).toMatchInlineSnapshot(`
+          {
+            "query": "query InternalFindFirstWidgetModel ($search: String, $first: Int) { internal  { listWidgetModel (search: $search, first: $first) { edges { node } } } }",
+            "variables": {
+              "first": 1,
+              "search": "term",
+            },
+          }
+        `);
+      });
+
+      test("should build a find first query with filter", () => {
+        expect(internalFindFirstQuery("widget_model", { filter: [{ id: { equals: "1" } }] })).toMatchInlineSnapshot(`
+          {
+            "query": "query InternalFindFirstWidgetModel ($filter: [WidgetModelFilter!], $first: Int) { internal  { listWidgetModel (filter: $filter, first: $first) { edges { node } } } }",
+            "variables": {
+              "filter": [
+                {
+                  "id": {
+                    "equals": "1",
+                  },
+                },
+              ],
+              "first": 1,
+            },
+          }
+        `);
+      });
+    });
   });
 });

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -10,7 +10,7 @@ import {
   assertNullableOperationSuccess,
   assertOperationSuccess,
   camelize,
-  capitalize,
+  capitalizeIdentifier,
   hydrateConnection,
   hydrateRecord,
   hydrateRecordArray,
@@ -40,7 +40,7 @@ const internalHydrationPlan = (modelApiIdentifer: string) => `
 `;
 
 export const internalFindOneQuery = (apiIdentifier: string) => {
-  const capitalizedApiIdentifier = capitalize(apiIdentifier);
+  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
   return `
     query InternalFind${capitalizedApiIdentifier}($id: GadgetID!) {
       ${internalHydrationPlan(apiIdentifier)}
@@ -52,7 +52,7 @@ export const internalFindOneQuery = (apiIdentifier: string) => {
 };
 
 export const internalFindFirstQuery = (apiIdentifier: string, options?: RecordData) => {
-  const capitalizedApiIdentifier = capitalize(apiIdentifier);
+  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
 
   const defaultVariables = {
     ...(options?.search && { search: { value: options?.search, type: "String", required: false } }),
@@ -86,7 +86,7 @@ export const internalFindFirstQuery = (apiIdentifier: string, options?: RecordDa
 };
 
 export const internalFindManyQuery = (apiIdentifier: string, options?: RecordData) => {
-  const capitalizedApiIdentifier = capitalize(apiIdentifier);
+  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
 
   const defaultVariables = {
     ...(options?.search && { search: { value: options?.search, type: "String", required: false } }),
@@ -126,7 +126,7 @@ export const internalFindManyQuery = (apiIdentifier: string, options?: RecordDat
 };
 
 export const internalCreateMutation = (apiIdentifier: string) => {
-  const capitalizedApiIdentifier = capitalize(apiIdentifier);
+  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
   return `
     ${internalErrorsDetails}
 
@@ -146,8 +146,8 @@ export const internalCreateMutation = (apiIdentifier: string) => {
 };
 
 export const internalBulkCreateMutation = (apiIdentifier: string, pluralApiIdentifier: string) => {
-  const capitalizedApiIdentifier = capitalize(apiIdentifier);
-  const capitalizedPluralApiIdentifier = capitalize(pluralApiIdentifier);
+  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
+  const capitalizedPluralApiIdentifier = capitalizeIdentifier(pluralApiIdentifier);
 
   return `
     ${internalErrorsDetails}
@@ -168,7 +168,7 @@ export const internalBulkCreateMutation = (apiIdentifier: string, pluralApiIdent
 };
 
 export const internalUpdateMutation = (apiIdentifier: string) => {
-  const capitalizedApiIdentifier = capitalize(apiIdentifier);
+  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
   return `
     ${internalErrorsDetails}
 
@@ -188,7 +188,7 @@ export const internalUpdateMutation = (apiIdentifier: string) => {
 };
 
 export const internalDeleteMutation = (apiIdentifier: string) => {
-  const capitalizedApiIdentifier = capitalize(apiIdentifier);
+  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
   return `
     ${internalErrorsDetails}
 
@@ -207,7 +207,7 @@ export const internalDeleteMutation = (apiIdentifier: string) => {
 };
 
 export const internalDeleteManyMutation = (apiIdentifier: string) => {
-  const capitalizedApiIdentifier = capitalize(apiIdentifier);
+  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
   return `
     ${internalErrorsDetails}
 
@@ -306,7 +306,7 @@ export class InternalModelManager {
         throw new GadgetClientError("Cannot perform bulkCreate without a pluralApiIdentifier");
       }
 
-      const capitalizedPluralApiIdentifier = capitalize(this.options.pluralApiIdentifier);
+      const capitalizedPluralApiIdentifier = capitalizeIdentifier(this.options.pluralApiIdentifier);
       const response = await transaction.client
         .mutation(internalBulkCreateMutation(this.apiIdentifier, this.options.pluralApiIdentifier), {
           records,

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -211,10 +211,9 @@ export const capitalizeIdentifier = (str: string | undefined | null): string => 
 const capitalizeFirstCharacter = (str: string) => {
   const result = str === null || str === undefined ? "" : String(str);
   return result.charAt(0).toUpperCase() + result.slice(1);
-}
+};
 
 export const camelize = (term: string, uppercaseFirstLetter = true) => {
-
   let result = "" + term;
 
   if (uppercaseFirstLetter) {

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -203,23 +203,23 @@ export const get = (object: Record<string, any> | null | undefined, path: string
 
 export const isCloseEvent = (event: any): event is CloseEvent => event?.type == "close";
 
-export const capitalize = (str: string | undefined | null): string => {
+export const capitalizeIdentifier = (str: string | undefined | null): string => {
   if (typeof str !== "string") return "";
   return camelize(str, true);
 };
 
+const capitalizeFirstCharacter = (str: string) => {
+  const result = str === null || str === undefined ? "" : String(str);
+  return result.charAt(0).toUpperCase() + result.slice(1);
+}
+
 export const camelize = (term: string, uppercaseFirstLetter = true) => {
 
-  const capitalize = (str: string) => {
-    const result = str === null || str === undefined ? "" : String(str);
-    return result.charAt(0).toUpperCase() + result.slice(1);
-  }
-  
   let result = "" + term;
 
   if (uppercaseFirstLetter) {
     result = result.replace(/^[a-z\d]*/, (a) => {
-      return capitalize(a);
+      return capitalizeFirstCharacter(a);
     });
   } else {
     result = result.replace(new RegExp("^(?:(?=\\b|[A-Z_])|\\w)"), (a) => {
@@ -229,7 +229,7 @@ export const camelize = (term: string, uppercaseFirstLetter = true) => {
 
   result = result.replace(/(?:_|(\/))([a-z\d]*)/gi, (_match, a, b, _idx, _string) => {
     a || (a = "");
-    return "" + a + capitalize(b);
+    return "" + a + capitalizeFirstCharacter(b);
   });
 
   return result;

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -203,9 +203,11 @@ export const get = (object: Record<string, any> | null | undefined, path: string
 
 export const isCloseEvent = (event: any): event is CloseEvent => event?.type == "close";
 
-export const capitalize = (str: string | undefined | null) => {
-  const result = str === null || str === undefined ? "" : String(str);
-  return result.charAt(0).toUpperCase() + result.slice(1);
+export const capitalize = (str: string | undefined | null): string => {
+  if(typeof str !== "string") return "";
+  return str.split("_").map((substr) => {
+    return substr.charAt(0).toUpperCase() + substr.slice(1);
+  }).join("");
 };
 
 export const camelize = (term: string, uppercaseFirstLetter = true) => {

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -204,10 +204,13 @@ export const get = (object: Record<string, any> | null | undefined, path: string
 export const isCloseEvent = (event: any): event is CloseEvent => event?.type == "close";
 
 export const capitalize = (str: string | undefined | null): string => {
-  if(typeof str !== "string") return "";
-  return str.split("_").map((substr) => {
-    return substr.charAt(0).toUpperCase() + substr.slice(1);
-  }).join("");
+  if (typeof str !== "string") return "";
+  return str
+    .split("_")
+    .map((substr) => {
+      return substr.charAt(0).toUpperCase() + substr.slice(1);
+    })
+    .join("");
 };
 
 export const camelize = (term: string, uppercaseFirstLetter = true) => {

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -205,15 +205,16 @@ export const isCloseEvent = (event: any): event is CloseEvent => event?.type == 
 
 export const capitalize = (str: string | undefined | null): string => {
   if (typeof str !== "string") return "";
-  return str
-    .split("_")
-    .map((substr) => {
-      return substr.charAt(0).toUpperCase() + substr.slice(1);
-    })
-    .join("");
+  return camelize(str, true);
 };
 
 export const camelize = (term: string, uppercaseFirstLetter = true) => {
+
+  const capitalize = (str: string) => {
+    const result = str === null || str === undefined ? "" : String(str);
+    return result.charAt(0).toUpperCase() + result.slice(1);
+  }
+  
   let result = "" + term;
 
   if (uppercaseFirstLetter) {

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.13.0",
+    "@gadgetinc/api-client-core": "^0.14.0",
     "@shopify/app-bridge-utils": "^3.1.1",
     "crypto-js": "^4.1.1",
     "lodash": "^4.17.21"

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.14.0",
+    "@gadgetinc/api-client-core": "^0.13.10",
     "@shopify/app-bridge-utils": "^3.1.1",
     "crypto-js": "^4.1.1",
     "lodash": "^4.17.21"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.13.4",
+    "@gadgetinc/api-client-core": "^0.14.0",
     "deep-equal": "^2.2.0",
     "urql": "^3.0.3"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.14.0",
+    "@gadgetinc/api-client-core": "^0.13.10",
     "deep-equal": "^2.2.0",
     "urql": "^3.0.3"
   },

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -1,5 +1,5 @@
 import type { ActionFunction, DefaultSelection, GadgetRecord, LimitToKnownKeys, Select } from "@gadgetinc/api-client-core";
-import { actionOperation, capitalize, get, hydrateRecord } from "@gadgetinc/api-client-core";
+import { actionOperation, capitalizeIdentifier, get, hydrateRecord } from "@gadgetinc/api-client-core";
 import { useCallback, useContext, useMemo } from "react";
 import type { AnyVariables, UseMutationState } from "urql";
 import { GadgetContext } from "./GadgetProvider";
@@ -83,7 +83,7 @@ export const useAction = <
         // selected (and sometimes we can't even select it, like delete actions!)
         const result = await runMutation(variables, {
           ...context,
-          additionalTypenames: [...(context?.additionalTypenames ?? []), capitalize(action.modelApiIdentifier)],
+          additionalTypenames: [...(context?.additionalTypenames ?? []), capitalizeIdentifier(action.modelApiIdentifier)],
         });
         return processResult({ fetching: false, stale: false, ...result }, action);
       },

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -1,5 +1,5 @@
 import type { BulkActionFunction, DefaultSelection, GadgetRecord, LimitToKnownKeys, Select } from "@gadgetinc/api-client-core";
-import { actionOperation, capitalize, get, hydrateRecordArray } from "@gadgetinc/api-client-core";
+import { actionOperation, capitalizeIdentifier, get, hydrateRecordArray } from "@gadgetinc/api-client-core";
 import { useCallback, useMemo } from "react";
 import type { UseMutationState } from "urql";
 import type { OptionsType } from "./OptionsType";
@@ -77,7 +77,7 @@ export const useBulkAction = <
         // selected (and sometimes we can't even select it, like delete actions!)
         const result = await runMutation(variables, {
           ...context,
-          additionalTypenames: [...(context?.additionalTypenames ?? []), capitalize(action.modelApiIdentifier)],
+          additionalTypenames: [...(context?.additionalTypenames ?? []), capitalizeIdentifier(action.modelApiIdentifier)],
         });
         return processResult({ fetching: false, stale: false, ...result }, action);
       },


### PR DESCRIPTION
(ex. hello_world => HelloWorld)

Came back to this ancient bug where model api identifiers with underscores fail to run CRUD API. 
This was because the behavior of the capitalize function was inconsistent with how we name our GraphQL types. 

internally this solves GGT-2123

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
