### PR TITLE
introduces useActionForm

### DIFF
--- a/packages/api-client-core/spec/mockUrqlClient.ts
+++ b/packages/api-client-core/spec/mockUrqlClient.ts
@@ -74,8 +74,10 @@ const newMockOperationFn = (assertions?: (request: GraphQLRequest) => void) => {
 
   const fn = jest.fn((request: GraphQLRequest, options?: Partial<OperationContext>) => {
     const { query } = request;
+
     const fetchOptions = options?.fetchOptions;
     const key = graphqlDocumentName(query) ?? "unknown";
+
     subjects[key] ??= makeSubject<OperationResult>();
 
     if (fetchOptions && typeof fetchOptions != "function") {
@@ -99,6 +101,7 @@ const newMockOperationFn = (assertions?: (request: GraphQLRequest) => void) => {
     if (!subjects[key]) {
       throw new Error(`No mock client subject started for key ${key}, options are ${Object.keys(subjects).join(", ")}`);
     }
+
     act(() => {
       subjects[key].next({
         operation: null as any,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.14.11",
+  "version": "0.14.12",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@gadgetinc/api-client-core": "^0.15.11",
     "react-fast-compare": "^3.2.2",
+    "react-hook-form": "^7.46.1",
     "urql": "^4.0.4"
   },
   "resolutions": {

--- a/packages/react/spec/useActionForm.spec.tsx
+++ b/packages/react/spec/useActionForm.spec.tsx
@@ -1,0 +1,1903 @@
+import { act, renderHook } from "@testing-library/react";
+import { assert, type IsExact } from "conditional-type-checks";
+import { CombinedError } from "urql";
+import { useActionForm } from "../src/useActionForm.js";
+import { bulkExampleApi, relatedProductsApi } from "./apis.js";
+import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
+
+describe("useActionForm", () => {
+  const _TestUseActionFormCanTypeRecordAsDefaultValues = async () => {
+    const { submit, setValue } = useActionForm(relatedProductsApi.user.update, {
+      defaultValues: { id: "123", email: "test@test.com" },
+      onSuccess: (data) => {
+        data.id;
+        data.email;
+      },
+    });
+
+    // @ts-expect-error Argument of type '"foo"' is not assignable to parameter
+    setValue("foo", "1");
+
+    setValue("email", "test@test.com");
+
+    const { data, error, fetching } = await submit();
+
+    if (data) {
+      data.id;
+      data.email;
+    }
+
+    if (error) {
+      error.message;
+      error.executionErrors;
+    }
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+  };
+
+  const _TestUseActionFormCanTypeNestedRecordAsDefaultValues = () => {
+    const { setValue } = useActionForm(relatedProductsApi.user.update, {
+      defaultValues: { id: "123", user: { email: "test@test.com" } },
+    });
+
+    // @ts-expect-error Argument of type '"foo"' is not assignable to parameter
+    setValue("foo", "1");
+
+    setValue("user.email", "test@test.com");
+  };
+
+  const _TestUseActionFormCanTypeExtraArguments = async () => {
+    const { submit, setValue } = useActionForm<
+      (typeof relatedProductsApi.user.update)["optionsType"],
+      (typeof relatedProductsApi.user.update)["schemaType"],
+      typeof relatedProductsApi.user.update,
+      { foo: string }
+    >(relatedProductsApi.user.update, {
+      defaultValues: { id: "123", user: { email: "test@test.com" } },
+    });
+
+    setValue("foo", "1");
+
+    setValue("user.email", "test@test.com");
+
+    const { data, error, fetching } = await submit();
+
+    if (data) {
+      data.id;
+      data.email;
+    }
+
+    if (error) {
+      error.message;
+      error.executionErrors;
+    }
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+  };
+
+  const _TestUseActionFormCanTypeGlobalActions = async () => {
+    const { submit, setValue } = useActionForm(bulkExampleApi.flipAll, {
+      onSuccess: (data) => {
+        data.foo;
+        data.bar;
+      },
+    });
+
+    // @ts-expect-error Argument of type '"foo"' is not assignable to parameter
+    setValue("foo", "1");
+
+    setValue("why", "foobar");
+
+    const { data, error, fetching } = await submit();
+
+    assert<IsExact<typeof data, any>>(true);
+
+    if (error) {
+      error.message;
+      error.executionErrors;
+    }
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+  };
+
+  test("can be used with a create action", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.user.create, {
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("email")).toBeUndefined();
+    expect(result.current.getValues("password")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("email", "test@test.com");
+      (result.current as any).setValue("password", "secret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("email")).toBe("test@test.com");
+    expect(result.current.getValues("password")).toBe("secret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      user: {
+        email: "test@test.com",
+        password: "secret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createUser", {
+      data: {
+        createUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "test@test.com",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "test@test.com",
+            "id": "123",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "test@test.com" });
+    expect(result.current.getValues("email")).toBe("test@test.com");
+    expect(result.current.getValues("password")).toBe("secret");
+  });
+
+  test("can be used with a create action with nested fields", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.user.create, {
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBeUndefined();
+    expect(result.current.getValues("user.password")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("user.email", "test@test.com");
+      (result.current as any).setValue("user.password", "secret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      user: {
+        email: "test@test.com",
+        password: "secret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createUser", {
+      data: {
+        createUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "test@test.com",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "test@test.com",
+            "id": "123",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "test@test.com" });
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+  });
+
+  test("can be used with a gloabal action", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(bulkExampleApi.flipAll, {
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(bulkExampleApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("why")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("why", "foobar");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("why")).toBe("foobar");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      why: "foobar",
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("flipAll", {
+      data: {
+        flipAll: {
+          success: true,
+          result: { flipped: true },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "flipped": true,
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ flipped: true });
+    expect(result.current.getValues("why")).toBe("foobar");
+  });
+
+  test("can be used with a create action on an ambiguous model", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.ambiguous.create, {
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("ambiguous.ambiguous")).toBeUndefined();
+    expect(result.current.getValues("ambiguous.booleanField")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("ambiguous.ambiguous", true);
+      (result.current as any).setValue("ambiguous.booleanField", false);
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("ambiguous.ambiguous")).toBe(true);
+    expect(result.current.getValues("ambiguous.booleanField")).toBe(false);
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      ambiguous: {
+        ambiguous: true,
+        booleanField: false,
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createAmbiguous", {
+      data: {
+        createAmbiguous: {
+          success: true,
+          ambiguous: {
+            id: "123",
+            ambiguous: true,
+            booleanField: false,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "ambiguous": true,
+            "booleanField": false,
+            "id": "123",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", ambiguous: true, booleanField: false });
+    expect(result.current.getValues("ambiguous.ambiguous")).toBe(true);
+    expect(result.current.getValues("ambiguous.booleanField")).toBe(false);
+  });
+
+  test("can handle errors during a create action", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.user.create, {
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.formState.submitCount).toBe(0);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBeUndefined();
+    expect(result.current.getValues("user.password")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("user.email", "test@test.com");
+      (result.current as any).setValue("user.password", "secret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.formState.submitCount).toBe(0);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      user: {
+        email: "test@test.com",
+        password: "secret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createUser", {
+      data: {
+        createUser: {
+          success: true,
+          errors: [
+            {
+              message: "Record is invalid, one error needs to be corrected. Email is not unique.",
+              code: "GGT_INVALID_RECORD",
+              validationErrors: [{ apiIdentifier: "email", message: "is not unique." }],
+            },
+          ],
+          user: null,
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": [ErrorWrapper: [GraphQL] Record is invalid, one error needs to be corrected. Email is not unique.],
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.formState.submitCount).toBe(1);
+    expect(result.current.error).toBeTruthy();
+    expect((result.current.error as any).validationErrors).toMatchInlineSnapshot(`
+      [
+        {
+          "apiIdentifier": "email",
+          "message": "is not unique.",
+        },
+      ]
+    `);
+    expect(result.current.formState.errors).toMatchInlineSnapshot(`
+      {
+        "user": {
+          "email": {
+            "message": "is not unique.",
+            "ref": undefined,
+          },
+        },
+      }
+    `);
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+
+    await act(async () => {
+      (result.current as any).setValue("user.email", "foo@test.com");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.formState.submitCount).toBe(1);
+    expect(result.current.formState.errors).toEqual({});
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("foo@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[1][0].variables).toEqual({
+      user: {
+        email: "foo@test.com",
+        password: "secret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createUser", {
+      data: {
+        createUser: {
+          success: true,
+          errors: [
+            {
+              message: "Invalid email or password.",
+              code: "GGT_INVALID_EMAIL_PASSWORD",
+            },
+          ],
+          user: null,
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": [ErrorWrapper: [GraphQL] GGT_INVALID_EMAIL_PASSWORD: Invalid email or password.],
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.formState.submitCount).toBe(2);
+    expect(result.current.error).toBeTruthy();
+    expect((result.current.error as any).message).toMatchInlineSnapshot(
+      `"[GraphQL] GGT_INVALID_EMAIL_PASSWORD: Invalid email or password."`
+    );
+    expect(result.current.formState.errors).toMatchInlineSnapshot(`
+      {
+        "root": {
+          "message": "Invalid email or password.",
+          "ref": undefined,
+        },
+      }
+    `);
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("foo@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+
+    await act(async () => {
+      (result.current as any).setValue("user.password", "Abc123123!");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.formState.submitCount).toBe(2);
+    expect(result.current.formState.errors).toEqual({});
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("foo@test.com");
+    expect(result.current.getValues("user.password")).toBe("Abc123123!");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[2][0].variables).toEqual({
+      user: {
+        email: "foo@test.com",
+        password: "Abc123123!",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createUser", {
+      data: null,
+      error: new CombinedError({ networkError: new Error("Network error") }),
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": [ErrorWrapper: [Network] Network error],
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.formState.submitCount).toBe(3);
+    expect(result.current.error).toBeTruthy();
+    expect((result.current.error as any).message).toMatchInlineSnapshot(`"[Network] Network error"`);
+    expect(result.current.formState.errors).toMatchInlineSnapshot(`
+      {
+        "root": {
+          "message": "Network error",
+          "ref": undefined,
+        },
+      }
+    `);
+    expect(result.current.actionData).toMatchInlineSnapshot(`null`);
+    expect(result.current.getValues("user.email")).toBe("foo@test.com");
+    expect(result.current.getValues("user.password")).toBe("Abc123123!");
+
+    await act(async () => {
+      (result.current as any).setValue("user.password", "Abc123123!");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.formState.submitCount).toBe(3);
+    expect(result.current.formState.errors).toEqual({});
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("foo@test.com");
+    expect(result.current.getValues("user.password")).toBe("Abc123123!");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[2][0].variables).toEqual({
+      user: {
+        email: "foo@test.com",
+        password: "Abc123123!",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createUser", {
+      data: {
+        createUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "foo@test.com",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "foo@test.com",
+            "id": "123",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.formState.submitCount).toBe(4);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.formState.errors).toEqual({});
+    expect(result.current.actionData).toMatchInlineSnapshot(`
+      {
+        "email": "foo@test.com",
+        "id": "123",
+      }
+    `);
+    expect(result.current.getValues("user.email")).toBe("foo@test.com");
+    expect(result.current.getValues("user.password")).toBe("Abc123123!");
+
+    await act(async () => {
+      result.current.reset();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.formState.submitCount).toBe(0);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.formState.errors).toEqual({});
+    expect(result.current.actionData).toMatchInlineSnapshot(`
+      {
+        "email": "foo@test.com",
+        "id": "123",
+      }
+    `);
+    expect(result.current.getValues("user.email")).toBeUndefined();
+    expect(result.current.getValues("user.password")).toBeUndefined();
+  });
+
+  test("can handle an form error", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.user.create, {
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    await act(async () => {
+      result.current.register("user.email", { required: true });
+      await result.current.submit();
+    });
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(true);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.formState.errors).toMatchInlineSnapshot(`
+      {
+        "user": {
+          "email": {
+            "message": "",
+            "ref": {
+              "name": "user.email",
+            },
+            "type": "required",
+          },
+        },
+      }
+    `);
+
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(0);
+  });
+
+  test("can only send certain fields in the action", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.user.create, {
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+          send: ["user.email"],
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBeUndefined();
+    expect(result.current.getValues("user.password")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("user.email", "test@test.com");
+      (result.current as any).setValue("user.password", "secret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      user: {
+        email: "test@test.com",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createUser", {
+      data: {
+        createUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "test@test.com",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "test@test.com",
+            "id": "123",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "test@test.com" });
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+  });
+
+  test("can be used with an update action when given an existing record as default values at the root level", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm<
+          (typeof relatedProductsApi.user.update)["optionsType"],
+          (typeof relatedProductsApi.user.update)["schemaType"],
+          typeof relatedProductsApi.user.update,
+          { password: string }
+        >(relatedProductsApi.user.update, {
+          defaultValues: {
+            id: "123",
+            email: "test@test.com",
+            __typename: "User",
+            createdAt: "2023-10-13T18:38:06.676Z",
+            updatedAt: "2023-10-13T18:40:36.741Z",
+          },
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("email")).toBe("test@test.com");
+    expect(result.current.getValues("password")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("email", "new@test.com");
+      (result.current as any).setValue("password", "newsecret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("email")).toBe("new@test.com");
+    expect(result.current.getValues("password")).toBe("newsecret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "123",
+      user: {
+        email: "new@test.com",
+        password: "newsecret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
+      data: {
+        updateUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "new@test.com",
+            password: "newsecret",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "new@test.com",
+            "id": "123",
+            "password": "newsecret",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "new@test.com", password: "newsecret" });
+    expect(result.current.getValues("email")).toBe("new@test.com");
+    expect(result.current.getValues("password")).toBe("newsecret");
+  });
+
+  test("can be used with an update action when given an existing record as default values at the record level", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm<
+          (typeof relatedProductsApi.user.update)["optionsType"],
+          (typeof relatedProductsApi.user.update)["schemaType"],
+          typeof relatedProductsApi.user.update,
+          { user: { password: string } }
+        >(relatedProductsApi.user.update, {
+          defaultValues: {
+            id: "123",
+            user: {
+              email: "test@test.com",
+            },
+          },
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("user.email", "new@test.com");
+      (result.current as any).setValue("user.password", "newsecret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("new@test.com");
+    expect(result.current.getValues("user.password")).toBe("newsecret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "123",
+      user: {
+        email: "new@test.com",
+        password: "newsecret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
+      data: {
+        updateUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "new@test.com",
+            password: "newsecret",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "new@test.com",
+            "id": "123",
+            "password": "newsecret",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "new@test.com", password: "newsecret" });
+    expect(result.current.getValues("user.email")).toBe("new@test.com");
+    expect(result.current.getValues("user.password")).toBe("newsecret");
+  });
+
+  test("can be used with an update action when finding record by id", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.user.update, {
+          findBy: "123",
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(true);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBeUndefined();
+    expect(result.current.getValues("user.password")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("user", {
+      data: {
+        user: {
+          id: "123",
+          email: "test@test.com",
+          password: "secret",
+          __typename: "User",
+          createdAt: "2023-10-13T18:38:06.676Z",
+          updatedAt: "2023-10-13T18:40:36.741Z",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("user.email", "new@test.com");
+      (result.current as any).setValue("user.password", "newsecret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("new@test.com");
+    expect(result.current.getValues("user.password")).toBe("newsecret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "123",
+      user: {
+        email: "new@test.com",
+        password: "newsecret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
+      data: {
+        updateUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "new@test.com",
+            password: "newsecret",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "new@test.com",
+            "id": "123",
+            "password": "newsecret",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "new@test.com", password: "newsecret" });
+    expect(result.current.getValues("user.email")).toBe("new@test.com");
+    expect(result.current.getValues("user.password")).toBe("newsecret");
+
+    await act(async () => {
+      result.current.reset();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "new@test.com", password: "newsecret" });
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+  });
+
+  test("can be used with an update action when finding record by id on an ambiguous model", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.ambiguous.update, {
+          findBy: "123",
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(true);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("ambiguous.ambiguous")).toBeUndefined();
+    expect(result.current.getValues("ambiguous.booleanField")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("ambiguous", {
+      data: {
+        ambiguous: {
+          id: "123",
+          ambiguous: "foo",
+          booleanField: false,
+          __typename: "Ambiguous",
+          createdAt: "2023-10-13T18:38:06.676Z",
+          updatedAt: "2023-10-13T18:40:36.741Z",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("ambiguous.ambiguous")).toBe("foo");
+    expect(result.current.getValues("ambiguous.booleanField")).toBe(false);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("ambiguous.ambiguous", "bar");
+      (result.current as any).setValue("ambiguous.booleanField", true);
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("ambiguous.ambiguous")).toBe("bar");
+    expect(result.current.getValues("ambiguous.booleanField")).toBe(true);
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "123",
+      ambiguous: {
+        ambiguous: "bar",
+        booleanField: true,
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updateAmbiguous", {
+      data: {
+        updateAmbiguous: {
+          success: true,
+          ambiguous: {
+            id: "123",
+            ambiguous: "bar",
+            booleanField: true,
+            __typename: "Ambiguous",
+            createdAt: "2023-10-13T18:38:06.676Z",
+            updatedAt: "2023-10-13T18:40:36.741Z",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "__typename": "Ambiguous",
+            "ambiguous": "bar",
+            "booleanField": true,
+            "createdAt": "2023-10-13T18:38:06.676Z",
+            "id": "123",
+            "updatedAt": "2023-10-13T18:40:36.741Z",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toMatchInlineSnapshot(`
+      {
+        "__typename": "Ambiguous",
+        "ambiguous": "bar",
+        "booleanField": true,
+        "createdAt": "2023-10-13T18:38:06.676Z",
+        "id": "123",
+        "updatedAt": "2023-10-13T18:40:36.741Z",
+      }
+    `);
+    expect(result.current.getValues("ambiguous.ambiguous")).toBe("bar");
+    expect(result.current.getValues("ambiguous.booleanField")).toBe(true);
+  });
+
+  test("can be used with an update action when finding record by email", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.user.update, {
+          findBy: { email: "test@test.com" },
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(true);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBeUndefined();
+    expect(result.current.getValues("user.password")).toBeUndefined();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("users", {
+      data: {
+        users: {
+          edges: [
+            {
+              cursor: "123",
+              node: {
+                id: "123",
+                email: "test@test.com",
+                password: "secret",
+                __typename: "User",
+                createdAt: "2023-10-13T18:38:06.676Z",
+                updatedAt: "2023-10-13T18:40:36.741Z",
+              },
+            },
+          ],
+          pageInfo: {
+            startCursor: "123",
+            endCursor: "123",
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("test@test.com");
+    expect(result.current.getValues("user.password")).toBe("secret");
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("user.email", "new@test.com");
+      (result.current as any).setValue("user.password", "newsecret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("new@test.com");
+    expect(result.current.getValues("user.password")).toBe("newsecret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "123",
+      user: {
+        email: "new@test.com",
+        password: "newsecret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
+      data: {
+        updateUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "new@test.com",
+            password: "newsecret",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "new@test.com",
+            "id": "123",
+            "password": "newsecret",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "new@test.com", password: "newsecret" });
+    expect(result.current.getValues("user.email")).toBe("new@test.com");
+    expect(result.current.getValues("user.password")).toBe("newsecret");
+  });
+
+  test("can be used with an update action when finding record by id and specifying a selection", async () => {
+    let submitted = false;
+    let success = false;
+    let error = false;
+
+    const { result } = renderHook(
+      () =>
+        useActionForm(relatedProductsApi.user.update, {
+          findBy: "123",
+          select: { id: true },
+          onSubmit: () => {
+            submitted = true;
+          },
+          onSuccess: () => {
+            success = true;
+          },
+          onError: () => {
+            error = true;
+          },
+        }),
+      { wrapper: MockClientWrapper(relatedProductsApi) }
+    );
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(true);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+    expect(mockUrqlClient.executeQuery.mock.calls[0][0].query.loc.source.body).toMatchInlineSnapshot(`
+      "query user($id: GadgetID!) {
+        user(id: $id) {
+          id
+          __typename
+        }
+        gadgetMeta {
+          hydrations(modelName: 
+      "user")
+        }
+      }"
+    `);
+
+    mockUrqlClient.executeQuery.pushResponse("user", {
+      data: {
+        user: {
+          id: "123",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(submitted).toBe(false);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBeUndefined();
+    expect(result.current.getValues("user.password")).toBeUndefined();
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("user.email", "new@test.com");
+      (result.current as any).setValue("user.password", "newsecret");
+      submitPromise = result.current.submit();
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(false);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+    expect(result.current.formState.isSubmitting).toBe(true);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toBeFalsy();
+    expect(result.current.getValues("user.email")).toBe("new@test.com");
+    expect(result.current.getValues("user.password")).toBe("newsecret");
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "123",
+      user: {
+        email: "new@test.com",
+        password: "newsecret",
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updateUser", {
+      data: {
+        updateUser: {
+          success: true,
+          user: {
+            id: "123",
+            email: "new@test.com",
+            password: "newsecret",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const result = await submitPromise;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "email": "new@test.com",
+            "id": "123",
+            "password": "newsecret",
+          },
+          "error": undefined,
+          "fetching": false,
+          "hasNext": false,
+          "operation": null,
+          "stale": false,
+        }
+      `);
+    });
+
+    expect(submitted).toBe(true);
+    expect(success).toBe(true);
+    expect(error).toBe(false);
+    expect(result.current.formState.isLoading).toBe(false);
+    expect(result.current.formState.isSubmitted).toBe(true);
+    expect(result.current.formState.isSubmitSuccessful).toBe(true);
+    expect(result.current.formState.isSubmitting).toBe(false);
+    expect(result.current.error).toBeFalsy();
+    expect(result.current.actionData).toEqual({ id: "123", email: "new@test.com", password: "newsecret" });
+    expect(result.current.getValues("user.email")).toBe("new@test.com");
+    expect(result.current.getValues("user.password")).toBe("newsecret");
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,6 +9,7 @@ export * from "./auth/useSession.js";
 export * from "./auth/useSignOut.js";
 export * from "./auth/useUser.js";
 export * from "./useAction.js";
+export * from "./useActionForm.js";
 export * from "./useBulkAction.js";
 export * from "./useFetch.js";
 export * from "./useFindBy.js";

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -89,6 +89,7 @@ export const useAction = <
           // Adding the model's additional typename ensures document cache will properly refresh, regardless of whether __typename was selected (and sometimes we can't even select it, like delete actions!)
           additionalTypenames: [...(context?.additionalTypenames ?? []), capitalizeIdentifier(action.modelApiIdentifier)],
         });
+
         return processResult({ fetching: false, ...result }, action);
       },
       [action, runMutation]

--- a/packages/react/src/useActionForm.ts
+++ b/packages/react/src/useActionForm.ts
@@ -1,0 +1,332 @@
+import type {
+  ActionFunction,
+  AnyModelManager,
+  DefaultSelection,
+  GadgetRecord,
+  GlobalActionFunction,
+  Select,
+} from "@gadgetinc/api-client-core";
+import { camelize } from "@gadgetinc/api-client-core";
+import { useCallback, useEffect, useRef } from "react";
+import type { DeepPartial, FieldErrors, FieldValues, UseFormProps, UseFormReturn } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import { useApi } from "./GadgetProvider.js";
+import { useAction } from "./useAction.js";
+import { useFindBy } from "./useFindBy.js";
+import { useFindOne } from "./useFindOne.js";
+import { useGlobalAction } from "./useGlobalAction.js";
+import type { ActionHookState, ErrorWrapper, OptionsType } from "./utils.js";
+import { get, set } from "./utils.js";
+
+export * from "react-hook-form";
+
+/** Finds a given record from the backend database by either id or a `{[field: string]: value}` slug */
+const useFindExistingRecord = (
+  modelManager: AnyModelManager | undefined,
+  findBy: string | { [key: string]: any },
+  options: { select?: Record<string, any>; pause?: boolean }
+): [{ data?: GadgetRecord<any>; fetching: boolean; error?: ErrorWrapper }, () => void] => {
+  // for simplicity, we conditionally call either the findBy or findOne hook. this violates the rules of hooks, but is a LOT simpler than mounting and pausing both hooks and massaging the results of each together. this means we don't support the same form toggling from being for a record found by id and then later a record found by some other criteria, but that's a very rare use case. you can workaround this by adding a `key` prop to the component calling `useActionForm`, and having the value change when the find method changes, which will give different instance of the component and avoid the hook order changing.
+  if (modelManager && typeof findBy === "string") {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    return useFindOne(modelManager as any, findBy, options);
+  } else if (modelManager) {
+    const [findByKey, findByValue] = Object.entries(findBy)[0];
+    const finder = (modelManager as Record<string, any>)[`findBy${camelize(findByKey)}`];
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    return (useFindBy as any)(finder, findByValue, options);
+  } else {
+    return [
+      { fetching: false },
+      () => {
+        // noop
+      },
+    ];
+  }
+};
+
+const OmittedKeys = ["__typename", "id", "createdAt", "updatedAt"] as const;
+type OmittedKey = (typeof OmittedKeys)[number];
+
+const omitKeys = (data: any) => {
+  const newData = { ...data };
+  for (const key of OmittedKeys) {
+    delete newData[key];
+  }
+  return newData;
+};
+
+const toDefaultValues = (modelApiIdentifier: string | undefined, data: any) => {
+  data = omitKeys(data);
+
+  if (modelApiIdentifier && data[modelApiIdentifier] && typeof data[modelApiIdentifier] === "object") {
+    data[modelApiIdentifier] = omitKeys(data[modelApiIdentifier]);
+  }
+
+  return data;
+};
+
+/**
+ * The identity of a record to build a form for
+ *
+ * - Pass the ID of a record as a string to look up a record by id
+ * - Pass a {<fieldValue>: <value>} object to look up a record by some other field. __Note__: a `findBy` function must exist for the field you wish to find the record by.
+ *
+ * @example
+ * // find the user record with ID=123
+ * const { submit } = useActionForm(api.user.update, { record: "123" });
+ *
+ * @example
+ * // find a record by email. `api.user.findByEmail` must exist
+ * const { submit } = useActionForm(api.user.update, { record: { email: "user@gadget.app" } });
+ */
+export type RecordIdentifier = string | { [key: string]: any };
+
+type UseActionFormHookStateData<F extends ActionFunction<any, any, any, any, any> | GlobalActionFunction<any>> = F extends ActionFunction<
+  any,
+  any,
+  any,
+  any,
+  any
+>
+  ? F["hasReturnType"] extends true
+    ? any
+    : GadgetRecord<
+        Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], F["optionsType"], F["defaultSelection"]>>
+      >
+  : any;
+
+type UseActionFormHookState<F extends ActionFunction<any, any, any, any, any> | GlobalActionFunction<any>> = ActionHookState<
+  UseActionFormHookStateData<F>,
+  Exclude<F["variablesType"], null | undefined>
+>;
+
+type UseActionFormSubmit<F extends ActionFunction<any, any, any, any, any> | GlobalActionFunction<any>> = (
+  event?: React.BaseSyntheticEvent<object, any, any> | undefined
+) => Promise<UseActionFormHookState<F>>;
+
+export type UseActionFormResult<
+  GivenOptions extends OptionsType,
+  SchemaT,
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>,
+  FormVariables extends FieldValues,
+  FormContext = any
+> = Omit<UseFormReturn<FormVariables, FormContext>, "handleSubmit"> & {
+  /**
+   * Any error that occurred during initial data fetching or action submission
+   */
+  error?: ErrorWrapper | Error | null;
+  /**
+   * Function to call to submit the form
+   */
+  submit: UseActionFormSubmit<ActionFunc>;
+  /**
+   * The data resulting from running the action
+   */
+  actionData?: ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>
+    ? ReturnType<typeof useAction<GivenOptions, SchemaT, ActionFunc, any>>[0]["data"]
+    : ReturnType<typeof useGlobalAction<any>>[0]["data"];
+};
+
+/**
+ * React hook to manage state for a form that calls a Gadget action. `useActionForm` must be passed an action function from an instance of your generated API client library, like `api.user.create`, `api.blogPost.publish` or `api.someGlobalAction`. `useActionForm` returns a `Form` object from `react-hook-form` which can be used to build great form experiences.
+ *
+ * `useActionForm` manages the Gadget API calls for the form, and handling validation errors returned by the Gadget backend. If your form is for an existing record, `useActionForm` will also fetch the record from the backend and populate the form with the existing values.
+ *
+ * `useActionForm` doesn't run the action when called. To actually submit the form, call the `submit` function on the returned `Form` object.
+ *
+ * @see https://react-hook-form.com/
+ *
+ * @param action an action function from a model manager in your application's client, like `api.user.create`
+ * @param options action options, like selecting the fields in the result
+ */
+export const useActionForm = <
+  GivenOptions extends OptionsType,
+  SchemaT,
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  ExtraFormVariables = {},
+  FormContext = any,
+  FormVariables extends FieldValues = ActionFunc["variablesType"] & ExtraFormVariables,
+  ActionResultData = UseActionFormHookStateData<ActionFunc>
+>(
+  action: ActionFunc,
+  options?: Omit<UseFormProps<FormVariables, FormContext>, "defaultValues"> & {
+    defaultValues?: DeepPartial<FormVariables> & { [key in OmittedKey]?: any };
+    /**
+     * The record identifier to run this action on, if it already exists.
+     * Should be undefined for create actions, or a record ID (or finder) for update / etc actions
+     **/
+    findBy?: RecordIdentifier;
+    /**
+     * Which fields to select on from the record when retrieving it from the backend.
+     */
+    select?: ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> ? ActionFunc["optionsType"]["select"] : never;
+    /**
+     * Which fields to send from the form's values when sending it from the backend.
+     */
+    send?: string[];
+    /**
+     * Called when the form submits
+     */
+    onSubmit?: () => void;
+    /**
+     * Called when the action completes successfully on the backend
+     */
+    onSuccess?: (actionResult: ActionResultData) => void;
+    /**
+     * Called when the form submission errors before sending, during the API call, or if the API call returns an error.
+     */
+    onError?: (error: Error | FieldErrors<ActionFunc["variablesType"]>) => void;
+  }
+): UseActionFormResult<GivenOptions, SchemaT, ActionFunc, FormVariables, FormContext> => {
+  const api = useApi();
+  const findExistingRecord = !!options?.findBy;
+  const hasSetInitialValues = useRef<boolean>(!findExistingRecord);
+
+  // find the existing record if there is one
+  const modelManager = "modelApiIdentifier" in action ? ((api as any)[action.modelApiIdentifier] as AnyModelManager) : undefined;
+  const [findResult] = useFindExistingRecord(modelManager, options?.findBy || "1", {
+    pause: !findExistingRecord,
+    select: options?.select,
+  });
+
+  const isReady = !findExistingRecord || !!findResult.data;
+
+  let defaultValues = options?.defaultValues;
+  if (!defaultValues && "modelApiIdentifier" in action && findResult.data) {
+    defaultValues = { [action.modelApiIdentifier]: { ...toDefaultValues(action.modelApiIdentifier, findResult.data) } } as any;
+  }
+
+  let existingRecordId: string | undefined = undefined;
+
+  if (findResult.data?.id) {
+    existingRecordId = findResult.data.id;
+  } else if (defaultValues?.id) {
+    existingRecordId = defaultValues.id;
+  } else if ("modelApiIdentifier" in action && defaultValues?.[action.modelApiIdentifier]?.id) {
+    existingRecordId = defaultValues?.[action.modelApiIdentifier]?.id;
+  }
+
+  // setup the react-hook-form object, passing any options from the props
+  const { handleSubmit, formState, ...formHook } = useForm<ActionFunc["variablesType"], FormContext>({
+    ...options,
+    defaultValues: toDefaultValues("modelApiIdentifier" in action ? action.modelApiIdentifier : undefined, defaultValues),
+  });
+
+  // when the default values arrive from the record find later, reset them into the form. react-hook-form doesn't watch the default values after the first render
+  useEffect(() => {
+    if (isReady && !hasSetInitialValues.current && defaultValues) {
+      hasSetInitialValues.current = true;
+      formHook.reset(defaultValues);
+    }
+  }, [isReady, defaultValues, formHook]);
+
+  // get the action runner to run on submit
+  const [actionResult, runAction] =
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    "modelApiIdentifier" in action ? useAction(action, { select: options?.select }) : useGlobalAction(action);
+
+  const handleSubmissionError = useCallback(
+    (error: Error | FieldErrors<ActionFunc["variablesType"]>) => {
+      if ("executionErrors" in error) {
+        const errorWrapper = error as unknown as ErrorWrapper;
+        const executionErrors = errorWrapper.executionErrors;
+
+        if (executionErrors.length > 0) {
+          for (const executionError of executionErrors) {
+            if ("validationErrors" in executionError) {
+              for (const validationError of executionError.validationErrors) {
+                const errorKey =
+                  "modelApiIdentifier" in action
+                    ? `${action.modelApiIdentifier}.${validationError.apiIdentifier}`
+                    : validationError.apiIdentifier;
+                formHook.setError(errorKey as any, {
+                  message: validationError.message,
+                });
+              }
+            } else {
+              const codeToReplace = "code" in executionError ? `${executionError.code}: ` : "";
+              const message = executionError.message.replace(codeToReplace, "");
+
+              formHook.setError("root", { message });
+            }
+          }
+        } else if (errorWrapper.networkError) {
+          formHook.setError("root", { message: errorWrapper.networkError.message });
+        }
+      }
+
+      options?.onError?.(error);
+    },
+    [action, formHook, options]
+  );
+
+  const submit = useCallback(
+    async (event?: React.BaseSyntheticEvent<object, any, any> | undefined) => {
+      let result: any;
+
+      formHook.clearErrors();
+
+      await handleSubmit(
+        async (data) => {
+          let variables: ActionFunc["variablesType"] = {
+            ...data,
+          };
+
+          if (existingRecordId) {
+            variables.id = existingRecordId;
+          }
+
+          if (options?.send) {
+            const unmasked = variables;
+            variables = {};
+            for (const key of options.send) {
+              set(variables, key, get(unmasked, key));
+            }
+          }
+
+          options?.onSubmit?.();
+
+          result = await runAction(variables);
+          if (!result.error) {
+            options?.onSuccess?.(result.data);
+          }
+        },
+        (errors) => {
+          handleSubmissionError(errors);
+        }
+      )(event);
+
+      if (result?.error) {
+        handleSubmissionError(result.error);
+      }
+
+      return result;
+    },
+    [handleSubmit, formHook, handleSubmissionError, existingRecordId, options, runAction]
+  );
+
+  const proxiedFormState = new Proxy(formState, {
+    get: (target, prop) => {
+      if (prop === "isSubmitting") {
+        return target.isSubmitting || actionResult.fetching;
+      } else if (prop === "isSubmitSuccessful") {
+        return target.isSubmitSuccessful && !actionResult.fetching && !actionResult.error;
+      } else if (prop === "isLoading") {
+        return target.isLoading || findResult.fetching;
+      } else {
+        return (target as any)[prop];
+      }
+    },
+  });
+
+  return {
+    ...formHook,
+    formState: proxiedFormState,
+    error: findResult.error || actionResult.error,
+    submit: submit as unknown as UseActionFormSubmit<ActionFunc>,
+    actionData: actionResult.data,
+  };
+};

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -328,7 +328,9 @@ export const disambiguateActionVariables = (
 ) => {
   variables ??= {};
   if (action.hasAmbiguousIdentifier) {
-    if (Object.keys(variables).some((key) => !action.paramOnlyVariables?.includes(key) && key !== action.modelApiIdentifier)) {
+    if (
+      Object.keys(variables).some((key) => key !== "id" && !action.paramOnlyVariables?.includes(key) && key !== action.modelApiIdentifier)
+    ) {
       throw Error(`Invalid arguments found in variables. Did you mean to use ({ ${action.modelApiIdentifier}: { ... } })?`);
     }
   }
@@ -363,4 +365,36 @@ export const disambiguateActionVariables = (
   }
 
   return newVariables;
+};
+
+/**
+ * Get a list of path segments from a dot-separated path
+ */
+const pathToPathArray = (path: string | string[]) => {
+  // Check if path is string or array. Regex : ensure that we do not have '.' and brackets.
+  // Regex explained: https://regexr.com/58j0k
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return Array.isArray(path) ? path : path.match(/([^[.\]])+/g)!;
+};
+
+/**
+ * Get a dot-separated path from an object
+ * From https://youmightnotneed.com/lodash
+ */
+export const get = (obj: any, path: string | string[]) => {
+  if (!path) return undefined;
+  return pathToPathArray(path).reduce((prevObj, key) => prevObj && prevObj[key], obj);
+};
+
+/**
+ * Set a dot-separated path to a value on an object
+ * From https://youmightnotneed.com/lodash
+ */
+export const set = (obj: any, path: string, value: any) => {
+  const pathArray = pathToPathArray(path);
+  pathArray.reduce((acc, key, i) => {
+    if (acc[key] === undefined) acc[key] = {};
+    if (i === pathArray.length - 1) acc[key] = value;
+    return acc[key];
+  }, obj);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       react-fast-compare:
         specifier: ^3.2.2
         version: 3.2.2
+      react-hook-form:
+        specifier: ^7.46.1
+        version: 7.46.1(react@18.2.0)
       urql:
         specifier: ^4.0.4
         version: 4.0.4(graphql@16.8.1)(react@18.2.0)
@@ -5636,6 +5639,15 @@ packages:
 
   /react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+    dev: false
+
+  /react-hook-form@7.46.1(react@18.2.0):
+    resolution: {integrity: sha512-0GfI31LRTBd5tqbXMGXT1Rdsv3rnvy0FjEk8Gn9/4tp6+s77T7DPZuGEpBRXOauL+NhyGT5iaXzdIM2R6F/E+w==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-is@16.13.1:


### PR DESCRIPTION
This PR introduces `useActionForm` that will allow us to use `react-form-hook` together with `useAction`; this hook will help us create smaller starting files for our web apps. @airhorns this is mostly the code you wrote with a few changes:

- I'm not returning `modelManager` from the hook; let's leave it out for now and if we need it later add it in
- the hook returns `actionData`
- the promise returned when calling `submit` waits until the action has resolved 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
