### PR TITLE
Allow a custom navigate to be provided to the Provider

### DIFF
--- a/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedOutOrRedirect.spec.tsx
@@ -7,108 +7,135 @@ import { MockClientWrapper } from "../../testWrappers.js";
 import { expectMockSignedInUser, expectMockSignedOutUser } from "../../utils.js";
 
 describe("SignedOutOrRedirect", () => {
-  const { location } = window;
-  const mockAssign = jest.fn();
+  describe.each([true, false])("using custom navigate: %s", (customNavigate) => {
+    const mockNavigate = jest.fn();
+    const { location } = window;
 
-  beforeAll(() => {
-    // @ts-expect-error mock
-    delete window.location;
-    // @ts-expect-error mock
-    window.location = { assign: mockAssign, origin: "https://test-app.gadget.app", pathname: "/sign-in" };
-  });
+    beforeAll(() => {
+      // @ts-expect-error mock
+      delete window.location;
 
-  afterEach(() => {
-    mockAssign.mockClear();
-  });
-
-  afterAll(() => {
-    window.location = location;
-  });
-
-  test("redirects when signed in", () => {
-    const component = (
-      <h1>
-        <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
-      </h1>
-    );
-
-    const { rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
-
-    expectMockSignedInUser();
-    rerender(component);
-
-    expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/");
-  });
-
-  test("redirects when signed in and a redirectOnSuccessfulSignInPath has been provided", () => {
-    const component = (
-      <h1>
-        <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
-      </h1>
-    );
-
-    const { rerender } = render(component, {
-      wrapper: MockClientWrapper(fullAuthApi, undefined, { redirectOnSuccessfulSignInPath: "/signed-in" }),
+      if (!customNavigate) {
+        // @ts-expect-error mock
+        window.location = { assign: mockNavigate, origin: "https://test-app.gadget.app", pathname: "/" };
+      } else {
+        // @ts-expect-error mock
+        window.location = { origin: "https://test-app.gadget.app" };
+      }
     });
 
-    expectMockSignedInUser();
-    rerender(component);
-
-    expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/signed-in");
-  });
-
-  test("redirects when signed in and a redirectOnSuccessfulSignInPath has been provided and has been overriden", () => {
-    const component = (
-      <h1>
-        <SignedOutOrRedirect path="/my-custom-path">Hello, Jane!</SignedOutOrRedirect>
-      </h1>
-    );
-
-    const { rerender } = render(component, {
-      wrapper: MockClientWrapper(fullAuthApi, undefined, { redirectOnSuccessfulSignInPath: "/signed-in" }),
+    afterEach(() => {
+      mockNavigate.mockClear();
     });
 
-    expectMockSignedInUser();
-    rerender(component);
-
-    expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/my-custom-path");
-  });
-
-  test("redirects after signing in to the redirect path", () => {
-    window.location.search = "?redirectTo=%2Fredirect-me";
-    const component = (
-      <h1>
-        <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
-      </h1>
-    );
-
-    const { rerender } = render(component, {
-      wrapper: MockClientWrapper(fullAuthApi, undefined, { redirectOnSuccessfulSignInPath: "/signed-in" }),
+    afterAll(() => {
+      if (!customNavigate) {
+        window.location = location;
+      }
     });
 
-    expectMockSignedInUser();
-    rerender(component);
+    test("redirects when signed in", () => {
+      const component = (
+        <h1>
+          <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
+        </h1>
+      );
 
-    expect(mockAssign).toHaveBeenCalledTimes(1);
-    expect(mockAssign).toHaveBeenCalledWith("https://test-app.gadget.app/redirect-me");
-  });
+      const { rerender } = render(component, {
+        wrapper: MockClientWrapper(fullAuthApi, undefined, {
+          navigate: customNavigate ? mockNavigate : undefined,
+        }),
+      });
 
-  test("renders when signed out", () => {
-    const component = (
-      <h1>
-        <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
-      </h1>
-    );
+      expectMockSignedInUser();
+      rerender(component);
 
-    const { container, rerender } = render(component, { wrapper: MockClientWrapper(fullAuthApi) });
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith("/");
+    });
 
-    expectMockSignedOutUser();
-    rerender(component);
+    test("redirects when signed in and a redirectOnSuccessfulSignInPath has been provided", () => {
+      const component = (
+        <h1>
+          <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
+        </h1>
+      );
 
-    expect(mockAssign).not.toBeCalled();
-    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
+      const { rerender } = render(component, {
+        wrapper: MockClientWrapper(fullAuthApi, undefined, {
+          auth: { redirectOnSuccessfulSignInPath: "/signed-in" },
+          navigate: customNavigate ? mockNavigate : undefined,
+        }),
+      });
+
+      expectMockSignedInUser();
+      rerender(component);
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith("/signed-in");
+    });
+
+    test("redirects when signed in and a redirectOnSuccessfulSignInPath has been provided and has been overriden", () => {
+      const component = (
+        <h1>
+          <SignedOutOrRedirect path="/my-custom-path">Hello, Jane!</SignedOutOrRedirect>
+        </h1>
+      );
+
+      const { rerender } = render(component, {
+        wrapper: MockClientWrapper(fullAuthApi, undefined, {
+          auth: { redirectOnSuccessfulSignInPath: "/signed-in" },
+          navigate: customNavigate ? mockNavigate : undefined,
+        }),
+      });
+
+      expectMockSignedInUser();
+      rerender(component);
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith("/my-custom-path");
+    });
+
+    test("redirects after signing in to the redirect path", () => {
+      window.location.search = "?redirectTo=%2Fredirect-me";
+      const component = (
+        <h1>
+          <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
+        </h1>
+      );
+
+      const { rerender } = render(component, {
+        wrapper: MockClientWrapper(fullAuthApi, undefined, {
+          auth: { redirectOnSuccessfulSignInPath: "/signed-in" },
+          navigate: customNavigate ? mockNavigate : undefined,
+        }),
+      });
+
+      expectMockSignedInUser();
+      rerender(component);
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith("/redirect-me");
+    });
+
+    test("renders when signed out", () => {
+      const component = (
+        <h1>
+          <SignedOutOrRedirect>Hello, Jane!</SignedOutOrRedirect>
+        </h1>
+      );
+
+      const { container, rerender } = render(component, {
+        wrapper: MockClientWrapper(fullAuthApi, undefined, {
+          navigate: customNavigate ? mockNavigate : undefined,
+        }),
+      });
+
+      expectMockSignedOutUser();
+      rerender(component);
+
+      expect(mockNavigate).not.toBeCalled();
+      expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
+    });
   });
 });

--- a/packages/react/spec/testWrappers.tsx
+++ b/packages/react/spec/testWrappers.tsx
@@ -6,13 +6,21 @@ import { createMockUrqlClient, mockGraphQLWSClient, mockUrqlClient } from "../..
 import { Provider, type GadgetAuthConfiguration } from "../src/GadgetProvider.js";
 
 export const MockClientWrapper =
-  (api: AnyClient, urqlClient?: MockUrqlClient, auth?: Partial<GadgetAuthConfiguration>) => (props: { children: ReactNode }) => {
+  (
+    api: AnyClient,
+    urqlClient?: MockUrqlClient,
+    propOverrides?: {
+      auth?: Partial<GadgetAuthConfiguration>;
+      navigate?: (url: string) => void;
+    }
+  ) =>
+  (props: { children: ReactNode }) => {
     const urql = urqlClient ?? mockUrqlClient;
 
     jest.spyOn(api.connection, "currentClient", "get").mockReturnValue(urql);
 
     return (
-      <Provider api={api} auth={auth}>
+      <Provider api={api} navigate={propOverrides?.navigate} auth={propOverrides?.auth}>
         <Suspense fallback={<div>Loading...</div>}>{props.children}</Suspense>
       </Provider>
     );

--- a/packages/react/src/GadgetProvider.tsx
+++ b/packages/react/src/GadgetProvider.tsx
@@ -26,6 +26,7 @@ export interface GadgetAuthConfiguration {
 export interface GadgetConfigurationContext {
   api: AnyClient | undefined;
   auth: GadgetAuthConfiguration;
+  navigate?: (path: string) => void;
 }
 
 /**
@@ -33,7 +34,12 @@ export interface GadgetConfigurationContext {
  */
 export const GadgetConfigurationContext = React.createContext<GadgetConfigurationContext | undefined>(undefined);
 
-export interface ProviderProps {
+interface BaseProviderProps {
+  children: ReactNode;
+  navigate?: (path: string) => void;
+}
+
+export interface ProviderProps extends BaseProviderProps {
   /**
    * An instance of your app's api client, often named `api`. This is the object that contains all of your generated query/mutation/subscription functions.
    *
@@ -48,17 +54,15 @@ export interface ProviderProps {
    */
   api: AnyClient;
   auth?: Partial<GadgetAuthConfiguration>;
-  children: ReactNode;
 }
 
 /** @deprecated -- pass an instance of your app's api client instead with the `api` prop */
-export interface DeprecatedProviderProps {
+export interface DeprecatedProviderProps extends BaseProviderProps {
   /**
    * an urql client object from your current Gadget client, like `api.connection.currentClient`
    * @deprecated -- pass an instance of your app's api client instead with the `api` prop
    */
   value: UrqlClient;
-  children: ReactNode;
 }
 
 const defaultSignInPath = "/";
@@ -126,6 +130,7 @@ export function Provider(props: ProviderProps | DeprecatedProviderProps) {
       <GadgetConfigurationContext.Provider
         value={{
           api: gadgetClient,
+          navigate: props.navigate,
           auth: {
             signInPath,
             signOutActionApiIdentifier,

--- a/packages/react/src/auth/SignedInOrRedirect.tsx
+++ b/packages/react/src/auth/SignedInOrRedirect.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import React, { useContext, useEffect, useState } from "react";
 import { GadgetConfigurationContext } from "../GadgetProvider.js";
 import { useAuth } from "./useAuth.js";
+import { windowNavigate } from "./utils.js";
 
 /**
  * Renders its `children` if the current `Session` is signed in, otherwise redirects the browser to the `signInPath` configured in the `Provider`. Uses `window.location.assign` to perform the redirect.
@@ -19,7 +20,9 @@ export const SignedInOrRedirect = (props: { path?: string; children: ReactNode }
       const redirectPath = props.path ?? auth.signInPath;
       const redirectUrl = new URL(redirectPath, window.location.origin);
       redirectUrl.searchParams.set("redirectTo", window.location.pathname);
-      window.location.assign(redirectUrl.toString());
+
+      const navigate = context?.navigate ?? windowNavigate;
+      navigate(`${redirectUrl.pathname}${redirectUrl.search}`);
     }
   }, [props.path, redirected, isSignedIn, auth, user]);
 

--- a/packages/react/src/auth/SignedOutOrRedirect.tsx
+++ b/packages/react/src/auth/SignedOutOrRedirect.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import React, { useContext, useEffect, useState } from "react";
 import { GadgetConfigurationContext } from "../GadgetProvider.js";
 import { useAuth } from "./useAuth.js";
+import { windowNavigate } from "./utils.js";
 
 /**
  * Renders its `children` if the current `Session` is signed out, otherwise redirects the browser to the `path` prop. Uses `window.location.assign` to perform the redirect.
@@ -20,7 +21,9 @@ export const SignedOutOrRedirect = (props: { path?: string; children: ReactNode 
       const searchParams = new URLSearchParams(window.location.search);
       const redirectPath = searchParams.get("redirectTo") ?? path ?? auth?.redirectOnSuccessfulSignInPath ?? "/";
       const redirectUrl = new URL(redirectPath, window.location.origin);
-      window.location.assign(redirectUrl.toString());
+
+      const navigate = context?.navigate ?? windowNavigate;
+      navigate(`${redirectUrl.pathname}${redirectUrl.search}`);
     }
   }, [redirected, isSignedIn, path, user, auth]);
 

--- a/packages/react/src/auth/utils.ts
+++ b/packages/react/src/auth/utils.ts
@@ -7,3 +7,7 @@ export const isSessionSignedOut = (session: GadgetSession) => {
 export const isSessionSignedIn = (session: GadgetSession) => {
   return !isSessionSignedOut(session);
 };
+
+export function windowNavigate(path: string) {
+  return window.location.assign(path);
+}


### PR DESCRIPTION
By default our components that control navigation `SignInOrRedirect`/`SignOutOrRedirect` use `window.location`. This causes window reloads and flashes of unstyled content. We can't make assumptions about an app's routing system, so we should allow consumers to pass in a custom navigate function that we'll use.

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
