### PR TITLE
Add `exchanges` option

### DIFF
--- a/packages/api-client-core/src/ClientOptions.ts
+++ b/packages/api-client-core/src/ClientOptions.ts
@@ -1,3 +1,4 @@
+import type { Exchange } from "@urql/core";
 import type { GadgetSubscriptionClientOptions } from "./GadgetConnection";
 
 /** All the options for a Gadget client */
@@ -40,6 +41,10 @@ export interface ClientOptions {
    * This only needs to be passed if you are overriding the `endpoint` parameter to something that can't be used for building fully-qualified URLs from relative imports.
    **/
   baseRouteURL?: string;
+  /**
+   * A list of exchanges to merge into the default exchanges used by the client.
+   */
+  exchanges?: Exchanges;
 }
 
 /** Options to configure a specific browser-based authentication mode */
@@ -96,4 +101,19 @@ export interface AuthenticationModeOptions {
     processFetch(input: RequestInfo | URL, init: RequestInit): Promise<void>;
     processTransactionConnectionParams(params: Record<string, any>): Promise<void>;
   };
+}
+
+export interface Exchanges {
+  /**
+   * Exchanges to add before all other exchanges.
+   */
+  beforeAll?: Exchange[];
+  /**
+   * Exchanges to add before any async exchanges.
+   */
+  beforeAsync?: Exchange[];
+  /**
+   * Exchanges to add after all other exchanges.
+   */
+  afterAll?: Exchange[];
 }


### PR DESCRIPTION
This adds an `exchanges` parameter to our client constructor so we can add custom ones in the sandbox. I decided to go with 3 hooks (beforeAll, beforeAsync, afterAll) based on the docs below:

https://formidable.com/open-source/urql/docs/advanced/authoring-exchanges/#synchronous-first-asynchronous-last

This API doesn't give us complete control over the exchanges (e.g. re-arrange, remove, replace), so if you think we will want to do any of that we should add it now.

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
