### PR TITLE
Add support for endpoints with existing query params

### DIFF
--- a/packages/api-client-core/src/exchanges/urlParamExchange.ts
+++ b/packages/api-client-core/src/exchanges/urlParamExchange.ts
@@ -2,8 +2,15 @@ import { mapExchange } from "@urql/core";
 
 export const urlParamExchange = mapExchange({
   onOperation: (operation) => {
-    if (operation.context.url && operation.context.operationName && !operation.context.url.includes("?")) {
-      operation.context.url += `?operation=${operation.context.operationName}`;
+    if (operation.context.url && operation.context.operationName) {
+      try {
+        const [start, params] = operation.context.url.split("?");
+        const paramsObj = new URLSearchParams(params);
+        paramsObj.set("operation", operation.context.operationName);
+        operation.context.url = `${start}?${paramsObj.toString()}`;
+      } catch (error) {
+        // not able to parse URL params, just don't add this optional param and let the rest of the system react to the invalid URL
+      }
     }
   },
 });


### PR DESCRIPTION
This is useful for gadget internally passing endpoints with existing query params to use for tagging, which we're gonna use for the consistent hashing business

## PR Checklist

- [X] Important or complicated code is tested
- [X] Any user facing changes are documented in the Gadget-side changelog
- [X] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [X] Versions within this monorepo are matching and there's a valid upgrade path
