### PR TITLE
Set up suspense only in react land

### DIFF
--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -358,7 +358,6 @@ export class GadgetConnection {
       fetch: this.fetch,
       exchanges,
       requestPolicy: this.requestPolicy,
-      suspense: true,
     });
     (client as any)[$gadgetConnection] = this;
     return client;

--- a/packages/react/spec/useGadgetMutation.spec.ts
+++ b/packages/react/spec/useGadgetMutation.spec.ts
@@ -1,6 +1,9 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
+import { gql } from "urql";
 import { useGadgetMutation } from "../src/useGadgetMutation";
 import { noProviderErrorMessage } from "../src/utils";
+import { relatedProductsApi } from "./apis";
+import { TestWrapper, mockUrqlClient } from "./testWrapper";
 
 describe("useGadgetMutation", () => {
   test("throw error when no provider included", () => {
@@ -10,5 +13,111 @@ describe("useGadgetMutation", () => {
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toBe(noProviderErrorMessage);
     }
+  });
+
+  test("can mutate data, not using suspense by default", async () => {
+    const { result } = renderHook(
+      () =>
+        useGadgetMutation(
+          gql`
+            mutation ($id: ID!, $post: PostInput!) {
+              createPost(id: $id, post: $post) {
+                success
+                post {
+                  id
+                }
+              }
+            }
+          `
+        ),
+      { wrapper: TestWrapper(relatedProductsApi) }
+    );
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(0);
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ id: "123", post: { title: "example" } });
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createPost", {
+      data: {
+        createPost: {
+          success: true,
+          post: {
+            id: "123",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data!.createPost.success).toEqual(true);
+      expect(promiseResult.data!.createPost.post.id).toEqual("123");
+      expect(promiseResult.error).toBeFalsy();
+    });
+
+    expect(result.current[0].data.createPost.success).toEqual(true);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("can mutate data using suspense when opted in", async () => {
+    const { result } = renderHook(
+      () =>
+        useGadgetMutation(
+          gql`
+            mutation ($id: ID!, $post: PostInput!) {
+              createPost(id: $id, post: $post) {
+                success
+                post {
+                  id
+                }
+              }
+            }
+          `
+        ),
+      { wrapper: TestWrapper(relatedProductsApi) }
+    );
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(0);
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ id: "123", post: { title: "example" } }, { suspense: true });
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createPost", {
+      data: {
+        createPost: {
+          success: true,
+          post: {
+            id: "123",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data!.createPost.success).toEqual(true);
+      expect(promiseResult.data!.createPost.post.id).toEqual("123");
+      expect(promiseResult.error).toBeFalsy();
+    });
+
+    expect(result.current[0].data.createPost.success).toEqual(true);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
   });
 });

--- a/packages/react/spec/useGadgetQuery.spec.ts
+++ b/packages/react/spec/useGadgetQuery.spec.ts
@@ -1,6 +1,9 @@
 import { renderHook } from "@testing-library/react";
+import { gql } from "urql";
 import { useGadgetQuery } from "../src/useGadgetQuery";
 import { noProviderErrorMessage } from "../src/utils";
+import { relatedProductsApi } from "./apis";
+import { TestWrapper, mockUrqlClient } from "./testWrapper";
 
 describe("useGadgetQuery", () => {
   test("throw error when no provider included", () => {
@@ -10,5 +13,78 @@ describe("useGadgetQuery", () => {
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toBe(noProviderErrorMessage);
     }
+  });
+
+  test("can query data, not using suspense by default", async () => {
+    const { result } = renderHook(
+      () =>
+        useGadgetQuery({
+          query: gql`
+            query {
+              gadgetMeta {
+                name
+              }
+            }
+          `,
+        }),
+      { wrapper: TestWrapper(relatedProductsApi) }
+    );
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("gadgetMeta", {
+      data: {
+        gadgetMeta: {
+          name: "Test App",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current[0].data.gadgetMeta.name).toEqual("Test App");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("can query data using suspense when opted in", async () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useGadgetQuery({
+          query: gql`
+            query {
+              gadgetMeta {
+                name
+              }
+            }
+          `,
+          suspense: true,
+        }),
+      { wrapper: TestWrapper(relatedProductsApi) }
+    );
+
+    // first render never completes as the component suspends
+    expect(result.current).toBeFalsy();
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("gadgetMeta", {
+      data: {
+        gadgetMeta: {
+          name: "Test App",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    // rerender as react would do when the suspense promise resolves
+    rerender();
+
+    expect(result.current[0].data.gadgetMeta.name).toEqual("Test App");
+    expect(result.current[0].error).toBeFalsy();
   });
 });

--- a/packages/react/src/GadgetProvider.tsx
+++ b/packages/react/src/GadgetProvider.tsx
@@ -87,6 +87,7 @@ const defaultSignOutPath = "/auth/signout";
  */
 export function Provider(props: ProviderProps | DeprecatedProviderProps) {
   let gadgetClient: AnyClient | undefined = undefined;
+
   let urqlClient: UrqlClient;
   if ("api" in props) {
     if (!isGadgetClient(props.api)) {
@@ -103,6 +104,9 @@ export function Provider(props: ProviderProps | DeprecatedProviderProps) {
       "No Gadget API client passed to <Provider /> component -- please pass an instance of your generated client, like <Provider api={api} />!"
     );
   }
+  // hack: make the client support suspending some queries when used by the react provider
+  // this flag is safe to mutably set here because it just serves as a flag for the urql react hooks, and doesn't affect imperative api client functioning
+  urqlClient.suspense = true;
 
   let signInPath = defaultSignInPath;
   let signOutPath = defaultSignOutPath;

--- a/packages/react/src/useFindBy.ts
+++ b/packages/react/src/useFindBy.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import type { OptionsType, ReadHookResult, ReadOperationOptions } from "./utils";
-import { ErrorWrapper, useMemoizedQueryArgs } from "./utils";
+import { ErrorWrapper, useQueryArgs } from "./utils";
 
 /**
  * React hook to fetch a Gadget record using the `findByXYZ` method of a given model manager. Useful for finding records by key fields which are used for looking up records by. Gadget autogenerates the `findByXYZ` methods on your model managers, and `useFindBy` can only be used with models that have these generated finder functions.
@@ -53,7 +53,7 @@ export const useFindBy = <
     );
   }, [finder, value, memoizedOptions]);
 
-  const [rawResult, refresh] = useGadgetQuery(useMemoizedQueryArgs(plan, options));
+  const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, options));
 
   const result = useMemo(() => {
     const dataPath = [finder.operationName];

--- a/packages/react/src/useFindFirst.ts
+++ b/packages/react/src/useFindFirst.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import type { OptionsType, ReadHookResult, ReadOperationOptions } from "./utils";
-import { ErrorWrapper, useMemoizedQueryArgs } from "./utils";
+import { ErrorWrapper, useQueryArgs } from "./utils";
 
 /**
  * React hook to fetch the first backend record matching a given filter and sort. Returns a standard hook result set with a tuple of the result object with `data`, `fetching`, and `error` keys, and a `refetch` function. `data` will be the first record found if there is one, and null otherwise.
@@ -52,7 +52,7 @@ export const useFindFirst = <
     );
   }, [manager, memoizedOptions]);
 
-  const [rawResult, refresh] = useGadgetQuery(useMemoizedQueryArgs(plan, firstOptions));
+  const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, firstOptions));
 
   const result = useMemo(() => {
     const dataPath = [manager.findFirst.operationName];

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import type { OptionsType, ReadHookResult, ReadOperationOptions } from "./utils";
-import { ErrorWrapper, useMemoizedQueryArgs } from "./utils";
+import { ErrorWrapper, useQueryArgs } from "./utils";
 
 /**
  * React hook to fetch a page of Gadget records from the backend, optionally sorted, filtered, searched, and selected from. Returns a standard hook result set with a tuple of the result object with `data`, `fetching`, and `error` keys, and a `refetch` function. `data` will be a `GadgetRecordList` object holding the list of returned records and pagination info.
@@ -51,7 +51,7 @@ export const useFindMany = <
     );
   }, [manager, memoizedOptions]);
 
-  const [rawResult, refresh] = useGadgetQuery(useMemoizedQueryArgs(plan, options));
+  const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, options));
 
   const result = useMemo(() => {
     const dataPath = [manager.findMany.operationName];

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import type { OptionsType, ReadHookResult, ReadOperationOptions } from "./utils";
-import { ErrorWrapper, useMemoizedQueryArgs } from "./utils";
+import { ErrorWrapper, useQueryArgs } from "./utils";
 
 /**
  * React hook to fetch one Gadget record by `id` from the backend. Returns a standard hook result set with a tuple of the result object with `data`, `fetching`, and `error` keys, and a `refetch` function. `data` will be the record if it was found, and `null` otherwise.
@@ -53,7 +53,7 @@ export const useFindOne = <
     );
   }, [manager, id, memoizedOptions]);
 
-  const [rawResult, refresh] = useGadgetQuery(useMemoizedQueryArgs(plan, options));
+  const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, options));
 
   const result = useMemo(() => {
     const dataPath = [manager.findOne.operationName];

--- a/packages/react/src/useGadgetQuery.ts
+++ b/packages/react/src/useGadgetQuery.ts
@@ -1,9 +1,21 @@
 import { useContext } from "react";
+import type { AnyVariables, UseQueryArgs, UseQueryResponse } from "urql";
 import { useQuery } from "urql";
 import { GadgetUrqlClientContext } from "./GadgetProvider";
-import { noProviderErrorMessage } from "./utils";
+import { noProviderErrorMessage, useMemoizedQueryOptions } from "./utils";
 
-export const useGadgetQuery: typeof useQuery = (args) => {
+export type UseGadgetQueryArgs<Variables extends AnyVariables, Data = any> = UseQueryArgs<Variables, Data> & {
+  /**
+   * Marks this query as one that should suspend the react component rendering while executing, instead of returning `{fetching: true}` to the caller.
+   * Useful if you want to allow components higher in the tree to show spinners instead of having every component manage its own loading state.
+   */
+  suspense?: boolean;
+};
+
+export const useGadgetQuery = <Data = any, Variables extends AnyVariables = AnyVariables>(
+  args: UseGadgetQueryArgs<Variables, Data>
+): UseQueryResponse<Data, Variables> => {
   if (!useContext(GadgetUrqlClientContext)) throw new Error(noProviderErrorMessage);
-  return useQuery(args);
+  const options = useMemoizedQueryOptions(args);
+  return useQuery(options);
 };

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import type { OptionsType, ReadHookResult, ReadOperationOptions } from "./utils";
-import { ErrorWrapper, useMemoizedQueryArgs } from "./utils";
+import { ErrorWrapper, useQueryArgs } from "./utils";
 
 /**
  * React hook that fetches a singleton record for an `api.currentSomething` style model manager. `useGet` fetches one global record, which is most often the current session. `useGet` doesn't require knowing the record's ID in order to fetch it, and instead returns the one current record for the current context.
@@ -52,7 +52,7 @@ export const useGet = <
     );
   }, [manager, memoizedOptions]);
 
-  const [rawResult, refresh] = useGadgetQuery(useMemoizedQueryArgs(plan, options));
+  const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, options));
 
   const result = useMemo(() => {
     let data = null;

--- a/packages/react/src/useMaybeFindFirst.ts
+++ b/packages/react/src/useMaybeFindFirst.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import type { OptionsType, ReadHookResult, ReadOperationOptions } from "./utils";
-import { ErrorWrapper, useMemoizedQueryArgs } from "./utils";
+import { ErrorWrapper, useQueryArgs } from "./utils";
 
 /**
  * React hook to fetch many Gadget records using the `maybeFindFirst` method of a given manager.
@@ -52,7 +52,7 @@ export const useMaybeFindFirst = <
     );
   }, [manager, memoizedOptions]);
 
-  const [rawResult, refresh] = useGadgetQuery(useMemoizedQueryArgs(plan, firstOptions));
+  const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, firstOptions));
 
   const result = useMemo(() => {
     const dataPath = [manager.findFirst.operationName];

--- a/packages/react/src/useMaybeFindOne.ts
+++ b/packages/react/src/useMaybeFindOne.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useGadgetQuery } from "./useGadgetQuery";
 import { useStructuralMemo } from "./useStructuralMemo";
 import type { OptionsType, ReadHookResult, ReadOperationOptions } from "./utils";
-import { ErrorWrapper, useMemoizedQueryArgs } from "./utils";
+import { ErrorWrapper, useQueryArgs } from "./utils";
 
 /**
  * React hook to fetch a Gadget record using the `maybeFindOne` method of a given manager.
@@ -53,7 +53,7 @@ export const useMaybeFindOne = <
     );
   }, [manager, id, memoizedOptions]);
 
-  const [rawResult, refresh] = useGadgetQuery(useMemoizedQueryArgs(plan, options));
+  const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, options));
 
   const result = useMemo(() => {
     let data = rawResult.data ?? null;

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -254,8 +254,12 @@ interface QueryOptions {
   suspense?: boolean;
 }
 
-/** Generate `urql` query argument object, for `useQuery` hook */
-export const useMemoizedQueryArgs = <Plan extends QueryPlan, Options extends QueryOptions>(plan: Plan, options?: Options): UseQueryArgs => {
+/**
+ * Generate the args for an `urql` useQuery hook, applying Gadget's defaults
+ *
+ * Gadget's React hooks support using the `suspense: true` option to enable React Suspense selectively per query. This means suspense is on at the client level, and then disabled by default for each hook until you opt in with `suspense: true`. This differs from urql, which has suspense on for hooks by default when it is enabled at the client level. So, this hook applies Gadget's (we think better) default to turn suspense off for each hook until you opt in, even when enabled at the client level.
+ */
+export const useMemoizedQueryOptions = <Options extends QueryOptions>(options?: Options): Options => {
   // use a memo as urql rerenders on context identity changes
   const context = useMemo(() => {
     return {
@@ -265,12 +269,19 @@ export const useMemoizedQueryArgs = <Plan extends QueryPlan, Options extends Que
   }, [options?.suspense, options?.context]);
 
   return {
-    query: plan.query,
-    variables: plan.variables,
     ...omit(options, ["context", "suspense"]),
     context,
-  };
+  } as unknown as Options;
 };
+
+/**
+ * Given a plan from a gadget query plan generator, create the query options object to pass to `urql`'s `useQuery` hook
+ **/
+export const useQueryArgs = <Plan extends QueryPlan, Options extends QueryOptions>(plan: Plan, options?: Options): UseQueryArgs => ({
+  query: plan.query,
+  variables: plan.variables,
+  ...options,
+});
 
 export type OptionsType = {
   [key: string]: any;


### PR DESCRIPTION
### Fix A: low level query hooks shouldn't suspend by default

In https://github.com/gadget-inc/js-clients/pull/215, we introduced automatic suspense support for the React query hooks, which allows developers (and us) to mark specific queries with "we want them to suspend" so that urql can do its thing under the hood and do so. We wanted this for a nice api in the `useSession` etc hooks.

To implement this though, we need to turn urql's suspense support on at the client level. This is a constructor option which makes suspense available at all *and* makes it the default for all queries. So that this wasn't a breaking change for all users, I turned on suspense support in the client, but then made all queries pass an explicit `suspense: false` down to urql so the behaviour was unchanged between versions. If a query wants to suspend, it has to opt-in by passing `suspense: true`.

I bungled this though, and did it for all the high level hooks like `useFindMany` and `useAction`, but I forgot that we export and make use of the low level `useGadgetQuery` hook for running manual GraphQL queries. Critically, we use this in the `@gadgetinc/react-shopify-app-bridge` package to detect installed status. The effect of this miss is that when the old react-shopify-app-bridge package is paired with a new api-client-core version, the bridge gets a client marked with `suspense: true` on the constructor, and then uses the low level `useGadgetQuery` hook, which doesn't apply the per-query default. The hook then suspends, which we learned breaks shopify installation.

### Fix B: we shouldn't drop a new api-client-core dependency into clients that is incompatible with existing reacts, as folks won't update both at the same time

This was a bad approach from https://github.com/gadget-inc/js-clients/pull/215. If we ship suspense on by default in api-client-core, it will be force-upgraded by Gadget regenerating packages on users *without* a react dependency bump at the same time, which means folks' clients will start suspending by default when used with old react hook versions. Oops -- thats a big breaking change that users don't have control over.

Instead, we only have new versions of the react hooks turn on suspense mode by hacking it in manually.