### PR TITLE
`baseRouteURL` connection option for proper absolute route building

### DIFF
--- a/packages/api-client-core/spec/GadgetConnection-suite.ts
+++ b/packages/api-client-core/spec/GadgetConnection-suite.ts
@@ -699,6 +699,21 @@ export const GadgetConnectionSharedSuite = (queryExtra = "") => {
       expect(await result.text()).toEqual("hello");
     });
 
+    test("fetch can pass relative string paths when used with a baseRouteURL", async () => {
+      const fetch = jest.fn().mockResolvedValue(new Response("hello")) as any;
+      const connection = new GadgetConnection({
+        endpoint: "https://api.internal.net/api/graphql?operation=meta",
+        authenticationMode: { apiKey: "gsk-abcde" },
+        fetchImplementation: fetch,
+        baseRouteURL: "https://example.gadget.app",
+      });
+
+      const result = await connection.fetch("/foo/bar");
+      expect(result.status).toEqual(200);
+      expect(await result.text()).toEqual("hello");
+      expect(fetch).toHaveBeenCalledWith("https://example.gadget.app/foo/bar", expect.anything());
+    });
+
     test("fetches can specify a desired content type", async () => {
       const connection = new GadgetConnection({
         endpoint: "https://someapp.gadget.app/api/graphql",

--- a/packages/api-client-core/src/ClientOptions.ts
+++ b/packages/api-client-core/src/ClientOptions.ts
@@ -1,11 +1,45 @@
+import type { GadgetSubscriptionClientOptions } from "./GadgetConnection";
+
 /** All the options for a Gadget client */
 export interface ClientOptions {
-  endpoint?: string; // The Gadget API endpoint this client should connect to, default "<%= defaultEndpoint %>"
-  authenticationMode?: AuthenticationModeOptions; // The way in which we will authenticate with Gadget
-  websocketsEndpoint?: string; // The Gadget API endpoint this client should connect to for batched websocket operations, default "<%= defaultEndpoint %>-ws"
-  websocketImplementation?: any; // What object to use as `WebSocket`, useful for overriding in tests
-  fetchImplementation?: typeof fetch; // What object to use to fetch, useful for overriding in tests
+  /**
+   *  The HTTP GraphQL endpoint this connection should connect to
+   **/
+  endpoint?: string;
+  /**
+   * The authentication strategy for connecting to the upstream API
+   **/
+  authenticationMode?: AuthenticationModeOptions;
+  /**
+   * The Websockets GraphQL endpoint this connection should connect to for transactional processing
+   **/
+  websocketsEndpoint?: string;
+  /**
+   * Custom options to pass along to the WS clients when creating them
+   **/
+  subscriptionClientOptions?: GadgetSubscriptionClientOptions;
+  /**
+   * The `WebSocket` constructor to use for building websockets. Defaults to `globalThis.WebSocket`.
+   **/
+  websocketImplementation?: any;
+  /**
+   * The `fetch` function to use for making HTTP requests. Defaults to `globalThis.fetch`.
+   **/
+  fetchImplementation?: typeof fetch;
+  /**
+   * Which of the Gadget application's environments this connection should connect to
+   **/
   environment?: "Development" | "Production";
+  /**
+   * The ID of the application. Not required -- only used for emitting telemetry
+   **/
+  applicationId?: string;
+  /**
+   * The root URL of the app's public HTTP surface. Used for building fully-qualified URLs when `api.fetch` is called with relative paths.
+   *
+   * This only needs to be passed if you are overriding the `endpoint` parameter to something that can't be used for building fully-qualified URLs from relative imports.
+   **/
+  baseRouteURL?: string;
 }
 
 /** Options to configure a specific browser-based authentication mode */

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -47,8 +47,9 @@ export interface GadgetConnectionOptions {
   websocketImplementation?: any;
   fetchImplementation?: typeof fetchPolyfill;
   environment?: "Development" | "Production";
-  applicationId?: string;
   requestPolicy?: ClientOptions["requestPolicy"];
+  applicationId?: string;
+  baseRouteURL?: string;
 }
 
 /**
@@ -275,7 +276,7 @@ export class GadgetConnection {
    * await api.connection.fetch("/foo/bar");
    **/
   fetch = traceFunction("api-client.fetch", async (input: RequestInfo | URL, init: RequestInit = {}) => {
-    input = processMaybeRelativeInput(input, this.options.endpoint);
+    input = processMaybeRelativeInput(input, this.options.baseRouteURL ?? this.options.endpoint);
 
     if (this.isGadgetRequest(input)) {
       init.headers = { ...this.requestHeaders(), ...init.headers };


### PR DESCRIPTION
Outside of Gadget's internal infrastructure, the endpoint the API client is configured with is the public HTTP URL for the app + "/api/graphql". This means we can use the endpoint to infer the public HTTP URL for the app, which we use for building a fully qualified URL when someone does `api.fetch("/some/relative/path")` or `useFetch("/some/relative/path")`.

Sadly, this breaks inside Gadget's infrastructure, where we set up api clients with a custom GraphQL endpoint that uses our internal sandbox<->api connection for performance. The endpoint inside the sandbox is `api.gadget-services.net`, which means `api.fetch("/foo"` becomes a request to `https://api.gadget-services.net/foo`, which isn't right at all. It's weird that folks would be doing `api.fetch` within the sandbox to make an API call back to the sandbox they are already in, but stranger things have happened, and I think it should still work despite being roundabout.

So, we need a way to build the correct absolute URLs for relative inputs from within the sandbox. To KISS, this just adds a new option that we can pass to the api client in the sandbox. It's backwards and forwards compatible in that old api clients wont break when passed this, and new api clients don't need it to be passed. API clients constructed outside the sandbox by anyone other than us can use the public API endpoint for inference and don't need to pass this option either.

## PR Checklist

- [X] Important or complicated code is tested
- [X] Any user facing changes are documented in the Gadget-side changelog
- [X] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [X] Versions within this monorepo are matching and there's a valid upgrade path
