### PR TITLE
Bump graphql dependency to latest

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@urql/core": "^4.0.10",
     "cross-fetch": "^3.1.5",
-    "graphql": "~16.6.0",
+    "graphql": "^16.8.1",
     "graphql-ws": "^5.13.1",
     "isomorphic-ws": "^5.0.0",
     "klona": "^2.0.6",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,7 @@
     "@types/react-dom": "^18.2.4",
     "@urql/core": "^4.0.10",
     "conditional-type-checks": "^1.0.6",
-    "graphql": "16.5.0",
+    "graphql": "^16.8.1",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,16 +92,16 @@ importers:
     dependencies:
       '@urql/core':
         specifier: ^4.0.10
-        version: 4.0.10(graphql@16.6.0)
+        version: 4.0.10(graphql@16.8.1)
       cross-fetch:
         specifier: ^3.1.5
         version: 3.1.5
       graphql:
-        specifier: ~16.6.0
-        version: 16.6.0
+        specifier: ^16.8.1
+        version: 16.8.1
       graphql-ws:
         specifier: ^5.13.1
-        version: 5.13.1(graphql@16.6.0)
+        version: 5.13.1(graphql@16.8.1)
       isomorphic-ws:
         specifier: ^5.0.0
         version: 5.0.0(ws@8.13.0)
@@ -187,7 +187,7 @@ importers:
         version: 3.2.2
       urql:
         specifier: ^4.0.4
-        version: 4.0.4(graphql@16.5.0)(react@18.2.0)
+        version: 4.0.4(graphql@16.8.1)(react@18.2.0)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.16.5
@@ -212,13 +212,13 @@ importers:
         version: 18.2.4
       '@urql/core':
         specifier: ^4.0.10
-        version: 4.0.10(graphql@16.5.0)
+        version: 4.0.10(graphql@16.8.1)
       conditional-type-checks:
         specifier: ^1.0.6
         version: 1.0.6
       graphql:
-        specifier: 16.5.0
-        version: 16.5.0
+        specifier: ^16.8.1
+        version: 16.8.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -335,7 +335,7 @@ importers:
 
 packages:
 
-  /@0no-co/graphql.web@1.0.4(graphql@16.5.0):
+  /@0no-co/graphql.web@1.0.4(graphql@16.8.1):
     resolution: {integrity: sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -343,18 +343,7 @@ packages:
       graphql:
         optional: true
     dependencies:
-      graphql: 16.5.0
-
-  /@0no-co/graphql.web@1.0.4(graphql@16.6.0):
-    resolution: {integrity: sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-    peerDependenciesMeta:
-      graphql:
-        optional: true
-    dependencies:
-      graphql: 16.6.0
-    dev: false
+      graphql: 16.8.1
 
   /@adobe/css-tools@4.2.0:
     resolution: {integrity: sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==}
@@ -2095,22 +2084,13 @@ packages:
       eslint-visitor-keys: 3.4.0
     dev: true
 
-  /@urql/core@4.0.10(graphql@16.5.0):
+  /@urql/core@4.0.10(graphql@16.8.1):
     resolution: {integrity: sha512-Vs3nOSAnYftqOCg034Ostp/uSqWlQg5ryLIzcOrm8+O43s4M+Ew4GQAuemIH7ZDB8dek6h61zzWI3ujd8FH3NA==}
     dependencies:
-      '@0no-co/graphql.web': 1.0.4(graphql@16.5.0)
+      '@0no-co/graphql.web': 1.0.4(graphql@16.8.1)
       wonka: 6.3.2
     transitivePeerDependencies:
       - graphql
-
-  /@urql/core@4.0.10(graphql@16.6.0):
-    resolution: {integrity: sha512-Vs3nOSAnYftqOCg034Ostp/uSqWlQg5ryLIzcOrm8+O43s4M+Ew4GQAuemIH7ZDB8dek6h61zzWI3ujd8FH3NA==}
-    dependencies:
-      '@0no-co/graphql.web': 1.0.4(graphql@16.6.0)
-      wonka: 6.3.2
-    transitivePeerDependencies:
-      - graphql
-    dev: false
 
   /@vitejs/plugin-react-swc@3.3.0(vite@4.2.2):
     resolution: {integrity: sha512-Ycg+n2eyCOTpn/wRy+evVo859+hw7qCj9iaX5CMny6x1fx1Uoq0xBG+a98lFtwLNGfGEnpI0F26YigRuxCRkwg==}
@@ -3698,23 +3678,23 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /graphql-ws@5.13.1(graphql@16.6.0):
+  /graphql-ws@5.13.1(graphql@16.8.1):
     resolution: {integrity: sha512-eiX7ES/ZQr0q7hSM5UBOEIFfaAUmAY9/CSDyAnsETuybByU7l/v46drRg9DQoTvVABEHp3QnrvwgTRMhqy7zxQ==}
     engines: {node: '>=10'}
     peerDependencies:
       graphql: '>=0.11 <=16'
     dependencies:
-      graphql: 16.6.0
+      graphql: 16.8.1
     dev: false
 
   /graphql@16.5.0:
     resolution: {integrity: sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
 
-  /graphql@16.6.0:
-    resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
+  /graphql@16.8.1:
+    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: false
 
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -6104,12 +6084,12 @@ packages:
       requires-port: 1.0.0
     dev: true
 
-  /urql@4.0.4(graphql@16.5.0)(react@18.2.0):
+  /urql@4.0.4(graphql@16.8.1)(react@18.2.0):
     resolution: {integrity: sha512-C5P4BMnAsk+rbytCWglit5ijXbIKXsa9wofSGPbuMyJKsDdL+9GfipS362Nff/Caag+eYOK5W+sox8fwEILT6Q==}
     peerDependencies:
       react: '>= 16.8.0'
     dependencies:
-      '@urql/core': 4.0.10(graphql@16.5.0)
+      '@urql/core': 4.0.10(graphql@16.8.1)
       react: 18.2.0
       wonka: 6.3.2
     transitivePeerDependencies:


### PR DESCRIPTION
Superseeds https://github.com/gadget-inc/js-clients/pull/266, resolves a security advisory when installing the client