### PR TITLE
Ensure that `api.fetch` doesn't mangle query params when used with relative urls

### DIFF
--- a/packages/api-client-core/spec/GadgetConnection-suite.ts
+++ b/packages/api-client-core/spec/GadgetConnection-suite.ts
@@ -678,6 +678,27 @@ export const GadgetConnectionSharedSuite = (queryExtra = "") => {
       expect(await result.text()).toEqual("hello");
     });
 
+    test("fetch can pass relative string paths with query params", async () => {
+      const connection = new GadgetConnection({
+        endpoint: "https://someapp.gadget.app/api/graphql",
+        authenticationMode: { apiKey: "gsk-abcde" },
+      });
+
+      nock("https://someapp.gadget.app")
+        .get("/foo/bar")
+        .query({
+          query: "baz",
+        })
+        .reply(200, function () {
+          expect(this.req.headers["authorization"]).toEqual([`Bearer gsk-abcde`]);
+          return "hello";
+        });
+
+      const result = await connection.fetch("/foo/bar?query=baz");
+      expect(result.status).toEqual(200);
+      expect(await result.text()).toEqual("hello");
+    });
+
     test("fetches can specify a desired content type", async () => {
       const connection = new GadgetConnection({
         endpoint: "https://someapp.gadget.app/api/graphql",

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -497,9 +497,7 @@ function processMaybeRelativeInput(input: RequestInfo | URL, endpoint: string): 
   if (typeof input != "string") return input;
   if (isRelativeUrl(input)) {
     try {
-      const url = new URL(endpoint);
-      url.pathname = input;
-      return url;
+      return String(new URL(input, endpoint));
     } catch (err) {
       return input;
     }


### PR DESCRIPTION
Fixes a bug where `useFetch("/some/path?foo=bar")` would send the included query params URL encoded. 