### PR TITLE
Add auth config to the object returned from useAuth

### DIFF
--- a/packages/react/spec/auth/useAuth.spec.ts
+++ b/packages/react/spec/auth/useAuth.spec.ts
@@ -69,4 +69,44 @@ describe("useAuth", () => {
       rerender();
     }).toThrowErrorMatchingInlineSnapshot(`"api client does not have a User model"`);
   });
+
+  test("returns the correct auth config when signed out", () => {
+    const { result, rerender } = renderHook(() => useAuth(), {
+      wrapper: MockClientWrapper(fullAuthApi, undefined, {
+        signInPath: "/foo-sign-in",
+        signOutActionApiIdentifier: "newSignOut",
+        redirectOnSuccessfulSignInPath: "/bar-signed-in",
+      }),
+    });
+
+    expectMockSignedOutUser();
+    rerender();
+
+    expect(result.current.configuration).toEqual({
+      signInPath: "/foo-sign-in",
+      signOutActionApiIdentifier: "newSignOut",
+      redirectOnSuccessfulSignInPath: "/bar-signed-in",
+    });
+    expect(result.current.isSignedIn).toBe(false);
+  });
+
+  test("returns the correct auth config when signed in", () => {
+    const { result, rerender } = renderHook(() => useAuth(), {
+      wrapper: MockClientWrapper(fullAuthApi, undefined, {
+        signInPath: "/foo-sign-in",
+        signOutActionApiIdentifier: "newSignOut",
+        redirectOnSuccessfulSignInPath: "/bar-signed-in",
+      }),
+    });
+
+    expectMockSignedInUser();
+    rerender();
+
+    expect(result.current.configuration).toEqual({
+      signInPath: "/foo-sign-in",
+      signOutActionApiIdentifier: "newSignOut",
+      redirectOnSuccessfulSignInPath: "/bar-signed-in",
+    });
+    expect(result.current.isSignedIn).toBe(true);
+  });
 });

--- a/packages/react/src/auth/useAuth.ts
+++ b/packages/react/src/auth/useAuth.ts
@@ -1,5 +1,8 @@
 import type { DefaultSelection, GadgetRecord, Select } from "@gadgetinc/api-client-core";
+import { useContext } from "react";
 import type { OptionsType, ReadOperationOptions } from "src/utils";
+import type { GadgetAuthConfiguration } from "../GadgetProvider.js";
+import { GadgetConfigurationContext } from "../GadgetProvider.js";
 import type { ClientWithSessionAndUserManagers, GadgetSession, GadgetUser } from "./useSession.js";
 import { useSession } from "./useSession.js";
 import { useUser } from "./useUser.js";
@@ -47,8 +50,15 @@ export const useAuth = <
       >
     | GadgetUser;
   isSignedIn: boolean;
+  configuration: GadgetAuthConfiguration;
 } => {
   const session = useSession(client);
   const user = useUser(client);
-  return { session, user, isSignedIn: !!user };
+  const context = useContext(GadgetConfigurationContext);
+
+  if (!context) {
+    throw new Error("useAuth must be used within a GadgetProvider");
+  }
+
+  return { session, user, isSignedIn: !!user, configuration: context.auth };
 };


### PR DESCRIPTION
Users may need to access things like `signInPath`, `redirectOnSuccessfulSignInPath`, etc... in components. An example would be 
```typescript
<Link to={authConfig.signInPath} />
```
instead of needing to do
```typescript
<Link to={window.gadgetConfig.authentication.signInPath />
```

closes GGT-5051

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
