### PR TITLE
Update the react provider to accept a full instance of an api client instead of just the urql client

### DIFF
--- a/packages/api-client-core/src/AnyClient.ts
+++ b/packages/api-client-core/src/AnyClient.ts
@@ -2,6 +2,9 @@ import type { GadgetConnection } from "./GadgetConnection";
 import type { GadgetTransaction } from "./GadgetTransaction";
 import type { InternalModelManager } from "./InternalModelManager";
 
+/**
+ * An instance of any Gadget app's API client object
+ */
 export interface AnyClient {
   connection: GadgetConnection;
   query(graphQL: string, variables?: Record<string, any>): Promise<any>;
@@ -11,3 +14,10 @@ export interface AnyClient {
     [key: string]: InternalModelManager;
   };
 }
+
+/**
+ * Checks if the given object is an instance of any Gadget app's generated JS client object
+ */
+export const isGadgetClient = (client: any): client is AnyClient => {
+  return client && "connection" in client && client.connection && "endpoint" in client.connection;
+};

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,7 +66,7 @@ const api = new Client({ authenticationMode: { browserSession: true } });
 
 export const MyApp = (props) => {
   // wrapp the application in the <Provider> so the hooks can find the current client
-  return <Provider value={api.connection.currentClient}>{props.children}</Provider>;
+  return <Provider api={api}>{props.children}</Provider>;
 };
 ```
 
@@ -85,7 +85,7 @@ const api = new Client({ authenticationMode: { browserSession: true } });
 export function MyComponent() {
   // ensure any components which use the @gadgetinc/react hooks are wrapped with the provider, and passed the current api client
   return (
-    <Provider value={api.connection.currentClient}>
+    <Provider api={api}>
       <WidgetDeleter />
     </Provider>
   );
@@ -991,7 +991,7 @@ query GetWidgets {
 };
 
 export const App = () => (
-  <Provider value={api.connection.currentClient}>
+  <Provider api={api}>
     <ShowWidgetNames />
   </Provider>
 );

--- a/packages/react/spec/GadgetProvider.spec.tsx
+++ b/packages/react/spec/GadgetProvider.spec.tsx
@@ -1,0 +1,65 @@
+// eslint-disable @typescript-eslint/ban-ts-comment
+import type { AnyClient } from "@gadgetinc/api-client-core";
+import { GadgetConnection } from "@gadgetinc/api-client-core";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { Provider, useConnection } from "../src/GadgetProvider";
+import { mockUrqlClient } from "./testWrapper";
+
+describe("GadgetProvider", () => {
+  let mockApiClient: AnyClient;
+  beforeEach(() => {
+    mockApiClient = {
+      connection: new GadgetConnection({
+        endpoint: "https://whatever.gadget.app/endpoint",
+      }),
+    } as any;
+  });
+
+  test("internal components can access the urql client when wrapped in the provider which is passed an api client", () => {
+    const { result } = renderHook(() => useConnection(), {
+      wrapper: (props: { children: ReactNode }) => {
+        return <Provider api={mockApiClient}>{props.children}</Provider>;
+      },
+    });
+
+    expect(result).toBeTruthy();
+  });
+
+  test("internal components can access the urql client when wrapped in the provider which is passed an urql client", () => {
+    const { result } = renderHook(() => useConnection(), {
+      wrapper: (props: { children: ReactNode }) => {
+        return <Provider value={mockUrqlClient}>{props.children}</Provider>;
+      },
+    });
+
+    expect(result).toBeTruthy();
+  });
+
+  test("the provider errors when not passed anything", () => {
+    expect(() =>
+      renderHook(() => useConnection(), {
+        wrapper: (props: { children: ReactNode }) => {
+          // @ts-expect-error checking error case
+          return <Provider>{props.children}</Provider>;
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"No Gadget API client passed to <Provider /> component -- please pass an instance of your generated client, like <Provider api={api} />!"`
+    );
+  });
+
+  test("the provider errors when passed an invalid api client", () => {
+    expect(() =>
+      renderHook(() => useConnection(), {
+        wrapper: (props: { children: ReactNode }) => {
+          // @ts-expect-error checking error case
+          return <Provider api={class {}}>{props.children}</Provider>;
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Invalid Gadget API client passed to <Provider /> component -- please pass an instance of your generated client, like <Provider api={api} />!"`
+    );
+  });
+});

--- a/packages/react/spec/testWrapper.tsx
+++ b/packages/react/spec/testWrapper.tsx
@@ -8,7 +8,7 @@ import type { Client, GraphQLRequest, OperationContext, OperationResult } from "
 import { makeErrorResult } from "urql";
 import type { Subject } from "wonka";
 import { makeSubject } from "wonka";
-import { GadgetProvider as Provider } from "../src/GadgetProvider";
+import { Provider } from "../src/GadgetProvider";
 
 export type MockOperationFn = jest.Mock & {
   subjects: Record<string, Subject<OperationResult>>;
@@ -122,17 +122,17 @@ const newMockFetchFn = () => {
   return fn;
 };
 
-export const mockClient = {} as MockUrqlClient;
+export const mockUrqlClient = {} as MockUrqlClient;
 beforeEach(() => {
-  mockClient.executeQuery = newMockOperationFn();
-  mockClient.executeMutation = newMockOperationFn();
-  mockClient.executeSubscription = newMockOperationFn();
-  mockClient[$gadgetConnection] = {
+  mockUrqlClient.executeQuery = newMockOperationFn();
+  mockUrqlClient.executeMutation = newMockOperationFn();
+  mockUrqlClient.executeSubscription = newMockOperationFn();
+  mockUrqlClient[$gadgetConnection] = {
     fetch: newMockFetchFn(),
   };
 });
 
-export const createMockCLient = (assertions?: {
+export const createMockUrqlCient = (assertions?: {
   mutationAssertions?: (request: GraphQLRequest) => void;
   queryAssertions?: (request: GraphQLRequest) => void;
 }) => {
@@ -147,5 +147,5 @@ export const createMockCLient = (assertions?: {
 };
 
 export const TestWrapper = (props: { children: ReactNode }) => {
-  return <Provider value={mockClient}>{props.children}</Provider>;
+  return <Provider value={mockUrqlClient}>{props.children}</Provider>;
 };

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -6,10 +6,10 @@ import { assert } from "conditional-type-checks";
 import React from "react";
 import type { AnyVariables } from "urql";
 import { useAction } from "../src";
-import { GadgetProvider as Provider } from "../src/GadgetProvider";
+import { Provider } from "../src/GadgetProvider";
 import type { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
-import { TestWrapper, createMockCLient, mockClient } from "./testWrapper";
+import { TestWrapper, createMockUrqlCient, mockUrqlClient } from "./testWrapper";
 
 describe("useAction", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -109,9 +109,9 @@ describe("useAction", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("updateUser", {
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
       data: {
         updateUser: {
           success: true,
@@ -154,9 +154,9 @@ describe("useAction", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("updateUser", {
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
       data: {
         updateUser: {
           success: false,
@@ -204,9 +204,9 @@ describe("useAction", () => {
       mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } });
     });
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("updateUser", {
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
       data: {
         updateUser: {
           success: true,
@@ -242,9 +242,9 @@ describe("useAction", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("updateUser", {
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
       data: {
         updateUser: {
           success: true,
@@ -277,9 +277,9 @@ describe("useAction", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeMutation).toBeCalledTimes(2);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(2);
 
-    mockClient.executeMutation.pushResponse("updateUser", {
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
       data: {
         updateUser: {
           success: true,
@@ -308,7 +308,7 @@ describe("useAction", () => {
   test("generates correct mutation and variables for a mutation without model api identifier", async () => {
     let variables: AnyVariables;
 
-    const client = createMockCLient({
+    const client = createMockUrqlCient({
       mutationAssertions: (request) => {
         variables = request.variables;
       },

--- a/packages/react/spec/useBulkAction.spec.ts
+++ b/packages/react/spec/useBulkAction.spec.ts
@@ -6,7 +6,7 @@ import { act } from "react-dom/test-utils";
 import { useBulkAction } from "../src";
 import type { ErrorWrapper } from "../src/utils";
 import { bulkExampleApi } from "./apis";
-import { mockClient, TestWrapper } from "./testWrapper";
+import { mockUrqlClient, TestWrapper } from "./testWrapper";
 
 describe("useBulkAction", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -70,9 +70,9 @@ describe("useBulkAction", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
+    mockUrqlClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
       data: {
         bulkFlipDownWidgets: {
           success: true,
@@ -117,9 +117,9 @@ describe("useBulkAction", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
+    mockUrqlClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
       data: {
         bulkFlipDownWidgets: {
           success: false,
@@ -155,9 +155,9 @@ describe("useBulkAction", () => {
       mutationPromise = result.current[1]({ ids: ["123", "124"] });
     });
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
+    mockUrqlClient.executeMutation.pushResponse("bulkFlipDownWidgets", {
       data: {
         bulkFlipDownWidgets: {
           success: true,

--- a/packages/react/spec/useFetch.spec.ts
+++ b/packages/react/spec/useFetch.spec.ts
@@ -5,7 +5,7 @@ import { assert } from "conditional-type-checks";
 import { Response } from "cross-fetch";
 import { useFetch } from "../src/useFetch";
 import type { ErrorWrapper } from "../src/utils";
-import { TestWrapper, mockClient } from "./testWrapper";
+import { TestWrapper, mockUrqlClient } from "./testWrapper";
 
 describe("useFetch", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -65,14 +65,14 @@ describe("useFetch", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch.requests[0].args).toEqual(["/foo/bar", {}]);
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("hello world"));
+    expect(mockUrqlClient[$gadgetConnection].fetch.requests[0].args).toEqual(["/foo/bar", {}]);
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("hello world"));
 
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].data).toEqual("hello world");
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
   });
 
   test("it can fetch json from the backend", async () => {
@@ -82,14 +82,14 @@ describe("useFetch", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch.requests[0].args).toEqual(["/foo/bar", { headers: { accept: "application/json" } }]);
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response('{"hello": 1}'));
+    expect(mockUrqlClient[$gadgetConnection].fetch.requests[0].args).toEqual(["/foo/bar", { headers: { accept: "application/json" } }]);
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response('{"hello": 1}'));
 
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].data).toEqual({ hello: 1 });
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
   });
 
   test("it reports response errors from the backend", async () => {
@@ -99,7 +99,7 @@ describe("useFetch", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("error response", { status: 500 }));
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("error response", { status: 500 }));
 
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].data).toBeUndefined();
@@ -108,15 +108,15 @@ describe("useFetch", () => {
     expect(result.current[0].error!.response).toBeTruthy();
     expect(result.current[0].error!.response.status).toEqual(500);
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
   });
 
   test("it can rexecute to fetch a new string from the backend", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: TestWrapper });
 
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("hello world"));
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("hello world"));
     expect(result.current[0].data).toEqual("hello world");
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
 
     let reexecutePromise: Promise<string>;
     act(() => {
@@ -126,7 +126,7 @@ describe("useFetch", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("hello canada"));
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("hello canada"));
 
     const reexecuteResult = await reexecutePromise!;
 
@@ -143,12 +143,12 @@ describe("useFetch", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("error response", { status: 500 }));
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("error response", { status: 500 }));
 
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].error).toBeTruthy();
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
 
     let reexecutePromise: Promise<string>;
     act(() => {
@@ -158,7 +158,7 @@ describe("useFetch", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("fixed"));
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("fixed"));
 
     const reexecuteResult = await reexecutePromise!;
 
@@ -173,28 +173,28 @@ describe("useFetch", () => {
     const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: TestWrapper });
 
     expect(result.current[0].fetching).toBe(true);
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
-    expect(mockClient[$gadgetConnection].fetch.requests[0].args).toEqual(["/foo/bar", {}]);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch.requests[0].args).toEqual(["/foo/bar", {}]);
   });
 
   test("it automatically starts sending requests with the GET method specified", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { method: "GET" }), { wrapper: TestWrapper });
 
     expect(result.current[0].fetching).toBe(true);
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
   });
 
   test("it does not automatically start sending requests with the GET method specified but sendImmediately: false", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { method: "GET", sendImmediately: false }), { wrapper: TestWrapper });
 
     expect(result.current[0].fetching).toBe(false);
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(0);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(0);
   });
 
   test("it doesn't automatically start sending POST requests by default", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { method: "POST" }), { wrapper: TestWrapper });
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(0);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(0);
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].error).toBeFalsy();
@@ -208,60 +208,60 @@ describe("useFetch", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch.requests[0].args).toEqual(["/foo/bar", { method: "POST" }]);
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("hello world"));
+    expect(mockUrqlClient[$gadgetConnection].fetch.requests[0].args).toEqual(["/foo/bar", { method: "POST" }]);
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("hello world"));
 
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].data).toEqual("hello world");
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
   });
 
   test("it automatically starts sending requests with the POST method specified and sendImmediately: true", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { method: "GET", sendImmediately: true }), { wrapper: TestWrapper });
 
     expect(result.current[0].fetching).toBe(true);
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
   });
 
   test("POST requests can be given options when executed", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { method: "POST" }), { wrapper: TestWrapper });
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(0);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(0);
 
     let reexecutePromise: Promise<string>;
     act(() => {
       reexecutePromise = result.current[1]({ headers: { "X-Test": "hello" }, body: JSON.stringify({ test: true }) });
     });
 
-    expect(mockClient[$gadgetConnection].fetch.requests[0].args).toEqual([
+    expect(mockUrqlClient[$gadgetConnection].fetch.requests[0].args).toEqual([
       "/foo/bar",
       { method: "POST", headers: { "X-Test": "hello" }, body: JSON.stringify({ test: true }) },
     ]);
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("hello world"));
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("hello world"));
 
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].data).toEqual("hello world");
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
 
     act(() => {
       reexecutePromise = result.current[1]({ headers: { "X-Test": "other" }, body: "other body" });
     });
 
-    expect(mockClient[$gadgetConnection].fetch.requests[0].args).toEqual([
+    expect(mockUrqlClient[$gadgetConnection].fetch.requests[0].args).toEqual([
       "/foo/bar",
       { method: "POST", headers: { "X-Test": "other" }, body: "other body" },
     ]);
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response("second response"));
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response("second response"));
 
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].data).toEqual("second response");
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(2);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(2);
   });
 
   test("it can fetch json from third party apis", async () => {
@@ -271,16 +271,16 @@ describe("useFetch", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch.requests[0].args).toEqual([
+    expect(mockUrqlClient[$gadgetConnection].fetch.requests[0].args).toEqual([
       "https://dummyjson.com/products",
       { headers: { accept: "application/json" } },
     ]);
-    await mockClient[$gadgetConnection].fetch.pushResponse(new Response('{"hello": 1}'));
+    await mockUrqlClient[$gadgetConnection].fetch.pushResponse(new Response('{"hello": 1}'));
 
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].data).toEqual({ hello: 1 });
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient[$gadgetConnection].fetch).toBeCalledTimes(1);
+    expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
   });
 });

--- a/packages/react/spec/useFindBy.spec.ts
+++ b/packages/react/spec/useFindBy.spec.ts
@@ -5,7 +5,7 @@ import { assert } from "conditional-type-checks";
 import { useFindBy } from "../src";
 import type { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
-import { mockClient, TestWrapper } from "./testWrapper";
+import { mockUrqlClient, TestWrapper } from "./testWrapper";
 
 describe("useFindBy", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -44,9 +44,9 @@ describe("useFindBy", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("users", {
+    mockUrqlClient.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],
@@ -73,9 +73,9 @@ describe("useFindBy", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("users", {
+    mockUrqlClient.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [],
@@ -101,9 +101,9 @@ describe("useFindBy", () => {
       wrapper: TestWrapper,
     });
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("users", {
+    mockUrqlClient.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -5,7 +5,7 @@ import { assert } from "conditional-type-checks";
 import { useFindMany } from "../src/useFindMany";
 import type { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
-import { mockClient, TestWrapper } from "./testWrapper";
+import { mockUrqlClient, TestWrapper } from "./testWrapper";
 
 describe("useFindMany", () => {
   // all these functions are typechecked but never run to avoid actually making API calls
@@ -40,9 +40,9 @@ describe("useFindMany", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("users", {
+    mockUrqlClient.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [
@@ -79,9 +79,9 @@ describe("useFindMany", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("users", {
+    mockUrqlClient.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [
@@ -113,9 +113,9 @@ describe("useFindMany", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(2);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(2);
 
-    mockClient.executeQuery.pushResponse("users", {
+    mockUrqlClient.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [
@@ -147,9 +147,9 @@ describe("useFindMany", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("users", {
+    mockUrqlClient.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [],
@@ -175,9 +175,9 @@ describe("useFindMany", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("users", {
+    mockUrqlClient.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -5,7 +5,7 @@ import { assert } from "conditional-type-checks";
 import { useFindOne } from "../src";
 import type { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
-import { mockClient, TestWrapper } from "./testWrapper";
+import { mockUrqlClient, TestWrapper } from "./testWrapper";
 
 describe("useFindOne", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -42,9 +42,9 @@ describe("useFindOne", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("user", {
+    mockUrqlClient.executeQuery.pushResponse("user", {
       data: {
         user: {
           id: "123",
@@ -66,9 +66,9 @@ describe("useFindOne", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("user", {
+    mockUrqlClient.executeQuery.pushResponse("user", {
       data: {
         user: null,
       },
@@ -89,9 +89,9 @@ describe("useFindOne", () => {
   test("returns the same data on rerender", async () => {
     const { result, rerender } = renderHook(() => useFindOne(relatedProductsApi.user, "123"), { wrapper: TestWrapper });
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("user", {
+    mockUrqlClient.executeQuery.pushResponse("user", {
       data: {
         user: {
           id: "123",

--- a/packages/react/spec/useGet.spec.ts
+++ b/packages/react/spec/useGet.spec.ts
@@ -5,7 +5,7 @@ import { assert } from "conditional-type-checks";
 import { useGet } from "../src/useGet";
 import type { ErrorWrapper } from "../src/utils";
 import { relatedProductsApi } from "./apis";
-import { TestWrapper, mockClient } from "./testWrapper";
+import { TestWrapper, mockUrqlClient } from "./testWrapper";
 
 describe("useGet", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -42,9 +42,9 @@ describe("useGet", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("currentSession", {
+    mockUrqlClient.executeQuery.pushResponse("currentSession", {
       data: {
         currentSession: {
           id: "123",
@@ -64,9 +64,9 @@ describe("useGet", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("currentSession", {
+    mockUrqlClient.executeQuery.pushResponse("currentSession", {
       data: {
         currentSession: null,
       },
@@ -80,9 +80,9 @@ describe("useGet", () => {
   test("it returns the same data on rerender", async () => {
     const { result, rerender } = renderHook(() => useGet(relatedProductsApi.currentSession), { wrapper: TestWrapper });
 
-    expect(mockClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
 
-    mockClient.executeQuery.pushResponse("currentSession", {
+    mockUrqlClient.executeQuery.pushResponse("currentSession", {
       data: {
         currentSession: {
           id: "123",

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -5,7 +5,7 @@ import { act } from "react-dom/test-utils";
 import { useGlobalAction } from "../src";
 import type { ErrorWrapper } from "../src/utils";
 import { bulkExampleApi } from "./apis";
-import { mockClient, TestWrapper } from "./testWrapper";
+import { mockUrqlClient, TestWrapper } from "./testWrapper";
 
 describe("useGlobalAction", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -43,9 +43,9 @@ describe("useGlobalAction", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("flipAll", {
+    mockUrqlClient.executeMutation.pushResponse("flipAll", {
       data: {
         flipAll: {
           success: true,
@@ -78,9 +78,9 @@ describe("useGlobalAction", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("flipAll", {
+    mockUrqlClient.executeMutation.pushResponse("flipAll", {
       data: {
         flipAll: {
           success: false,
@@ -113,9 +113,9 @@ describe("useGlobalAction", () => {
       mutationPromise = result.current[1]({ why: "foobar" });
     });
 
-    expect(mockClient.executeMutation).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
-    mockClient.executeMutation.pushResponse("flipAll", {
+    mockUrqlClient.executeMutation.pushResponse("flipAll", {
       data: {
         flipAll: {
           success: true,

--- a/packages/react/src/GadgetProvider.tsx
+++ b/packages/react/src/GadgetProvider.tsx
@@ -1,22 +1,98 @@
-import type { GadgetConnection } from "@gadgetinc/api-client-core";
-import { $gadgetConnection } from "@gadgetinc/api-client-core";
+import type { AnyClient, GadgetConnection } from "@gadgetinc/api-client-core";
+import { $gadgetConnection, isGadgetClient } from "@gadgetinc/api-client-core";
+import type { ReactNode } from "react";
 import React from "react";
-import type { Client } from "urql";
-import { Provider } from "urql";
+import type { Client as UrqlClient } from "urql";
+import { Provider as UrqlProvider } from "urql";
 
-export const GadgetContext = React.createContext<Client | undefined>(undefined);
-export const GadgetProvider: React.FC<React.PropsWithChildren<{ value: Client }>> = ({ children, value }) => {
+/**
+ * React context that stores the current urql client
+ *
+ * urql doesn't have its own useClient hook, so we store it on our own context to get at the client object later
+ **/
+export const GadgetUrqlClientContext = React.createContext<UrqlClient | undefined>(undefined);
+
+/**
+ * React context that stores an instance of the JS Client for an app (AKA the `api` object)
+ */
+export const GadgetClientContext = React.createContext<AnyClient | undefined>(undefined);
+
+export interface ProviderProps {
+  /**
+   * An instance of your app's api client, often named `api`. This is the object that contains all of your generated query/mutation/subscription functions.
+   *
+   * @example
+   * import { Client } from "@gadget-client/example-app"
+   * const api = new Client();
+   * const App = () => {
+   *   return <Provider api={api}>
+   *     <Routes/>
+   *   </Provider>;
+   * }
+   */
+  api: AnyClient;
+  children: ReactNode;
+}
+
+/** @deprecated -- pass an instance of your app's api client instead with the `api` prop */
+export interface DeprecatedProviderProps {
+  /**
+   * an urql client object from your current Gadget client, like `api.connection.currentClient`
+   * @deprecated -- pass an instance of your app's api client instead with the `api` prop
+   */
+  value: UrqlClient;
+  children: ReactNode;
+}
+
+/**
+ * Provider wrapper component that passes an api client instance to the other hooks.
+ *
+ * This component is __required__ as a wrapper around any React components using the other hooks in this library, like `useFindMany` or `useAction`.
+ *
+ * Pass an instance of your app's api client to the `value` prop.
+ *
+ * @example
+ * <Provider value={api}>
+ *   <MyApp />
+ * </Provider>
+ *
+ * @example the Provider accepts the deprecated form of passing an urql client object right in -- this is deprecated and will be removed in a future version. Instead, just pass the whole api instance.
+ * <Provider value={api.connection.currentClient}>
+ *   <MyApp />
+ * </Provider>
+ */
+export function Provider(props: ProviderProps | DeprecatedProviderProps) {
+  let gadgetClient: AnyClient | undefined = undefined;
+  let urqlClient: UrqlClient;
+  if ("api" in props) {
+    if (!isGadgetClient(props.api)) {
+      throw new Error(
+        "Invalid Gadget API client passed to <Provider /> component -- please pass an instance of your generated client, like <Provider api={api} />!"
+      );
+    }
+    gadgetClient = props.api;
+    urqlClient = props.api.connection.currentClient;
+  } else if (props.value) {
+    urqlClient = props.value;
+  } else {
+    throw new Error(
+      "No Gadget API client passed to <Provider /> component -- please pass an instance of your generated client, like <Provider api={api} />!"
+    );
+  }
+
   return (
-    <GadgetContext.Provider value={value}>
-      <Provider value={value}>{children}</Provider>
-    </GadgetContext.Provider>
+    <GadgetUrqlClientContext.Provider value={urqlClient}>
+      <GadgetClientContext.Provider value={gadgetClient}>
+        <UrqlProvider value={urqlClient}>{props.children}</UrqlProvider>
+      </GadgetClientContext.Provider>
+    </GadgetUrqlClientContext.Provider>
   );
-};
+}
 
 export const useConnection = () => {
-  const urqlClient = React.useContext(GadgetContext);
+  const urqlClient = React.useContext(GadgetUrqlClientContext);
   if (!urqlClient) {
-    throw new Error("No urql client object in React context, have you added the GadgetProvider wrapper?");
+    throw new Error("No urql client object in React context, have you added the <Provider/> wrapper component from @gadgetinc/react?");
   }
   const connection = (urqlClient as any)[$gadgetConnection] as GadgetConnection | undefined;
   if (!connection) {
@@ -25,7 +101,7 @@ export const useConnection = () => {
       
       Possible remedies: 
        - ensuring you have the <Provider/> component wrapped around your hook invocation
-       - ensuring you are passing a value to the provider, usually <Provider value={api.connection.currentClient}>
+       - ensuring you are passing a value to the provider, usually <Provider api={api}>
        - ensuring your @gadget-client/<your-app> package and your @gadgetinc/react package are up to date`
     );
   }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
 export { Consumer, Context } from "urql";
-export { GadgetProvider as Provider } from "./GadgetProvider";
+export { Provider } from "./GadgetProvider";
 export * from "./useAction";
 export * from "./useBulkAction";
 export * from "./useFetch";

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -2,7 +2,7 @@ import type { ActionFunction, DefaultSelection, GadgetRecord, LimitToKnownKeys, 
 import { actionOperation, capitalizeIdentifier, get, hydrateRecord } from "@gadgetinc/api-client-core";
 import { useCallback, useContext, useMemo } from "react";
 import type { AnyVariables, UseMutationState } from "urql";
-import { GadgetContext } from "./GadgetProvider";
+import { GadgetUrqlClientContext } from "./GadgetProvider";
 import type { OptionsType } from "./OptionsType";
 import { useGadgetMutation } from "./useGadgetMutation";
 import { useStructuralMemo } from "./useStructuralMemo";
@@ -51,7 +51,7 @@ export const useAction = <
   GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>,
   Exclude<F["variablesType"], null | undefined>
 > => {
-  if (!useContext(GadgetContext)) throw new Error(noProviderErrorMessage);
+  if (!useContext(GadgetUrqlClientContext)) throw new Error(noProviderErrorMessage);
 
   const memoizedOptions = useStructuralMemo(options);
   const plan = useMemo(() => {

--- a/packages/react/src/useGadgetMutation.ts
+++ b/packages/react/src/useGadgetMutation.ts
@@ -1,9 +1,9 @@
 import { useContext } from "react";
 import { useMutation } from "urql";
-import { GadgetContext } from "./GadgetProvider";
+import { GadgetUrqlClientContext } from "./GadgetProvider";
 import { noProviderErrorMessage } from "./utils";
 
 export const useGadgetMutation: typeof useMutation = (query) => {
-  if (!useContext(GadgetContext)) throw new Error(noProviderErrorMessage);
+  if (!useContext(GadgetUrqlClientContext)) throw new Error(noProviderErrorMessage);
   return useMutation(query);
 };

--- a/packages/react/src/useGadgetQuery.ts
+++ b/packages/react/src/useGadgetQuery.ts
@@ -1,9 +1,9 @@
 import { useContext } from "react";
 import { useQuery } from "urql";
-import { GadgetContext } from "./GadgetProvider";
+import { GadgetUrqlClientContext } from "./GadgetProvider";
 import { noProviderErrorMessage } from "./utils";
 
 export const useGadgetQuery: typeof useQuery = (args) => {
-  if (!useContext(GadgetContext)) throw new Error(noProviderErrorMessage);
+  if (!useContext(GadgetUrqlClientContext)) throw new Error(noProviderErrorMessage);
   return useQuery(args);
 };


### PR DESCRIPTION
This changes the signature of the React `<Provider/>` component in a backwards compatible way to accept the `api` client instance instead of an urql client instance. We're likely to need access to more than just the urql client in the react hooks over time. We already have a nasty hack to get back from the urql client to the actual GadgetConnection object in order to power `useFetch`, and I expect more of this kind of thing to happen in the future. Let's update the API from being

```typescript
<Provider value={api.connection.currentClient} />
```

to be

```typescript
<Provider api={api} />
```

This matches the Shopify provider component, which takes an `api` prop as well.

We ensure this change is backwards compatible by still supporting the `value` prop, and still expecting it to be passed an urql client. Added a few tests to this effect as well.

Gadget side PR here: https://github.com/gadget-inc/gadget/pull/6923
