### PR TITLE
`@live` Queries

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -28,6 +28,9 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
+    "@n1ru4l/graphql-live-query": "^0.10.0",
+    "@n1ru4l/graphql-live-query-patch-jsondiffpatch": "^0.8.0",
+    "@n1ru4l/push-pull-async-iterable-iterator": "^3.2.0",
     "@urql/core": "^4.0.10",
     "cross-fetch": "^3.1.5",
     "graphql": "^16.8.1",

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -42,6 +42,27 @@ describe("operation builders", () => {
         }
       `);
     });
+
+    test("findOneOperation should build a live query for a model", () => {
+      expect(findOneOperation("widget", "123", { __typename: true, id: true, state: true }, "widget", { live: true }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widget($id: GadgetID!) @live {
+          widget(id: $id) {
+            __typename
+            id
+            state
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {
+            "id": "123",
+          },
+        }
+      `);
+    });
   });
 
   describe("findManyOperation", () => {
@@ -209,6 +230,35 @@ describe("operation builders", () => {
         }
       `);
     });
+
+    test("findManyOperation should build a live findMany query for a model", () => {
+      expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { live: true })).toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) @live {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                __typename
+                id
+                state
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
   });
 
   describe("findOneByFieldOperation", () => {
@@ -269,6 +319,43 @@ describe("operation builders", () => {
                 id
                 name
                 __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {
+            "filter": {
+              "foo": {
+                "equals": "bar",
+              },
+            },
+            "first": 2,
+          },
+        }
+      `);
+    });
+
+    test("findOneByFieldOperation should build a live query", () => {
+      expect(findOneByFieldOperation("widget", "foo", "bar", { __typename: true, id: true, state: true }, "widget", { live: true }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widget($after: String, $first: Int, $before: String, $last: Int, $filter: [WidgetFilter!]) @live {
+          widget(after: $after, first: $first, before: $before, last: $last, filter: $filter) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                __typename
+                id
+                state
               }
             }
           }

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -22,7 +22,7 @@ import {
   hydrateRecord,
   hydrateRecordArray,
 } from "./support.js";
-import type { FindManyOptions, SelectionOptions, VariablesOptions } from "./types.js";
+import type { BaseFindOptions, FindManyOptions, VariablesOptions } from "./types.js";
 
 export const findOneRunner = async <Shape extends RecordShape = any>(
   modelManager: { connection: GadgetConnection },
@@ -30,7 +30,7 @@ export const findOneRunner = async <Shape extends RecordShape = any>(
   id: string | undefined,
   defaultSelection: FieldSelection,
   modelApiIdentifier: string,
-  options?: SelectionOptions | null,
+  options?: BaseFindOptions | null,
   throwOnEmptyData = true
 ) => {
   const plan = findOneOperation(operation, id, defaultSelection, modelApiIdentifier, options);
@@ -47,7 +47,7 @@ export const findOneByFieldRunner = async <Shape extends RecordShape = any>(
   fieldValue: string,
   defaultSelection: FieldSelection,
   modelApiIdentifier: string,
-  options?: SelectionOptions | null
+  options?: BaseFindOptions | null
 ) => {
   const plan = findOneByFieldOperation(operation, fieldName, fieldValue, defaultSelection, modelApiIdentifier, options);
   const response = await modelManager.connection.currentClient.query(plan.query, plan.variables).toPromise();
@@ -95,7 +95,7 @@ export interface ActionRunner {
     modelSelectionField: string,
     isBulkAction: false,
     variables: VariablesOptions,
-    options?: SelectionOptions | null,
+    options?: BaseFindOptions | null,
     namespace?: string | null,
     hasReturnType?: true
   ): Promise<any>;
@@ -108,7 +108,7 @@ export interface ActionRunner {
     modelSelectionField: string,
     isBulkAction: false,
     variables: VariablesOptions,
-    options?: SelectionOptions | null,
+    options?: BaseFindOptions | null,
     namespace?: string | null,
     hasReturnType?: false
   ): Promise<Shape extends void ? void : GadgetRecord<Shape>>;
@@ -121,7 +121,7 @@ export interface ActionRunner {
     modelSelectionField: string,
     isBulkAction: false,
     variables: VariablesOptions,
-    options?: SelectionOptions | null,
+    options?: BaseFindOptions | null,
     namespace?: string | null
   ): Promise<Shape extends void ? void : GadgetRecord<Shape>>;
 
@@ -133,7 +133,7 @@ export interface ActionRunner {
     modelSelectionField: string,
     isBulkAction: true,
     variables: VariablesOptions,
-    options?: SelectionOptions | null,
+    options?: BaseFindOptions | null,
     namespace?: string | null
   ): Promise<Shape extends void ? void : GadgetRecord<Shape>[]>;
 
@@ -145,7 +145,7 @@ export interface ActionRunner {
     modelSelectionField: string,
     isBulkAction: true,
     variables: VariablesOptions,
-    options?: SelectionOptions | null,
+    options?: BaseFindOptions | null,
     namespace?: string | null,
     hasReturnType?: true
   ): Promise<any[]>;
@@ -158,7 +158,7 @@ export interface ActionRunner {
     modelSelectionField: string,
     isBulkAction: true,
     variables: VariablesOptions,
-    options?: SelectionOptions | null,
+    options?: BaseFindOptions | null,
     namespace?: string | null,
     hasReturnType?: false
   ): Promise<Shape extends void ? void : GadgetRecord<Shape>[]>;
@@ -172,7 +172,7 @@ export const actionRunner: ActionRunner = async <Shape extends RecordShape = any
   modelSelectionField: string,
   isBulkAction: boolean,
   variables: VariablesOptions,
-  options?: SelectionOptions | null,
+  options?: BaseFindOptions | null,
   namespace?: string | null,
   hasReturnType?: boolean | null
 ) => {

--- a/packages/api-client-core/src/types.ts
+++ b/packages/api-client-core/src/types.ts
@@ -15,16 +15,18 @@ export type VariablesOptions = Record<string, VariableOptions>;
  */
 export type DefaultSelection<
   SelectionType,
-  Options extends Selectable<SelectionType>,
+  Options extends { select?: SelectionType | null },
   Defaults extends SelectionType
 > = Options["select"] extends SelectionType ? Options["select"] : Defaults;
 
 /**
- * Describes any object that can have a selection specified
+ * Describes the base options that many record finders accept
  */
-export interface Selectable<SelectionType> {
+export interface BaseFindOptions<SelectionType = any> {
   /** Select fields other than the defaults of the record to return */
   select?: SelectionType | null;
+  /** Turn on live query mode, where the query will trigger re-renders when data changes on the backend */
+  live?: boolean;
 }
 
 /**
@@ -552,11 +554,8 @@ export interface AnySelection {
 export type SelectionOptions = { select?: AnySelection };
 
 /** The options a record find operation takes that can return many records */
-export type FindManyOptions = {
-  /** Return only the given fields on the backend record (and related records) */
-  select?: AnySelection;
-
-  /** Sort the returned records by the given critera */
+export interface FindManyOptions extends BaseFindOptions {
+  /** Sort the returned records by the given criteria */
   sort?: AnySort | null;
   /** Only return records which match the given set of filters */
   filter?: AnyFilter | AnyFilter[] | null;
@@ -579,7 +578,7 @@ export type FindManyOptions = {
    * Return this number of records. Useful in tandem with the `before` cursor option for pagination.
    **/
   last?: number | null;
-};
+}
 
 /** The options a record find operation takes that can return many records */
 export type FindFilteredOptions = {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",
+    "@n1ru4l/json-patch-plus": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@types/jest": "^29.5.5",
@@ -47,6 +48,7 @@
     "@urql/core": "^4.0.10",
     "conditional-type-checks": "^1.0.6",
     "graphql": "^16.8.1",
+    "graphql-ws": "^5.13.1",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/react/spec/jest.setup.ts
+++ b/packages/react/spec/jest.setup.ts
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom/extend-expect";
 jest.setTimeout(process.env.CI == "vscode-jest-tests" ? 20 * 60 * 1000 : 5 * 1000);
 
 export {};

--- a/packages/react/spec/liveQueries.spec.tsx
+++ b/packages/react/spec/liveQueries.spec.tsx
@@ -1,0 +1,205 @@
+import { Client } from "@gadget-client/related-products-example";
+import { diff } from "@n1ru4l/json-patch-plus";
+import { render, renderHook } from "@testing-library/react";
+import React from "react";
+import { useFindMany } from "../src/useFindMany.js";
+import { MockGraphQLWSClientWrapper, mockGraphQLWSClient } from "./testWrappers.js";
+import { sleep } from "./utils.js";
+
+describe("live queries", () => {
+  let api: Client;
+  beforeEach(async () => {
+    api = new Client({ environment: "Development" });
+  });
+
+  test("live queries can go from having no data to having some data", async () => {
+    const { result } = renderHook(() => useFindMany(api.user, { live: true }), {
+      wrapper: MockGraphQLWSClientWrapper(api),
+    });
+
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+    expect(result.current[0].data).toBeFalsy();
+
+    await Promise.resolve();
+    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
+    expect(subscription.payload.query).toContain("@live");
+
+    const initial = {
+      users: {
+        edges: [],
+      },
+    };
+
+    subscription.push({
+      data: initial,
+      revision: 1,
+    } as any);
+
+    await sleep(100);
+
+    expect(result.current[0].data!.length).toEqual(0);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    const next = {
+      users: {
+        edges: [
+          {
+            node: {
+              id: "123",
+              email: "a-new-email@test.com",
+            },
+          },
+        ],
+      },
+    };
+
+    subscription.push({
+      patch: diff({ left: initial, right: next }),
+      revision: 2,
+    } as any);
+
+    await sleep(100);
+
+    expect(result.current[0].data![0].id).toEqual("123");
+    expect(result.current[0].data![0].email).toEqual("a-new-email@test.com");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("live queries can go from having some data to having no data", async () => {
+    const { result } = renderHook(() => useFindMany(api.user, { live: true }), {
+      wrapper: MockGraphQLWSClientWrapper(api),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    await Promise.resolve();
+    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
+    expect(subscription.payload.query).toContain("@live");
+
+    const initial = {
+      users: {
+        edges: [
+          {
+            node: {
+              id: "123",
+              email: "a-new-email@test.com",
+            },
+          },
+        ],
+      },
+    };
+
+    subscription.push({
+      data: initial,
+      revision: 1,
+    } as any);
+
+    await sleep(100);
+
+    expect(result.current[0].data!.length).toEqual(1);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    const next = {
+      users: {
+        edges: [],
+      },
+    };
+
+    subscription.push({
+      patch: diff({ left: initial, right: next }),
+      revision: 2,
+    } as any);
+
+    await sleep(100);
+
+    expect(result.current[0].data!.length).toEqual(0);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("multiple live queries can be mounted within the same component", async () => {
+    const Component = () => {
+      const [{ data: users }] = useFindMany(api.user, { live: true });
+      const [{ data: products }] = useFindMany(api.shopifyProduct, { live: true });
+
+      return (
+        <>
+          Users: {users?.length ?? "<none>"}, Products: {products?.length ?? "<none>"}
+        </>
+      );
+    };
+
+    const { container } = render(<Component />, {
+      wrapper: MockGraphQLWSClientWrapper(api),
+    });
+
+    expect(container).toHaveTextContent("Users: <none>, Products: <none>");
+
+    await Promise.resolve();
+    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(2);
+    const users = mockGraphQLWSClient.subscribe.subscriptions[0];
+    const products = mockGraphQLWSClient.subscribe.subscriptions[1];
+
+    users.push({
+      data: {
+        users: {
+          edges: [
+            {
+              node: {
+                id: "123",
+                email: "a-new-email@test.com",
+              },
+            },
+            {
+              node: {
+                id: "456",
+                email: null,
+              },
+            },
+          ],
+        },
+      },
+      revision: 1,
+    } as any);
+
+    products.push({
+      data: {
+        shopifyProducts: {
+          edges: [
+            {
+              node: {
+                id: "123",
+              },
+            },
+          ],
+        },
+      },
+      revision: 1,
+    } as any);
+
+    await sleep(100);
+
+    expect(container).toHaveTextContent("Users: 2, Products: 1");
+
+    products.push({
+      data: {
+        shopifyProducts: {
+          edges: [],
+        },
+      },
+      revision: 1,
+    } as any);
+
+    await sleep(100);
+
+    expect(container).toHaveTextContent("Users: 2, Products: 0");
+  });
+});

--- a/packages/react/spec/testWrappers.tsx
+++ b/packages/react/spec/testWrappers.tsx
@@ -2,7 +2,7 @@ import type { AnyClient } from "@gadgetinc/api-client-core";
 import type { ReactNode } from "react";
 import React, { Suspense } from "react";
 import type { MockUrqlClient } from "../../api-client-core/spec/mockUrqlClient.js";
-import { createMockUrqlClient, mockUrqlClient } from "../../api-client-core/spec/mockUrqlClient.js";
+import { createMockUrqlClient, mockGraphQLWSClient, mockUrqlClient } from "../../api-client-core/spec/mockUrqlClient.js";
 import { Provider } from "../src/GadgetProvider.js";
 
 export const MockClientWrapper = (api: AnyClient, urqlClient?: MockUrqlClient) => (props: { children: ReactNode }) => {
@@ -16,4 +16,16 @@ export const MockClientWrapper = (api: AnyClient, urqlClient?: MockUrqlClient) =
     </Provider>
   );
 };
-export { MockUrqlClient, mockUrqlClient, createMockUrqlClient };
+
+export const MockGraphQLWSClientWrapper = (api: AnyClient) => (props: { children: ReactNode }) => {
+  jest.replaceProperty(api.connection, "baseSubscriptionClient", mockGraphQLWSClient as any);
+
+  return (
+    <Provider api={api}>
+      <Suspense fallback={<div>Loading...</div>}>{props.children}</Suspense>
+    </Provider>
+  );
+};
+
+export { mockUrqlClient, mockGraphQLWSClient, createMockUrqlClient };
+export type { MockUrqlClient };

--- a/packages/react/spec/useFindFirst.spec.ts
+++ b/packages/react/spec/useFindFirst.spec.ts
@@ -1,11 +1,13 @@
 import type { GadgetRecord } from "@gadgetinc/api-client-core";
+import { diff } from "@n1ru4l/json-patch-plus";
 import { renderHook } from "@testing-library/react";
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
 import { useFindFirst } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { relatedProductsApi } from "./apis.js";
-import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
+import { MockClientWrapper, MockGraphQLWSClientWrapper, mockGraphQLWSClient, mockUrqlClient } from "./testWrappers.js";
+import { sleep } from "./utils.js";
 
 describe("useFindFirst", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -220,5 +222,68 @@ describe("useFindFirst", () => {
     expect(result.current[0].data!.id).toEqual("123");
     expect(result.current[0].data!.email).toEqual("test@test.com");
     expect(result.current[0].fetching).toBe(false);
+  });
+
+  test("can query for live data", async () => {
+    const { result } = renderHook(() => useFindFirst(relatedProductsApi.user, { live: true }), {
+      wrapper: MockGraphQLWSClientWrapper(relatedProductsApi),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    await Promise.resolve();
+    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
+    expect(subscription.payload.query).toContain("@live");
+
+    const initial = {
+      users: {
+        edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],
+        pageInfo: {
+          startCursor: "123",
+          endCursor: "123",
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+
+    subscription.push({
+      data: initial,
+      revision: 1,
+    } as any);
+
+    await sleep(30);
+
+    expect(result.current[0].data!.id).toEqual("123");
+    expect(result.current[0].data!.email).toEqual("test@test.com");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    const next = {
+      users: {
+        edges: [{ cursor: "123", node: { id: "123", email: "a-new-email@test.com" } }],
+        pageInfo: {
+          startCursor: "123",
+          endCursor: "123",
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+
+    subscription.push({
+      patch: diff({ left: initial, right: next }),
+      revision: 2,
+    } as any);
+
+    await sleep(50);
+
+    expect(result.current[0].data!.id).toEqual("123");
+    expect(result.current[0].data!.email).toEqual("a-new-email@test.com");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
   });
 });

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -1,11 +1,13 @@
 import type { GadgetRecordList } from "@gadgetinc/api-client-core";
+import { diff } from "@n1ru4l/json-patch-plus";
 import { renderHook } from "@testing-library/react";
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
 import { useFindMany } from "../src/useFindMany.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { relatedProductsApi } from "./apis.js";
-import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
+import { MockClientWrapper, MockGraphQLWSClientWrapper, mockGraphQLWSClient, mockUrqlClient } from "./testWrappers.js";
+import { sleep } from "./utils.js";
 
 describe("useFindMany", () => {
   // all these functions are typechecked but never run to avoid actually making API calls
@@ -265,5 +267,96 @@ describe("useFindMany", () => {
     expect(result.current[0].error).toBeFalsy();
 
     expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+  });
+
+  describe("live queries", () => {
+    test("can query for live data", async () => {
+      const { result } = renderHook(() => useFindMany(relatedProductsApi.user, { live: true }), {
+        wrapper: MockGraphQLWSClientWrapper(relatedProductsApi),
+      });
+
+      expect(result.current[0].data).toBeFalsy();
+      expect(result.current[0].fetching).toBe(true);
+      expect(result.current[0].error).toBeFalsy();
+
+      await Promise.resolve();
+      expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+      const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
+      expect(subscription.payload.query).toContain("@live");
+
+      const initial = {
+        users: {
+          edges: [
+            {
+              node: {
+                id: "123",
+                email: "test@test.com",
+              },
+            },
+            {
+              node: {
+                id: "456",
+                email: "test@gadget.dev",
+              },
+            },
+          ],
+        },
+      };
+
+      subscription.push({
+        data: initial,
+        revision: 1,
+      } as any);
+
+      await sleep(30);
+
+      expect(result.current[0].data![0].id).toEqual("123");
+      expect(result.current[0].data![0].email).toEqual("test@test.com");
+      expect(result.current[0].data![1].id).toEqual("456");
+      expect(result.current[0].data![1].email).toEqual("test@gadget.dev");
+      expect(result.current[0].fetching).toBe(false);
+      expect(result.current[0].error).toBeFalsy();
+
+      const next = {
+        users: {
+          edges: [
+            {
+              node: {
+                id: "123",
+                email: "a-new-email@test.com",
+              },
+            },
+            {
+              node: {
+                id: "456",
+                email: "test@gadget.dev",
+              },
+            },
+            {
+              node: {
+                id: "789",
+                email: null,
+              },
+            },
+          ],
+        },
+      };
+
+      subscription.push({
+        patch: diff({ left: initial, right: next }),
+        revision: 2,
+      } as any);
+
+      await sleep(50);
+
+      expect(result.current[0].data![0].id).toEqual("123");
+      expect(result.current[0].data![0].email).toEqual("a-new-email@test.com");
+      expect(result.current[0].data![1].id).toEqual("456");
+      expect(result.current[0].data![1].email).toEqual("test@gadget.dev");
+      expect(result.current[0].data![2].id).toEqual("789");
+      expect(result.current[0].data![2].email).toBe(null);
+      expect(result.current[0].fetching).toBe(false);
+      expect(result.current[0].error).toBeFalsy();
+    });
   });
 });

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -5,7 +5,8 @@ import { assert } from "conditional-type-checks";
 import { useFindOne } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { relatedProductsApi } from "./apis.js";
-import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
+import { MockClientWrapper, MockGraphQLWSClientWrapper, mockGraphQLWSClient, mockUrqlClient } from "./testWrappers.js";
+import { sleep } from "./utils.js";
 
 describe("useFindOne", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -163,5 +164,53 @@ describe("useFindOne", () => {
     expect(result.current[0].error).toBeFalsy();
 
     expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+  });
+
+  test("can query for live data", async () => {
+    const { result } = renderHook(() => useFindOne(relatedProductsApi.user, "123", { live: true }), {
+      wrapper: MockGraphQLWSClientWrapper(relatedProductsApi),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    await Promise.resolve();
+    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
+    expect(subscription.payload.query).toContain("@live");
+
+    subscription.push({
+      data: {
+        user: {
+          id: "123",
+          email: "test@test.com",
+        },
+      },
+      revision: 1,
+    } as any);
+
+    await sleep(30);
+
+    expect(result.current[0].data!.id).toEqual("123");
+    expect(result.current[0].data!.email).toEqual("test@test.com");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    subscription.push({
+      patch: {
+        user: {
+          email: [null, "test-new@test.com"],
+        },
+      },
+      revision: 2,
+    } as any);
+
+    await sleep(50);
+
+    expect(result.current[0].data!.id).toEqual("123");
+    expect(result.current[0].data!.email).toEqual("test-new@test.com");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
   });
 });

--- a/packages/react/spec/utils.ts
+++ b/packages/react/spec/utils.ts
@@ -70,3 +70,8 @@ export const mockNetworkError = () => {
     hasNext: false,
   });
 };
+export const sleep = (delay: number) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+};

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -67,6 +67,10 @@ export declare type ReadOperationOptions = {
    * Useful if you want to allow components higher in the tree to show spinners instead of having every component manage its own loading state.
    */
   suspense?: boolean;
+  /**
+   * Marks this query as a live query that will subscribe to changes from the backend and re-render when backend data changes with the newest data.
+   */
+  live?: boolean;
 };
 
 /**
@@ -305,7 +309,10 @@ export const useQueryArgs = <Plan extends QueryPlan, Options extends QueryOption
 
 export type OptionsType = {
   [key: string]: any;
+  /** What fields to select from the resulting object */
   select?: FieldSelection;
+  /** Subscribe to changes from the backend and return a new result as it changes */
+  live?: boolean;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,15 @@ importers:
 
   packages/api-client-core:
     dependencies:
+      '@n1ru4l/graphql-live-query':
+        specifier: ^0.10.0
+        version: 0.10.0(graphql@16.8.1)
+      '@n1ru4l/graphql-live-query-patch-jsondiffpatch':
+        specifier: ^0.8.0
+        version: 0.8.0(graphql@16.8.1)
+      '@n1ru4l/push-pull-async-iterable-iterator':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@urql/core':
         specifier: ^4.0.10
         version: 4.0.10(graphql@16.8.1)
@@ -189,6 +198,9 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4(graphql@16.8.1)(react@18.2.0)
     devDependencies:
+      '@n1ru4l/json-patch-plus':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -219,6 +231,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
+      graphql-ws:
+        specifier: ^5.13.1
+        version: 5.13.1(graphql@16.8.1)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1553,6 +1568,41 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.13
     dev: true
 
+  /@n1ru4l/graphql-live-query-patch-jsondiffpatch@0.8.0(graphql@16.8.1):
+    resolution: {integrity: sha512-m5OPdEhBbqQ+pkFz2dQmPl10JW/RB1Qc2zoVn9QTEXvyeSzQmrl+qNtn3nvv87P9rQDiRD/JWlD86BFX0XloBg==}
+    peerDependencies:
+      graphql: ^15.4.0 || ^16.0.0
+    dependencies:
+      '@n1ru4l/graphql-live-query-patch': 0.7.0(graphql@16.8.1)
+      '@n1ru4l/json-patch-plus': 0.2.0
+      graphql: 16.8.1
+    dev: false
+
+  /@n1ru4l/graphql-live-query-patch@0.7.0(graphql@16.8.1):
+    resolution: {integrity: sha512-1q49iNxqEIbmUp+qFAEVEn4ts344Cw72g5OtAuFeTwKtJT3V91kTPGMcRk5Pxb5FPHbvn52q+PCVKOAyVrtPwQ==}
+    peerDependencies:
+      graphql: ^15.4.0 || ^16.0.0
+    dependencies:
+      '@repeaterjs/repeater': 3.0.4
+      graphql: 16.8.1
+    dev: false
+
+  /@n1ru4l/graphql-live-query@0.10.0(graphql@16.8.1):
+    resolution: {integrity: sha512-qZ7OHH/NB0NcG/Xa7irzgjE63UH0CkofZT0Bw4Ko6iRFagPRHBM8RgFXwTt/6JbFGIEUS4STRtaFoc/Eq/ZtzQ==}
+    peerDependencies:
+      graphql: ^15.4.0 || ^16.0.0
+    dependencies:
+      graphql: 16.8.1
+    dev: false
+
+  /@n1ru4l/json-patch-plus@0.2.0:
+    resolution: {integrity: sha512-pLkJy83/rVfDTyQgDSC8GeXAHEdXNHGNJrB1b7wAyGQu0iv7tpMXntKVSqj0+XKNVQbco40SZffNfVALzIt0SQ==}
+
+  /@n1ru4l/push-pull-async-iterable-iterator@3.2.0:
+    resolution: {integrity: sha512-3fkKj25kEjsfObL6IlKPAlHYPq/oYwUkkQ03zsTTiDjD7vg/RxjdiLeCydqtxHZP0JgsXL3D/X5oAkMGzuUp/Q==}
+    engines: {node: '>=12'}
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1573,6 +1623,10 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
     dev: true
+
+  /@repeaterjs/repeater@3.0.4:
+    resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
+    dev: false
 
   /@shopify/app-bridge-core@1.0.2:
     resolution: {integrity: sha512-lI+nZHMDqBJSqTBQiI1GY3Xs7YjPuZ83/sW7TIvWtTsxQZyoanAVXloo63sGEd58t1KvKFnDtVFN1NJYe/zouQ==}
@@ -3841,7 +3895,6 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.8.1
-    dev: false
 
   /graphql@16.5.0:
     resolution: {integrity: sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==}


### PR DESCRIPTION
Using the `@live` query directive, we can ask Gadget to give us back a stream of data as it changes from the backend! We can use the graphql-ws transport we already have setup and productionized for this, and we can use urql's ability to rerender at will to trigger a nice rerender. To start, live queries are only available in the React hooks for rendering. 

Depends on https://github.com/gadget-inc/gadget/pull/8413 for the json diff patch format stuff.