### PR TITLE
Use typescript incremental building for a little bit more speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier": "^2.8.8",
     "semver": "^7.3.8",
     "ts-node": "^10.9.1",
-    "typescript": "5.0.4",
+    "typescript": "5.1.3",
     "zx": "^7.1.1",
     "@gadgetinc/api-client-core": "workspace:*",
     "@gadgetinc/react": "workspace:*"

--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -13,8 +13,8 @@
   "homepage": "https://github.com/gadget-inc/js-clients/tree/main/packages/api-client-core",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "rm -rf dist && tsc",
-    "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
+    "build": "tsc",
+    "watch": "tsc --watch --preserveWatchOutput",
     "prepublishOnly": "pnpm build",
     "prerelease": "gitpkg publish"
   },
@@ -38,6 +38,6 @@
     "gql-tag": "^1.0.1",
     "nock": "^13.3.1",
     "type-fest": "^3.3.0",
-    "typescript": "5.0.4"
+    "typescript": "5.1.3"
   }
 }

--- a/packages/blog-example/package.json
+++ b/packages/blog-example/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.2.9",
     "@types/react-dom": "^18.2.4",
     "@vitejs/plugin-react-swc": "^3.0.0",
-    "typescript": "5.0.4",
+    "typescript": "5.1.3",
     "vite": "^4.2.0"
   }
 }

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -13,8 +13,8 @@
   "homepage": "https://github.com/gadget-inc/js-clients/tree/main/packages/react-shopify-app-bridge",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "rm -rf dist && tsc",
-    "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
+    "build": "tsc",
+    "watch": "tsc --watch --preserveWatchOutput",
     "prepublishOnly": "pnpm build",
     "prerelease": "gitpkg publish"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,8 +13,8 @@
   "homepage": "https://github.com/gadget-inc/js-clients/tree/main/packages/react",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "rm -rf dist && tsc",
-    "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
+    "build": "tsc",
+    "watch": "tsc --watch --preserveWatchOutput",
     "prepublishOnly": "pnpm build",
     "prerelease": "gitpkg publish"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,10 @@ importers:
         version: link:packages/api-client-core
       '@gadgetinc/eslint-config':
         specifier: ^0.6.1
-        version: 0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.39.0)(jest@29.3.1)(lodash@4.17.21)(typescript@5.0.4)
+        version: 0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.39.0)(jest@29.3.1)(lodash@4.17.21)(typescript@5.1.3)
       '@gadgetinc/prettier-config':
         specifier: ^0.4.0
-        version: 0.4.0(prettier@2.8.8)(typescript@5.0.4)
+        version: 0.4.0(prettier@2.8.8)(typescript@5.1.3)
       '@gadgetinc/react':
         specifier: workspace:*
         version: link:packages/react
@@ -74,10 +74,10 @@ importers:
         version: 7.3.8
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@swc/core@1.3.42)(@types/node@14.18.26)(typescript@5.0.4)
+        version: 10.9.1(@swc/core@1.3.42)(@types/node@14.18.26)(typescript@5.1.3)
       typescript:
-        specifier: 5.0.4
-        version: 5.0.4
+        specifier: 5.1.3
+        version: 5.1.3
       zx:
         specifier: ^7.1.1
         version: 7.1.1
@@ -137,8 +137,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: 5.0.4
-        version: 5.0.4
+        specifier: 5.1.3
+        version: 5.1.3
 
   packages/blog-example:
     dependencies:
@@ -165,8 +165,8 @@ importers:
         specifier: ^3.0.0
         version: 3.3.0(vite@4.2.2)
       typescript:
-        specifier: 5.0.4
-        version: 5.0.4
+        specifier: 5.1.3
+        version: 5.1.3
       vite:
         specifier: ^4.2.0
         version: 4.2.2(@types/node@14.18.26)
@@ -913,7 +913,7 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadgetinc/eslint-config@0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.39.0)(jest@29.3.1)(lodash@4.17.21)(typescript@5.0.4):
+  /@gadgetinc/eslint-config@0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.39.0)(jest@29.3.1)(lodash@4.17.21)(typescript@5.1.3):
     resolution: {integrity: sha512-RFxEUYbQS9feOikGDphXWdHTkMHtO3g8x6XYwo9FPRK1VuzRpRhsiU1QXA1yU+KEGW5kMNU02t/iCFLoXkdl3g==}
     peerDependencies:
       '@gadgetinc/prettier-config': '>=0'
@@ -921,22 +921,22 @@ packages:
       lodash: '>=4'
       typescript: '>=2.8.0'
     dependencies:
-      '@gadgetinc/prettier-config': 0.4.0(prettier@2.8.8)(typescript@5.0.4)
-      '@typescript-eslint/eslint-plugin': 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@gadgetinc/prettier-config': 0.4.0(prettier@2.8.8)(typescript@5.1.3)
+      '@typescript-eslint/eslint-plugin': 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.1.3)
       eslint: 8.39.0
       eslint-config-prettier: 8.8.0(eslint@8.39.0)
       eslint-plugin-baseui: 10.12.1(eslint@8.39.0)
       eslint-plugin-cypress: 2.12.1(eslint@8.39.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)
-      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.59.2)(eslint@8.39.0)(jest@29.3.1)(typescript@5.0.4)
+      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.59.2)(eslint@8.39.0)(jest@29.3.1)(typescript@5.1.3)
       eslint-plugin-jsdoc: 39.9.1(eslint@8.39.0)
       eslint-plugin-lodash: 7.4.0(eslint@8.39.0)
       eslint-plugin-react: 7.32.2(eslint@8.39.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.39.0)
       eslint-plugin-workspaces: 0.7.0
       lodash: 4.17.21
-      typescript: 5.0.4
+      typescript: 5.1.3
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -944,13 +944,13 @@ packages:
       - supports-color
     dev: true
 
-  /@gadgetinc/prettier-config@0.4.0(prettier@2.8.8)(typescript@5.0.4):
+  /@gadgetinc/prettier-config@0.4.0(prettier@2.8.8)(typescript@5.1.3):
     resolution: {integrity: sha512-a5jSbHlFjg3WojaDONSGPPvwJdToqpSAixHpLOJ55xMqnfOTRxY2Qr41lPDmLryfch0vD8v/Fnue3/pkwZKVdQ==}
     peerDependencies:
       prettier: ^2.8.1
     dependencies:
       prettier: 2.8.8
-      prettier-plugin-organize-imports: 3.2.2(prettier@2.8.8)(typescript@5.0.4)
+      prettier-plugin-organize-imports: 3.2.2(prettier@2.8.8)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@volar/vue-language-plugin-pug'
       - '@volar/vue-typescript'
@@ -1704,7 +1704,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.1.3):
     resolution: {integrity: sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1716,23 +1716,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.1.3)
       '@typescript-eslint/scope-manager': 5.59.2
-      '@typescript-eslint/type-utils': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 5.59.2(eslint@8.39.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.39.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.2(eslint@8.39.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@5.59.2(eslint@8.39.0)(typescript@5.1.3):
     resolution: {integrity: sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1744,10 +1744,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.2
       '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.39.0
-      typescript: 5.0.4
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1760,7 +1760,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.2
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.2(eslint@8.39.0)(typescript@5.0.4):
+  /@typescript-eslint/type-utils@5.59.2(eslint@8.39.0)(typescript@5.1.3):
     resolution: {integrity: sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1770,12 +1770,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.39.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1785,7 +1785,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.2(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@5.59.2(typescript@5.1.3):
     resolution: {integrity: sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1800,13 +1800,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.2(eslint@8.39.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@5.59.2(eslint@8.39.0)(typescript@5.1.3):
     resolution: {integrity: sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1817,7 +1817,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.59.2
       '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.1.3)
       eslint: 8.39.0
       eslint-scope: 5.1.1
       semver: 7.5.0
@@ -2806,7 +2806,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.1.3)
       debug: 3.2.7
       eslint: 8.39.0
       eslint-import-resolver-node: 0.3.7
@@ -2842,7 +2842,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.1.3)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -2865,7 +2865,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.59.2)(eslint@8.39.0)(jest@29.3.1)(typescript@5.0.4):
+  /eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.59.2)(eslint@8.39.0)(jest@29.3.1)(typescript@5.1.3):
     resolution: {integrity: sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2878,8 +2878,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.1.3)
       eslint: 8.39.0
       jest: 29.3.1(@types/node@14.18.26)(ts-node@10.9.1)
     transitivePeerDependencies:
@@ -3968,7 +3968,7 @@ packages:
       pretty-format: 29.3.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.42)(@types/node@14.18.26)(typescript@5.0.4)
+      ts-node: 10.9.1(@swc/core@1.3.42)(@types/node@14.18.26)(typescript@5.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4008,7 +4008,7 @@ packages:
       pretty-format: 29.3.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.42)(@types/node@14.18.26)(typescript@5.0.4)
+      ts-node: 10.9.1(@swc/core@1.3.42)(@types/node@14.18.26)(typescript@5.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5061,7 +5061,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-organize-imports@3.2.2(prettier@2.8.8)(typescript@5.0.4):
+  /prettier-plugin-organize-imports@3.2.2(prettier@2.8.8)(typescript@5.1.3):
     resolution: {integrity: sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==}
     peerDependencies:
       '@volar/vue-language-plugin-pug': ^1.0.4
@@ -5075,7 +5075,7 @@ packages:
         optional: true
     dependencies:
       prettier: 2.8.8
-      typescript: 5.0.4
+      typescript: 5.1.3
     dev: true
 
   /prettier@2.8.8:
@@ -5681,7 +5681,7 @@ packages:
       punycode: 2.1.1
     dev: true
 
-  /ts-node@10.9.1(@swc/core@1.3.42)(@types/node@14.18.26)(typescript@5.0.4):
+  /ts-node@10.9.1(@swc/core@1.3.42)(@types/node@14.18.26)(typescript@5.1.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -5708,7 +5708,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.0.4
+      typescript: 5.1.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -5726,14 +5726,14 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsutils@3.21.0(typescript@5.0.4):
+  /tsutils@3.21.0(typescript@5.1.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 5.1.3
     dev: true
 
   /type-check@0.3.2:
@@ -5778,9 +5778,9 @@ packages:
       is-typed-array: 1.1.10
     dev: true
 
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  /typescript@5.1.3:
+    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,12 @@
     "emitDecoratorMetadata": true,
     "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": true,
-    "isolatedModules":true,
+    "isolatedModules": true,
     "target": "es2020",
     "lib": ["es2020", "DOM"],
     "skipLibCheck": true,
-    "declaration": true
+    "declaration": true,
+    "composite": true
   },
   "include": ["./packages"],
   "exclude": ["**/node_modules", "**/.*/"]


### PR DESCRIPTION
Jest tests require the build artifacts from the other workspace packages, which can take a while. For builds to go a bit faster, we can use typescript's handy incremental build support, which allows it to pick up where it left off.

A cold build for me locally:

```
❯ p build

> @gadgetinc/js-clients@0.1.0 build /Users/airhorns/Code/js-clients
> pnpm -r --no-bail run --if-present build

Scope: 4 of 5 workspace projects
packages/api-client-core build$ tsc
└─ Done in 4.9s
packages/react build$ tsc
└─ Done in 6s
packages/react-shopify-app-bridge build$ tsc
└─ Done in 4.3s
```

And then the one after:

```
❯ p build

> @gadgetinc/js-clients@0.1.0 build /Users/airhorns/Code/js-clients
> pnpm -r --no-bail run --if-present build

Scope: 4 of 5 workspace projects
packages/api-client-core build$ tsc
└─ Done in 2.8s
packages/react build$ tsc
└─ Done in 3.2s
packages/react-shopify-app-bridge build$ tsc
└─ Done in 3s
```
