### PR TITLE
Add support for bulk actions which accept params beyond just an ID

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "files": [
     "Readme.md",
     "dist/**/*"
@@ -39,7 +39,7 @@
     "ws": "^8.13.0"
   },
   "devDependencies": {
-    "tiny-graphql-query-compiler": "workspace:*",
+    "tiny-graphql-query-compiler": "*",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.isequal": "^4.5.5",
     "@types/node": "^16.11.7",

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -90,6 +90,10 @@ interface BulkActionWithIdsAndNoVariables<OptionsT> {
   <Options extends OptionsT>(ids: string[], options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;
 }
 
+interface BulkActionWithInputs<OptionsT, VariablesT> {
+  <Options extends OptionsT>(inputs: VariablesT, options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;
+}
+
 interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, SchemaT, DefaultsT, IsBulk> {
   type: "action";
   operationName: string;
@@ -134,7 +138,7 @@ export type BulkActionFunction<OptionsT, VariablesT, SelectionT, SchemaT, Defaul
   DefaultsT,
   true
 > &
-  BulkActionWithIdsAndNoVariables<OptionsT>;
+  (BulkActionWithIdsAndNoVariables<OptionsT> | BulkActionWithInputs<OptionsT, VariablesT>);
 
 export interface GetFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<GadgetRecord<any>>;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -77,7 +77,10 @@ export const useBulkAction = <
   return [
     transformedResult,
     useCallback(
-      async (variables: F["variablesType"], context?: Partial<OperationContext>) => {
+      async (inputs: F["variablesType"], context?: Partial<OperationContext>) => {
+        // accept the old style of {ids: ["1", "2", "3"]} as well as the new style of [{id: 1, foo: "bar"}, {id: 2, foo: "baz"}]
+        const variables = inputs && "ids" in inputs ? inputs : { inputs };
+
         // Adding the model's additional typename ensures document cache will properly refresh, regardless of whether __typename was
         // selected (and sometimes we can't even select it, like delete actions!)
         const result = await runMutation(variables, {


### PR DESCRIPTION
Tiny type change and support for accepting bulk params. Tests to come in a second PR once Gadget proper creates clients with support for this