### PR TITLE
Support custom return types from actions

### DIFF
--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -412,5 +412,83 @@ describe("operation builders", () => {
         }
       `);
     });
+
+    test("actionOperation should build a mutation query for an action that has a return type", () => {
+      expect(
+        actionOperation(
+          "createWidget",
+          { __typename: true, id: true, state: true },
+          "widget",
+          "widget",
+          {},
+          { select: { id: true } },
+          undefined,
+          false,
+          true
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "mutation createWidget {
+          createWidget {
+            success
+            errors {
+              message
+              code
+              ... on InvalidRecordError {
+                validationErrors {
+                  message
+                  apiIdentifier
+                }
+              }
+            }
+            result
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("actionOperation should build a bulk mutation query for an action that has a return type", () => {
+      expect(
+        actionOperation(
+          "bulkCreateWidgets",
+          { __typename: true, id: true, state: true },
+          "widget",
+          "widget",
+          {},
+          { select: { id: true } },
+          undefined,
+          true,
+          true
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "mutation bulkCreateWidgets {
+          bulkCreateWidgets {
+            success
+            errors {
+              message
+              code
+              ... on InvalidRecordError {
+                validationErrors {
+                  message
+                  apiIdentifier
+                }
+              }
+            }
+            results
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
   });
 });

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -106,6 +106,7 @@ interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, SchemaT, Defa
   hasAmbiguousIdentifier?: boolean;
   hasCreateOrUpdateEffect?: boolean;
   paramOnlyVariables?: readonly string[];
+  hasReturnType?: boolean;
 }
 
 export type ActionFunction<OptionsT, VariablesT, SelectionT, SchemaT, DefaultsT> = ActionFunctionMetadata<

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -131,7 +131,9 @@ export const actionOperation = (
   modelSelectionField: string,
   variables: VariablesOptions,
   options?: SelectionOptions | null,
-  namespace?: string | null
+  namespace?: string | null,
+  isBulkAction?: boolean | null,
+  hasReturnType?: boolean | null
 ) => {
   const selection = options?.select || defaultSelection;
 
@@ -139,7 +141,8 @@ export const actionOperation = (
     [operation]: Call(variableOptionsToVariables(variables), {
       success: true,
       errors: ErrorsSelection,
-      [modelSelectionField]: selection ? fieldSelectionToQueryCompilerFields(selection, true) : false,
+      [modelSelectionField]: selection && !hasReturnType ? fieldSelectionToQueryCompilerFields(selection, true) : false,
+      [isBulkAction ? "results" : "result"]: !!hasReturnType,
     }),
   };
 

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -47,7 +47,11 @@ export const useAction = <
   action: F,
   options?: LimitToKnownKeys<Options, F["optionsType"]>
 ): ActionHookResult<
-  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>,
+  F["hasReturnType"] extends true
+    ? any
+    : GadgetRecord<
+        Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>
+      >,
   Exclude<F["variablesType"], null | undefined>
 > => {
   if (!useContext(GadgetUrqlClientContext)) throw new Error(noProviderErrorMessage);
@@ -61,7 +65,9 @@ export const useAction = <
       action.modelSelectionField,
       action.variables,
       memoizedOptions,
-      action.namespace
+      action.namespace,
+      action.isBulk,
+      action.hasReturnType
     );
   }, [action, memoizedOptions]);
 
@@ -144,7 +150,7 @@ const processResult = <Data, Variables extends AnyVariables>(
       if (errors && errors[0]) {
         error = ErrorWrapper.forErrorsResponse(errors, error?.response);
       } else {
-        data = hydrateRecord(result, mutationData[action.modelSelectionField]);
+        data = action.hasReturnType ? mutationData.result : hydrateRecord(result, mutationData[action.modelSelectionField]);
       }
     }
   }

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -43,7 +43,11 @@ export const useBulkAction = <
   action: F,
   options?: LimitToKnownKeys<Options, F["optionsType"]>
 ): ActionHookResult<
-  GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>[],
+  F["hasReturnType"] extends true
+    ? any[]
+    : GadgetRecord<
+        Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>
+      >[],
   Exclude<F["variablesType"], null | undefined>
 > => {
   const memoizedOptions = useStructuralMemo(options);
@@ -55,7 +59,9 @@ export const useBulkAction = <
       action.modelSelectionField,
       action.variables,
       memoizedOptions,
-      action.namespace
+      action.namespace,
+      action.isBulk,
+      action.hasReturnType
     );
   }, [action, memoizedOptions]);
 
@@ -101,7 +107,7 @@ const processResult = (result: UseMutationState<any, any>, action: BulkActionFun
         if (errors && errors[0]) {
           error = ErrorWrapper.forErrorsResponse(errors, (error as any)?.response);
         } else {
-          data = hydrateRecordArray(result, mutationData[action.modelSelectionField]);
+          data = action.hasReturnType ? mutationData.results : hydrateRecordArray(result, mutationData[action.modelSelectionField]);
         }
       }
     }


### PR DESCRIPTION
We need to update the action runner and builders to take `hasReturnType` into consideration when generating graphQL and selecting the result. This also updates the hooks to do the same. To release this we should first release api-client-core, then update gadget, and then react

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
