### PR TITLE
Export the nix env to all subshells

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -8,11 +8,32 @@ runs:
     - uses: cachix/install-nix-action@v18
       with:
         install_url: https://releases.nixos.org/nix/nix-2.11.1/install
-    - run: nix flake check
+    - run: |
+        source <(nix print-dev-env --show-trace) 
+        output_file="nix-env.txt"
+
+        # Clear the output file
+        > $output_file
+
+        # Loop over each variable in the environment
+        while IFS='=' read -r -d '' name value; do
+            # Skip if the variable is a function or read-only or non-alphanumeric
+            [[ "$(declare -p $name)" =~ "declare -[a-z]*r[a-z]* " ]] && continue
+            [[ ! $name =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] && continue
+
+            # Check if the variable value contains a newline
+            if [[ "$value" != *$'\n'* ]]; then
+                # It doesn't, so write the variable and its value (stripping quotes) to the file
+                echo "${name}=${value//\"/}" >> $output_file
+            fi
+        done < <(env -0)
+        cat nix-env.txt
+      shell: bash
+    - run: cat nix-env.txt >> "$GITHUB_ENV"
       shell: bash
     - name: Add Gadget npm registry
-      shell: nix develop -c bash -eo pipefail -l {0}
+      shell: bash
       run: npm config set @gadget-client:registry https://registry.gadget.dev/npm
     - name: Install dependencies with pnpm
-      shell: nix develop -c bash -eo pipefail -l {0}
+      shell: bash
       run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-test-env
       - name: Build all packages
-        shell: nix develop -c bash -eo pipefail -l {0}
         run: pnpm build
       - name: Publish @gadgetinc/api-client-core
         uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-test-env
       - name: Build all packages (so they can require each other)
-        shell: nix develop -c bash -eo pipefail -l {0}
         run: pnpm build
       - name: Test
-        shell: nix develop -c bash -eo pipefail -l {0}
         run: pnpm test
   lint:
     runs-on: ubuntu-latest
@@ -20,10 +18,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-test-env
       - name: Build all packages (so they can require each other)
-        shell: nix develop -c bash -eo pipefail -l {0}
         run: pnpm build
       - name: Lint
-        shell: nix develop -c bash -eo pipefail -l {0}
         run: pnpm lint
   versions:
     runs-on: ubuntu-latest
@@ -31,5 +27,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-test-env
       - name: Check dependency versions
-        shell: nix develop -c bash -eo pipefail -l {0}
         run: pnpm check-dependency-versions


### PR DESCRIPTION
The release workflow for this repo broke with the switch to `pnpm`. `pnpm` only comes from the nix env, and not from the github action runner's built in environment, which means the nix env had to be in the shell's environment for it to be available. To do that we can run a login shell by setting the `shell: ` param of each action step. Login shells will source .bash_profile etc where we can hook in to load up the nix environment, but, we can't set the shell for other people's actions.