### PR TITLE
release @gadgetinc/react 0.14.1

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -48,7 +48,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@gadgetinc/react": "^0.14.0",
+    "@gadgetinc/react": "^0.14.1",
     "@shopify/app-bridge": "^2.0.0 || ^3.0.0",
     "@shopify/app-bridge-react": "^2.0.0 || ^3.0.0",
     "react": "^18.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "files": [
     "README.md",
     "dist/**/*"


### PR DESCRIPTION
releases changes from https://github.com/gadget-inc/js-clients/pull/248

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
