### PR TITLE
pass the value of the stream to the onComplete callback

### DIFF
--- a/packages/react/spec/useFetch.spec.ts
+++ b/packages/react/spec/useFetch.spec.ts
@@ -165,14 +165,14 @@ describe("useFetch", () => {
   });
 
   test("it can fetch a string stream from the backend", async () => {
-    let onStreamCompleteCalled = false;
+    let onStreamCompleteCalled: boolean | string = false;
     const { result } = renderHook(
       () =>
         useFetch("/foo/bar", {
           stream: "string",
           sendImmediately: false,
-          onStreamComplete: () => {
-            onStreamCompleteCalled = true;
+          onStreamComplete: (value) => {
+            onStreamCompleteCalled = value;
           },
         }),
       {
@@ -258,7 +258,7 @@ describe("useFetch", () => {
     });
     expect(result.current[0].data).toEqual("hello world");
     expect(result.current[0].streaming).toBe(false);
-    expect(onStreamCompleteCalled).toBe(true);
+    expect(onStreamCompleteCalled).toBe("hello world");
 
     expect(mockUrqlClient[$gadgetConnection].fetch).toBeCalledTimes(1);
   });

--- a/packages/react/src/useFetch.ts
+++ b/packages/react/src/useFetch.ts
@@ -46,7 +46,7 @@ export interface FetchHookOptions extends RequestInit {
   stream?: boolean | string;
   json?: boolean;
   sendImmediately?: boolean;
-  onStreamComplete?: () => void;
+  onStreamComplete?: (value: string) => void;
 }
 
 const startRequestByDefault = (options?: FetchHookOptions) => {
@@ -91,7 +91,7 @@ const dispatchError = (
  * Pass the `{ stream: "string" }` to decode the `ReadableStream` as a string and update data as it arrives. If the stream is in an encoding other than utf8 use i.e. `{ stream: "utf-16" }`.
  *
  * When `{ stream: "string" }` is used, the `streaming` field in the state will be set to `true` while the stream is active, and `false` when the stream is complete. You can use this to show a loading indicator while the stream is active.
- * You can also pass an `onStreamComplete` callback to be notified when the stream is complete.
+ * You can also pass an `onStreamComplete` callback that will be called with the value of the streamed string once it has completed.
  *
  * If you want to read model data, see the `useFindMany` function and similar. If you want to invoke a backend Action, use the `useAction` hook instead.
  *
@@ -207,7 +207,7 @@ export function useFetch<T = string>(path: string, options?: FetchHookOptions): 
               }
             }
 
-            mergedOptions.onStreamComplete?.();
+            mergedOptions.onStreamComplete?.(responseText);
           })()
             .catch((error) => {
               if (!abortContoller.signal.aborted) {


### PR DESCRIPTION
In using the `onComplete` callback its annoying to try and access the completed result of the text stream; this PR passes that value to the `onComplete` callback

## PR Checklist

- [x] Important or complicated code is tested
- [x] Any user facing changes are documented in the Gadget-side changelog
- [x] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [x] Versions within this monorepo are matching and there's a valid upgrade path
