### PR TITLE
Add more complete types for the InternalModelManager

### DIFF
--- a/packages/api-client-core/src/DataHydrator.ts
+++ b/packages/api-client-core/src/DataHydrator.ts
@@ -6,6 +6,7 @@ export const Hydrators = {
 
 export type Hydration = keyof typeof Hydrators;
 
+/** Instructions for a client to turn raw transport types (like strings) into useful client side types (like Dates). Unstable and not intended for developer use. */
 export interface HydrationPlan {
   [key: string]: Hydration;
 }

--- a/packages/api-client-core/src/GadgetRecordList.ts
+++ b/packages/api-client-core/src/GadgetRecordList.ts
@@ -4,12 +4,12 @@ import type { Jsonify } from "type-fest";
 import type { GadgetRecord, RecordShape } from "./GadgetRecord.js";
 import type { InternalModelManager } from "./InternalModelManager.js";
 import type { AnyModelManager } from "./ModelManager.js";
-import type { PaginationOptions } from "./operationBuilders.js";
 import { GadgetClientError, GadgetOperationError } from "./support.js";
+import { PaginateOptions } from "./types.js";
 
 type PaginationConfig = {
   pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor: string; endCursor: string };
-  options?: PaginationOptions;
+  options?: PaginateOptions;
 };
 
 /** Represents a list of objects returned from the API. Facilitates iterating and paginating. */

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -15,6 +15,7 @@ import {
   hydrateRecord,
   hydrateRecordArray,
 } from "./support.js";
+import type { InternalFieldSelection, InternalFindListOptions, InternalFindManyOptions, InternalFindOneOptions } from "./types";
 
 const internalErrorsDetails = `
 fragment InternalErrorsDetails on ExecutionError {
@@ -50,87 +51,6 @@ export const internalFindOneQuery = (apiIdentifier: string) => {
     }
     `;
 };
-
-/**
- * A list of fields to select from the internal API
- * Matches the format of the Public API `select` option, but only allows going one level deep -- no relationships can be selected using the internal API.
- *
- * Supports passing a list of strings as a shorthand.
- *
- * @example
- * { fieldA: true, fieldB: true, fieldC: false }
- *
- * @example
- * ['fieldA', 'fieldB']
- */
-export type InternalFieldSelection = string[] | { [field: string]: boolean | null | undefined };
-
-/** Options for the api functions that return one record on an InternalModelManager */
-export interface InternalFindOneOptions {
-  /**
-   * What fields to retrieve from the API for this API call
-   **/
-  select?: InternalFieldSelection;
-}
-
-/** Options for functions that query a list of records on an InternalModelManager */
-export interface InternalFindListOptions {
-  /**
-   * A string to search for within all the stringlike fields of the records
-   * Matches the behavior of the Public API `search` option
-   **/
-  search?: string;
-  /**
-   * How to sort the returned records
-   * Matches the format and behavior of the Public API `sort` option
-   *
-   * @example
-   * {
-   *   sort: { publishedAt: "Descending" }
-   * }
-   **/
-  sort?: Record<string, "Ascending" | "Descending"> | Record<string, "Ascending" | "Descending">[];
-  /**
-   * Only return records matching this filter
-   * Matches the format and behavior of the Public API `filter` option
-   *
-   * @example
-   * {
-   *   filter: { published: { equals: true } }
-   * }
-   * */
-  filter?: Record<string, any>;
-  /**
-   * What fields to retrieve from the API for this API call
-   **/
-  select?: InternalFieldSelection;
-}
-
-/** Options for functions that return a paginated list of records from an InternalModelManager */
-export interface InternalFindManyOptions extends InternalFindListOptions {
-  /**
-   * A count of records to return
-   * Often used in tandem with the `after` option for GraphQL relay-style cursor pagination
-   * Matches the pagination style and behavior of the Public API
-   **/
-  first?: number;
-  /**
-   * The `after` cursor from the GraphQL Relay pagination spec
-   * Matches the pagination style and behavior of the Public API
-   **/
-  after?: string;
-  /**
-   * A count of records to return
-   * Often used in tandem with the `before` option for GraphQL relay-style cursor pagination
-   * Matches the pagination style and behavior of the Public API
-   **/
-  last?: number;
-  /**
-   * The `before` cursor from the GraphQL Relay pagination spec
-   * Matches the pagination style and behavior of the Public API
-   **/
-  before?: string;
-}
 
 const internalFindListVariables = (capitalizedApiIdentifier: string, options?: InternalFindListOptions) => {
   return {

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -2,7 +2,7 @@ import type { FieldSelection as BuilderFieldSelection, BuilderOperation, Variabl
 import { Call, Var, compileWithVariableValues } from "tiny-graphql-query-compiler";
 import type { FieldSelection } from "./FieldSelection.js";
 import { filterTypeName, sortTypeName } from "./support.js";
-import type { VariablesOptions } from "./types.js";
+import type { FindManyOptions, SelectionOptions, VariablesOptions } from "./types.js";
 
 const hydrationOptions = (modelApiIdentifier: string): BuilderFieldSelection => {
   return {
@@ -21,22 +21,7 @@ const fieldSelectionToQueryCompilerFields = (selection: FieldSelection, includeT
   return output;
 };
 
-type AnySort = any;
-type AnyFilter = any;
-
-export type SelectionOptions = { select?: any };
-
-export type PaginationOptions = {
-  sort?: AnySort | null;
-  filter?: AnyFilter | null;
-  search?: string | null;
-  after?: string | null;
-  first?: number | null;
-  before?: string | null;
-  last?: number | null;
-} & SelectionOptions;
-
-export type FindFirstPaginationOptions = Omit<PaginationOptions, "first" | "last" | "before" | "after">;
+export type FindFirstPaginationOptions = Omit<FindManyOptions, "first" | "last" | "before" | "after">;
 
 export const findOneOperation = (
   operation: string,
@@ -80,7 +65,7 @@ export const findManyOperation = (
   operation: string,
   defaultSelection: FieldSelection,
   modelApiIdentifier: string,
-  options?: PaginationOptions
+  options?: FindManyOptions
 ) => {
   return compileWithVariableValues({
     type: "query",

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -3,7 +3,6 @@ import type { GadgetConnection } from "./GadgetConnection.js";
 import type { GadgetRecord, RecordShape } from "./GadgetRecord.js";
 import { GadgetRecordList } from "./GadgetRecordList.js";
 import type { AnyModelManager } from "./ModelManager.js";
-import type { PaginationOptions, SelectionOptions } from "./operationBuilders.js";
 import {
   actionOperation,
   findManyOperation,
@@ -23,7 +22,7 @@ import {
   hydrateRecord,
   hydrateRecordArray,
 } from "./support.js";
-import type { VariablesOptions } from "./types.js";
+import type { FindManyOptions, SelectionOptions, VariablesOptions } from "./types.js";
 
 export const findOneRunner = async <Shape extends RecordShape = any>(
   modelManager: { connection: GadgetConnection },
@@ -67,7 +66,7 @@ export const findManyRunner = async <Shape extends RecordShape = any>(
   operation: string,
   defaultSelection: FieldSelection,
   modelApiIdentifier: string,
-  options?: PaginationOptions,
+  options?: FindManyOptions,
   throwOnEmptyData?: boolean
 ) => {
   const plan = findManyOperation(operation, defaultSelection, modelApiIdentifier, options);

--- a/packages/api-client-core/src/types.ts
+++ b/packages/api-client-core/src/types.ts
@@ -79,3 +79,621 @@ export type DeepFilterNever<T> = T extends Record<string, unknown>
  * ```
  */
 export type Select<Schema, Selection extends FieldSelection | null | undefined> = DeepFilterNever<InnerSelect<Schema, Selection>>;
+
+/** Represents an amount of some currency. Specified as a string so user's aren't tempted to do math on the value. */
+export type CurrencyAmount = string;
+
+/** Represents a UTC date formatted an ISO-8601 formatted 'full-date' string. */
+export type ISO8601DateString = string;
+
+/** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+export type JSONObject = { [key: string]: any };
+
+/** The ID of a record in Gadget */
+export type GadgetID = string;
+
+/** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
+export type DateTime = Date;
+
+/** Represents the state of one record in a Gadget database. Represented as either a string or set of strings nested in objects. */
+export type RecordState = string | { [key: string]: RecordState };
+
+/** A field whose value conforms to the standard internet email address format as specified in RFC822: https://www.w3.org/Protocols/rfc822/. */
+export type EmailAddress = string;
+
+/** A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt. */
+export type URLString = string;
+
+/** The `JSONBlob` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+export type JSONBlob = { [key: string]: any } | string | null | any[];
+
+/**
+ * The filters available for filtering an ID type field on the backend
+ *
+ * @example
+ * { id: { equals: "123" } }
+ *
+ * @example
+ * { id: { in: ["123", "456"] } }
+ **/
+export interface IDFilter {
+  /** Filter to where the backend value is equal to this ID value */
+  equals?: GadgetID | null;
+
+  /** Filter to where the backend value anything other than this ID value */
+  notEquals?: GadgetID | null;
+
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: boolean | null;
+
+  /** Filter to where the backend value is within this set of IDs */
+  in?: (GadgetID | null)[];
+
+  /** Filter to where the backend value is not included in this set of IDs */
+  notIn?: (GadgetID | null)[];
+
+  /** Filter to where the backend value is numerically lower than this value */
+  lessThan?: GadgetID | null;
+
+  /** Filter to where the backend value is numerically lower or equal to this value */
+  lessThanOrEqual?: GadgetID | null;
+
+  /** Filter to where the backend value is numerically greater than this value */
+  greaterThan?: GadgetID | null;
+
+  /** Filter to where the backend value is numerically greater than or equal to this value */
+  greaterThanOrEqual?: GadgetID | null;
+}
+
+/**
+ * The filters available for filtering an Number field type that has no decimals on the backend
+ *
+ * @example
+ * { age: { equals: 18 } }
+ *
+ * @example
+ * { age: { in: [18, 19, 20] } }
+ *
+ * @example
+ * { age: { greaterThan: 18 } }
+ **/
+export interface IntFilter {
+  /** Filter to where the backend value is equal to this value */
+  equals?: number | null;
+
+  /** Filter to where the backend value is not equal to this value */
+  notEquals?: number | null;
+
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: boolean | null;
+
+  /** Filter to where the backend value is within this set of numbers */
+  in?: (number | null)[];
+
+  /** Filter to where the backend value is not within this set of numbers */
+  notIn?: (number | null)[];
+
+  /** Filter to where the backend value is lower than this number */
+  lessThan?: number | null;
+
+  /** Filter to where the backend value is lower than or equal to this number */
+  lessThanOrEqual?: number | null;
+
+  /** Filter to where the backend value is greater than to this number */
+  greaterThan?: number | null;
+
+  /** Filter to where the backend value is greater than or equal to this number */
+  greaterThanOrEqual?: number | null;
+}
+
+/**
+ * The filters available for filtering an Number field type that has decimals on the backend
+ *
+ * @example
+ * { age: { equals: 18.5 } }
+ *
+ * @example
+ * { age: { in: [18.5, 19.5, 20.5] } }
+ *
+ * @example
+ * { age: { greaterThan: 18.5 } }
+ * */
+export interface FloatFilter {
+  /** Filter to where the backend value is equal to this value */
+  equals?: number | null;
+
+  /** Filter to where the backend value is not equal to this value */
+  notEquals?: number | null;
+
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: boolean | null;
+
+  /** Filter to where the backend value is within this set of numbers */
+  in?: (number | null)[];
+
+  /** Filter to where the backend value is not within this set of numbers */
+  notIn?: (number | null)[];
+
+  /** Filter to where the backend value is lower than this number */
+  lessThan?: number | null;
+
+  /** Filter to where the backend value is lower than or equal to this number */
+  lessThanOrEqual?: number | null;
+
+  /** Filter to where the backend value is greater than to this number */
+  greaterThan?: number | null;
+
+  /** Filter to where the backend value is greater than or equal to this number */
+  greaterThanOrEqual?: number | null;
+}
+
+/**
+ * The filters available for filtering a Date type field on the backend that includes the time part of a date time
+ *
+ * @example
+ * { createdAt: { equals: new Date() } }
+ *
+ * @example
+ * { createdAt: { after: "2020-01-01T00:00:00.000Z" } }
+ *
+ * @example
+ * { publishedAt: { isSet: true } }
+ *
+ **/
+export interface DateTimeFilter {
+  /** Filter to where the backend value is equal to this date value. Accepts `Date` objects or ISO8601 formatted date strings */
+  equals?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend value is anything other than this value. Accepts `Date` objects or ISO8601 formatted date strings */
+  notEquals?: Date | ISO8601DateString | null;
+
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: (boolean | null) | null;
+
+  /** Filter to where the backend value is included in this given set of dates. Accepts an array of `Date` objects or ISO8601 formatted date strings */
+  in?: (Date | ISO8601DateString | null)[];
+
+  /** Filter to where the backend value is not included in this given set of dates. Accepts an array of `Date` objects or ISO8601 formatted date strings */
+  notIn?: (Date | ISO8601DateString | null)[];
+
+  /** Filter to where the backend value is numerically lower than this given date value, as in, before this given date in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  lessThan?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend value is numerically lower or equal to this given date value, as in, before or equal to this given date in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  lessThanOrEqual?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend value is numerically greater than to this given date value, as in, after this given date in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  greaterThan?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend value is numerically greater than or equal to to this given date value, as in, after or equal to this given date in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  greaterThanOrEqual?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend date value is before this given date value in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  before?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend date value is after this given date value in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  after?: Date | ISO8601DateString | null;
+}
+
+/** The filters available for filtering a Date type field on the backend that is just the date part of a timestamp and does not include the time. */
+export interface DateFilter {
+  /** Filter to where the backend value is equal to this date value. Accepts `Date` objects or ISO8601 formatted date strings */
+  equals?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend value is anything other than this value. Accepts `Date` objects or ISO8601 formatted date strings */
+  notEquals?: Date | ISO8601DateString | null;
+
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: (boolean | null) | null;
+
+  /** Filter to where the backend value is included in this given set of dates. Accepts an array of `Date` objects or ISO8601 formatted date strings */
+  in?: (Date | ISO8601DateString | null)[];
+
+  /** Filter to where the backend value is not included in this given set of dates. Accepts an array of `Date` objects or ISO8601 formatted date strings */
+  notIn?: (Date | ISO8601DateString | null)[];
+
+  /** Filter to where the backend value is numerically lower than this given date value, as in, before this given date in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  lessThan?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend value is numerically lower or equal to this given date value, as in, before or equal to this given date in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  lessThanOrEqual?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend value is numerically greater than to this given date value, as in, after this given date in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  greaterThan?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend value is numerically greater than or equal to to this given date value, as in, after or equal to this given date in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  greaterThanOrEqual?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend date value is before this given date value in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  before?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend date value is before or the same as this given date value. Accepts a `Date` object or a ISO8601 formatted date string */
+  beforeOrOn?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend date value is after this given date value in time. Accepts a `Date` object or a ISO8601 formatted date string */
+  after?: Date | ISO8601DateString | null;
+
+  /** Filter to where the backend date value is after or the same as this given date value. Accepts a `Date` object or a ISO8601 formatted date string */
+  afterOrOn?: Date | ISO8601DateString | null;
+}
+
+/** The filters available for filtering a JSON type field on the backend */
+export interface JSONFilter {
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: boolean | null;
+
+  /** Filter to where the backend value is equal to this value. Does an exact comparison of JSON key-by-key. */
+  equals?: JSONBlob | null;
+
+  /** Filter to where the backend value is equal to any of the given values. Accepts a list of JSON objects. */
+  in?: (JSONBlob | null)[];
+
+  /** Filter to where the backend value is not equal to any of the given values. Accepts a list of JSON objects. */
+  notIn?: (JSONBlob | null)[];
+
+  /** Filter to where the backend value is not exactly equal to the given value. Accepts one JSON object. Will filter out any records with exact matches, but will allow records with partial matches through. To do partial testing, use the `matches` operator. */
+  notEquals?: JSONBlob | null;
+
+  /** Filter to where the backend value matches the given value on a key by key basis. Accepts one JSON object. Will filter down to only records that have the same value in their backend data as is specified in this value. Backend records can have other keys or values as well. */
+  matches?: JSONBlob | null;
+}
+
+/** The filters available for filtering a String type field on the backend */
+export interface StringFilter {
+  /** Filter to where the backend value is equal to this string */
+  equals?: string | null;
+
+  /** Filter to where the backend value is not equal to this string */
+  notEquals?: string | null;
+
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: boolean | null;
+
+  /** Filter to where the backend value is exactly equal to any of the given strings */
+  in?: (string | null)[];
+
+  /** Filter to where the backend value is not exactly equal to any of the given strings */
+  notIn?: (string | null)[];
+
+  /** Filter to where the backend value sorts alphanumerically lower than this given string. Sorts using Postgres string sorting rules. */
+  lessThan?: string | null;
+
+  /** Filter to where the backend value sorts alphanumerically lower than or equal to this given string. Sorts using Postgres string sorting rules. */
+  lessThanOrEqual?: string | null;
+
+  /** Filter to where the backend value sorts alphanumerically greater than this given string. Sorts using Postgres string sorting rules. */
+  greaterThan?: string | null;
+
+  /** Filter to where the backend value sorts alphanumerically greater than or equal to this given string. Sorts using Postgres string sorting rules. */
+  greaterThanOrEqual?: string | null;
+
+  /** Filter to where the backend string starts with this exact string. */
+  startsWith?: string | null;
+}
+
+/**
+ * Filters available on an Enum type field
+ *
+ * @example
+ * { equals: 'Green' }
+ *
+ * @example
+ * { isSet: true }
+ *
+ * @example
+ * { notEquals: "Red" }
+ */
+export interface SingleEnumFilter {
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: boolean | null;
+
+  /** Filter to where the backend value exactly equal to this given enum value */
+  equals?: string | null;
+
+  /** Filter to where the backend value is not exactly equal to this given enum value */
+  notEquals?: string | null;
+
+  /** Filter to where the backend value is included in this list of of enum values */
+  in?: (string | null)[];
+}
+
+/**
+ * Filters available on an Enum type field where the backend can select multiple values
+ *
+ * @example
+ * { equals: ['Green', 'Red'] }
+ *
+ * @example
+ * { contains: 'Green' }
+ *
+ * @example
+ * { isSet: true }
+ *
+ * @example
+ * { notEquals: ["Red"] }
+ */
+export interface MultiEnumFilter {
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: boolean | null;
+
+  /** Filter to where the backend value exactly equal to this list of given enum values. The backend value must be exactly this list to match. */
+  equals?: (string | null)[];
+
+  /** Filter to where the backend value is not equal to this list of given enum values. Any records with exactly this list will not be returned, but partial matches will be. */
+  notEquals?: (string | null)[];
+
+  /** Filter to where the backend value list of enums includes this given value or list of values. */
+  contains?: string | null | (string | null)[];
+}
+
+/**
+ * Filters available for filtering boolean type fields on the backend
+ *
+ * @example
+ * { equals: true }
+ *
+ * @example
+ * { notEquals: false }
+ */
+export interface BooleanFilter {
+  /** Filter to where the backend value is equal to this boolean. */
+  equals?: boolean | null;
+
+  /** Filter to where the backend value is not equal to this boolean. */
+  notEquals?: boolean | null;
+
+  /**
+   * Filter to where the backend value is set to any value at all.
+   *  - if true, will exclude records where this field is null.
+   *  - if false, will only return records where this field is null.
+   **/
+  isSet?: boolean | null;
+}
+
+/** The order to sort records by when returning from the backend */
+export type SortOrder = "Ascending" | "Descending";
+
+/** A sort for one field by a particular order. Can only include one key for one field to be valid. */
+export type FieldSort = { [field: string]: SortOrder };
+
+/**
+ * A sort to return backend records by
+ * @example
+ * { name: 'Ascending' }
+ *
+ * @example
+ * [{ name: 'Ascending'}, {id: 'Descending' }]
+ **/
+export type AnySort = FieldSort | FieldSort[];
+
+export type AnyFieldFilter =
+  | IDFilter
+  | DateTimeFilter
+  | DateFilter
+  | JSONFilter
+  | StringFilter
+  | SingleEnumFilter
+  | MultiEnumFilter
+  | IntFilter
+  | FloatFilter
+  | BooleanFilter;
+
+export type FilterElement = {
+  /** A list of filter conditions that all must be matched for the record to be returned */
+  AND?: FilterElement[] | null;
+  /** A list of filter conditions where any one within can be matched for the record to be returned */
+  OR?: FilterElement[] | null;
+  /** A list of filter conditions to invert for matching */
+  NOT?: FilterElement[] | null;
+
+  [field: string]: AnyFieldFilter | FilterElement[] | undefined | null;
+};
+/**
+ * A filter for filtering the records returned by the backed.
+ * Is not specific to any backend model. Look for the backend specific types in the generated API client if you need strong type safety.
+ *
+ * @example
+ * { name: { equals: 'Jane' } }
+ *
+ * @example
+ * { name: { equals: 'Bob' }, age: { greaterThan: 18 } }
+ *
+ * @example
+ * { AND: [{ name: { equals: 'Bob' } }, { age: { greaterThan: 18 } }, { age: { lessThan: 50 } }] }
+ *
+ **/
+export type AnyFilter = FilterElement | FilterElement[];
+
+/**
+ * A list of fields to return from the backend
+ * Is not specific to any backend model. Look for the backend specific types in the generated API client if you need strong type safety.
+ */
+export interface AnySelection {
+  [key: string]: boolean | null | undefined | AnySelection;
+}
+
+/** The options a record find operation takes that selects which fields are returned from the backend */
+export type SelectionOptions = { select?: AnySelection };
+
+/** The options a record find operation takes that can return many records */
+export type FindManyOptions = {
+  /** Return only the given fields on the backend record (and related records) */
+  select?: AnySelection;
+
+  /** Sort the returned records by the given critera */
+  sort?: AnySort | null;
+  /** Only return records which match the given set of filters */
+  filter?: AnyFilter | AnyFilter[] | null;
+  /** Only return records which match this given search string */
+  search?: string | null;
+
+  /**
+   * Return records after the given cursor for pagination. Useful in tandem with the `first` count option for pagination.
+   **/
+  after?: string | null;
+  /**
+   * Return this number of records. Useful in tandem with the `after` cursor option for pagination.
+   **/
+  first?: number | null;
+  /**
+   * Return records before the given cursor for pagination. Useful in tandem with the `last` count option for pagination.
+   **/
+  before?: string | null;
+  /**
+   * Return this number of records. Useful in tandem with the `before` cursor option for pagination.
+   **/
+  last?: number | null;
+};
+
+/** The options a record find operation takes that can return many records */
+export type FindFilteredOptions = {
+  /** Return only the given fields on the backend record (and related records) */
+  select?: AnySelection;
+
+  /** Sort the returned records by the given critera */
+  sort?: AnySort | null;
+  /** Only return records which match the given set of filters */
+  filter?: AnyFilter | null;
+  /** Only return records which match this given search string */
+  search?: string | null;
+};
+
+/**
+ * A list of fields to select from the internal API
+ *
+ * Matches the format of the Public API `select` option, but only allows going one level deep -- no relationships can be selected using the internal API.
+ *
+ * Supports passing a list of strings as a shorthand.
+ *
+ * @example
+ * { fieldA: true, fieldB: true, fieldC: false }
+ *
+ * @example
+ * ['fieldA', 'fieldB']
+ */
+export type InternalFieldSelection = string[] | { [field: string]: boolean | null | undefined };
+
+/** Options for the api functions that return one record on an InternalModelManager */
+export interface InternalFindOneOptions {
+  /**
+   * What fields to retrieve from the API for this API call
+   * __Note__: This selection is different than the top level select option -- it just accepts a list of string fields, and not a nested selection. To use a nested selection, use the top level API.
+   **/
+  select?: InternalFieldSelection;
+}
+
+/** Options for functions that query a list of records on an InternalModelManager */
+export interface InternalFindListOptions {
+  /**
+   * A string to search for within all the stringlike fields of the records
+   * Matches the behavior of the Public API `search` option
+   **/
+  search?: string;
+  /**
+   * How to sort the returned records
+   * Matches the format and behavior of the Public API `sort` option
+   *
+   * @example
+   * {
+   *   sort: { publishedAt: "Descending" }
+   * }
+   **/
+  sort?: AnySort;
+  /**
+   * Only return records matching this filter
+   * Matches the format and behavior of the Public API `filter` option
+   *
+   * @example
+   * {
+   *   filter: { published: { equals: true } }
+   * }
+   * */
+  filter?: AnyFilter;
+  /**
+   * What fields to retrieve from the API for this API call
+   * __Note__: This selection is different than the top level select option -- it just accepts a list of string fields, and not a nested selection. To use a nested selection, use the top level API.
+   **/
+  select?: InternalFieldSelection;
+}
+
+/** Options for functions that return a paginated list of records from an InternalModelManager */
+export interface InternalFindManyOptions extends InternalFindListOptions {
+  /**
+   * A count of records to return
+   * Often used in tandem with the `after` option for GraphQL relay-style cursor pagination
+   * Matches the pagination style and behavior of the Public API
+   **/
+  first?: number;
+  /**
+   * The `after` cursor from the GraphQL Relay pagination spec
+   * Matches the pagination style and behavior of the Public API
+   **/
+  after?: string;
+  /**
+   * A count of records to return
+   * Often used in tandem with the `before` option for GraphQL relay-style cursor pagination
+   * Matches the pagination style and behavior of the Public API
+   **/
+  last?: number;
+  /**
+   * The `before` cursor from the GraphQL Relay pagination spec
+   * Matches the pagination style and behavior of the Public API
+   **/
+  before?: string;
+}
+
+/** The options an internal record mutation takes */
+export type InternalMutationOptions = {
+  /**
+   * Which fields to return from the backend
+   * __Note__: This selection is different than the top level select option -- it just accepts a list of string fields, and not a nested selection. To use a nested selection, use the top level API.
+   **/
+  select?: InternalFieldSelection;
+};
+
+/**
+ * @private
+ */
+export type PaginateOptions = {
+  after?: string | null;
+  first?: number | null;
+  before?: string | null;
+  last?: number | null;
+  select?: AnySelection | InternalFieldSelection | null;
+};


### PR DESCRIPTION
The InternalModelManager is public API for Gadget developers, so it should be well documented and have nice types for use inside the editor. We had `any`s everywhere when we can instead have nice types! This adds those.
