### PR TITLE
better typing for useActionForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@gadget-client/app-with-no-user-model": "^1.5.0",
     "@gadget-client/bulk-actions-test": "^1.104.0",
     "@gadget-client/related-products-example": "^1.854.0",
-    "@gadget-client/super-auth": "^1.37.0",
+    "@gadget-client/full-auth": "^1.4.0",
     "@gadgetinc/api-client-core": "workspace:*",
     "@gadgetinc/eslint-config": "^0.6.1",
     "@gadgetinc/prettier-config": "^0.4.0",

--- a/packages/react/spec/apis.ts
+++ b/packages/react/spec/apis.ts
@@ -1,9 +1,9 @@
 import { Client as NoUserClient } from "@gadget-client/app-with-no-user-model";
 import { Client as BulkClient } from "@gadget-client/bulk-actions-test";
+import { Client as AuthClient } from "@gadget-client/full-auth";
 import { Client } from "@gadget-client/related-products-example";
-import { Client as AuthClient } from "@gadget-client/super-auth";
 
 export const relatedProductsApi = new Client({ environment: "Development" });
 export const bulkExampleApi = new BulkClient({ environment: "Development" });
-export const superAuthApi = new AuthClient({ environment: "Development" });
+export const fullAuthApi = new AuthClient({ environment: "Development" });
 export const noUserModelApi = new NoUserClient({ environment: "Development" });

--- a/packages/react/spec/auth/useAuth.spec.ts
+++ b/packages/react/spec/auth/useAuth.spec.ts
@@ -1,12 +1,12 @@
 import { renderHook } from "@testing-library/react";
 import { useAuth } from "../../src/auth/useAuth.js";
-import { noUserModelApi, superAuthApi } from "../apis.js";
+import { fullAuthApi, noUserModelApi } from "../apis.js";
 import { MockClientWrapper } from "../testWrappers.js";
 import { expectMockSignedInUser, expectMockSignedOutUser, mockInternalServerError, mockNetworkError } from "../utils.js";
 
 describe("useAuth", () => {
   test("returns the correct auth state as generic GadgetRecords if no api client is provided", () => {
-    const { result, rerender } = renderHook(() => useAuth(), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useAuth(), { wrapper: MockClientWrapper(fullAuthApi) });
     expectMockSignedInUser();
 
     rerender();
@@ -16,7 +16,7 @@ describe("useAuth", () => {
   });
 
   test("returns the correct auth state if the user is signed in", async () => {
-    const { result, rerender } = renderHook(() => useAuth(superAuthApi), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useAuth(fullAuthApi), { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedInUser();
 
@@ -27,7 +27,7 @@ describe("useAuth", () => {
   });
 
   test("returns the correct auth state if the user is signed out", async () => {
-    const { result, rerender } = renderHook(() => useAuth(superAuthApi), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useAuth(fullAuthApi), { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
 
@@ -39,7 +39,7 @@ describe("useAuth", () => {
 
   test("it throws when the server responds with an error", async () => {
     expect(() => {
-      const { rerender } = renderHook(() => useAuth(superAuthApi), { wrapper: MockClientWrapper(superAuthApi) });
+      const { rerender } = renderHook(() => useAuth(fullAuthApi), { wrapper: MockClientWrapper(fullAuthApi) });
 
       mockInternalServerError();
 
@@ -52,7 +52,7 @@ describe("useAuth", () => {
 
   test("it throws when request fails to complete", async () => {
     expect(() => {
-      const { rerender } = renderHook(() => useAuth(superAuthApi), { wrapper: MockClientWrapper(superAuthApi) });
+      const { rerender } = renderHook(() => useAuth(fullAuthApi), { wrapper: MockClientWrapper(fullAuthApi) });
 
       mockNetworkError();
 

--- a/packages/react/spec/auth/useSession.spec.ts
+++ b/packages/react/spec/auth/useSession.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { noUserModelApi, superAuthApi } from "../../spec/apis.js";
+import { fullAuthApi, noUserModelApi } from "../../spec/apis.js";
 import { expectMockSignedInUser, expectMockSignedOutUser, mockInternalServerError, mockNetworkError } from "../../spec/utils.js";
 import { useSession } from "../../src/auth/useSession.js";
 import type { MockUrqlClient } from "../testWrappers.js";
@@ -20,7 +20,7 @@ describe("useSession", () => {
 
   test("it returns the current session when the user is logged in and no options are passed", async () => {
     const { result, rerender } = renderHook(() => useSession(), {
-      wrapper: MockClientWrapper(superAuthApi, client),
+      wrapper: MockClientWrapper(fullAuthApi, client),
     });
 
     expectMockSignedInUser(client);
@@ -32,19 +32,27 @@ describe("useSession", () => {
           __typename
           createdAt
           id
-          roles {
-            key
-            name
-          }
+          state
           updatedAt
           user {
             __typename
             createdAt
             email
+            emailVerificationToken
+            emailVerificationTokenExpiration
+            emailVerified
             firstName
             googleImageUrl
+            googleProfileId
             id
             lastName
+            lastSignedIn
+            resetPasswordToken
+            resetPasswordTokenExpiration
+            roles {
+              key
+              name
+            }
             updatedAt
           }
         }
@@ -61,7 +69,7 @@ describe("useSession", () => {
   });
 
   test("it returns the current session when the user is logged in and api client is passed", async () => {
-    const { result, rerender } = renderHook(() => useSession(superAuthApi), { wrapper: MockClientWrapper(superAuthApi, client) });
+    const { result, rerender } = renderHook(() => useSession(fullAuthApi), { wrapper: MockClientWrapper(fullAuthApi, client) });
 
     expectMockSignedInUser(client);
     rerender();
@@ -72,19 +80,27 @@ describe("useSession", () => {
           __typename
           createdAt
           id
-          roles {
-            key
-            name
-          }
+          state
           updatedAt
           user {
             __typename
             createdAt
             email
+            emailVerificationToken
+            emailVerificationTokenExpiration
+            emailVerified
             firstName
             googleImageUrl
+            googleProfileId
             id
             lastName
+            lastSignedIn
+            resetPasswordToken
+            resetPasswordTokenExpiration
+            roles {
+              key
+              name
+            }
             updatedAt
           }
         }
@@ -101,8 +117,8 @@ describe("useSession", () => {
   });
 
   test("it returns the current session when the user is logged in and api client with options is passed", async () => {
-    const { result, rerender } = renderHook(() => useSession(superAuthApi, { select: { id: true, user: { id: true, firstName: true } } }), {
-      wrapper: MockClientWrapper(superAuthApi, client),
+    const { result, rerender } = renderHook(() => useSession(fullAuthApi, { select: { id: true, user: { id: true, firstName: true } } }), {
+      wrapper: MockClientWrapper(fullAuthApi, client),
     });
 
     expectMockSignedInUser(client);
@@ -129,15 +145,15 @@ describe("useSession", () => {
     expect(result.current.user?.firstName).toEqual("Jane");
 
     const { result: noUserResult, rerender: _noUserRerender } = renderHook(
-      () => useSession(superAuthApi, { filter: { user: { firstName: { equals: "Bob" } } } }),
-      { wrapper: MockClientWrapper(superAuthApi) }
+      () => useSession(fullAuthApi, { filter: { user: { firstName: { equals: "Bob" } } } }),
+      { wrapper: MockClientWrapper(fullAuthApi) }
     );
 
     expect(noUserResult.current).toBeNull();
   });
 
   test("it returns the current session when the user is logged out", async () => {
-    const { result, rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
     rerender();
@@ -148,7 +164,7 @@ describe("useSession", () => {
   });
 
   test("it returns the current session when the user is logged out and no options are passed", async () => {
-    const { result, rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
     rerender();
@@ -159,7 +175,7 @@ describe("useSession", () => {
   });
 
   test("it returns the current session when the user is logged out and an api client with options is passed", async () => {
-    const { result, rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
     rerender();
@@ -171,7 +187,7 @@ describe("useSession", () => {
 
   test("it throws when the server responds with an error", async () => {
     expect(() => {
-      const { rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(superAuthApi) });
+      const { rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(fullAuthApi) });
 
       mockInternalServerError();
 
@@ -184,7 +200,7 @@ describe("useSession", () => {
 
   test("it throws when request fails to complete", async () => {
     expect(() => {
-      const { rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(superAuthApi) });
+      const { rerender } = renderHook(() => useSession(), { wrapper: MockClientWrapper(fullAuthApi) });
 
       mockNetworkError();
 

--- a/packages/react/spec/auth/useSignOut.spec.ts
+++ b/packages/react/spec/auth/useSignOut.spec.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { useSignOut } from "../../src/auth/useSignOut.js";
-import { superAuthApi } from "../apis.js";
+import { fullAuthApi } from "../apis.js";
 import { MockClientWrapper, mockUrqlClient } from "../testWrappers.js";
 import { expectMockSignedInUser, expectMockSignedOutUser } from "../utils.js";
 
@@ -24,7 +24,7 @@ describe("useSignOut", () => {
   });
 
   test("it redirects to the provider signInPath when the user is signed in", async () => {
-    const { result, rerender } = renderHook(() => useSignOut(), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useSignOut(), { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedInUser();
     rerender();
@@ -60,7 +60,7 @@ describe("useSignOut", () => {
 
   test("it redirects to the optional redirectToPath when the user is signed in", async () => {
     const { result, rerender } = renderHook(() => useSignOut({ redirectToPath: "/somewhere-special" }), {
-      wrapper: MockClientWrapper(superAuthApi),
+      wrapper: MockClientWrapper(fullAuthApi),
     });
 
     expectMockSignedInUser();
@@ -95,7 +95,7 @@ describe("useSignOut", () => {
   });
 
   test("it does not redirect when the redirectOnSuccess option is false", async () => {
-    const { result, rerender } = renderHook(() => useSignOut({ redirectOnSuccess: false }), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useSignOut({ redirectOnSuccess: false }), { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedInUser();
     rerender();
@@ -131,7 +131,7 @@ describe("useSignOut", () => {
   test("it does not redirect and throws when an error occurs during signOut", async () => {
     let caughtError = null;
     try {
-      const { result, rerender } = renderHook(() => useSignOut(), { wrapper: MockClientWrapper(superAuthApi) });
+      const { result, rerender } = renderHook(() => useSignOut(), { wrapper: MockClientWrapper(fullAuthApi) });
 
       expectMockSignedInUser();
       rerender();
@@ -173,7 +173,7 @@ describe("useSignOut", () => {
   test("it throws an error when there is no signed in user", async () => {
     let caughtError = null;
     try {
-      const { result, rerender } = renderHook(() => useSignOut(), { wrapper: MockClientWrapper(superAuthApi) });
+      const { result, rerender } = renderHook(() => useSignOut(), { wrapper: MockClientWrapper(fullAuthApi) });
       expectMockSignedOutUser();
       rerender();
 

--- a/packages/react/spec/auth/useUser.spec.ts
+++ b/packages/react/spec/auth/useUser.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { noUserModelApi, superAuthApi } from "../../spec/apis.js";
+import { fullAuthApi, noUserModelApi } from "../../spec/apis.js";
 import { expectMockSignedInUser, expectMockSignedOutUser, mockInternalServerError, mockNetworkError } from "../../spec/utils.js";
 import { useUser } from "../../src/auth/useUser.js";
 import type { MockUrqlClient } from "../testWrappers.js";
@@ -19,7 +19,7 @@ describe("useUser", () => {
   });
 
   test("it returns the current user when the user is logged in with no options passed", async () => {
-    const { result, rerender } = renderHook(() => useUser(), { wrapper: MockClientWrapper(superAuthApi, client) });
+    const { result, rerender } = renderHook(() => useUser(), { wrapper: MockClientWrapper(fullAuthApi, client) });
 
     expectMockSignedInUser(client);
 
@@ -31,19 +31,27 @@ describe("useUser", () => {
           __typename
           createdAt
           id
-          roles {
-            key
-            name
-          }
+          state
           updatedAt
           user {
             __typename
             createdAt
             email
+            emailVerificationToken
+            emailVerificationTokenExpiration
+            emailVerified
             firstName
             googleImageUrl
+            googleProfileId
             id
             lastName
+            lastSignedIn
+            resetPasswordToken
+            resetPasswordTokenExpiration
+            roles {
+              key
+              name
+            }
             updatedAt
           }
         }
@@ -59,7 +67,7 @@ describe("useUser", () => {
   });
 
   test("it returns the current user when the user is logged in with an api client passed", async () => {
-    const { result, rerender } = renderHook(() => useUser(superAuthApi), { wrapper: MockClientWrapper(superAuthApi, client) });
+    const { result, rerender } = renderHook(() => useUser(fullAuthApi), { wrapper: MockClientWrapper(fullAuthApi, client) });
 
     expectMockSignedInUser(client);
 
@@ -71,19 +79,27 @@ describe("useUser", () => {
           __typename
           createdAt
           id
-          roles {
-            key
-            name
-          }
+          state
           updatedAt
           user {
             __typename
             createdAt
             email
+            emailVerificationToken
+            emailVerificationTokenExpiration
+            emailVerified
             firstName
             googleImageUrl
+            googleProfileId
             id
             lastName
+            lastSignedIn
+            resetPasswordToken
+            resetPasswordTokenExpiration
+            roles {
+              key
+              name
+            }
             updatedAt
           }
         }
@@ -99,8 +115,8 @@ describe("useUser", () => {
   });
 
   test("it returns the current user when the user is logged in with an api client and options passed", async () => {
-    const { result, rerender } = renderHook(() => useUser(superAuthApi, { select: { firstName: true } }), {
-      wrapper: MockClientWrapper(superAuthApi, client),
+    const { result, rerender } = renderHook(() => useUser(fullAuthApi, { select: { firstName: true } }), {
+      wrapper: MockClientWrapper(fullAuthApi, client),
     });
 
     expectMockSignedInUser(client);
@@ -113,10 +129,7 @@ describe("useUser", () => {
           __typename
           createdAt
           id
-          roles {
-            key
-            name
-          }
+          state
           updatedAt
           user {
             firstName
@@ -139,7 +152,7 @@ describe("useUser", () => {
   });
 
   test("it returns null when the user is logged out", async () => {
-    const { result, rerender } = renderHook(() => useUser(), { wrapper: MockClientWrapper(superAuthApi) });
+    const { result, rerender } = renderHook(() => useUser(), { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
 
@@ -149,7 +162,7 @@ describe("useUser", () => {
 
   test("it throws when the server responds with an error", async () => {
     expect(() => {
-      const { rerender } = renderHook(() => useUser(), { wrapper: MockClientWrapper(superAuthApi) });
+      const { rerender } = renderHook(() => useUser(), { wrapper: MockClientWrapper(fullAuthApi) });
 
       mockInternalServerError();
 
@@ -162,7 +175,7 @@ describe("useUser", () => {
 
   test("it throws when request fails to complete", async () => {
     expect(() => {
-      const { rerender } = renderHook(() => useUser(), { wrapper: MockClientWrapper(superAuthApi) });
+      const { rerender } = renderHook(() => useUser(), { wrapper: MockClientWrapper(fullAuthApi) });
 
       mockNetworkError();
 

--- a/packages/react/spec/components/auth/SignedIn.spec.tsx
+++ b/packages/react/spec/components/auth/SignedIn.spec.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
 import { SignedIn } from "../../../src/auth/SignedIn.js";
-import { superAuthApi } from "../../apis.js";
+import { fullAuthApi } from "../../apis.js";
 import { MockClientWrapper } from "../../testWrappers.js";
 import { expectMockDeletedUser, expectMockSignedInUser, expectMockSignedOutUser } from "../../utils.js";
 
@@ -14,7 +14,7 @@ describe("SignedIn", () => {
       </h1>
     );
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedInUser();
 
@@ -30,7 +30,7 @@ describe("SignedIn", () => {
       </h1>
     );
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
     rerender(component);
@@ -44,7 +44,7 @@ describe("SignedIn", () => {
       </h1>
     );
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockDeletedUser();
     rerender(component);

--- a/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
 import { SignedInOrRedirect } from "../../../src/auth/SignedInOrRedirect.js";
-import { superAuthApi } from "../../apis.js";
+import { fullAuthApi } from "../../apis.js";
 import { MockClientWrapper } from "../../testWrappers.js";
 import { expectMockDeletedUser, expectMockSignedInUser, expectMockSignedOutUser } from "../../utils.js";
 
@@ -32,7 +32,7 @@ describe("SignedInOrRedirect", () => {
       </h1>
     );
 
-    const { rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
     rerender(component);
@@ -48,7 +48,7 @@ describe("SignedInOrRedirect", () => {
       </h1>
     );
 
-    const { rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockDeletedUser();
     rerender(component);
@@ -64,7 +64,7 @@ describe("SignedInOrRedirect", () => {
       </h1>
     );
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedInUser();
     rerender(component);

--- a/packages/react/spec/components/auth/SignedOut.spec.tsx
+++ b/packages/react/spec/components/auth/SignedOut.spec.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
 import { SignedOut } from "../../../src/auth/SignedOut.js";
-import { superAuthApi } from "../../apis.js";
+import { fullAuthApi } from "../../apis.js";
 import { MockClientWrapper } from "../../testWrappers.js";
 import { expectMockDeletedUser, expectMockSignedInUser, expectMockSignedOutUser } from "../../utils.js";
 
@@ -14,7 +14,7 @@ describe("SignedOut", () => {
       </h1>
     );
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
 
@@ -29,7 +29,7 @@ describe("SignedOut", () => {
       </h1>
     );
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockDeletedUser();
 
@@ -44,7 +44,7 @@ describe("SignedOut", () => {
       </h1>
     );
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedInUser();
 

--- a/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
 import { SignedOutOrRedirect } from "../../../src/auth/SignedOutOrRedirect.js";
-import { superAuthApi } from "../../apis.js";
+import { fullAuthApi } from "../../apis.js";
 import { MockClientWrapper } from "../../testWrappers.js";
 import { expectMockSignedInUser, expectMockSignedOutUser } from "../../utils.js";
 
@@ -32,7 +32,7 @@ describe("SignedOutOrRedirect", () => {
       </h1>
     );
 
-    const { rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedInUser();
     rerender(component);
@@ -48,7 +48,7 @@ describe("SignedOutOrRedirect", () => {
       </h1>
     );
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(superAuthApi) });
+    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
 
     expectMockSignedOutUser();
     rerender(component);

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -8,7 +8,7 @@ import type { AnyVariables } from "urql";
 import { Provider } from "../src/GadgetProvider.js";
 import { useAction } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
-import { relatedProductsApi, superAuthApi } from "./apis.js";
+import { fullAuthApi, relatedProductsApi } from "./apis.js";
 import { MockClientWrapper, createMockUrqlClient, mockUrqlClient } from "./testWrappers.js";
 
 describe("useAction", () => {
@@ -428,7 +428,7 @@ describe("useAction", () => {
 
     const wrapper = (props: { children: React.ReactNode }) => <Provider value={client}>{props.children}</Provider>;
 
-    const { result } = renderHook(() => useAction(superAuthApi.user.signUp), {
+    const { result } = renderHook(() => useAction(fullAuthApi.user.signUp), {
       wrapper,
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,12 +18,12 @@ importers:
       '@gadget-client/bulk-actions-test':
         specifier: ^1.104.0
         version: 1.104.0
+      '@gadget-client/full-auth':
+        specifier: ^1.4.0
+        version: 1.4.0
       '@gadget-client/related-products-example':
         specifier: ^1.854.0
         version: 1.854.0
-      '@gadget-client/super-auth':
-        specifier: ^1.37.0
-        version: 1.37.0
       '@gadgetinc/api-client-core':
         specifier: workspace:*
         version: link:packages/api-client-core
@@ -1192,14 +1192,14 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/related-products-example@1.854.0:
-    resolution: {integrity: sha1-yEytaM9x8otBV06i0Cw/F6zsglo=, tarball: https://registry.gadget.dev/npm/_/tarball/1268/1361/5562}
+  /@gadget-client/full-auth@1.4.0:
+    resolution: {integrity: sha1-npUnTWStWGH5v2nmd5hPrLQBZwA=, tarball: https://registry.gadget.dev/npm/_/tarball/66538/131724/5610}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/super-auth@1.37.0:
-    resolution: {integrity: sha1-VE4TFObMZD4e0Lh/Wd03J6AOpX4=, tarball: https://registry.gadget.dev/npm/_/tarball/50045/98771/5458}
+  /@gadget-client/related-products-example@1.854.0:
+    resolution: {integrity: sha1-yEytaM9x8otBV06i0Cw/F6zsglo=, tarball: https://registry.gadget.dev/npm/_/tarball/1268/1361/5562}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
once https://github.com/gadget-inc/js-clients/pull/286 we found that the typing in our email password template had issues; this was mainly because we didn't add the server side validation types to `formState: {errors}` this PR adds that typing (I'm sorry it's so confusing 😢 ) to say that the server side validation errors can be any of the field values of the model or any of the variable keys.

There is one issue in that for reset password for the typing to work we need to have:

```
useActionForm<
      (typeof fullAuthApi.user.resetPassword)["optionsType"],
      (typeof fullAuthApi.user.resetPassword)["schemaType"],
      typeof fullAuthApi.user.resetPassword,
      { confirmPassword?: string }
    >(fullAuthApi.user.resetPassword, {
      defaultValues: { code: "abc123" },
    });
```

I'm not sure how we can do this typing in the js file?

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
