### PR TITLE
(fix) Set redirectUrl in SignedOutOrRedirect to the signOutPath

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
@@ -38,7 +38,7 @@ describe("SignedOutOrRedirect", () => {
     rerender(component);
 
     expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/?redirectTo=%2F");
+    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/signed-in?redirectTo=%2F");
   });
 
   test("renders when signed out", () => {

--- a/packages/react/src/components/auth/SignedOutOrRedirect.tsx
+++ b/packages/react/src/components/auth/SignedOutOrRedirect.tsx
@@ -16,7 +16,7 @@ export const SignedOutOrRedirect = (props: { children: ReactNode }) => {
   useEffect(() => {
     if (auth && !redirected && (isSignedIn || user)) {
       setRedirected(true);
-      const redirectUrl = new URL(auth.signInPath, window.location.origin);
+      const redirectUrl = new URL(auth.signOutPath, window.location.origin);
       redirectUrl.searchParams.set("redirectTo", window.location.pathname);
       window.location.assign(redirectUrl.toString());
     }


### PR DESCRIPTION
Fix a typo

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
