### PR TITLE
Ensure hook pausing with urql works

### DIFF
--- a/packages/react/spec/useFindFirst.spec.ts
+++ b/packages/react/spec/useFindFirst.spec.ts
@@ -170,4 +170,16 @@ describe("useFindFirst", () => {
     rerender();
     expect(result.current[0]).toBe(beforeObject);
   });
+
+  test("doesn't issue a request if paused", async () => {
+    const { result } = renderHook(() => useFindFirst(relatedProductsApi.user, { pause: true }), {
+      wrapper: MockClientWrapper(relatedProductsApi),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+  });
 });

--- a/packages/react/spec/useFindFirst.spec.ts
+++ b/packages/react/spec/useFindFirst.spec.ts
@@ -1,0 +1,173 @@
+import type { GadgetRecord } from "@gadgetinc/api-client-core";
+import { renderHook } from "@testing-library/react";
+import type { IsExact } from "conditional-type-checks";
+import { assert } from "conditional-type-checks";
+import { useFindFirst } from "../src/index.js";
+import type { ErrorWrapper } from "../src/utils.js";
+import { relatedProductsApi } from "./apis.js";
+import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
+
+describe("useFindFirst", () => {
+  // these functions are typechecked but never run to avoid actually making API calls
+  const _TestFindFirstReturnsTypedDataWithExplicitSelection = () => {
+    const [{ data, fetching, error }, refresh] = useFindFirst(relatedProductsApi.user, {
+      filter: { email: { equals: "hello@gello.com" } },
+      select: { id: true, email: true },
+    });
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+    assert<IsExact<typeof data, undefined | GadgetRecord<{ id: string; email: string | null }>>>(true);
+    assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+
+    // data is accessible via dot access
+    if (data) {
+      data.id;
+      data.email;
+    }
+
+    // hook return value includes the urql refresh function
+    refresh();
+  };
+
+  const _TestFindFirstReturnsTypedDataWithNoSelection = () => {
+    const [{ data }] = useFindFirst(relatedProductsApi.user);
+
+    if (data) {
+      data.id;
+      data.email;
+    }
+  };
+
+  test("it can find the first record", async () => {
+    const { result } = renderHook(() => useFindFirst(relatedProductsApi.user), {
+      wrapper: MockClientWrapper(relatedProductsApi),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],
+          pageInfo: {
+            startCursor: "123",
+            endCursor: "123",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current[0].data!.id).toEqual("123");
+    expect(result.current[0].data!.email).toEqual("test@test.com");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("it return null if the record with the given field value can't be found", async () => {
+    const { result } = renderHook(() => useFindFirst(relatedProductsApi.user), {
+      wrapper: MockClientWrapper(relatedProductsApi),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [],
+          pageInfo: {
+            startCursor: null,
+            endCursor: null,
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeUndefined();
+  });
+
+  test("returns the same data object on rerender", async () => {
+    const { result, rerender } = renderHook(() => useFindFirst(relatedProductsApi.user), {
+      wrapper: MockClientWrapper(relatedProductsApi),
+    });
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],
+          pageInfo: {
+            startCursor: "123",
+            endCursor: "123",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    const data = result.current[0].data;
+    expect(data).toBeTruthy();
+
+    rerender();
+
+    expect(result.current[0].data).toBe(data);
+  });
+
+  test("it can suspend when finding data", async () => {
+    const { result, rerender } = renderHook(() => useFindFirst(relatedProductsApi.user, { suspense: true }), {
+      wrapper: MockClientWrapper(relatedProductsApi),
+    });
+
+    // first render never completes as the component suspends
+    expect(result.current).toBeFalsy();
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],
+          pageInfo: {
+            startCursor: "123",
+            endCursor: "123",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    // rerender as react would do when the suspense promise resolves
+    rerender();
+    expect(result.current).toBeTruthy();
+    expect(result.current[0].data!.id).toEqual("123");
+    expect(result.current[0].data!.email).toEqual("test@test.com");
+    expect(result.current[0].error).toBeFalsy();
+
+    const beforeObject = result.current[0];
+    rerender();
+    expect(result.current[0]).toBe(beforeObject);
+  });
+});

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -254,4 +254,16 @@ describe("useFindMany", () => {
     rerender();
     expect(result.current[0]).toBe(beforeObject);
   });
+
+  test("doesn't issue a request if paused", async () => {
+    const { result } = renderHook(() => useFindMany(relatedProductsApi.user, { pause: true }), {
+      wrapper: MockClientWrapper(relatedProductsApi),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+  });
 });

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -152,4 +152,16 @@ describe("useFindOne", () => {
     rerender();
     expect(result.current[0]).toBe(beforeObject);
   });
+
+  test("doesn't issue a request if paused", async () => {
+    const { result } = renderHook(() => useFindOne(relatedProductsApi.user, "123", { pause: true }), {
+      wrapper: MockClientWrapper(relatedProductsApi),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+  });
 });

--- a/packages/react/src/useFindFirst.ts
+++ b/packages/react/src/useFindFirst.ts
@@ -66,7 +66,7 @@ export const useFindFirst = <
       }
     }
 
-    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath);
+    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath, options?.pause);
 
     return { ...rawResult, data, error };
   }, [manager, rawResult]);

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -64,7 +64,7 @@ export const useFindMany = <
       }
     }
 
-    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath);
+    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath, options?.pause);
 
     return { ...rawResult, data, error };
   }, [manager, rawResult]);

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -61,7 +61,7 @@ export const useFindOne = <
     if (data) {
       data = hydrateRecord(rawResult, data);
     }
-    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath);
+    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath, options?.pause);
 
     return { ...rawResult, data, error };
   }, [rawResult, manager]);

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -180,10 +180,10 @@ export class ErrorWrapper extends Error {
     });
   }
   /** @private */
-  static errorIfDataAbsent(result: UseQueryState<any>, dataPath: string[]) {
+  static errorIfDataAbsent(result: UseQueryState<any>, dataPath: string[], paused = false) {
     const nonNullableError = getNonNullableError(result, dataPath);
     let error = ErrorWrapper.forMaybeCombinedError(result.error);
-    if (!error && nonNullableError) {
+    if (!error && nonNullableError && !paused) {
       error = ErrorWrapper.forClientSideError(nonNullableError);
     }
     return error;


### PR DESCRIPTION
urql hooks have a `pause` option that allows preventing sending the initial request. We should respect this option and pass it through to urql and avoid doing anything that requires never pausing a request.

## PR Checklist

- [X] Important or complicated code is tested
- [X] Any user facing changes are documented in the Gadget-side changelog
- [X] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [X] Versions within this monorepo are matching and there's a valid upgrade path
