### PR TITLE
Nathan/add parameter to capitalize identifier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
     "christian-kohler.npm-intellisense",
     "christian-kohler.path-intellisense",
     "wix.glean",
+    "silvenon.mdx",
     "bbenoist.nix",
     "jnoortheen.nix-ide"
   ]

--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -206,8 +206,8 @@ export const isCloseEvent = (event: any): event is CloseEvent => event?.type == 
 /**
  * Converts a string to camel case, optionally capitalizing the first character.
  * Defaults to capitalizing the first character.
- * @param str 
- * @param capitalizeFirstCharacter 
+ * @param str
+ * @param capitalizeFirstCharacter
  * @returns Camelize string
  */
 export const capitalizeIdentifier = (str: string | undefined | null, capitalizeFirstCharacter?: boolean): string => {

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -203,9 +203,16 @@ export const get = (object: Record<string, any> | null | undefined, path: string
 
 export const isCloseEvent = (event: any): event is CloseEvent => event?.type == "close";
 
-export const capitalizeIdentifier = (str: string | undefined | null): string => {
+/**
+ * Converts a string to camel case, optionally capitalizing the first character.
+ * Defaults to capitalizing the first character.
+ * @param str 
+ * @param capitalizeFirstCharacter 
+ * @returns Camelize string
+ */
+export const capitalizeIdentifier = (str: string | undefined | null, capitalizeFirstCharacter?: boolean): string => {
   if (typeof str !== "string") return "";
-  return camelize(str, true);
+  return camelize(str, capitalizeFirstCharacter);
 };
 
 const capitalizeFirstCharacter = (str: string) => {


### PR DESCRIPTION
This adds a `capitalizeFirstCharacter` parameter to capitalizeIdentifier so we can completely replace calls to inflected's camelize. 

(The tests ran against production identifiers pass)

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
