### PR TITLE
Set redirectTo param when redirecting with <SignInOrRedirect />

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
@@ -72,5 +72,4 @@ describe("SignedInOrRedirect", () => {
     expect(mockAssign).not.toBeCalled();
     expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
   });
-
 });

--- a/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
@@ -14,7 +14,7 @@ describe("SignedInOrRedirect", () => {
     // @ts-expect-error mock
     delete window.location;
     // @ts-expect-error mock
-    window.location = { assign: mockAssign };
+    window.location = { assign: mockAssign, origin: "https://test-app.gadget.app", pathname: "/" };
   });
 
   afterEach(() => {
@@ -38,7 +38,7 @@ describe("SignedInOrRedirect", () => {
     rerender(component);
 
     expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("/");
+    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/auth/signin?redirectTo=%2F");
   });
 
   test("redirects when signed in but has no associated user", () => {
@@ -54,7 +54,7 @@ describe("SignedInOrRedirect", () => {
     rerender(component);
 
     expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("/");
+    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/auth/signin?redirectTo=%2F");
   });
 
   test("renders when signed in", () => {
@@ -72,4 +72,5 @@ describe("SignedInOrRedirect", () => {
     expect(mockAssign).not.toBeCalled();
     expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
   });
+
 });

--- a/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
@@ -38,7 +38,7 @@ describe("SignedInOrRedirect", () => {
     rerender(component);
 
     expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/auth/signin?redirectTo=%2F");
+    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/?redirectTo=%2F");
   });
 
   test("redirects when signed in but has no associated user", () => {
@@ -54,7 +54,7 @@ describe("SignedInOrRedirect", () => {
     rerender(component);
 
     expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/auth/signin?redirectTo=%2F");
+    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/?redirectTo=%2F");
   });
 
   test("renders when signed in", () => {

--- a/packages/react/src/components/auth/SignedInOrRedirect.tsx
+++ b/packages/react/src/components/auth/SignedInOrRedirect.tsx
@@ -16,7 +16,9 @@ export const SignedInOrRedirect = (props: { children: ReactNode }) => {
   useEffect(() => {
     if (auth && !redirected && (!isSignedIn || !user)) {
       setRedirected(true);
-      window.location.assign(auth.signInPath);
+      const redirectUrl = new URL(auth.signInPath, window.location.origin);
+      redirectUrl.searchParams.set("redirectTo", window.location.pathname);
+      window.location.assign(redirectUrl.toString());
     }
   }, [redirected, isSignedIn, auth]);
 


### PR DESCRIPTION
This will allow routes to consume the originally intended `pathname` and redirect their once signed in

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
