### PR TITLE
change: resolution for deep-equal on react package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,6 +31,9 @@
     "deep-equal": "^2.2.0",
     "urql": "^4.0.4"
   },
+  "resolutions": {
+    "regexp.prototype.flags": "1.5.0"
+  },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "files": [
     "README.md",
     "dist/**/*"


### PR DESCRIPTION
Failing dependency on the deep-equal package. Using this to override during an incident.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
