### PR TITLE
Fix for useAction incorrectly mapping non nested auth action inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@gadget-client/app-with-no-user-model": "^1.3.0",
     "@gadget-client/bulk-actions-test": "^1.102.0",
     "@gadget-client/related-products-example": "^1.848.0",
-    "@gadget-client/super-auth": "^1.17.0",
+    "@gadget-client/super-auth": "^1.27.0",
     "@gadgetinc/api-client-core": "workspace:*",
     "@gadgetinc/eslint-config": "^0.6.1",
     "@gadgetinc/prettier-config": "^0.4.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/spec/auth/useSession.spec.ts
+++ b/packages/react/spec/auth/useSession.spec.ts
@@ -29,23 +29,23 @@ describe("useSession", () => {
     expect(query).toMatchInlineSnapshot(`
       "query currentSession {
         currentSession {
-          id
           __typename
           createdAt
-          updatedAt
+          id
           roles {
             key
             name
           }
+          updatedAt
           user {
-            id
             __typename
             createdAt
-            updatedAt
-            lastName
-            firstName
             email
+            firstName
             googleImageUrl
+            id
+            lastName
+            updatedAt
           }
         }
         gadgetMeta {
@@ -69,23 +69,23 @@ describe("useSession", () => {
     expect(query).toMatchInlineSnapshot(`
       "query currentSession {
         currentSession {
-          id
           __typename
           createdAt
-          updatedAt
+          id
           roles {
             key
             name
           }
+          updatedAt
           user {
-            id
             __typename
             createdAt
-            updatedAt
-            lastName
-            firstName
             email
+            firstName
             googleImageUrl
+            id
+            lastName
+            updatedAt
           }
         }
         gadgetMeta {

--- a/packages/react/spec/auth/useUser.spec.ts
+++ b/packages/react/spec/auth/useUser.spec.ts
@@ -28,23 +28,23 @@ describe("useUser", () => {
     expect(query).toMatchInlineSnapshot(`
       "query currentSession {
         currentSession {
-          id
           __typename
           createdAt
-          updatedAt
+          id
           roles {
             key
             name
           }
+          updatedAt
           user {
-            id
             __typename
             createdAt
-            updatedAt
-            lastName
-            firstName
             email
+            firstName
             googleImageUrl
+            id
+            lastName
+            updatedAt
           }
         }
         gadgetMeta {
@@ -68,23 +68,23 @@ describe("useUser", () => {
     expect(query).toMatchInlineSnapshot(`
       "query currentSession {
         currentSession {
-          id
           __typename
           createdAt
-          updatedAt
+          id
           roles {
             key
             name
           }
+          updatedAt
           user {
-            id
             __typename
             createdAt
-            updatedAt
-            lastName
-            firstName
             email
+            firstName
             googleImageUrl
+            id
+            lastName
+            updatedAt
           }
         }
         gadgetMeta {
@@ -110,14 +110,14 @@ describe("useUser", () => {
     expect(query).toMatchInlineSnapshot(`
       "query currentSession {
         currentSession {
-          id
           __typename
           createdAt
-          updatedAt
+          id
           roles {
             key
             name
           }
+          updatedAt
           user {
             firstName
           }

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -417,7 +417,7 @@ describe("useAction", () => {
     `);
   });
 
-  test("generates correct mutation and variables for fat trigger", async () => {
+  test("generates correct mutation and variables for trigger that contributes inputs", async () => {
     let variables: AnyVariables;
 
     const client = createMockUrqlClient({

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -8,7 +8,7 @@ import type { AnyVariables } from "urql";
 import { Provider } from "../src/GadgetProvider.js";
 import { useAction } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
-import { relatedProductsApi } from "./apis.js";
+import { relatedProductsApi, superAuthApi } from "./apis.js";
 import { MockClientWrapper, createMockUrqlClient, mockUrqlClient } from "./testWrappers.js";
 
 describe("useAction", () => {
@@ -413,6 +413,54 @@ describe("useAction", () => {
           "numberField": 21,
           "stringField": "hello world",
         },
+      }
+    `);
+  });
+
+  test("generates correct mutation and variables for fat trigger", async () => {
+    let variables: AnyVariables;
+
+    const client = createMockUrqlClient({
+      mutationAssertions: (request) => {
+        variables = request.variables;
+      },
+    });
+
+    const wrapper = (props: { children: React.ReactNode }) => <Provider value={client}>{props.children}</Provider>;
+
+    const { result } = renderHook(() => useAction(superAuthApi.user.signUp), {
+      wrapper,
+    });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ email: "bob@test.com", password: "password123!" });
+    });
+
+    client.executeMutation.pushResponse("signUpUser", {
+      data: {
+        signUpUser: {
+          result: {
+            result: "ok",
+          },
+          success: true,
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data).toEqual({ result: "ok" });
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeFalsy();
+    });
+
+    expect(variables).toMatchInlineSnapshot(`
+      {
+        "email": "bob@test.com",
+        "password": "password123!",
       }
     `);
   });

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -327,9 +327,10 @@ export const disambiguateActionVariables = (
 
   if (action.acceptsModelInput || action.hasCreateOrUpdateEffect) {
     if (
-      action.modelApiIdentifier in variables &&
-      typeof variables[action.modelApiIdentifier] === "object" &&
-      variables[action.modelApiIdentifier] !== null
+      (action.modelApiIdentifier in variables &&
+        typeof variables[action.modelApiIdentifier] === "object" &&
+        variables[action.modelApiIdentifier] !== null) ||
+      !action.variables[action.modelApiIdentifier]
     ) {
       newVariables = variables;
     } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^1.848.0
         version: 1.848.0
       '@gadget-client/super-auth':
-        specifier: ^1.17.0
-        version: 1.17.0
+        specifier: ^1.27.0
+        version: 1.27.0
       '@gadgetinc/api-client-core':
         specifier: workspace:*
         version: link:packages/api-client-core
@@ -1182,8 +1182,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/super-auth@1.17.0:
-    resolution: {integrity: sha1-x6rQ58gKtE3JRBUJGWoV3uASMaw=, tarball: https://registry.gadget.dev/npm/_/tarball/50045/98771/5053}
+  /@gadget-client/super-auth@1.27.0:
+    resolution: {integrity: sha1-gbvjTId/sQnsYBACEc93yEyw18g=, tarball: https://registry.gadget.dev/npm/_/tarball/50045/98771/5428}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
`useAction` was nesting variables under the action model api identifier, but the graphql api for these actions were expecting them to be non-nested (`api.user.signUp({email..})` is not nested under `user` like it would be in `api.user.signUp({user: {email:...}`). This caused us to pass in the variables to graphql in a shape it was not expecting (and could not parse the data for)!

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
