### PR TITLE
support optional model api identifier in react hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@gadget-client/bulk-actions-test": "^1.101.0",
-    "@gadget-client/related-products-example": "^1.783.0",
+    "@gadget-client/related-products-example": "^1.844.0",
     "@gadgetinc/eslint-config": "^0.6.1",
     "@gadgetinc/prettier-config": "^0.4.0",
     "@swc/core": "^1.3.42",

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -101,6 +101,9 @@ interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, SchemaT, Defa
   variables: VariableOptions;
   variablesType: VariablesT;
   isBulk: IsBulk;
+  hasAmbiguousIdentifier?: boolean;
+  hasCreateOrUpdateEffect?: boolean;
+  paramOnlyVariables?: readonly string[];
 }
 
 export type ActionFunction<OptionsT, VariablesT, SelectionT, SchemaT, DefaultsT> = ActionFunctionMetadata<

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -508,9 +508,7 @@ export const CreatePost = () => {
           // run the action when the button is clicked
           // the action runner function accepts action inputs in the same format as api.blogPost.create, and the GraphQL API
           createBlogPost({
-            blogPost: {
-              title: "New post created from React",
-            },
+            title: "New post created from React",
           });
         }}
       >
@@ -549,9 +547,7 @@ export const UpdatePost = (props: { id: string }) => {
         // pass the id of the blog post we're updating as one parameter, and the new post attributes as another
         updateBlogPost({
           id: props.id,
-          post: {
-            title,
-          },
+          title,
         });
       }}
     >
@@ -574,7 +570,7 @@ const [{ data, fetching, error }, _refetch] = useFindBy(api.blogPost.findBySlug,
 
 ### `useGlobalAction(actionFunction: GlobalActionFunction, options: UseGlobalActionOptions = {}): [{data, fetching, error}, refetch]`
 
-`useGlobalAction` is a hook for running a backend Global Action. `useGlobalAction(api.widget.create)` is the React equivalent of `await api.someGlobalAction({...})`. `useGlobalAction` doesn't immediately dispatch a request to run an action server side, but instead returns a result object and a function which runs the action, similar to [`urql`'s `useMutation` hook](https://formidable.com/open-source/urql/docs/api/urql/#usemutation). `useGlobalAction` must be passed one of the global action functions from an instance of your application's generated API client. Options:
+`useGlobalAction` is a hook for running a backend Global Action. `useGlobalAction(api.someGlobalAction)` is the React equivalent of `await api.someGlobalAction({...})`. `useGlobalAction` doesn't immediately dispatch a request to run an action server side, but instead returns a result object and a function which runs the action, similar to [`urql`'s `useMutation` hook](https://formidable.com/open-source/urql/docs/api/urql/#usemutation). `useGlobalAction` must be passed one of the global action functions from an instance of your application's generated API client. Options:
 
 - `globalActionFunction`: The action function from your application's API client. Gadget generates these global action functions for each global action defined in your Gadget backend. Required. Example: `api.runSync`, or `api.purgeData` (corresponding to Global Actions named `Run Sync` or `Purge Data`).
 - `options`: Options for making the call to the backend. Not required and all keys are optional.

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -25,10 +25,8 @@ import { ErrorWrapper, noProviderErrorMessage } from "./utils";
  *   });
  *
  *   const onClick = () => createUser({
- *     user: {
- *       name: props.name,
- *       email: props.email,
- *     }
+ *     name: props.name,
+ *     email: props.email,
  *   });
  *
  *   return (
@@ -86,6 +84,8 @@ export const useAction = <
         }
 
         let newVariables: Exclude<F["variablesType"], null | undefined>;
+        const idVariable = Object.entries(action.variables).find(([key, value]) => key === "id" && value.type === "GadgetID");
+
         if (action.hasCreateOrUpdateEffect) {
           if (
             action.modelApiIdentifier in variables &&
@@ -101,7 +101,7 @@ export const useAction = <
               if (action.paramOnlyVariables?.includes(key)) {
                 newVariables[key] = value;
               } else {
-                if (key === "id") {
+                if (idVariable && key === idVariable[0]) {
                   newVariables.id = value;
                 } else {
                   newVariables[action.modelApiIdentifier][key] = value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,12 +661,12 @@
   dependencies:
     "@gadgetinc/api-client-core" "0.11.0"
 
-"@gadget-client/related-products-example@^1.783.0":
-  version "1.783.0"
-  resolved "https://registry.gadget.dev/npm/_/tarball/1268/1361/1486#fddfba4e201f4d30478c7a03de30ca14185d687d"
-  integrity sha1-/d+6TiAfTTBHjHoD3jDKFBhdaH0=
+"@gadget-client/related-products-example@^1.844.0":
+  version "1.844.0"
+  resolved "https://registry.gadget.dev/npm/_/tarball/1268/1361/4716#7110b19ac473252b3f3966be74454b08226caa04"
+  integrity sha1-cRCxmsRzJSs/OWa+dEVLCCJsqgQ=
   dependencies:
-    "@gadgetinc/api-client-core" "0.9.0"
+    "@gadgetinc/api-client-core" "0.13.9"
 
 "@gadget-client/simple-blog@^1.130.0":
   version "1.130.0"
@@ -676,7 +676,7 @@
     "@gadgetinc/api-client-core" "0.13.3"
 
 "@gadgetinc/api-client-core@0.11.0":
-  version "0.13.6"
+  version "0.13.9"
   dependencies:
     "@opentelemetry/api" "^1.4.0"
     "@urql/core" "^3.0.1"
@@ -691,22 +691,7 @@
     ws "^8.11.0"
 
 "@gadgetinc/api-client-core@0.13.3":
-  version "0.13.6"
-  dependencies:
-    "@opentelemetry/api" "^1.4.0"
-    "@urql/core" "^3.0.1"
-    "@urql/exchange-multipart-fetch" "^1.0.1"
-    cross-fetch "^3.0.6"
-    gql-query-builder "^3.7.2"
-    graphql "^16.5.0"
-    graphql-ws "^5.5.5"
-    isomorphic-ws "^4.0.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.isequal "^4.5.0"
-    ws "^8.11.0"
-
-"@gadgetinc/api-client-core@0.9.0":
-  version "0.13.6"
+  version "0.13.9"
   dependencies:
     "@opentelemetry/api" "^1.4.0"
     "@urql/core" "^3.0.1"


### PR DESCRIPTION
We need to update the react hooks to also allow optional model api identifiers. This follows the same logic that the internal and public model managers.

closes GGT-4093

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
