### PR TITLE
Add SignedOutOrRedirect auth component

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -77,7 +77,6 @@ export const MyApp = (props) => {
 import { Client } from "@gadget-client/my-gadget-app";
 // import the required Provider object and some example hooks from this package
 import { Provider, useAction, useFindMany } from "@gadgetinc/react";
-import React from "react";
 
 // instantiate the API client for our app
 const api = new Client({ authenticationMode: { browserSession: true } });
@@ -1039,6 +1038,7 @@ export const App = () => (
   </Provider>
 );
 ```
+
 ## Authentication
 
 When working with Gadget auth, there are several hooks and components that can help you manage the authentication state of your application.
@@ -1050,7 +1050,7 @@ The hooks use the Gadget client's `suspense: true` option, making it easier to m
 ```tsx
 import { Client } from "@gadget-client/my-gadget-app";
 import { Provider } from "@gadgetinc/react";
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import App from "./App";
 
 // instantiate the API client for our app
@@ -1059,7 +1059,7 @@ const api = new Client({ authenticationMode: { browserSession: true } });
 export function main() {
   // ensure any components which use the @gadgetinc/react hooks are wrapped with the Provider and a Suspense component
   return (
-    <Provider api={api} auth={{ signInPath: '/auth/signin', signOutPath: '/auth/signout' }}>
+    <Provider api={api} auth={{ signInPath: "/auth/signin", signOutPath: "/auth/signout" }}>
       <Suspense fallback={<>Loading...</>}>
         <App />
       </Suspense>
@@ -1073,12 +1073,15 @@ export function main() {
 React hooks are available to help you manage the authentication state of your application.
 
 ### `useSession()`
+
 Returns the current session, equivalent to `await api.currentSession.get()` or `useGet(api.currentSession)`, but uses Promises for an easier interface. Throws a Suspense promise while the session is being loaded.
 
 ### `useUser()`
+
 Returns the current user of the session, if present. For unauthenticated sessions, returns `null`. Throws a Suspense promise while the session/user are loading.
 
 ### `useAuth()`
+
 Returns an object representing the current authentication state of the session. Throws a Suspense promise while the session is being loaded.
 
 `user` - the current `User`, if signed in. Similar to `useUser`.
@@ -1106,32 +1109,62 @@ export default function App() {
 If you are trying to control the layout of your application based on authentication state, it may be helpful to use the Gadget auth React components instead of, or in addition to, the hooks.
 
 ### `<SignedIn />`
+
 Conditionally renders its children if the current session has a user associated with it, similar to the `isSignedIn` property of the `useAuth()` hook.
 
 ```tsx
-<h1>Hello<SignedIn>, human</SignedIn>!</h1>
+<h1>
+  Hello<SignedIn>, human</SignedIn>!
+</h1>
 ```
 
 ### `<SignedOut />`
+
 Conditionally renders its children if the current session has a user associated with it.
 
 ```tsx
-<SignedOut><a href="/auth/signin">Sign In!</a></SignedOut>
+<SignedOut>
+  <a href="/auth/signin">Sign In!</a>
+</SignedOut>
 ```
 
 ### `<SignedInOrRedirect />`
+
 Conditionally renders its children if the current session has a user associated with it, or redirects the browser via `window.location.assign` if the user is not currently signed in. This component is helpful for protecting front-end routes.
 
 ```tsx
- <BrowserRouter>
+<BrowserRouter>
   <Routes>
     <Route path="/" element={<Layout />}>
       <Route index element={<Home />} />
-      <Route path="my-profile" element={
-        <SignedInOrRedirect>
-          <MyProfile />
-        </SignedInOrRedirect>
-      } />
+      <Route
+        path="my-profile"
+        element={
+          <SignedInOrRedirect>
+            <MyProfile />
+          </SignedInOrRedirect>
+        }
+      />
+    </Route>
+  </Routes>
+</BrowserRouter>
+```
+
+### `<SignedOutOrRedirect />`
+
+Conditionally renders its children if the current session has no user associated with it, or redirects the browser via `window.location.assign` if the user is not currently signed out. This component is helpful for redirecting front-end routes.
+
+```tsx
+<BrowserRouter>
+  <Routes>
+    <Route path="/" element={<Layout />}>
+      <Route index element={
+        <SignedOutOrRedirect>
+          <Home />
+        </SignedOutOrRedirect>
+      }>
+      <Route path="my-profile" element={<MyProfile />}
+      />
     </Route>
   </Routes>
 </BrowserRouter>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
@@ -1,10 +1,10 @@
 import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
+import { SignedOutOrRedirect } from "../../../src/components/auth/SignedOutOrRedirect";
 import { superAuthApi } from "../../apis";
 import { TestWrapper } from "../../testWrapper";
-import { expectMockDeletedUser, expectMockSignedInUser, expectMockSignedOutUser } from "../../utils";
-import { SignedOutOrRedirect } from "../../../src/components/auth/SignedOutOrRedirect";
+import { expectMockSignedInUser, expectMockSignedOutUser } from "../../utils";
 
 describe("SignedOutOrRedirect", () => {
   const { location } = window;

--- a/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
@@ -1,0 +1,59 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+import { superAuthApi } from "../../apis";
+import { TestWrapper } from "../../testWrapper";
+import { expectMockDeletedUser, expectMockSignedInUser, expectMockSignedOutUser } from "../../utils";
+import { SignedOutOrRedirect } from "../../../src/components/auth/SignedOutOrRedirect";
+
+describe("SignedOutOrRedirect", () => {
+  const { location } = window;
+  const mockAssign = jest.fn();
+
+  beforeAll(() => {
+    // @ts-expect-error mock
+    delete window.location;
+    // @ts-expect-error mock
+    window.location = { assign: mockAssign, origin: "https://test-app.gadget.app", pathname: "/" };
+  });
+
+  afterEach(() => {
+    mockAssign.mockClear();
+  });
+
+  afterAll(() => {
+    window.location = location;
+  });
+
+  test("redirects when signed in", () => {
+    const component = (
+      <h1>
+        <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
+      </h1>
+    );
+
+    const { rerender } = render(component, { wrapper: TestWrapper(superAuthApi) });
+
+    expectMockSignedInUser();
+    rerender(component);
+
+    expect(mockAssign).toHaveBeenCalledTimes(1);
+    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/?redirectTo=%2F");
+  });
+
+  test("renders when signed out", () => {
+    const component = (
+      <h1>
+        <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
+      </h1>
+    );
+
+    const { container, rerender } = render(component, { wrapper: TestWrapper(superAuthApi) });
+
+    expectMockSignedOutUser();
+    rerender(component);
+
+    expect(mockAssign).not.toBeCalled();
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
+  });
+});

--- a/packages/react/src/components/auth/SignedOutOrRedirect.tsx
+++ b/packages/react/src/components/auth/SignedOutOrRedirect.tsx
@@ -15,10 +15,10 @@ export const SignedOutOrRedirect = (props: { children: ReactNode }) => {
 
   useEffect(() => {
     if (auth && !redirected && (isSignedIn || user)) {
-        setRedirected(true);
-        const redirectUrl = new URL(auth.signInPath, window.location.origin);
-        redirectUrl.searchParams.set("redirectTo", window.location.pathname);
-        window.location.assign(redirectUrl.toString());
+      setRedirected(true);
+      const redirectUrl = new URL(auth.signInPath, window.location.origin);
+      redirectUrl.searchParams.set("redirectTo", window.location.pathname);
+      window.location.assign(redirectUrl.toString());
     }
   }, [redirected, isSignedIn, auth]);
 

--- a/packages/react/src/components/auth/SignedOutOrRedirect.tsx
+++ b/packages/react/src/components/auth/SignedOutOrRedirect.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import { GadgetConfigurationContext } from "../../../src/GadgetProvider";
+import { useAuth } from "../../auth/useAuth";
+
+/**
+ * Renders its `children` if the current `Session` is signed out, otherwise redirects the browser to the `signOutPath` configured in the `Provider`. Uses `window.location.assign` to perform the redirect.
+ */
+export const SignedOutOrRedirect = (props: { children: ReactNode }) => {
+  const [redirected, setRedirected] = useState(false);
+
+  const { user, isSignedIn } = useAuth();
+  const context = useContext(GadgetConfigurationContext);
+  const { auth } = context ?? {};
+
+  useEffect(() => {
+    if (auth && !redirected && (isSignedIn || user)) {
+        setRedirected(true);
+        const redirectUrl = new URL(auth.signInPath, window.location.origin);
+        redirectUrl.searchParams.set("redirectTo", window.location.pathname);
+        window.location.assign(redirectUrl.toString());
+    }
+  }, [redirected, isSignedIn, auth]);
+
+  if (!user && !isSignedIn) {
+    return <>{props.children}</>;
+  } else {
+    return null;
+  }
+};


### PR DESCRIPTION
We have a `SignedInOrRedirect` component that checks if the user is signed in and if they're not redirect them to the path specified in the `<Provider auth={{signInPath="/"}}>`

We should have a `SignedOutOrRedirect` component that does the opposite so we don't have to do something like 
`<Route index element={isSignedIn ? <Navigate to="/signed-in" /> : <Index />} />`
## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
