### PR TITLE
Fix support for POST requests run in strict mode from useFetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@gadget-client/app-with-no-user-model": "^1.5.0",
     "@gadget-client/bulk-actions-test": "^1.104.0",
-    "@gadget-client/related-products-example": "^1.853.0",
+    "@gadget-client/related-products-example": "^1.854.0",
     "@gadget-client/super-auth": "^1.37.0",
     "@gadgetinc/api-client-core": "workspace:*",
     "@gadgetinc/eslint-config": "^0.6.1",

--- a/packages/api-client-core/spec/mockUrqlClient.ts
+++ b/packages/api-client-core/spec/mockUrqlClient.ts
@@ -41,6 +41,7 @@ export type MockOperationFn = jest.Mock & {
 export type MockFetchFn = jest.Mock & {
   requests: { args: any[]; resolve: (response: Response) => void; reject: (error: Error) => void }[];
   pushResponse: (response: Response) => Promise<void>;
+  reportAbort: () => Promise<void>;
 };
 
 export interface MockUrqlClient extends Client {
@@ -134,7 +135,28 @@ const newMockFetchFn = () => {
       if (!request) {
         throw new Error("no requests started for response pushing");
       }
+      const signal = request.args[1]?.signal;
+      if (signal && signal.aborted) {
+        throw new Error("signal on request has been aborted, can't respond to a mock fetch that has been aborted");
+      }
+
       await request.resolve(response);
+    });
+  };
+  fn.reportAbort = async () => {
+    await act(async () => {
+      const request = requests.shift();
+      if (!request) {
+        throw new Error("no requests started for response pushing");
+      }
+      const signal = request.args[1]?.signal;
+      if (!signal) {
+        throw new Error("no signal on request, can't report an abort that has happened");
+      }
+      if (!signal.aborted) {
+        throw new Error("signal on request has not been aborted, can't report an abort that has happened");
+      }
+      await request.reject(new Error("AbortError: The user aborted a request."));
     });
   };
 

--- a/packages/blog-example/src/App.tsx
+++ b/packages/blog-example/src/App.tsx
@@ -23,6 +23,33 @@ function ExampleFetch() {
   );
 }
 
+function ExampleFetchInUseEffect() {
+  const [history, setHistory] = useState<any[]>([]);
+  const [result, send] = useFetch("https://dummyjson.com/products/add", {
+    method: "POST",
+    body: JSON.stringify({ title: "BMW Pencil" }),
+    headers: {
+      "content-type": "application/json",
+    },
+    json: true,
+  });
+
+  useEffect(() => {
+    setHistory([...history, result]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [result]);
+
+  return (
+    <section className="card">
+      <h2>Example Fetch from useEffect</h2>
+      <code>
+        <pre>{JSON.stringify(history, null, 2)}</pre>
+      </code>
+      <button onClick={() => void send()}>Fetch</button>
+    </section>
+  );
+}
+
 function ExampleFindMany() {
   const [history, setHistory] = useState<any[]>([]);
   const [result, send] = useFindMany(api.post);
@@ -83,12 +110,15 @@ function ExampleSuspenseInner() {
 
 function App() {
   return (
-    <div className="App">
-      <h1>Vite + Gadget</h1>
-      <ExampleFetch />
-      <ExampleFindMany />
-      <ExampleSuspense />
-    </div>
+    <Suspense fallback={<>Suspended...</>}>
+      <div className="App">
+        <h1>Vite + Gadget</h1>
+        <ExampleFetch />
+        <ExampleFindMany />
+        <ExampleSuspense />
+        <ExampleFetchInUseEffect />
+      </div>
+    </Suspense>
   );
 }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,6 +40,7 @@
     "@n1ru4l/json-patch-plus": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.5",
     "@types/lodash": "^4.14.191",
     "@types/node": "^18.0.0",

--- a/packages/react/spec/useFetch.spec.tsx
+++ b/packages/react/spec/useFetch.spec.tsx
@@ -1,11 +1,23 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, render, renderHook, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
+import type { ReactNode } from "react";
+import React, { StrictMode, Suspense } from "react";
 import { Readable } from "stream";
 import { useFetch } from "../src/useFetch.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { relatedProductsApi } from "./apis.js";
 import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
+
+const RelatedProductsWrapper = MockClientWrapper(relatedProductsApi);
+const StrictRelatedProductsWrapper = (props: { children: ReactNode }) => (
+  <StrictMode>
+    <Suspense fallback="suspended">
+      <RelatedProductsWrapper>{props.children}</RelatedProductsWrapper>
+    </Suspense>
+  </StrictMode>
+);
 
 describe("useFetch", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -71,7 +83,7 @@ describe("useFetch", () => {
   };
 
   test("it can fetch a string from the backend", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: RelatedProductsWrapper });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
@@ -89,8 +101,32 @@ describe("useFetch", () => {
     expect(mockUrqlClient.mockFetch).toBeCalledTimes(1);
   });
 
+  test("it can fetch a string from the backend in strict mode", async () => {
+    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: StrictRelatedProductsWrapper });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+    expect(result.current[0].streaming).toBe(false);
+
+    // first useEffect's request in strict mode
+    expect(mockUrqlClient.mockFetch.requests[0].args).toEqual(["/foo/bar", expect.objectContaining({})]);
+    await mockUrqlClient.mockFetch.reportAbort();
+
+    // second useEffect's request in strict mode
+    expect(mockUrqlClient.mockFetch.requests[0].args).toEqual(["/foo/bar", expect.objectContaining({})]);
+    await mockUrqlClient.mockFetch.pushResponse(new Response("hello world"));
+
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].data).toEqual("hello world");
+    expect(result.current[0].error).toBeFalsy();
+    expect(result.current[0].streaming).toBe(false);
+
+    expect(mockUrqlClient.mockFetch).toBeCalledTimes(2);
+  });
+
   test("it can fetch json from the backend", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar", { json: true }), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar", { json: true }), { wrapper: RelatedProductsWrapper });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
@@ -112,7 +148,7 @@ describe("useFetch", () => {
   });
 
   test("it can fetch stream from the backend", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar", { stream: true }), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar", { stream: true }), { wrapper: RelatedProductsWrapper });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
@@ -175,7 +211,7 @@ describe("useFetch", () => {
           },
         }),
       {
-        wrapper: MockClientWrapper(relatedProductsApi),
+        wrapper: RelatedProductsWrapper,
       }
     );
 
@@ -261,7 +297,7 @@ describe("useFetch", () => {
 
   test("it can fetch a string stream from the backend with a custom encoding", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { stream: "windows-1251", sendImmediately: false }), {
-      wrapper: MockClientWrapper(relatedProductsApi),
+      wrapper: RelatedProductsWrapper,
     });
 
     expect(result.current[0].data).toBeFalsy();
@@ -331,7 +367,7 @@ describe("useFetch", () => {
 
   test("it can when a string stream is requested a second time in the middle of processing", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { stream: "string", sendImmediately: false }), {
-      wrapper: MockClientWrapper(relatedProductsApi),
+      wrapper: RelatedProductsWrapper,
     });
 
     expect(result.current[0].data).toBeFalsy();
@@ -462,7 +498,7 @@ describe("useFetch", () => {
   });
 
   test("it reports response errors from the backend", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: RelatedProductsWrapper });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
@@ -481,7 +517,7 @@ describe("useFetch", () => {
   });
 
   test("it can rexecute to fetch a new string from the backend", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: RelatedProductsWrapper });
 
     await mockUrqlClient.mockFetch.pushResponse(new Response("hello world"));
     expect(result.current[0].data).toEqual("hello world");
@@ -507,7 +543,7 @@ describe("useFetch", () => {
   });
 
   test("it can recover from response errors if the next request succeeds", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: RelatedProductsWrapper });
 
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
@@ -539,7 +575,7 @@ describe("useFetch", () => {
   });
 
   test("it automatically starts sending requests with no method specified", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar"), { wrapper: RelatedProductsWrapper });
 
     expect(result.current[0].fetching).toBe(true);
     expect(mockUrqlClient.mockFetch).toBeCalledTimes(1);
@@ -547,7 +583,7 @@ describe("useFetch", () => {
   });
 
   test("it automatically starts sending requests with the GET method specified", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar", { method: "GET" }), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar", { method: "GET" }), { wrapper: RelatedProductsWrapper });
 
     expect(result.current[0].fetching).toBe(true);
     expect(mockUrqlClient.mockFetch).toBeCalledTimes(1);
@@ -555,7 +591,7 @@ describe("useFetch", () => {
 
   test("it does not automatically start sending requests with the GET method specified but sendImmediately: false", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { method: "GET", sendImmediately: false }), {
-      wrapper: MockClientWrapper(relatedProductsApi),
+      wrapper: RelatedProductsWrapper,
     });
 
     expect(result.current[0].fetching).toBe(false);
@@ -563,7 +599,7 @@ describe("useFetch", () => {
   });
 
   test("it doesn't automatically start sending POST requests by default", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar", { method: "POST" }), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar", { method: "POST" }), { wrapper: RelatedProductsWrapper });
 
     expect(mockUrqlClient.mockFetch).toBeCalledTimes(0);
     expect(result.current[0].data).toBeFalsy();
@@ -590,7 +626,7 @@ describe("useFetch", () => {
 
   test("it automatically starts sending requests with the POST method specified and sendImmediately: true", async () => {
     const { result } = renderHook(() => useFetch("/foo/bar", { method: "GET", sendImmediately: true }), {
-      wrapper: MockClientWrapper(relatedProductsApi),
+      wrapper: RelatedProductsWrapper,
     });
 
     expect(result.current[0].fetching).toBe(true);
@@ -598,7 +634,7 @@ describe("useFetch", () => {
   });
 
   test("POST requests can be given options when executed", async () => {
-    const { result } = renderHook(() => useFetch("/foo/bar", { method: "POST" }), { wrapper: MockClientWrapper(relatedProductsApi) });
+    const { result } = renderHook(() => useFetch("/foo/bar", { method: "POST" }), { wrapper: RelatedProductsWrapper });
 
     expect(mockUrqlClient.mockFetch).toBeCalledTimes(0);
 
@@ -637,7 +673,7 @@ describe("useFetch", () => {
 
   test("it can fetch json from third party apis", async () => {
     const { result } = renderHook(() => useFetch("https://dummyjson.com/products", { json: true }), {
-      wrapper: MockClientWrapper(relatedProductsApi),
+      wrapper: RelatedProductsWrapper,
     });
 
     expect(result.current[0].data).toBeFalsy();
@@ -655,5 +691,61 @@ describe("useFetch", () => {
     expect(result.current[0].error).toBeFalsy();
 
     expect(mockUrqlClient.mockFetch).toBeCalledTimes(1);
+  });
+
+  const FetchTester = () => {
+    const [{ data, fetching, error }, send] = useFetch("/test", {
+      method: "POST",
+      body: JSON.stringify({ body: true }),
+      headers: {
+        "content-type": "application/json",
+      },
+      json: true,
+    });
+
+    return (
+      <div>
+        <button data-testid="send" onClick={() => void send()}>
+          Send
+        </button>
+        {fetching && <div role="spinner" className="loading" />}
+        {error && (
+          <div role="error" className="error">
+            {String(error)}
+          </div>
+        )}
+        {data && (
+          <div role="data">
+            <code>
+              <pre>{JSON.stringify(data)}</pre>
+            </code>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  describe.each([
+    ["in lax mode", RelatedProductsWrapper],
+    ["in strict mode", StrictRelatedProductsWrapper],
+  ])(`%s`, (_, Wrapper) => {
+    test("it can fetch a result in a component", async () => {
+      render(<FetchTester />, {
+        wrapper: Wrapper,
+      });
+
+      await userEvent.click(screen.getByTestId("send"));
+      await screen.findByRole("spinner");
+
+      expect(screen.queryByRole("error")).not.toBeInTheDocument();
+
+      expect(mockUrqlClient.mockFetch.requests[0].args).toEqual([
+        "/test",
+        expect.objectContaining({ headers: { accept: "application/json", "content-type": "application/json" } }),
+      ]);
+      await mockUrqlClient.mockFetch.pushResponse(new Response('{"hello":1}'));
+
+      expect(await screen.findByRole("data")).toHaveTextContent(`{"hello":1}`);
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^1.104.0
         version: 1.104.0
       '@gadget-client/related-products-example':
-        specifier: ^1.853.0
-        version: 1.853.0
+        specifier: ^1.854.0
+        version: 1.854.0
       '@gadget-client/super-auth':
         specifier: ^1.37.0
         version: 1.37.0
@@ -210,6 +210,9 @@ importers:
       '@testing-library/react':
         specifier: ^13.4.0
         version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.5.1
+        version: 14.5.1(@testing-library/dom@8.17.1)
       '@types/jest':
         specifier: ^29.5.5
         version: 29.5.5
@@ -1186,8 +1189,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/related-products-example@1.853.0:
-    resolution: {integrity: sha1-sVae38NnlyRsaj7WzQvH7kfyQHY=, tarball: https://registry.gadget.dev/npm/_/tarball/1268/1361/5460}
+  /@gadget-client/related-products-example@1.854.0:
+    resolution: {integrity: sha1-yEytaM9x8otBV06i0Cw/F6zsglo=, tarball: https://registry.gadget.dev/npm/_/tarball/1268/1361/5562}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
@@ -1949,6 +1952,15 @@ packages:
       '@types/react-dom': 18.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
+  /@testing-library/user-event@14.5.1(@testing-library/dom@8.17.1):
+    resolution: {integrity: sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+    dependencies:
+      '@testing-library/dom': 8.17.1
     dev: true
 
   /@tootallnate/once@2.0.0:


### PR DESCRIPTION
This fixes a very subtle bug in `useFetch`. When running a fetch request with `shouldSendImmediately: false` and `json: true`, users would get an error looking like this:

```
Uncaught (in promise) ErrorWrapper: [GraphQL] The user aborted a request.
    at _ErrorWrapper.forClientSideError (https://fetch-testing--development.gadget.app/node_modules/.vite/deps/@gadgetinc_react.js?v=19130701:484:12)
    at dispatchError (https://fetch-testing--development.gadget.app/node_modules/.vite/deps/@gadgetinc_react.js?v=19130701:966:32)
    at https://fetch-testing--development.gadget.app/node_modules/.vite/deps/@gadgetinc_react.js?v=19130701:1048:25
```

This is because the POST request was immediately, erroneously being aborted as soon as it was run. We don't want to abort the request, we want to run it!

We have a bunch of existing code to abort requests on component unmount for good hygiene. We don't need the response for a component that is no longer on screen and we don't want to charge users (or make expensive openai requests) that take a long time that no one wants anymore. So, we use a useEffect teardown to abort defunct requests. This works good, but, the bug stemmed from the dependencies to that useEffect changing at the wrong time. We were accidentally mutating one of the options objects that gets passed to that useEffect as a dependency on request start, which had the effect of triggering the useEffect to do its unmount/remount thing immediately on the next render. Simply running the request should not ever cause the dependencies to change.

Most confusingly, this mutate-the-options-and-trigger-a-depenendcies-change only happened when you passed a different option in to the hook (`json: true`) which I think is why this bug lurked so long.

The fix is to just not mutate the options object we're using as a dependency in the dependencies array, which means no dependencies change and the useEffect doesn't abort the request. We keep it around though for the actual unmount case.

This also showed a bit of a test hole, which I fixed. useEffects are also pains in the ass for react strict mode which I initially thought was the culprit. I kept those tests around, and added a test that passes in `json` and failed before these changes.
