### PR TITLE
Bulk action return value

### DIFF
--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -334,7 +334,44 @@ describe("operationRunners", () => {
       expect(error!).toBeTruthy();
       expect(error!.errors.length).toBe(2);
       expect(error!.code).toMatchInlineSnapshot(`"GGT_ERROR_GROUP(GGT_ERROR_CODE_A,GGT_ERROR_CODE_B)"`);
-      expect(error!.results[0].id).toBeTruthy();
+      expect(error!.results?.[0].id).toBeTruthy();
+    });
+
+    test("returns undefined when bulk action does not have a result", async () => {
+      const promise = actionRunner<{ id: string; name: string }>(
+        {
+          connection,
+        },
+        "bulkDeleteWidgets",
+        { id: true, name: true },
+        "widget",
+        "widgets",
+        true,
+        {
+          ids: {
+            value: ["123", "234"],
+            required: true,
+            type: "[GadgetID!]",
+          },
+        },
+        {},
+        null,
+        false
+      );
+
+      mockUrqlClient.executeMutation.pushResponse("bulkDeleteWidgets", {
+        data: {
+          bulkDeleteWidgets: {
+            success: true,
+            errors: null,
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -209,7 +209,7 @@ export const actionRunner: ActionRunner = async <Shape extends RecordShape = any
     const results =
       mutationTriple[modelSelectionField] && defaultSelection
         ? hydrateRecordArray<Shape>(response, mutationTriple[modelSelectionField])
-        : [];
+        : undefined;
     if (mutationTriple.errors) {
       const errors = mutationTriple.errors.map((error: any) => gadgetErrorFor(error));
       throw new GadgetErrorGroup(errors, results);

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -181,7 +181,7 @@ export class GadgetErrorGroup<Result> extends Error {
     /** The list of inner errors that occurred */
     public readonly errors: GadgetError[],
     /* Any objects that were successfully processed during the bulk operation (the ones that didn't throw errors) */
-    public readonly results: Result[]
+    public readonly results: Result[] | undefined
   ) {
     super(errors.length > 1 ? "Multiple errors occurred" : errors[0].message);
   }


### PR DESCRIPTION
We inadvertently changed the behaviour of the return value on bulk deletes with the Error group changes. This goes back to returning `undefined` instead of `[]`

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
