### PR TITLE
Use new api prop to pass in api client in react-shopify-app-bridge

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -220,7 +220,7 @@ export const Provider = ({
   }, []);
 
   let app = (
-    <GadgetUrqlProvider value={api.connection.currentClient}>
+    <GadgetUrqlProvider api={api}>
       <InnerGadgetProvider
         forceRedirect={forceRedirect}
         isEmbedded={isEmbedded}

--- a/packages/react/src/GadgetProvider.tsx
+++ b/packages/react/src/GadgetProvider.tsx
@@ -75,12 +75,12 @@ const defaultSignOutApiIdentifier = "signOut";
  * </Provider>
  *
  * @example the Provider accepts the deprecated form of passing an urql client object right in -- this is deprecated and will be removed in a future version. Instead, just pass the whole api instance.
- * <Provider api={api.connection.currentClient}>
+ * <Provider value={api.connection.currentClient}>
  *   <MyApp />
  * </Provider>
  *
  * @example the Provider accepts option sign in and sign out paths.
- * <Provider api={api.connection.currentClient} signInPath="/auth/signin" signOutActionApiIdentifier="signOut">
+ * <Provider api={api} signInPath="/auth/signin" signOutActionApiIdentifier="signOut">
  *   <MyApp />
  * </Provider>
  */


### PR DESCRIPTION
We should use the new `api` prop when passing in the client to the gadget react client so that devs can use `useApi`.

closes GGT-4604

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
