### PR TITLE
Update environment type to string

### DIFF
--- a/packages/api-client-core/src/ClientOptions.ts
+++ b/packages/api-client-core/src/ClientOptions.ts
@@ -30,7 +30,7 @@ export interface ClientOptions {
   /**
    * Which of the Gadget application's environments this connection should connect to
    **/
-  environment?: "Development" | "Production";
+  environment?: string;
   /**
    * The ID of the application. Not required -- only used for emitting telemetry
    **/

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -43,7 +43,7 @@ export interface GadgetConnectionOptions {
   subscriptionClientOptions?: GadgetSubscriptionClientOptions;
   websocketImplementation?: any;
   fetchImplementation?: typeof globalThis.fetch;
-  environment?: "Development" | "Production";
+  environment?: string;
   requestPolicy?: ClientOptions["requestPolicy"];
   applicationId?: string;
   baseRouteURL?: string;
@@ -77,7 +77,7 @@ export class GadgetConnection {
   private websocketsEndpoint: string;
   private websocketImplementation?: WebSocket;
   private _fetchImplementation: typeof globalThis.fetch;
-  private environment: "Development" | "Production";
+  private environment: string;
   private exchanges: Required<Exchanges>;
 
   // the base client using HTTP requests that non-transactional operations will use


### PR DESCRIPTION
In an n-environment world we aren't limited to simply development and productions thus we should accept any string. We still handle normalizing the environments in gadget when generate the client so I think is fine to change.

closes GGT-5386

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
