### PR TITLE
Add support for sending the shopify session token via websocket requests in the React provider

### DIFF
--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -73,7 +73,7 @@ const InnerGadgetProvider = memo(
       // setup the api client to always query using the custom shopify auth implementation
       api.connection.setAuthenticationMode({
         custom: {
-          processFetch: async (_input, init) => {
+          async processFetch(_input, init) {
             const headers = new Headers(init.headers);
             headers.append("Authorization", `ShopifySessionToken ${await getSessionToken(appBridge)}`);
             init.headers ??= {};
@@ -81,8 +81,8 @@ const InnerGadgetProvider = memo(
               (init.headers as Record<string, string>)[key] = value;
             });
           },
-          processTransactionConnectionParams(_params) {
-            throw new Error("client side transactions yet not supported in Shopify Gadget provider");
+          async processTransactionConnectionParams(params) {
+            params.auth.shopifySessionToken = await getSessionToken(appBridge);
           },
         },
       });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "files": [
     "README.md",
     "dist/**/*"


### PR DESCRIPTION
The Gadget client already knows how to talk websockets to the Gadget backend, but the custom auth mode we use in the React provider didn't have support for passing the Shopify JWT for this. Now it does!
