### PR TITLE
add: rate limit error handling

### DIFF
--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -24,6 +24,10 @@ import {
 } from "./support.js";
 
 export type TransactionRun<T> = (transaction: GadgetTransaction) => Promise<T>;
+
+export enum GadgetGraphQLCloseCode {
+  TooManyRequests = 4294,
+}
 export interface GadgetSubscriptionClientOptions extends Partial<SubscriptionClientOptions> {
   urlParams?: Record<string, string | null | undefined>;
   connectionAttempts?: number;
@@ -502,8 +506,8 @@ export class GadgetConnection {
 
       const retryOnClose = (event: unknown) => {
         if (isCloseEvent(event)) {
-          if (event.code == 4294) {
-            resetListeners();
+          if (event.code == GadgetGraphQLCloseCode.TooManyRequests) {
+            clearListeners();
             return wrappedReject(new GadgetTooManyRequestsError(event.reason));
           }
 

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -502,7 +502,8 @@ export class GadgetConnection {
 
       const retryOnClose = (event: unknown) => {
         if (isCloseEvent(event)) {
-          if (event.code == 4429) {
+          if (event.code == 4294) {
+            resetListeners();
             return wrappedReject(new GadgetTooManyRequestsError(event.reason));
           }
 

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -96,6 +96,19 @@ export class GadgetWebsocketConnectionTimeoutError extends Error {
 }
 
 /**
+ * A Gadget API error when there are more requests sent in the alloted time window then permitted
+ */
+export class GadgetTooManyRequestsError extends Error {
+  code = "GGT_TOO_MANY_REQUESTS";
+  name = "TooManyRequestsError";
+
+  /** @private */
+  statusCode = 429;
+  /** @private */
+  causedByClient = false;
+}
+
+/*
  * A Gadget API error representing a backend validation error on the input data for an action. Thrown when any of the validations configured on a model fail for the given input data. Has a `validationErrors` property describing which fields failed validation, with messages for each.
  **/
 export class InvalidRecordError extends Error {


### PR DESCRIPTION
This change implements handling rate limit errors on the GadgetConnection clientside communicating to the core Gadget API over websockets.  The  server sends a rate limit code and closes the websocket over the wire.


