### PR TITLE
Verify Session has associated User for auth components

### DIFF
--- a/packages/react/spec/components/auth/SignedIn.spec.tsx
+++ b/packages/react/spec/components/auth/SignedIn.spec.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { SignedIn } from "../../../src/components/auth/SignedIn";
 import { superAuthApi } from "../../apis";
 import { TestWrapper } from "../../testWrapper";
-import { expectMockSignedInUser, expectMockSignedOutUser } from "../../utils";
+import { expectMockDeletedUser, expectMockSignedInUser, expectMockSignedOutUser } from "../../utils";
 
 describe("SignedIn", () => {
   test("renders children when signed in", () => {
@@ -33,6 +33,20 @@ describe("SignedIn", () => {
     const { container, rerender } = render(component, { wrapper: TestWrapper(superAuthApi) });
 
     expectMockSignedOutUser();
+    rerender(component);
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello</h1></div>"`);
+  });
+
+  test("renders nothing when signed in but has no user on the session", () => {
+    const component = (
+      <h1>
+        Hello<SignedIn>, Jane!</SignedIn>
+      </h1>
+    );
+
+    const { container, rerender } = render(component, { wrapper: TestWrapper(superAuthApi) });
+
+    expectMockDeletedUser();
     rerender(component);
     expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello</h1></div>"`);
   });

--- a/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react";
 import React from "react";
 import { superAuthApi } from "../../../spec/apis";
 import { TestWrapper } from "../../../spec/testWrapper";
-import { expectMockSignedInUser, expectMockSignedOutUser } from "../../../spec/utils";
+import { expectMockDeletedUser, expectMockSignedInUser, expectMockSignedOutUser } from "../../../spec/utils";
 import { SignedInOrRedirect } from "../../../src/components/auth/SignedInOrRedirect";
 
 describe("SignedInOrRedirect", () => {
@@ -35,6 +35,22 @@ describe("SignedInOrRedirect", () => {
     const { rerender } = render(component, { wrapper: TestWrapper(superAuthApi) });
 
     expectMockSignedOutUser();
+    rerender(component);
+
+    expect(mockAssign).toHaveBeenCalledTimes(1);
+    expect(mockAssign).toHaveBeenCalledWith("/auth/signin");
+  });
+
+  test("redirects when signed in but has no associated user", () => {
+    const component = (
+      <h1>
+        <SignedInOrRedirect>Hello, Jane!</SignedInOrRedirect>
+      </h1>
+    );
+
+    const { rerender } = render(component, { wrapper: TestWrapper(superAuthApi) });
+
+    expectMockDeletedUser();
     rerender(component);
 
     expect(mockAssign).toHaveBeenCalledTimes(1);

--- a/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
@@ -38,7 +38,7 @@ describe("SignedInOrRedirect", () => {
     rerender(component);
 
     expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("/auth/signin");
+    expect(mockAssign).toHaveBeenCalledWith("/");
   });
 
   test("redirects when signed in but has no associated user", () => {
@@ -54,7 +54,7 @@ describe("SignedInOrRedirect", () => {
     rerender(component);
 
     expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("/auth/signin");
+    expect(mockAssign).toHaveBeenCalledWith("/");
   });
 
   test("renders when signed in", () => {

--- a/packages/react/spec/components/auth/SignedOut.spec.tsx
+++ b/packages/react/spec/components/auth/SignedOut.spec.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react";
 import React from "react";
 import { superAuthApi } from "../../../spec/apis";
 import { TestWrapper } from "../../../spec/testWrapper";
-import { expectMockSignedInUser, expectMockSignedOutUser } from "../../../spec/utils";
+import { expectMockDeletedUser, expectMockSignedInUser, expectMockSignedOutUser } from "../../../spec/utils";
 import { SignedOut } from "../../../src/components/auth/SignedOut";
 
 describe("SignedOut", () => {
@@ -17,6 +17,21 @@ describe("SignedOut", () => {
     const { container, rerender } = render(component, { wrapper: TestWrapper(superAuthApi) });
 
     expectMockSignedOutUser();
+
+    rerender(component);
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
+  });
+
+  test("renders children when there exists no associated user for the session", () => {
+    const component = (
+      <h1>
+        Hello<SignedOut>, Jane!</SignedOut>
+      </h1>
+    );
+
+    const { container, rerender } = render(component, { wrapper: TestWrapper(superAuthApi) });
+
+    expectMockDeletedUser();
 
     rerender(component);
     expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);

--- a/packages/react/spec/utils.ts
+++ b/packages/react/spec/utils.ts
@@ -35,6 +35,21 @@ export const expectMockSignedOutUser = () => {
   });
 };
 
+export const expectMockDeletedUser = () => {
+  expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+  mockUrqlClient.executeQuery.pushResponse("currentSession", {
+    data: {
+      currentSession: {
+        id: "123",
+        userId: 1,
+        user: null,
+      },
+    },
+    stale: false,
+    hasNext: false,
+  });
+};
+
 export const mockInternalServerError = () => {
   expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
   mockUrqlClient.executeQuery.pushResponse("currentSession", {

--- a/packages/react/src/GadgetProvider.tsx
+++ b/packages/react/src/GadgetProvider.tsx
@@ -59,7 +59,7 @@ export interface DeprecatedProviderProps {
   children: ReactNode;
 }
 
-// default Gadgte auth signIn and signOut paths
+// default Gadget auth signIn and signOut paths
 const defaultSignInPath = "/";
 const defaultSignOutPath = "/signed-in";
 

--- a/packages/react/src/GadgetProvider.tsx
+++ b/packages/react/src/GadgetProvider.tsx
@@ -60,8 +60,8 @@ export interface DeprecatedProviderProps {
 }
 
 // default Gadgte auth signIn and signOut paths
-const defaultSignInPath = "/auth/signin";
-const defaultSignOutPath = "/auth/signout";
+const defaultSignInPath = "/";
+const defaultSignOutPath = "/signed-in";
 
 /**
  * Provider wrapper component that passes an api client instance to the other hooks.

--- a/packages/react/src/components/auth/SignedIn.tsx
+++ b/packages/react/src/components/auth/SignedIn.tsx
@@ -8,7 +8,7 @@ import { isSessionSignedIn } from "../../auth/utils";
  */
 export const SignedIn = (props: { children: ReactNode }) => {
   const session = useSession();
-  if (session && isSessionSignedIn(session)) {
+  if (session.user && isSessionSignedIn(session)) {
     return <>{props.children}</>;
   } else {
     return null;

--- a/packages/react/src/components/auth/SignedIn.tsx
+++ b/packages/react/src/components/auth/SignedIn.tsx
@@ -1,14 +1,14 @@
 import type { ReactNode } from "react";
 import React from "react";
-import { useSession } from "../../auth/useSession";
+import { useAuth } from "../../auth/useAuth";
 import { isSessionSignedIn } from "../../auth/utils";
 
 /**
  * Renders its `children` if the current `Session` is signed in (has an associated `User`), otherwise renders nothing.
  */
 export const SignedIn = (props: { children: ReactNode }) => {
-  const session = useSession();
-  if (session.user && isSessionSignedIn(session)) {
+  const { session, user, isSignedIn } = useAuth();
+  if (user && isSignedIn && isSessionSignedIn(session)) {
     return <>{props.children}</>;
   } else {
     return null;

--- a/packages/react/src/components/auth/SignedInOrRedirect.tsx
+++ b/packages/react/src/components/auth/SignedInOrRedirect.tsx
@@ -1,27 +1,26 @@
 import type { ReactNode } from "react";
 import React, { useContext, useEffect, useState } from "react";
 import { GadgetConfigurationContext } from "../../../src/GadgetProvider";
-import { useSession } from "../../../src/auth/useSession";
-import { isSessionSignedIn } from "../../../src/auth/utils";
+import { useAuth } from "../../auth/useAuth";
 
 /**
  * Renders its `children` if the current `Session` is signed in, otherwise redirects the browser to the `signInPath` configured in the `Provider`. Uses `window.location.assign` to perform the redirect.
  */
 export const SignedInOrRedirect = (props: { children: ReactNode }) => {
   const [redirected, setRedirected] = useState(false);
-  const session = useSession();
-  const isSignedIn = session && isSessionSignedIn(session);
+
+  const { user, isSignedIn } = useAuth();
   const context = useContext(GadgetConfigurationContext);
   const { auth } = context ?? {};
 
   useEffect(() => {
-    if (auth && !redirected && !isSignedIn) {
+    if (auth && !redirected && !isSignedIn ) {
       setRedirected(true);
       window.location.assign(auth.signInPath);
     }
   }, [redirected, isSignedIn, auth]);
 
-  if (isSignedIn) {
+  if (user && isSignedIn) {
     return <>{props.children}</>;
   } else {
     return null;

--- a/packages/react/src/components/auth/SignedInOrRedirect.tsx
+++ b/packages/react/src/components/auth/SignedInOrRedirect.tsx
@@ -14,7 +14,7 @@ export const SignedInOrRedirect = (props: { children: ReactNode }) => {
   const { auth } = context ?? {};
 
   useEffect(() => {
-    if (auth && !redirected && !isSignedIn ) {
+    if (auth && !redirected && !isSignedIn) {
       setRedirected(true);
       window.location.assign(auth.signInPath);
     }

--- a/packages/react/src/components/auth/SignedInOrRedirect.tsx
+++ b/packages/react/src/components/auth/SignedInOrRedirect.tsx
@@ -14,7 +14,7 @@ export const SignedInOrRedirect = (props: { children: ReactNode }) => {
   const { auth } = context ?? {};
 
   useEffect(() => {
-    if (auth && !redirected && !isSignedIn) {
+    if (auth && !redirected && (!isSignedIn || !user)) {
       setRedirected(true);
       window.location.assign(auth.signInPath);
     }

--- a/packages/react/src/components/auth/SignedOut.tsx
+++ b/packages/react/src/components/auth/SignedOut.tsx
@@ -7,7 +7,7 @@ import { isSessionSignedOut } from "../../../src/auth/utils";
  * Renders its `children` if the current `Session` is signed out (no associated `User`), otherwise renders nothing.
  */
 export const SignedOut = (props: { children: ReactNode }) => {
-  const {session, user} = useAuth();
+  const { session, user } = useAuth();
   if (!session || isSessionSignedOut(session) || !user) {
     return <>{props.children}</>;
   } else {

--- a/packages/react/src/components/auth/SignedOut.tsx
+++ b/packages/react/src/components/auth/SignedOut.tsx
@@ -7,7 +7,7 @@ import { isSessionSignedOut } from "../../../src/auth/utils";
  * Renders its `children` if the current `Session` is signed out (no associated `User`), otherwise renders nothing.
  */
 export const SignedOut = (props: { children: ReactNode }) => {
-  const {session, user, isSignedIn} = useAuth();
+  const {session, user} = useAuth();
   if (!session || isSessionSignedOut(session) || !user) {
     return <>{props.children}</>;
   } else {

--- a/packages/react/src/components/auth/SignedOut.tsx
+++ b/packages/react/src/components/auth/SignedOut.tsx
@@ -1,14 +1,14 @@
 import type { ReactNode } from "react";
 import React from "react";
-import { useSession } from "../../../src/auth/useSession";
+import { useAuth } from "../../../src/auth/useAuth";
 import { isSessionSignedOut } from "../../../src/auth/utils";
 
 /**
  * Renders its `children` if the current `Session` is signed out (no associated `User`), otherwise renders nothing.
  */
 export const SignedOut = (props: { children: ReactNode }) => {
-  const session = useSession();
-  if (!session || isSessionSignedOut(session)) {
+  const {session, user, isSignedIn} = useAuth();
+  if (!session || isSessionSignedOut(session) || !user) {
     return <>{props.children}</>;
   } else {
     return null;


### PR DESCRIPTION
This PR updates the logic to check for user on the session that is signed in/out. Handles a possible scenario in which a user record is deleted without having signed out, and so the session record still exists as `signed-in` with a user id that doesn't actually point anywhere anymore. Our current auth `SignedIn/Out/orRedirect` components would then misbehave and users would get caught in a weird state.

[GGT-4440](https://linear.app/gadget-dev/issue/GGT-4440/signedin-component-renders-children-when-a-session-has-no-user)

Current behaviour 
- with old template: https://hello-test--development.gadget.app/ 
- with new/upcoming template: https://new-auth-template--development.gadget.app/

1. Log in to app
2. Delete user record
3. Refresh app page - weird state, you can go back to `/` / and says you're signed out but you can go back to `/signed-in` and it seems you're signed in (though no data is rendered)

With updates to the auth components (stuck them in App.jsx): https://auth-react-components-test--development.gadget.app/ 
1. Log in to app
2. Delete user record
3. Refresh page- should not give you access to `/signed-in` and redirect you to the `/` with an option to sign back in

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
