### PR TITLE
Fix typecheck in all packages after switch to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,15 @@ jobs:
         run: pnpm build
       - name: Lint
         run: pnpm lint
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-test-env
+      - name: Build all packages (so they can require each other)
+        run: pnpm build
+      - name: Typecheck
+        run: pnpm typecheck
   versions:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:prettier": "NODE_OPTIONS=\"--max-old-space-size=4096\" prettier --check \"(packages|scripts)/**/*.{js,ts,tsx}\"",
     "lint:eslint": "NODE_OPTIONS=\"--max-old-space-size=4096\" eslint --quiet --ext ts,tsx packages scripts",
     "lint:fix": "NODE_OPTIONS=\"--max-old-space-size=4096\" prettier --write --check \"(packages|scripts)/**/*.{js,ts,tsx}\" && eslint --ext ts,tsx --fix packages scripts",
-    "typecheck": "pnpm -r --no-bail exec tsc --noEmit",
+    "typecheck": "pnpm -r --no-bail run --if-present typecheck",
     "build": "pnpm -r --no-bail run --if-present build",
     "prerelease": "pnpm -r --no-bail run --if-present prerelease",
     "watch": "run-p --print-label watch:*",

--- a/packages/api-client-core/spec/imports/imports.spec.ts
+++ b/packages/api-client-core/spec/imports/imports.spec.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "child_process";
-import { fileURLToPath } from "url";
+import { URL, fileURLToPath } from "url";
 
 describe("importing from different contexts", () => {
   test("can be imported from cjs code", () => {

--- a/packages/api-client-core/spec/support.spec.ts
+++ b/packages/api-client-core/spec/support.spec.ts
@@ -64,7 +64,7 @@ describe("support utilities", () => {
           {
             operation: null as any,
             data: null,
-            error: new CombinedError({ networkError: [new Error("foo"), new Error("foo")] }),
+            error: new CombinedError({ networkError: [new Error("foo"), new Error("foo")] as any }),
             stale: false,
             hasNext: false,
           },

--- a/packages/react-shopify-app-bridge/spec/imports/imports.spec.ts
+++ b/packages/react-shopify-app-bridge/spec/imports/imports.spec.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "child_process";
-import { fileURLToPath } from "url";
+import { URL, fileURLToPath } from "url";
 
 describe("importing from different contexts", () => {
   test("can be imported from cjs code", () => {

--- a/packages/react/spec/imports/imports.spec.ts
+++ b/packages/react/spec/imports/imports.spec.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "child_process";
-import { fileURLToPath } from "url";
+import { URL, fileURLToPath } from "url";
 
 describe("importing from different contexts", () => {
   test("can be imported from cjs code", () => {

--- a/packages/react/spec/useBulkAction.spec.ts
+++ b/packages/react/spec/useBulkAction.spec.ts
@@ -3,7 +3,7 @@ import { renderHook } from "@testing-library/react";
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
 import { act } from "react-dom/test-utils";
-import { useBulkAction } from "../src.js";
+import { useBulkAction } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { bulkExampleApi } from "./apis.js";
 import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
 import { act } from "react-dom/test-utils";
-import { useGlobalAction } from "../src.js";
+import { useGlobalAction } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { bulkExampleApi } from "./apis.js";
 import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";

--- a/packages/test-bundles/build.ts
+++ b/packages/test-bundles/build.ts
@@ -2,7 +2,7 @@ import react from "@vitejs/plugin-react-swc";
 import fs from "fs";
 import { join, parse } from "path";
 import { visualizer } from "rollup-plugin-visualizer";
-import { fileURLToPath } from "url";
+import { URL, fileURLToPath } from "url";
 import { build } from "vite";
 
 const bundleDir = fileURLToPath(new URL("bundles", import.meta.url));
@@ -18,7 +18,8 @@ for (const entrypoint of entrypoints) {
     template: "treemap",
     brotliSize: true,
     gzipSize: true,
-  });
+  }) as any;
+
   const plugins = parsed.ext.endsWith("x") ? [react(), visualizerPlugin] : [visualizerPlugin];
 
   await build({

--- a/packages/test-bundles/bundles/shopify-read.tsx
+++ b/packages/test-bundles/bundles/shopify-read.tsx
@@ -10,7 +10,7 @@ export const Reader = () => {
 
 export const App = () => {
   return (
-    <Provider>
+    <Provider api={api} shopifyApiKey="deadbeef">
       <Reader />
     </Provider>
   );

--- a/packages/test-bundles/tsconfig.json
+++ b/packages/test-bundles/tsconfig.json
@@ -2,10 +2,14 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "es2020",
-    "module": "ESNext",
+    "baseUrl": "./",
+    "moduleResolution": "node",
+    "module": "ES2022",
     "lib": ["es2020", "DOM"],
+    "jsx": "react-jsx",
     "noEmit": true,
     "skipLibCheck": true,
     "declaration": false
-  }
+  },
+  "include": ["./build.ts", "./bundles"]
 }

--- a/packages/tiny-graphql-query-compiler/src/index.ts
+++ b/packages/tiny-graphql-query-compiler/src/index.ts
@@ -86,7 +86,7 @@ export interface VariableOptions {
   type: string;
   name?: string;
   value?: any;
-  required?: string;
+  required?: boolean;
 }
 
 /** Represents one reference to a variable somewhere in a selection */


### PR DESCRIPTION
When I switched js-clients to start publishing both CJS and ESM, I had to mess with the tsconfigs and add separate ones for each build mode. This works fine for the `src` directory of each project, but I missed the fact that because those tsconfigs only apply to the src dirs, running a build only typechecks the `src` dirs. Nothing in CI was typechecking the `spec` dirs or the test bundless, whoops!

This adds an explicit new CI step to typecheck all the files in every package that has a `typecheck` script defined, and fixes a few errors that crept in.
