### PR TITLE
Add support for calling fields with arguments

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "files": [
     "Readme.md",
     "dist/**/*"
@@ -37,7 +37,7 @@
     "graphql-ws": "^5.13.1",
     "isomorphic-ws": "^5.0.0",
     "klona": "^2.0.6",
-    "tiny-graphql-query-compiler": "^0.2.2",
+    "tiny-graphql-query-compiler": "^0.2.3",
     "tslib": "^2.6.2",
     "ws": "^8.13.0"
   },

--- a/packages/api-client-core/spec/TestSchema.ts
+++ b/packages/api-client-core/spec/TestSchema.ts
@@ -32,11 +32,37 @@ export type TestSchema = {
       }[]
     | null;
   someConnection: {
+    ["$args"]: {
+      first?: number;
+      last?: number;
+      before?: string;
+      after?: string;
+    };
     edges:
       | ({
           node: {
             id: string;
             state: string;
+            children: {
+              ["$args"]: {
+                first?: number;
+                last?: number;
+                before?: string;
+                after?: string;
+              };
+              pageInfo: {
+                hasNextPage: boolean;
+                hasPreviousPage: boolean;
+              };
+              edges:
+                | ({
+                    node: {
+                      id: string;
+                      state: string;
+                    };
+                  } | null)[]
+                | null;
+            };
           } | null;
         } | null)[]
       | null;

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -1,4 +1,4 @@
-import { actionOperation, findManyOperation, findOneByFieldOperation, findOneOperation } from "../src/index.js";
+import { Call, actionOperation, findManyOperation, findOneByFieldOperation, findOneOperation } from "../src/index.js";
 
 describe("operation builders", () => {
   describe("findOneOperation", () => {
@@ -52,6 +52,41 @@ describe("operation builders", () => {
             __typename
             id
             state
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {
+            "id": "123",
+          },
+        }
+      `);
+    });
+
+    test("findOneOperation should build a query with a call in it", () => {
+      expect(
+        findOneOperation(
+          "widget",
+          "123",
+          { __typename: true, id: true, state: true, gizmos: Call({ first: 10 }, { edges: { node: { id: true } } }) },
+          "widget",
+          { live: true }
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "query widget($id: GadgetID!) @live {
+          widget(id: $id) {
+            __typename
+            id
+            state
+            gizmos(first: 10) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
           }
           gadgetMeta {
             hydrations(modelName: "widget")
@@ -248,6 +283,92 @@ describe("operation builders", () => {
                 __typename
                 id
                 state
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("findManyOperation should build a query with arguments in it", () => {
+      expect(
+        findManyOperation(
+          "widgets",
+          { __typename: true, id: true, state: true, gizmos: Call({ first: 10, after: "foobar" }, { edges: { node: { id: true } } }) },
+          "widget",
+          { live: true }
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) @live {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                __typename
+                id
+                state
+                gizmos(first: 10, after: "foobar") {
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("findManyOperation should build a query with a call but no arguments", () => {
+      expect(
+        findManyOperation(
+          "widgets",
+          { __typename: true, id: true, state: true, gizmos: Call({}, { edges: { node: { id: true } } }) },
+          "widget",
+          { live: true }
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) @live {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                __typename
+                id
+                state
+                gizmos {
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
               }
             }
           }
@@ -568,6 +689,52 @@ describe("operation builders", () => {
               }
             }
             results
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("actionOperation should build a mutation query for a result that has a call in it", () => {
+      expect(
+        actionOperation(
+          "createWidget",
+          { __typename: true, id: true, state: true, gizmos: Call({ first: 10 }, { edges: { node: { id: true } } }) },
+          "widget",
+          "widget",
+          {}
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "mutation createWidget {
+          createWidget {
+            success
+            errors {
+              message
+              code
+              ... on InvalidRecordError {
+                validationErrors {
+                  message
+                  apiIdentifier
+                }
+              }
+            }
+            widget {
+              __typename
+              id
+              state
+              gizmos(first: 10) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
           }
           gadgetMeta {
             hydrations(modelName: "widget")

--- a/packages/api-client-core/src/FieldSelection.ts
+++ b/packages/api-client-core/src/FieldSelection.ts
@@ -1,7 +1,26 @@
+import { FieldCall as QueryCompilerFieldCall } from "tiny-graphql-query-compiler";
+
+/** Object capturing the call arguments for a call to a field in a selection */
+export class FieldCall<
+  Args extends Record<string, any>,
+  Subselection extends FieldSelection | null | undefined,
+  Schema = unknown
+> extends QueryCompilerFieldCall {
+  constructor(readonly args: Args, readonly subselection?: Subselection) {
+    super(args, subselection);
+  }
+}
+
+/** Use this to pass a GraphQL field arguments in the `select` param */
+export const Call = <Args extends Record<string, any>, Subselection extends FieldSelection | null | undefined, Schema = unknown>(
+  args: Args,
+  subselection?: Subselection
+) => new FieldCall<Args, Subselection, Schema>(args, subselection);
+
 /**
  * Represents a list of fields selected from a GraphQL API call. Allows nesting, conditional selection.
  * Example: `{ id: true, name: false, richText: { markdown: true, html: false } }`
  **/
 export interface FieldSelection {
-  [key: string]: boolean | null | undefined | FieldSelection;
+  [key: string]: boolean | null | undefined | FieldSelection | FieldCall<any, any, any>;
 }

--- a/packages/tiny-graphql-query-compiler/package.json
+++ b/packages/tiny-graphql-query-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-graphql-query-compiler",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/tiny-graphql-query-compiler/src/index.ts
+++ b/packages/tiny-graphql-query-compiler/src/index.ts
@@ -14,7 +14,7 @@ const compileFieldSelection = (fields: FieldSelection): string[] => {
     .flatMap(([field, value]) => {
       if (typeof value === "boolean") {
         return value ? field : false;
-      } else if (value instanceof FieldCall) {
+      } else if (isFieldCall(value)) {
         let args = "";
         const signatures = Object.entries(value.args)
           .filter(([_, value]) => value !== null && value !== undefined)
@@ -78,9 +78,12 @@ const compileVariables = (operation: BuilderOperation) => {
   return `(${signatures.join(", ")})`;
 };
 
-class FieldCall {
-  constructor(readonly args: Record<string, any>, readonly subselection?: FieldSelection) {}
+const kIsCall = Symbol.for("gadget/isCall");
+export class FieldCall {
+  [kIsCall] = true as const;
+  constructor(readonly args: Record<string, any>, readonly subselection?: FieldSelection | null) {}
 }
+const isFieldCall = (value: any): value is FieldCall => value && value[kIsCall];
 
 export interface VariableOptions {
   type: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         specifier: ^2.0.6
         version: 2.0.6
       tiny-graphql-query-compiler:
-        specifier: ^0.2.2
+        specifier: ^0.2.3
         version: link:../tiny-graphql-query-compiler
       tslib:
         specifier: ^2.6.2


### PR DESCRIPTION
GraphQL supports fields at arbitrary depths that take arguments. We already support passing args at the base-most level of a query, like with:

```typescript
await api.widget.findMany({filter: { ... }});
```

but, GraphQL supports sending args at any depth at all! For example, you might want to fetch a filtered list of widgets, and their child gizmos, and filter the list of gizmos for each widget as well! In GraphQL, this looks like:

```graphql
query {
 widgets(filter: { inventoryCount: { greaterThan: 10 } }) {
   edges {
     node {
       id
       inventoryCount
       gizmos(first: 10, filter: { published: { equals: true } }) {
         edges {
           node {
             id
             published
           }
        }
      }
    }
  }
}
```

We don't currently support this in the JS client, even though our GraphQL schema supports it fine. The main use case is adjusting how many child records you get back for each parent on a nested fetch, as well as filtering those child records, and asks in discord have cropped up a bunch for this. In this code snippet, where do you put arguments for gizmos?:

```typescript
// before, no calls supported
await api.widget.findMany({
  select: {
    id: true,
    name: true,
   // how pass args right here?
    gizmos: {
      edges: {
        node: {
          id: true,
          published: true,
        }
      }
    }
  }
});
```

This adds a thing to do this just this! There's two parts to it: knowing which fields take arguments, which we currently don't really describe, and then adding a JS-land syntax for passing calls at an arbitrary place in the selection. I chose to do this with a new primitive that looks like this:

```typescript
import { Call } from "@gadget-client/kitchen-sink";

await api.widget.findMany({
  select: {
    id: true,
    name: true,
    gizmos: Call({
      first: 10,
      filter: { published: { equals: true } },
    }, {
      edges: {
        node: {
          id: true,
          published: true,
        }
      }
    })
  }
});
```

What I like about this is that it isn't a breaking change, and you only have to deal with it once you start caring about calling fields -- selections remain nice and simple in the general case. I don't love it though, its a bit weird to mix objects into the tree like this, and it sucks that you still need to care about edges and nodes for connections, which I think will be the lion's share of the use case.

Also tricky is making this typesafe. Args like this don't really affect the output type, but ideally, the arguments you did pass are typechecked too. Currently, the `Select<>` type helper traverses a `Schema` type that looks like this:

```typescript
export type Schema = {
  widgets: { 
    edges: {
      node: { 
        id: string;
        name: string;
        gizmos: {
          edges: { 
            node: { 
              id: string;
              name: string;
```

which doesn't describe the type of the arguments. We need to get them in somehow. We could make a breaking change to this type, but in case anyone is importing it, and to lower the risk we accidentally break something, I would love to keep the structure of this schema type largely the same. Open to other ideas, but I propose we change the generated type Gadget side to look like this:

 ```typescript
export type Schema = {
  widgets: { 
    ["$args"]: {
      first: number;
      last: number;
      after: string;
      before: string;
      filter: WidgetFilter;
    };
    edges: {
      node: { 
        id: string;
        name: string;
        gizmos: {
          ["$args"]: {
            first: number;
            last: number;
            after: string;
            before: string;
            filter: GizmosFilter;
           };
          edges: { 
            node: { 
              id: string;
              name: string;
```

Field Identifiers starting with `$` are illegal in GraphQL, so we know there will never be a field named `$args`, and can thusly stash the types there. Then, the `Select<>` type gets a bit smarter and starts looking for `Call` objects, and inspecting for args if there are any.

## PR Checklist

- [X] Important or complicated code is tested
- [X] Any user facing changes are documented in the Gadget-side changelog
- [X] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [X] Versions within this monorepo are matching and there's a valid upgrade path
