### PR TITLE
update useSignout to also use navigate prop if possible

### DIFF
--- a/packages/react/src/auth/useSignOut.ts
+++ b/packages/react/src/auth/useSignOut.ts
@@ -1,7 +1,8 @@
-import { useCallback, useContext } from "react";
+import { useCallback, useContext, useEffect } from "react";
 import { GadgetConfigurationContext, useApi } from "../GadgetProvider.js";
 import { useAction } from "../useAction.js";
 import { useUser } from "./useUser.js";
+import { windowNavigate } from "./utils.js";
 
 /**
  * Returns a callback that will call the configured `signOutActionApiIdentifier` on the `User` model and optionally redirect (by default). Throws an `error` if one occurs while performing the `signOut` action, or if the `User` is not signed in.
@@ -23,10 +24,14 @@ export const useSignOut = (opts?: { redirectOnSuccess?: boolean; redirectToPath?
 
     if (error) throw error;
 
-    if (redirectOnSuccess && data) {
-      const redirectUrl = new URL(redirectToPath ?? signInPath, window.location.origin);
-      window.location.assign(redirectUrl.toString());
-    }
+    // eslint-disable-next-line
+    useEffect(() => {
+      if (redirectOnSuccess && data) {
+        const redirectUrl = new URL(redirectToPath ?? signInPath, window.location.origin);
+        const navigate = context?.navigate ?? windowNavigate;
+        navigate(`${redirectUrl.pathname}${redirectUrl.search}`);
+      }
+    }, [data]);
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return useCallback(async () => {


### PR DESCRIPTION
Missed `useSignout` when updating components to use the `navigate` prop

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
