### PR TITLE
Restore support for explicitly required variables in the tiny operation compiler

### DIFF
--- a/packages/tiny-graphql-query-compiler/package.json
+++ b/packages/tiny-graphql-query-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-graphql-query-compiler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/tiny-graphql-query-compiler/spec/calls.spec.ts
+++ b/packages/tiny-graphql-query-compiler/spec/calls.spec.ts
@@ -42,6 +42,46 @@ describe("compiling queries with field calls", () => {
     `);
   });
 
+  test("it should compile a query that calls a field with a required variable value", () => {
+    const result = compile({
+      type: "query",
+      fields: {
+        id: true,
+        name: true,
+        truncatedHTML: Call({ length: Var({ type: "Int", required: true }) }),
+      },
+    });
+
+    expectValidGraphQLQuery(result);
+    expect(result).toMatchInlineSnapshot(`
+      "query ($length: Int!) {
+        id
+        name
+        truncatedHTML(length: $length)
+      }"
+    `);
+  });
+
+  test("it should compile a query that calls a field with an explicitly non-required variable value", () => {
+    const result = compile({
+      type: "query",
+      fields: {
+        id: true,
+        name: true,
+        truncatedHTML: Call({ length: Var({ type: "Int", required: false }) }),
+      },
+    });
+
+    expectValidGraphQLQuery(result);
+    expect(result).toMatchInlineSnapshot(`
+      "query ($length: Int) {
+        id
+        name
+        truncatedHTML(length: $length)
+      }"
+    `);
+  });
+
   test("it should compile a query that calls fields with multiple variable values", () => {
     const result = compile({
       type: "query",

--- a/packages/tiny-graphql-query-compiler/src/index.ts
+++ b/packages/tiny-graphql-query-compiler/src/index.ts
@@ -86,6 +86,7 @@ export interface VariableOptions {
   type: string;
   name?: string;
   value?: any;
+  required?: string;
 }
 
 /** Represents one reference to a variable somewhere in a selection */
@@ -100,7 +101,7 @@ export class Variable {
 export const Call = (args: Record<string, Variable | any>, subselection?: FieldSelection) => new FieldCall(args, subselection);
 
 /** Used for calling a field with a variable within the args to a field */
-export const Var = (options: VariableOptions) => new Variable(options.type, options.name, options.value);
+export const Var = (options: VariableOptions) => new Variable(options.type + (options.required ? "!" : ""), options.name, options.value);
 
 /** Compiles one JS object describing a query into a GraphQL string */
 export const compile = (operation: BuilderOperation): string => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
In #231, we dropped the `required` key from the inputs to the `Var` doodad for building graphql queries. This makes the code a bit simpler, but, it was a load-bearing key that the metadata from Gadget passed into api-client-core by means of the metadata on the model managers. So, let's keep supporting it to keep compatibility with already generated api clients and not require a cross-package coordination. 
