### PR TITLE
Convert react-shopify-app-bridge to also be CJS/ESM

### DIFF
--- a/packages/react-shopify-app-bridge/gitpkg.config.js
+++ b/packages/react-shopify-app-bridge/gitpkg.config.js
@@ -1,5 +1,0 @@
-const { execSync } = require("child_process");
-
-module.exports = () => ({
-  getTagName: (pkg) => `${pkg.name}-v${pkg.version}-gitpkg-${execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim()}`,
-});

--- a/packages/react-shopify-app-bridge/jest.config.js
+++ b/packages/react-shopify-app-bridge/jest.config.js
@@ -1,8 +1,7 @@
-const path = require("path");
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
-module.exports = {
+export default {
   displayName: "react-shopify-app-bridge",
   // All imported modules in your tests should be mocked automatically
   // automock: false,
@@ -78,7 +77,9 @@ module.exports = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],
@@ -138,7 +139,7 @@ module.exports = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  testMatch: [path.join(__dirname, "spec/(*.)+(spec|test).[tj]s?(x)")],
+  // testMatch: [path.join(__dirname, "spec/(*.)+(spec|test).[tj]s?(x)")],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: ["/node_modules/"],

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,19 +1,27 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.12.0",
-  "source": "src/index.ts",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "version": "0.13.1",
   "files": [
     "README.md",
-    "dist/src/**/*"
+    "dist/**/*"
   ],
   "license": "MIT",
   "repository": "github:gadget-inc/js-clients",
   "homepage": "https://github.com/gadget-inc/js-clients/tree/main/packages/react-shopify-app-bridge",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "source": "src/index.ts",
+  "main": "dist/cjs/index.js",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc -b tsconfig.cjs.json tsconfig.esm.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json && echo '{\"type\": \"module\"}' > dist/esm/package.json",
     "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
     "prepublishOnly": "pnpm build",
     "prerelease": "gitpkg publish"
@@ -21,8 +29,7 @@
   "dependencies": {
     "@gadgetinc/api-client-core": "^0.15.0",
     "@shopify/app-bridge-utils": "^3.1.1",
-    "crypto-js": "^4.1.1",
-    "lodash": "^4.17.21"
+    "crypto-js": "^4.1.1"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",

--- a/packages/react-shopify-app-bridge/spec/imports/cjs-import.js
+++ b/packages/react-shopify-app-bridge/spec/imports/cjs-import.js
@@ -1,0 +1,3 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Provider } = require("../..");
+if (typeof Provider == "undefined") throw new Error("GadgetProvider is undefined");

--- a/packages/react-shopify-app-bridge/spec/imports/imports.spec.ts
+++ b/packages/react-shopify-app-bridge/spec/imports/imports.spec.ts
@@ -1,0 +1,16 @@
+import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+
+describe("importing from different contexts", () => {
+  test("can be imported from cjs code", () => {
+    const { status } = spawnSync("node", [fileURLToPath(new URL("cjs-import.js", import.meta.url))]);
+
+    expect(status).toBe(0);
+  });
+
+  test("can be imported from esm code", () => {
+    const { status } = spawnSync("node", [fileURLToPath(new URL("named-esm-import.mjs", import.meta.url))]);
+
+    expect(status).toBe(0);
+  });
+});

--- a/packages/react-shopify-app-bridge/spec/imports/named-esm-import.mjs
+++ b/packages/react-shopify-app-bridge/spec/imports/named-esm-import.mjs
@@ -1,0 +1,1 @@
+import { Provider } from "../../dist/esm/index.js";

--- a/packages/react-shopify-app-bridge/spec/imports/package.json
+++ b/packages/react-shopify-app-bridge/spec/imports/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/react-shopify-app-bridge/spec/useGadget.spec.ts
+++ b/packages/react-shopify-app-bridge/spec/useGadget.spec.ts
@@ -1,8 +1,8 @@
 import type { AppBridgeState, ClientApplication } from "@shopify/app-bridge";
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
-import type { AppType } from "../src";
-import { useGadget } from "../src";
+import type { AppType } from "../src/index.js";
+import { useGadget } from "../src/index.js";
 
 // these functions are typechecked but never run to avoid actually making API calls
 const TestUseGadgetReturnsAppropriateTypes = () => {

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -1,14 +1,13 @@
 import type { AnyClient } from "@gadgetinc/api-client-core";
 import { Provider as GadgetUrqlProvider, useQuery } from "@gadgetinc/react";
 import type { History, LocationOrHref } from "@shopify/app-bridge-react";
-import { Provider as AppBridgeProvider } from "@shopify/app-bridge-react";
-import { AppBridgeContext } from "@shopify/app-bridge-react/context";
+import AppBridgeReact from "@shopify/app-bridge-react";
+import { AppBridgeContext } from "@shopify/app-bridge-react/context.js";
 import { getSessionToken } from "@shopify/app-bridge-utils";
-import { Redirect } from "@shopify/app-bridge/actions";
-import { isUndefined } from "lodash";
+import { Redirect } from "@shopify/app-bridge/actions/index.js";
 import React, { memo, useContext, useEffect, useMemo, useState } from "react";
-import type { GadgetAuthContextValue } from "./index";
-import { GadgetAuthContext } from "./index";
+import type { GadgetAuthContextValue } from "./index.js";
+import { GadgetAuthContext } from "./index.js";
 
 export enum AppType {
   Standalone,
@@ -209,7 +208,7 @@ export const Provider = ({
   // We need to inform developers if the component is being rendered in a non embedded context when it should be AND we're not in an interstitial installation state. This is determined for now by the absence of both hmac and shop. This will generally occur when someone visits the app url while not in the Shopify admin.
   const isRootFrameRequest = !query?.has("hmac") && !query?.has("shop") && coalescedType == AppType.Embedded;
 
-  const forceRedirect = isReady && !isUndefined(host) && !inDestinationContext;
+  const forceRedirect = isReady && typeof host !== "undefined" && !inDestinationContext;
 
   const gadgetAppUrl = new URL(api.connection.options.endpoint).origin;
 
@@ -253,7 +252,7 @@ export const Provider = ({
   // app bridge provider seems to prevent urql from sending graphql requests when it cannot communicate using postMessage when not embedded so we must skip using the app bridge provider on the very first redirect from shopify
   if (shouldMountAppBridge) {
     app = (
-      <AppBridgeProvider
+      <AppBridgeReact.Provider
         config={{
           apiKey: shopifyApiKey,
           host,
@@ -262,7 +261,7 @@ export const Provider = ({
         router={router}
       >
         {app}
-      </AppBridgeProvider>
+      </AppBridgeReact.Provider>
     );
   }
 

--- a/packages/react-shopify-app-bridge/src/context.ts
+++ b/packages/react-shopify-app-bridge/src/context.ts
@@ -1,6 +1,6 @@
 import type { AppBridgeState, ClientApplication } from "@shopify/app-bridge";
 import { createContext, useContext } from "react";
-import type { AppType } from "./Provider";
+import type { AppType } from "./Provider.js";
 
 export type GadgetAuthContextValue = {
   /** Is the AppBridge provider or the Gadget auth system loading or redirecting the user to make requests elsewhere */

--- a/packages/react-shopify-app-bridge/src/index.ts
+++ b/packages/react-shopify-app-bridge/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./Provider";
-export * from "./context";
+export * from "./Provider.js";
+export * from "./context.js";

--- a/packages/react-shopify-app-bridge/tsconfig.base.json
+++ b/packages/react-shopify-app-bridge/tsconfig.base.json
@@ -5,10 +5,7 @@
     "jsx": "react",
     "baseUrl": "./",
     "moduleResolution": "node",
-    "module": "ES2022",
     "target": "es2020",
-    "types": ["jest", "node"],
-    "outDir": "./dist"
-  },
-  "include": ["./src", "./spec"]
+    "types": ["jest", "node"]
+  }
 }

--- a/packages/react-shopify-app-bridge/tsconfig.cjs.json
+++ b/packages/react-shopify-app-bridge/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "CommonJS"
+  },
+  "include": ["./src"]
+}

--- a/packages/react-shopify-app-bridge/tsconfig.esm.json
+++ b/packages/react-shopify-app-bridge/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "ESNext"
+  },
+  "include": ["./src"]
+}

--- a/packages/test-bundles/bundles/shopify-read.tsx
+++ b/packages/test-bundles/bundles/shopify-read.tsx
@@ -1,0 +1,17 @@
+import { Client } from "@gadget-client/related-products-example";
+import { useFindMany } from "@gadgetinc/react";
+import { Provider } from "@gadgetinc/react-shopify-app-bridge";
+const api = new Client();
+
+export const Reader = () => {
+  const [{ data }] = useFindMany(api.shopifyProduct);
+  return <>{JSON.stringify(data)}</>;
+};
+
+export const App = () => {
+  return (
+    <Provider>
+      <Reader />
+    </Provider>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,9 +246,6 @@ importers:
       crypto-js:
         specifier: ^4.1.1
         version: 4.1.1
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
     devDependencies:
       '@gadgetinc/react':
         specifier: workspace:*
@@ -4964,6 +4961,7 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}


### PR DESCRIPTION
This fixes a bug where react-shopify-app-bridge being CJS only breaks vite setups that use the ESM/CJS versions of @gadgetinc/react as well, where vite imported the ESM version of the react context and the CJS version in two different spots, resulting in context identities not matching.
