### PR TITLE
Add support to useActionForm to handle nested relationships

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   "devDependencies": {
     "@gadget-client/app-with-no-user-model": "^1.5.0",
     "@gadget-client/bulk-actions-test": "^1.104.0",
-    "@gadget-client/related-products-example": "^1.854.0",
     "@gadget-client/full-auth": "^1.4.0",
+    "@gadget-client/related-products-example": "^1.859.0",
+    "@gadget-client/zxcv-deeply-nested": "^1.207.0",
+    "@gadget-client/zxcv-simple-relationship": "^1.17.0",
     "@gadgetinc/api-client-core": "workspace:*",
     "@gadgetinc/eslint-config": "^0.6.1",
     "@gadgetinc/prettier-config": "^0.4.0",
@@ -44,7 +46,7 @@
     "prettier": "^2.8.8",
     "semver": "^7.3.8",
     "ts-node": "^10.9.1",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "zx": "^7.1.1"
   },
   "pnpm": {

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -27,7 +27,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.11",
+    "@gadgetinc/api-client-core": "^0.15.13",
     "@shopify/app-bridge-utils": "^3.1.1",
     "crypto-js": "^4.1.1"
   },
@@ -47,7 +47,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@gadgetinc/react": "^0.14.1",
+    "@gadgetinc/react": "^0.15.0",
     "@shopify/app-bridge": "^2.0.0 || ^3.0.0",
     "@shopify/app-bridge-react": "^2.0.0 || ^3.0.0",
     "react": "^18.0.0",

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -132,7 +132,7 @@ export default {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: "./spec/jsdom-environment.ts",
+  testEnvironment: "setup-polly-jest/jest-environment-jsdom",
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.14.16",
+  "version": "0.15.0",
   "files": [
     "README.md",
     "dist/**/*"
@@ -28,7 +28,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.11",
+    "@gadgetinc/api-client-core": "^0.15.13",
     "react-fast-compare": "^3.2.2",
     "react-hook-form": "~7.48.2",
     "urql": "^4.0.4"
@@ -39,6 +39,11 @@
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",
     "@n1ru4l/json-patch-plus": "^0.2.0",
+    "@pollyjs/adapter-fetch": "^6.0.6",
+    "@pollyjs/adapter-node-http": "^6.0.6",
+    "@pollyjs/adapter-xhr": "^6.0.6",
+    "@pollyjs/core": "^6.0.6",
+    "@pollyjs/persister-fs": "^6.0.6",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.5.1",
@@ -47,6 +52,7 @@
     "@types/node": "^18.0.0",
     "@types/react": "^18.2.9",
     "@types/react-dom": "^18.2.4",
+    "@types/setup-polly-jest": "^0.5.5",
     "@urql/core": "^4.0.10",
     "conditional-type-checks": "^1.0.6",
     "graphql": "^16.8.1",
@@ -54,6 +60,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "setup-polly-jest": "^0.11.0",
     "wonka": "^6.3.2"
   },
   "peerDependencies": {

--- a/packages/react/spec/FormInput-type.spec.ts
+++ b/packages/react/spec/FormInput-type.spec.ts
@@ -1,0 +1,45 @@
+import type { AssertTrue, IsExact } from "conditional-type-checks";
+import type { FormInput } from "./../src/useActionForm.js";
+
+describe("FormInput", () => {
+  type _scalarFormInput = AssertTrue<IsExact<FormInput<number>, number | null | undefined>>;
+  const _scalarForm: FormInput<number> = 1;
+
+  type _arrayFormInput = AssertTrue<IsExact<FormInput<number[]>, (number | null | undefined)[]>>;
+  const _arrayForm: FormInput<number[]> = [1, 2, 3];
+
+  type _anyTypeFormInput = AssertTrue<IsExact<FormInput<any>, any>>;
+
+  type _objectFormInput = AssertTrue<
+    IsExact<
+      FormInput<{ create?: { name?: string }; update?: { id?: number } }>,
+      { name?: string | null | undefined } | { id?: number | null | undefined } | null | undefined
+    >
+  >;
+
+  type _objectNestedFormInput = AssertTrue<
+    IsExact<
+      FormInput<{ name?: string; inventoryCount?: number; gizmos?: { create?: { name?: string }; update?: { id?: number } } }>,
+      {
+        name?: string | null | undefined;
+        inventoryCount?: number | null | undefined;
+        gizmos?: { name?: string | null | undefined } | { id?: number | null | undefined } | null | undefined;
+      }
+    >
+  >;
+
+  type _depthGuard1 = AssertTrue<
+    IsExact<FormInput<{ a: { b: { c: { d: { e: { f: { g: { h: { i: { id: string } } } } } } } } } }, 1>, { a: any }>
+  >;
+  type _depthGuard2 = AssertTrue<
+    IsExact<FormInput<{ a: { b: { c: { d: { e: { f: { g: { h: { i: { id: string } } } } } } } } } }, 2>, { a: { b: any } }>
+  >;
+  type _depthGuard3 = AssertTrue<
+    IsExact<FormInput<{ a: { b: { c: { d: { e: { f: { g: { h: { i: { id: string } } } } } } } } } }, 3>, { a: { b: { c: any } } }>
+  >;
+  type _depthGuard4 = AssertTrue<
+    IsExact<FormInput<{ a: { b: { c: { d: { e: { f: { g: { h: { i: { id: string } } } } } } } } } }, 4>, { a: { b: { c: { d: any } } } }>
+  >;
+
+  test("true", () => undefined);
+});

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship-with-support-for-Id-pre_1709343723/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship-with-support-for-Id-pre_1709343723/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create a single HasMany -> HasMany -> HasOne -> BelongsTo relationship with support for Id prefix",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "cf3c4a593907da2a1d1b4e65688bb5e9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 893,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "893"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"shopifyProducts\",\"query\":\"query shopifyProducts($after: String, $first: Int, $before: String, $last: Int) {\\n  shopifyProducts(after: $after, first: $first, before: $before, last: $last) {\\n    pageInfo {\\n      hasNextPage\\n      hasPreviousPage\\n      startCursor\\n      endCursor\\n      __typename\\n    }\\n    edges {\\n      cursor\\n      node {\\n        __typename\\n        body\\n        compareAtPriceRange\\n        createdAt\\n        handle\\n        id\\n        productCategory\\n        productType\\n        publishedAt\\n        publishedScope\\n        shopifyCreatedAt\\n        shopifyUpdatedAt\\n        status\\n        tags\\n        templateSuffix\\n        title\\n        updatedAt\\n        vendor\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"shopifyProduct\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"first\":1}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "shopifyProducts"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
+        },
+        "response": {
+          "bodySize": 747,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 747,
+            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twEgVKboitVlTqCi3spdWqGuJJ8G6wLdtBRBX/vkoaaEITyi3KvPdm3vPYbwNCKAcHNCJvA0IIoXartEiKpVE8j509FwihGlJcyEQ1/hFCt2B/4sEtIUUakQQyi99a1aXBvVC57UFYB8bNc2OVoRGhWDzq5/livPj7UDwVj1PagKLktwFfX12hUcKubEiXp7lrwPGEpMhTLC2+nKkfxgih8S3NCKFScWyF0jHEqpVri08I3SheVH0OsNMZkj1kOZJEGVJVLtCx2mkwOHNLI2L8BbIKVuZZdgk0CA75zJXaPvODO8+/8/y1N458P/LDIWPe86X6FiTPegQFL5U8P7gk6Xdfc3CYKlN0s2vQutA98jrfZMJu64mvAVax6hOpN3je5Z15axZGjEWMDRljn7zX3N+an7ldHRy43HbXHKR9FdzpDByu8iQRhx6McH3R542Zbj7LPUpebXAp2CgdW/t7bVMfeIr0DD7WX3/OV+gad66kxNgJJd8V6g==\",\"rjQFnqJ7wsa7U+5dwQ2UYNt+YLrO8zs4XIsdNi99e3k6IfFXGq2QuwAdC/KB+/S+tMP5UdmeaZ2JuDJaJTA45VrRKB4cSttKgWaq2im6dU7baDRKUzfMhPw3KgsjL2Rjdj8KQi/YsCAJN+NJHIT3fjBhU5zCxBtPAT2/dkGdgRgX1T3+klJONTj+BwAA//8DAK3C9bwmBgAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "7d842e9dfdc244ffe5b1d849a5db2955"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "3513b03f5b67c35823709e9a7169ae12"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=Il4pJv%2Fyc0%2FNtBq8E6dAlCRh3G5OyJz9z%2B2v6DaQJUvOC30NZj5FHywM2LY9kgqZAn6ZhtMZJ5ZMX0yAUrtF4gP1MoCMagPqEzkyYHT3Kr8nLLa7blQ48%2FmlL5fhOaVa2JQygnZ24bPTd426i8t6voYKqLgFJm3rbyRIFA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e953898fc356-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:56.967Z",
+        "time": 141,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 141
+        }
+      },
+      {
+        "_id": "be0fd31a4adea3fe07ef99136eeacddd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 772,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "772"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVYFEQbqZNmh56aOOpF7OyA5Ii4O6QaI3/vWGlVJo09rhv3pv5ZvbsAKCSLDGBswMAgKkmyfTaFp+DBoCmTVMyBhNg3dLkWyata92pVVuWg3oYhwFws+FTQ5XcEyaAtvnkp3odqVbcFYUngqkvpv58LUQSBMkimgWReL8NFMo6w/mtyHS0DZgMw+HXiLZR/xjR+y/DJmPuh+E0b2Takq/+3o25VDnxC90cEwB3J6UlF3VlxhcZ7fwomdbFnv4kHgx3CJ8sw6ppyiK1Uy3OFdPpY0hHpsqMkLCs8+6FO+bGJK6b5zwri+rD7Qquv/BCb+lmIhIUx/PY20a0DZdLFYVZrDLfi7Mw9WWPj6xlSs/2j+5GOirn8gUAAP//AwDqaRb/iAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "5acae61dd4ac99a53445b8098b27d17b"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "f272e99490b7eb688d76f9df109f6c1a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=MD5KTZr0xpbdri3uNiMfKpqrRng385WtclDl%2F2K9KmZt0MKtylvU4OA9cgqpKDa3pZGn30RD2b5Kq%2BcuK34Ou3uBEvGBSrlDtGiPY1ONQMKaQVoN0PhU7mBD5ZI1RA3Tf0qRpXCeQZQxHztRO6N9eKHYzSVR%2BlQesYvj%2BA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e954992d0f8c-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:57.141Z",
+        "time": 306,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 306
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship_3235963512/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship_3235963512/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create a single HasMany -> HasMany -> HasOne -> BelongsTo relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "cf3c4a593907da2a1d1b4e65688bb5e9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 893,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "893"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"shopifyProducts\",\"query\":\"query shopifyProducts($after: String, $first: Int, $before: String, $last: Int) {\\n  shopifyProducts(after: $after, first: $first, before: $before, last: $last) {\\n    pageInfo {\\n      hasNextPage\\n      hasPreviousPage\\n      startCursor\\n      endCursor\\n      __typename\\n    }\\n    edges {\\n      cursor\\n      node {\\n        __typename\\n        body\\n        compareAtPriceRange\\n        createdAt\\n        handle\\n        id\\n        productCategory\\n        productType\\n        publishedAt\\n        publishedScope\\n        shopifyCreatedAt\\n        shopifyUpdatedAt\\n        status\\n        tags\\n        templateSuffix\\n        title\\n        updatedAt\\n        vendor\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"shopifyProduct\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"first\":1}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "shopifyProducts"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
+        },
+        "response": {
+          "bodySize": 747,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 747,
+            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twQkGQG2KrFZW6Qgt7abWqBnsSsmtsy3YQUcW/r5IGmtCEcosy772ZeX72W48QKsADjchbjxBCqNtqk8b50mqRce/OBUKogQQXKta1f4TQLbifePBLSJBGJAbp8FujurS4T3XmOhDOg/XzzDptaUQo5o/meb4YL/4+5E/545TWoKjEbcDXV58bVLArGtLlae4KcDwhKYoEixVfztSPxQih/JZmhFClBTZMaRli1fC1wSeEbrTIyz4H2BmJZA8yQxJrS8rKBZrrnQGLM7+0KcdfoEpjVSblJdAieBQzX2iHLBzeBeFdEK6DcRSGUTjqMxY8X6pvQQnZIZiKQikIh5ck877XHDwm2ubt7Aq0zk2HvMk2MnXbauJrgBXXXSJVgudtu7NgzUYRYxFjfcbYp90r7m8jzty2Dh585tprHpKuCu6MBI+rLI7TQwcm9V3WZ7WZbj7LPSpRJrgQrJWOjfxeS+qDSJCewcfq68/5Cl3jzrVSyH2q1bs=\",\"QtWVJiAS9E9Ye3eK3OXCQgF2zQem7Ty/g8d1usP6pW+GpxXCv9JomNwGaAnIB+7T+9I050e59swYmfJy0dKB3snXkkbx4FG5hgtU6jJTdOu9cdFgkCS+L1P1b1AUBsGIjdlkEE/v78PJKBYceDANJ2OOHNg0HAWb6XDDTzeWegscF+U9/pJSTNU7/gcAAP//AwDAFcFCJgYAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:55 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "143be2b9f4327af7b618f2ae3d2ba1ca"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "f944285fdcac19286ceca09251b93bc3"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=ZylCK2XuRsxQ5WAnowwcyFWdlo3FKxq4tkxUsQ%2Fn4sobvR8Mf3AFQIiiI9Az6DxnjxY77sgpWw6WqiRwAhSrTK8j%2FvPpVn3BTg0IcM6IBR%2FtcI1UKABlB1WJYF%2BFGhIGaO20pKZ1U4gTMf1fJuwGdcNtP%2BsBe0YtjwAhWA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e94c2c658cd4-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 949,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:55.800Z",
+        "time": 144,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 144
+        }
+      },
+      {
+        "_id": "be0fd31a4adea3fe07ef99136eeacddd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 772,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "772"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9AkxRK1xvapGmHHTZx2gVljSnVSimJK8EQ/31q6Do6aWLHPL9nf3ZOAQAazRpTOAUAAJhZ0kwvTfHZawDomiwj5zAFtg2NvmWydmdbtWrKslf3wzAArlZ8rKnSW8IU0Dcf/VQvI82C26ISKhpLNZbTpVJpFKWzeBLNkrfrQGG8M1bXItPBN2ByDPtfI5ra/GNE5z/3mwy57/vTvJJrSr74Ozfm2uTEz3R1TADcHI3VXOwqN7zIYOcHzbQstvQncW+4QfjoGRZ1XRaZn+pxLphBF0M6MFVugITlLm9fuGGuXRqGec6Tsqg+wrYQypmIRRLG0+xurt9jmUg5XydSqLkW8dqQNkKsSXb4yFZn9OT/6GakpQrOXwAAAP//AwDK+TbviAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:56 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "4210084abc8d4500c716b4d4697cb75f"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "64c97ab618117f81027a06fdead00fe1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=vbb4PiMm86gS5xb7V0nRuOg2Lss4yU5R3DGeSlbADGfX63hIuD0Svb6f8VxVwPeiIaUjadRGlEBCWn3TQn34Dcl%2FOHzDTGiQTOALkz9UhFVnRlDxHw%2FgG5pUHwp5FL2D0Gg0kNafUl2FXWQMOcrnikwd5D9%2BoPh3ZjQ3%2BA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e94d8e7b426d-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:56.021Z",
+        "time": 408,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 408
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship-with-support-f_3501493881/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship-with-support-f_3501493881/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create a single HasMany -> HasMany -> HasOne -> multiple BelongsTo relationship with support for Id prefix",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "cf3c4a593907da2a1d1b4e65688bb5e9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 893,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "893"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"shopifyProducts\",\"query\":\"query shopifyProducts($after: String, $first: Int, $before: String, $last: Int) {\\n  shopifyProducts(after: $after, first: $first, before: $before, last: $last) {\\n    pageInfo {\\n      hasNextPage\\n      hasPreviousPage\\n      startCursor\\n      endCursor\\n      __typename\\n    }\\n    edges {\\n      cursor\\n      node {\\n        __typename\\n        body\\n        compareAtPriceRange\\n        createdAt\\n        handle\\n        id\\n        productCategory\\n        productType\\n        publishedAt\\n        publishedScope\\n        shopifyCreatedAt\\n        shopifyUpdatedAt\\n        status\\n        tags\\n        templateSuffix\\n        title\\n        updatedAt\\n        vendor\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"shopifyProduct\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"first\":1}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "shopifyProducts"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
+        },
+        "response": {
+          "bodySize": 743,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 743,
+            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twwoIgN8RWFZW6Qgt76WpVDfEkpBtsy54goop/XyUNNKEJ5RZl3nsz73nstx5jXAIBD9hbjzHGuNtqk0T50mqZheTOBca4gRgXKtK1f4zxLbifeKAlxMgDFkHq8FujurS4T3TmOhCOwNI8s05bHjCO+aN5ni/Gi9f7/Cl/nPIaFJW8DfjyQrlBBbuiIV+e5q4AxxOSo4yxsPjnTP0wxhgPb2nGGFdaYiOUliFWjVwbfMb4Rsu87HOAnUmR7SHNkEXasrJygQ71zoDFGS1tEuIvUGWwKkvTS6BFIJQzKrR94Q/vPP/O89feOPD9wB/1hfCeL9W3oGTaIZjIQsnzh5ck8+5rDoSxtnk7uwKtc9Mhb7JNmrhtNfE1wCrUXSLVBs/bvAtvLUaBEIEQfSHEJ+8V97eRZ25bBwLKXHuNIO6q4M6kQLjKoig5dGAS6oo+q81081nuUclygwvBWunY2N9rm3ovY+Rn8LH6+nu+Qte4c60UhpRo\",\"9a5QdeUxyBjpCWvvTrF3ubRQgF3zgWk7zx9AuE52WL/0zeVphYRfaTRCbgO0LMgH7tP70gznobQ9MyZNwtJomUDvlGtJ43ggVK6RAk91uVN8S2RcMBjEMfXTRP0bFIWBNxJjMRkMN1M5nUTRdx/QH4koDBGEHG+kPxwjbiaVC04WQlyU9/hLSjFV7/gfAAD//wMA0R3SfyYGAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "086962d1925cf28f2a6a45a9cd6932a1"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "3b9d98ff42ae250fccea0d6bd236eeb8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=hwyOuMywrvUv3njL5Vxhmz38hvgservqWOU%2BEDx6VO%2ByhUDvNwM2zvO895dJVyemvfLMbr7Q5iQeDbFZg4w6yOA8zcfYd07U%2BTsrjQJh9DAhxsM8uu9xuyF%2Bz%2BcesRs3owyMa8iwG5ddPhmrsLPCavRbzyBpBJFu6DQA%2Fg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e956ae1fc324-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 951,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:57.478Z",
+        "time": 143,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 143
+        }
+      },
+      {
+        "_id": "f682894f147ce2bebf571d95cd5c59a7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 815,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "815"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"anotherProductSuggestion\":{\"_link\":\"123\"},\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9Aaej/G9qkaYcdNnHaBUWNW6qVtiSuBEN896mh6+ikiR3z/J79s3N2AFBJlpjC2QEAwEyTZHrtys9RA0DTZRkZgymw7mj2LZPWje7VuquqUT1MwwC43fKppVruCVNA23z2U72OVGvui2IpVnNPzD1/I0S6WqVBtIij8P02UCrrDINbkeloGzAZhsOvEV2r/jFi8F/GTabcD+Np3sh0FV/9gxsLqQriF7o5JgDuTkpLLpvaTC8y2flRMm3KPf1JPBruED5ZhnXbVmVmp1qcK6YzxJCOTLWZIGHVFP0Ld8ytSV23KHhRlfWH2xdcL1iGy9glPw78MAnzXOW5kmGce5GfiNjP/MQTUTLgI2uZ0bP9o7uRnsq5fAEAAP//AwAQv+miiAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "05dbf9ba5f87c5d526cd3e75e90c2190"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "e4854696ffdffda68f1749284c491279"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=sPbc6%2BY%2BctasnKQE2P6ORyRo%2F4KBd9%2FEkL0%2FhCK57rNN15XnSToHNrog3%2FGpJEqR8j2Zku8troVHobDo0ARGNE7sbQAJfnalC02Wt9LfIG5qefAldm%2BZSXEy7iQ4kM4MQCqSOB8IvIcpTby9ht5s6aPFDGWdCZfwX3fI9g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e957a9798c11-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 953,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:57.642Z",
+        "time": 282,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 282
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship_1667904710/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship_1667904710/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create a single HasMany -> HasMany -> HasOne -> multiple BelongsTo relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "cf3c4a593907da2a1d1b4e65688bb5e9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 893,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "893"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"shopifyProducts\",\"query\":\"query shopifyProducts($after: String, $first: Int, $before: String, $last: Int) {\\n  shopifyProducts(after: $after, first: $first, before: $before, last: $last) {\\n    pageInfo {\\n      hasNextPage\\n      hasPreviousPage\\n      startCursor\\n      endCursor\\n      __typename\\n    }\\n    edges {\\n      cursor\\n      node {\\n        __typename\\n        body\\n        compareAtPriceRange\\n        createdAt\\n        handle\\n        id\\n        productCategory\\n        productType\\n        publishedAt\\n        publishedScope\\n        shopifyCreatedAt\\n        shopifyUpdatedAt\\n        status\\n        tags\\n        templateSuffix\\n        title\\n        updatedAt\\n        vendor\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"shopifyProduct\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"first\":1}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "shopifyProducts"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
+        },
+        "response": {
+          "bodySize": 747,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 747,
+            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWzy04gYRtbohWKyp1hRb20tWqcuNJyK6xLXuCiCr+fZU00IQmlFuUee/NvOex3waEUMGR04i8DQghhLqNNllSLK0WeYzuVCCEGp7CQiW68Y8QuuHuB+xxyVOgEUm4dHDTqi4t7DKdux6EQ25xnlunLY0IheLRPM8X4eLvQ/FUPN7RBhSUuA748oKFAcW3ZUO6PM5dAw5HJAWRQmnx94n6YYwQGl/TjBCqtIBWKB1DrFq5tviE0FctiqrPnm+NBLLjMgeSaEuqyhk61lvDLcxwabMYfnJVBatyKc+BFjiCmGGp7TN/fOv5t56/9sLI9yM/GDLmPZ+rb7gSskcwE6WS54/PSebd15wjpNoW3ewatC5Mj7zJX2XmNvXElwCrWPeJ1Bs87/LOvDULIsYixoaMsU/ea+4vI07crg7IMXfdNeRpXwW2RnKEVZ4k2b4Hk2Ff9HljpqvPcgdKVBtcCjZKh9b+XtrUB5ECPYEP9def0xW6xJ1rpQ==\",\"IMZMq3eFuitNuUgBn6Dx7pR7VwjLS7BrPzBd53nPEdbZFpqXvr08nZD4K41WyF2AjgX5wH16X9rhfK9sz4yRWVwZrRIYHHOtaBT2CMq1UqBSVztFN4jGRaNRmuJQZurfqCyMvICF7NsonI6TMLgLJkkcTAN/wpKp8GGShAAMwiCuXVC0PIZFdY+/pJRTDQ7/AQAA//8DALiSTGEmBgAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:56 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "30f7f42855adf9d690f47c4b8d489e7a"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "673f65954fc575240f7d2e4f6ee0e65c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=Tc5AfxCnb%2FNZ5NYwNR4ff%2FSYgXX7oaJ%2BRSmFDfMIZ0z4Lu8iGPk515gz5gWXm9zyWJ4ixD8bW%2B3bpNp%2Fu484LdUAmNYzhLca0b%2F7bwre3glMZ1%2Bvm3qkfLoB9wIc7CgDOPzDMrUkNntnASLleutNmigNioX5BuV02zIFoA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e9504a0f41af-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 953,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:56.461Z",
+        "time": 216,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 216
+        }
+      },
+      {
+        "_id": "f682894f147ce2bebf571d95cd5c59a7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 815,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "815"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"anotherProductSuggestion\":{\"_link\":\"123\"},\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVFhAUbqZNmh56aOOpF7PuTpEUEXeHRGv87w0rpWLS2OO+eW/mm9mTB4BassQMTh4AACpDkum1Kb56DQBtoxRZixmwaWj0I5MxO9OqVVOWvbofhgFwteJjTZXcEmaArvnot3oZqRfcFkMRRuMgHAfTZRhmUZTFySQVwft1oNDOmUTXItPBNWCyDPubEU2t/zGi85/7TYbcD/1p3sg2JV/8nRtzqXPiF7o6JgBujtpILnaVHV5ksPOjZFoWW/qTuDfcIXxyDIu6LgvlpjqcC6bXxZAOTJUdIGG5y9sXbphrm/l+nvOkLKpPvy34QSwSMffnwToRcZrSOhVxHH+Qmgo9EyoKp3pGybrDRzZS0bP7o7uRlso7fwMAAP//AwBEFxzjiAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:56 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "dcffef91a3d737fc2b375b2048b0e3d1"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "81b60599eb90555fec40d70c324d7e6b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=ry%2BeY7kQp5oYj8CzE2HzK3CLg4C%2BTKYMH6p4cClMeiX%2Bvp8iO6wO46ktyfxSjLZC2b8oOX2ftHzrQz8EkBJMwITo9Muj1G49bZo%2Fj3kmYuKyHHnrTwqohuCroAhizXw%2BNH5JKdR20ESPyRP3Tyk5%2Bulb2XYvbsz7tPCPnQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e9520a811845-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 951,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:56.734Z",
+        "time": 210,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 210
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-relationship_933332662/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-relationship_933332662/recording.har
@@ -1,0 +1,179 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create a single HasMany -> HasMany -> HasOne relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "e07b2c757d353088f440046b49aea44d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 745,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "745"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVWBBKuZk2aXrooY2nXsyyOyIpIu4Oidb43xtWpWLS2OO+eW/mm9mDB4BassQMDh4AACpDkum9Lb97DQBtqxRZixmwaWl0kcmYjenUuq2qXt0OwwC4WPC+oVquCTNA13z0Wz2N1DPuimEQRmMRjsV0HoZZFGVxPBFp+HkdKLVzJsG1yLRzDZgsw/ZmRNvof4w4+4/9JkPup/40H2Tbik/+sxsLqQviN7o6JgCu9tpILje1HV5ksPOzZJqXa/qTuDfcIXxxDLOmqUrlpjqcE6Z3jiHtmGo7QMJqU3QvXDE3NvP9ouBJVdZfflfwRRwkQeqniV4+Lh9iGYgk0dNcyVyISKcqznWUxxd8ZCMVvbo/uhvpqLzjDwAAAP//AwCeGyXwiAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:55 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "de5ee7fa696921261182ae85d1772a1f"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "86df9f75a0166d4bcab113d8c5bd3b5e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=ajgg7nyDMux0OjvXYyeCDxAbhjY9X30uFJmpmRc1AmMqk0ULcInpr%2FzJpT%2Fzly4ALNvklHvKLDjR7GXc0fuIflcR%2FGfGm73Kqp4ROhk5eL1qBGbW1KpjNaVtL7YAMsc3YPW06TzHdweBdFWE9v9EUt8HaZWeX%2B9gZ%2BFKXA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e946ce951791-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 949,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:54.939Z",
+        "time": 303,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 303
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-relationship_2952094097/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-relationship_2952094097/recording.har
@@ -1,0 +1,179 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create a single HasMany -> HasMany relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "69bf5cde0c38a7c44872426973698910",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 702,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "702"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 424,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 424,
+            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9A2zTtWG9ok6YddtjEaRcUEqtUK6UkrgRD/PepATo6CbFjnt+zPzuHAACNYoU5HAIAANSWFNN7W373GgC6VmtyDnNg29LoIpO1G9updVtVvbodhgFwseB9Q7VaE+aAvvnot3oaaWbcFUUkknEsxrGcC5EnSZ7KiZTR53WgNN6ZTq9Fpp1vwOQYtn9GtI35x4iz/9hvMuR+6k/zQa6t+OQ/u7FQpiB+o6tjAuBqb6ziclO74UUGOz8rpnm5ppvEveEO4YtnmDVNVWo/1eOcMINzDGnHVLsBElabonvhirlxeRgWBU+qsv4Ku0IYp1EWTUP9IIVcplIaOY1jTeIx01Eis2WSZGapLvjIVml69X90N9JRBccfAAAA//8DAJvCU7GIAgAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:54 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "edd7dda4f2a372cd5a2a452d6ea8ac76"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "c7424b544d4811ce296c0346b336dbae"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=xVnljyhnhHS%2BAY2V%2BnHTPR55ftsFnm0Cw16vBIxcmsYIajJ3eqkHQNx94%2BOMnmzU9pXa7UOSxc5pF32AFKm41RCj%2Brgi0BlZ%2FgHzgvUysBsHPb0utDlvHBRy04v%2Ft%2Fa7RAt2OAwSW4T5oms7BuxLVaBXoYwBgRCfJMD97Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e941fb6f32d3-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 953,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:54.168Z",
+        "time": 325,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 325
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-relationship_3875503635/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-relationship_3875503635/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create a single HasMany relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "24aca3aa6395eada79beed11b646c7df",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 87,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "87"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 479,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"query\":\"{\\n  gadgetMeta {\\n    allHydrations\\n    __typename\\n  }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "gadgetMeta"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=gadgetMeta"
+        },
+        "response": {
+          "bodySize": 851,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 851,
+            "text": "[\"H4sIAAAAAAAAA8xYTW+jMBC98yssn6OFpEnU5tbtSs0eolab7rly8ECsBZtio1226n9fmZAuEAMNH1FviRm/mXnzxh54tRDClCiCV+jVQggh7BPqg9pAYQ0hTIJgndKYKCa4LDxACEuQkgleWtTLexFV1hDCKo0ArxD+CoHgvnwSeFI2CAWFQFvo/cxLtxqmYPJWtMduDEQBvVV6xzei4ImFUILESUQNJpYBD78k7G81jc4eSiYvCUhNHdkFIOtZWRO5ITyt5aQIU0/K0WoARyUnNZzllhXeCJe/Ie4RwgFghNJXuDop+Vkqzfa3kpTnUqGohroz/RsKNQJPXCjmMZc0x7sm8oFDbbAlkFb5ZiIfgJrmZonBFWEInAJ9jAVNXNU5PQNUqzJa3ePosLxNfL+/XMY9VCenB0CfYNtOAMKF2kP8eAmCjMVraAosgdOHRGlu6jkavjc3ICXxYZAWPWI1FGCEErcybU5xFC4VKc1GHRI04tUS+rFT9jyv55JrzHk8pfaYENq0akw2b/B7GsU/ILs=\",\"IsZJdazxtympmhskf3rXnleU7AIm981Gw/HDvPTn52Rye+oTy5S7PdR6RE65W38A5Jd9fzemAWTSTRT+/1bpH1ex70YeQD6usNMhrEeiXabAojYMqtsy7sIlGvJibdYw4w//SjbacDvs261V/fUeOH5+1richBn2ffaF5jaKgsKlfYDSW7NtGP4o4LL0FQAHwtf/8F6pSK5s2/fVl4DxX7Z+YE8XztK5tnfLKV3c0OV0Nqczb3FzDTOgy8X8yrmazh3Hy1PCKiYufKcar3WLjsp6+wcAAP//AwAW7AqJbRIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "35b462666a9e6c865d0399232c0a22fb"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "b61d59d6124d2f598e2ed6543031400f"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=F7ZcosgyKaKdZuOYKbi0skg4PETH9GaCYm7quvHEDHAY00pn2iofkqaQH5iwgHBQQUPS0hZabhxKOb1we%2FhZn1waOUIXXvt9kJItQLYnKnz8hjek8bvu14d7d6gaucjSVGhW0L0ru1UzMTOkb1f5ZnB%2FMX2nBJvCoXNq2g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e93c79d11809-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 943,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:53.262Z",
+        "time": 140,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 140
+        }
+      },
+      {
+        "_id": "5e1cb85c45ecc6b20b4cb3b41411934b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 648,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "648"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"text\":\"test question\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRT0+DQBDF73yKyZzb8neRcms0MR48aHry0mzZkRIppbtD0tr0uxsWRDAx9bhv3pv5zezFAUAlWWIKFwcAADNNkumlKT4HDQBNk2VkDKbAuqHZt0xaH3SrVk1ZDupxGgbAzYbPNVVyT5gC2uazn2o3Uq24LQZeEM79YO5H6yBIwzAV4eJORG/jQKGsU8RjkelkGzAZhuOvEU2t/jGi91+HTabc98NpXsk0JXf+3o25VDnxM42OCYC7s9KSi0NlpheZ7PwgmdbFnv4kHgw3CB8tw6quyyKzUy1Oh+n0MaQTU2UmSFge8vaFO+bapK6b57woi+rDbQuuL7zYS9wkin2xTShKPE8tM7mNlVpG70IEoQp9sezxkbXM6Mn+0c1IS+VcvwAAAP//AwCNw6GTiAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "72aaf32f9c6dd36a2f7487608f260270"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "84615b8e4800d9cab6dd94f5523d3159"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=QA%2B3tEGsqQqXlG1TBGfr9W7doEUSSujGLQ56Gf93AQrrAY1fWw16DZ%2BEilTdmhYL2KysTS%2BrKyXwueo4Z5AESd69FSsE0lrF%2BybODBObk3Zxzwz1eIf6bqKWh5Ru41cg4h0%2FZUFKsfkBPRSLeC31acULknTRLeMPpShhew%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e93d69e75e76-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 949,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:53.445Z",
+        "time": 364,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 364
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-HasOne-relationships_2856696492/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-HasOne-relationships_2856696492/recording.har
@@ -1,0 +1,179 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create multiple HasMany -> HasMany -> HasOne relationships",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "44c1446218c7c6dd25a52edbe0aad455",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 878,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "878"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}},{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9A29A/rDe0SdMOO2zitAvKElOqlbYkrgRDfPepoevopIkd8/ye/bNz8gBQS5aYwckDAEBlSDK9tMXnoAGgbZUiazEDNi1NvmUypjadWrVlOaj7cRgA12s+NlTJHWEG6JpPfqqXkXrJXVEEYj4NxTSMVkJk83kWx7N4kb5dBwrtnEl4LTIdXAMmy7D/NaJt9D9G9P7zsMmY+344zSvZtuSLv3djLnVO/ExXxwTA7VEbyUVd2fFFRjs/SKZVsaM/iQfDDcJHx7BsmrJQbqrDuWB6fQzpwFTZERKWdd69cMvc2Mz385xnZVF9+F3BD+MgCRa+VtFmIyOVSpUKGUd3lAgdpWGSLN6TMIh6fGQjFT25P7oZ6ai88xcAAAD//wMAEUqWJogCAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:55 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "6edffaacd72bcf34d1f1be3011c628eb"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "dc4ffa4c7ac72a549e62d471668b6104"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=1TVUKfsH9a14KIzHFe6rzBM%2FyrilqUuwaC1%2FXQKOGj0%2FfA1bgwK%2FbzCW5S%2FV7RME8ansIwYzISGtH1dHj7eO3B8EV%2BEJjd239X139bWm3BuN2%2B1VRhjw5XRttfHtDPATJAIllmBI%2FqCvR1SOWPhCeavFhI0LnrNLha4YNA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e948eb26435b-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 955,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:55.277Z",
+        "time": 492,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 492
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-relationships_3250074585/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-relationships_3250074585/recording.har
@@ -1,0 +1,179 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create multiple HasMany -> HasMany relationships",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "3d0dbc97120f68c8fa9edf99fd49921b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 792,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "792"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}},{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 2\"}}],\"text\":\"test question - 2\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9A2zSZWG9ok6YddtjEaReUJqZUK6UkrgRD/PeppevopIkd8/ye/dk5BQBoNWtM4RQAAKBxpJlem+Jz0ADQN8aQ95gCu4Ym3zI5t3OtWjVlOaj7cRgAVys+1lTpLWEK2DWf/FQvI+2C26KIRDKNxTSWSyHSJEmVnM2j6P06UNjOqe6vRaZD14DJM+x/jWhq+48Rvf88bDLmfhhO80a+Kfni792Ya5sTv9DVMQFwc7ROc7Gr/Pgio50fNdOy2NKfxIPhBuFTx7Co67Iw3dQO54IZ9DGkA1PlR0hY7vL2hRvm2qdhmOc8K4vqI2wLYayiu2geylhkJouNVGtj5d1aKGXVXCZJJLPM6LjHR3ba0HP3RzcjLVVw/gIAAP//AwDgECPviAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:54 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "2a7dff7a001421b2f68e71e8b9006d87"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "412bcb1c45fcd46f255d5843304bbca1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=xjO9xwLAIp7pkkymOTJYALyvJgDoBnn3259C2xz56kq%2Bj1bytiFfbdM1xuVU8kmNQBp%2BVVR6zeSELasytne0DO1sawVpk%2FeQsM%2Fwdqup0Qpk2%2BLvrQ8KIOlDLPlAlgCPIO%2Fz3F3ZLR1fqGGlBTA2RUSJRZ96Q6Yu0RKpLw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e94428d442ab-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 951,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:54.527Z",
+        "time": 383,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 383
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-relationships_2510062961/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-relationships_2510062961/recording.har
@@ -1,0 +1,179 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can create multiple HasMany relationships",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "4377f7651cadafe8c37232abd47c644f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 692,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "692"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"text\":\"test question - 1\"}},{\"create\":{\"text\":\"test question - 2\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9A04b+WW9ok6YddtjEaReUNV6pVkpJXAmG+O5TQ9dRpIkd8/ye/bNz9ABQK1aYwdEDAMDckGJ6acuvQQNA2+Y5WYsZsGlp8iOTMVvTqXVbVYO6G4cBcLXiQ0O12hBmgK755Ld6HqkX3BVDEcppEE6D+TIMMymzaD4Tafp2GSi1c0bJpci0dw2YLMPuakTb6H+M6P2nYZMx9/1wmleybcVnf+/GQumC+JkujgmA64M2isttbccXGe38oJiW5Yb+JB4MNwgfHcOiaaoyd1MdzhnT62NIe6bajpCw2hbdC9fMjc18vyh4VpX1p98V/CASsUh9nVMSh3OpZXQXC50EgVCBklomH0JF9N7jIxuV05P7o5uRjso7fQMAAP//AwD9gMqliAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:54 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "705e50f8b8214abee023b80547f221ba"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "dce76243d35960d7110a1a3d37f0a5eb"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=KgBtdNzfYbp7DxRzfwNqZbGbG%2Fv4weYgk0bMhoXifaF3wnyD7CqsjOc2S4Pd01yQtejCkSh9ar%2BXl2PWiB3fPCRjcwmib6lZw5BU552FavNBtWLSmLYfuYMXT7S2nXO6CI9Zy%2B2tdFTCbeJb76OObBs4ClnCMt5H2GOzkQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e93ff8858cca-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 945,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:53.846Z",
+        "time": 288,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 288
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship-with-support-for-Id-prefix-test_2503398001/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship-with-support-for-Id-prefix-test_2503398001/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update a single BelongsTo relationship with support for Id prefix test",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "4b94e5d5c308b4860c9c86ce369397c0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 249,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "249"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 476,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"answer\",\"query\":\"query answer($id: GadgetID!) {\\n  answer(id: $id) {\\n    id\\n    text\\n    questionId\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"187\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "answer"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=answer"
+        },
+        "response": {
+          "bodySize": 360,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 360,
+            "text": "[\"H4sIAAAAAAAAA4SQzWrDQAyE734KoXPo2jGJf26GQuiht96D1qs6SxzH9So0Ifjdy3rdJC2UHjWj0XzoGgGgISEs4RoBACB17pOH2wyA1mAJmOQZLr4l4bN4UdgJhISDU29I2Ny3Pk7sxB67l3Bgmd6t7VYuPXd0YG9VoXMyx7CDDZmG5ZUf2ABwdzED+ZvuQQXAemDfXU1UzyT8Zg98qwPAGe7XwuyPf3BtJoaq71tbT60TTsCM5hjyWbhzP5CwPTZ+wp1I70qlmkaeWtvtlTdUsorXca50bLiIc52lNaXLWr9nrA2tC80FJZStZnyUgWoOP/w34qmi8QsAAP//AwCAWudA1wEAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:03 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "6e5fd58ce76f4bbef6ad9476cc174e03"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "b0de908b73ca32cbf7ebda69be9a1a75"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=Z1p6n2VAe2gDzLIXq34H0jc1VNBIpouIMH3YXUPO26uufI86kn84EoRyxhFb9UmjUFb9fqq07cgGyawz7a4CcFa7dd3tNebuBWQl9Q40NDao7LSWdtJUe6mf7gATKAk%2BIWhp1YvUeV5AmKSukRT28ZKVcNlS0LSqo6Ty%2Bg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e97ba9e61a44-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 943,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:03.393Z",
+        "time": 206,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 206
+        }
+      },
+      {
+        "_id": "a757901f9b650e6bcb328f24bf1a6e71",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 674,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "674"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 482,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      questionId\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"question\":{\"_link\":123},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateAnswer"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateAnswer"
+        },
+        "response": {
+          "bodySize": 404,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 404,
+            "text": "[\"H4sIAAAAAAAAA4SQu26DQBBFe75iNLUVHuZh0yFFilKkiZLaWrMDRsZAdgfFluV/j5bFBNy45D6Wc+fqAKAULDCFqwMAgH0nBVPW6F9SkwqAus9z0hpTYNXT6i6TUq0yatPX9aSKxzoAVhJTQH+T4OpfZDqzkZk0g21psAhynvvpSXPVNu/2kWA9N3c7vnTUiBMZc0Qf7dvEtEx9z2Z+ku5rto0xj6WQJfEHzU4DgIeLVMJw6OW2XJEhzoYtr4LpqzrRHHGc9BB4wvg2MGRdV1f58NcBx2I6Yw3pzNToBRLWbWm+8MDc6dR1y5Jf6qo5usZw/ciLvY0bFkWUFMFWxnGy9r292G9lQXEow0AIP7pfGFmJnOzdn1YMlXP7AwAA//8DAJQhszJWAgAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:03 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "23e5f9abfed7b4f26b691a0451f3eb58"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "4ff57f29d667310bab9dfe64d42aa153"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=M25rkmlMtMg3VG0uWdmbD3Oee5WluYgpNUo4vq%2F%2FupbsYUqUsq0fj5bcLauKuC3WbzU4znfLGi5TXNtXuQDwIcaHuvKIPL4oIS4xBWggmqhxAERtj178aKh3obUecoaUbfpmie%2BCAYLn0GBHaFYhlJnfLbm3oHki2niT9Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e97d49e54405-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 945,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:03.658Z",
+        "time": 272,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 272
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update a single BelongsTo relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "4df2ca4801a9a1bd4ec0b93515476da0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 284,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "284"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 476,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"answer\",\"query\":\"query answer($id: GadgetID!) {\\n  answer(id: $id) {\\n    id\\n    text\\n    question {\\n      id\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"187\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "answer"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=answer"
+        },
+        "response": {
+          "bodySize": 368,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 368,
+            "text": "[\"H4sIAAAAAAAAA4SQMW/CMBCFd/+K081VHRMMNFukSqhDh0rdkRMfIWoIIT5UEOK/V3ZCSLow3t17z9/zVQCgNWwwgasAAEBTu19qhxkAS4sJoFot8eW+YjqzXzI5hs7h4NRYw2QfquOJHJeHehT2iJvFgxAANxu+NFSbPfnj193YC25D5FSXdqxipMHC2IL4k0adAHB3sa3xkW4Kk7fkmdPQ5t0wfZd7GoP1pf4JnnCtA0PaNFWZh1cDTocpehvSmal2EySsDoWfcMfcuETKouDXqqx/pD9IpaNFtJI5aaPnimK9zBYzq6I81vOYaKu2WRa/qR4fuTU5fYTffmrxVOL2BwAA//8DAP4lhVEPAgAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:03 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "bebeb068104fdfc54f7e19dd67f0e424"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "ce5a541e357b62d10c3543eef1fbb391"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=iz%2FSpLxJBKIBLWohFb2EYXje5V7QRoYUhPZy%2BTzksfG8Ez2owW3xOw0h6IlCQ0TxeZK3IS5tyCgxTCVTuizDcT1QSpABkoNsvJpvrH%2Fy8kh7wMsI9JHiORvmHA0qPE6PdCK%2FESxpWYQzqSgqPPcIBO%2BM%2FJHES1mF0H0lIQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e9784f95c34a-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 951,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:02.861Z",
+        "time": 299,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 299
+        }
+      },
+      {
+        "_id": "9e4318fcbb5299c65cc74ceb38676db4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 715,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "715"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 482,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      question {\\n        id\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"question\":{\"_link\":123},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateAnswer"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateAnswer"
+        },
+        "response": {
+          "bodySize": 424,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 424,
+            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9R+ROFcEOqVPXQQ6v2HBl7Q1AJUHtRE0V598pACHDJ0eOZ9bfjiwOASrDAFC4OAAB2rRJMWW3+SE8qAJpOSjIGU2Dd0eYmk9aNtmrdVdWkinUcAEuFKaCfxLi5i0wntjKTYRhSBgYENff9dmS4bOrFyPvQIJyZAXC343NLtTiSvf64hSfLdTZ66R0Xd1a+let7VtInma7iITH6sRCqIH6nWbEAeDgrLSyIWTYjNdl9s76JF8H0VR5pvv1YyMrwgPG1Z8jatipl/2qPM2A6YwzpxFSbBRJWTWFPeGBuTeq6RcFPVVn/uPbC9SPv2UtcFVPkJUruxX4bBoEXyzz0ExFGeezl21yM+MhaSHrrf+lhxFI5138AAAD//wMAwK2g2pQCAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:03 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "59f7cbef465403bc6df6e92d6470d77c"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "d7e508dcfaf932207cb318a35b70b9ba"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=%2BCV%2BUORFbTwyxl%2BvSS8FGdfsXyjDLY6PXHa%2BxY%2FeQy6yoyLddi6EAFzO%2F02JKxr3o33XL6KZCxGEaeClRiXg%2Btk0j8q62KGhNxvAIJ%2FRZbyamxhzuC9IYGH6dFHl2jnppC6okZItRkNOG%2BLrKpyI4nHlIlFPJ%2B4mUltWyQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e97a4e95c42f-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 959,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:03.177Z",
+        "time": 191,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 191
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update a single HasMany -> Multiple HasMany relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "c8c651eded1e5525c16e3e822995c87c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 619,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "619"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 474,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quiz\",\"query\":\"query quiz($id: GadgetID!) {\\n  quiz(id: $id) {\\n    id\\n    text\\n    questions {\\n      edges {\\n        node {\\n          id\\n          text\\n          answers {\\n            edges {\\n              node {\\n                id\\n                text\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"192\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
+        },
+        "response": {
+          "bodySize": 559,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 559,
+            "text": "[\"H4sIAAAAAAAAA9SUTU+DQBCG7/yKyZxVYFsI7a1RYzx4MPFmTLOyAyW2QGEb+5H+d7NAkY+tTetFjzs77zvPzuzuzgBAwSXHMewMAABcrqJtvQLASOAY0B4xvDqEJK2lCkrKJah8WKWCSxLfKcsV5TJK4rxhBYAkQlKh1zoEje0iJU4EtUQtDjYc1EXqrQ5PWfnABNdg9yU8zj8pyzWFjlDqaU9Rd+htr4+iP0XJ9+MZauF0KjcpxXyhCHBSKFGbvNd7aB3uRUg6F63HL7vCLu0K+zNd6cXe+q5ax9skjslXN7br2+Pq6J+rm97WdVRHNN1ztFRnvsjh+S+SXfoi/1lXDc1tOKLtE9c1e4poW+ZUGRhyEZJ8osY/DoCzjci45hP2M1JjmBQTuuOSXqIFNQaC1Zw6CSeoHgqGSZrOI7+oWuAYhzYUMqS1pDhvIeE8CdUKZ1Km+dg0w1DezKP4w1Qbpu1YruWZzBs4dhA4Lg2Dd0YDlweWazkjm4184TG/wkeZcZ8ey4t5SqKo\",\"jP0XAAAA//8DAGEntsMDBwAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "d5bfcb6bd7b0841ab434db6b8b8ca44f"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "28351ff56e4fb2e36af06059129cd82c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=BKWWrnpKgBP%2BzjQH5EVyX1uc74CZnxwt8c%2FreohTAevTYNGS9X%2B9XuqDDhVt7kOSK6sOWkPXoJ74oHTXLApMsn33ok2F2H0lE0QJVlIVx%2BvxmEfcasmY5NK2aKIu9A0QjkvGcl2g35%2FlggqkAPzqWsAKkT7M3OacW%2F3jDA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e96a3f475e76-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 951,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:00.609Z",
+        "time": 234,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 234
+        }
+      },
+      {
+        "_id": "888e8ea49ddeea7721179d6e14fdcdce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1317,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1317"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 481,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            answers {\\n              edges {\\n                node {\\n                  id\\n                  text\\n                  __typename\\n                }\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"192\",\"quiz\":{\"questions\":[{\"update\":{\"answers\":[{\"update\":{\"id\":\"181\",\"text\":\"test answer updated - 1\"}},{\"update\":{\"id\":\"182\",\"text\":\"test answer updated - 2\"}}],\"id\":\"243\",\"text\":\"test question updated - 1\"}},{\"update\":{\"answers\":[],\"id\":\"244\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
+        },
+        "response": {
+          "bodySize": 611,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 611,
+            "text": "[\"H4sIAAAAAAAAA9RVy07DMBC85ytWewbShrZAbxUgxIEDCE4IITfephGpE+KNeIl/R06bkIetSoUDHDudmZ1de+MPDwClYIFT+PAAALDIpGC6LuL3GgNAXYQhaY1T4LygvQqmPE9zg6oiSWr0uS0GwFjiFHB4EuDeN8j0ygZm0gxGA+vaskl6LkhznCrdMjSlZUQGvG+A0KKUNJVK6khbmYLRYaOcK9s6Q5UP9mFoEwmlXyjX1nLOxK7k2zvoTvfYFsre0Trpln5q6eMjv2WkxMrkwFmpRQf90+VjdTmXEdmdHD6/MKVg9ykFf25KFvTB5m31PU2VotDc7L67JWHH43qzFV1tT+nQ9bvqKHfY5dEuuxz8ZJf/8bQ9x51xONjyN6r3VPF7xatZHc5d/dTckC4SXvM3bIyEjIivqPE4AeDyTeai/yBgmJM5zll50meC6TZeUfMh2Zx3h7Al4UWZYZZlSRyWVcs4XjW+Uob0yqR0KxImaWR+4ZI501PfjyI+SGL15Js//OF4MBkc\",\"++PFfD4ZHYnFCYXzgQzni9F4MjkMRDAcBwtZfZORcxHSZXnFt0pMKu/zCwAA//8DAAmgrFPYBwAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:01 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "b32fb3fffc047bf4c0c1df4da2376222"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "5fbb647af9ecb0dcbf456632a2152fd1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=k1Y1EC1zgmjD3zfE9ePCsQWqNL9xyielD6%2Bx%2B5YqbBiHLS%2FFGM8h0DyNHz4seCNpL2lXRHvgorhpdlOfPPmdxBZKKUKvAF%2BoxwmRqzv46M6NHxnzHiUux5RVj3POs%2BIjO2v4EvSytxJ%2B89rY3cscBofw9kidSVmoM6DTCw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e96becec5e6a-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 951,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:00.877Z",
+        "time": 475,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 475
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update a single HasMany relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "28ef470ca9b07e9dac36797891532f24",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 390,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "390"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 474,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quiz\",\"query\":\"query quiz($id: GadgetID!) {\\n  quiz(id: $id) {\\n    id\\n    text\\n    questions {\\n      edges {\\n        node {\\n          id\\n          text\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"164\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
+        },
+        "response": {
+          "bodySize": 436,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 436,
+            "text": "[\"H4sIAAAAAAAAA4SSS2/CMBCE7/kVqz1XjSmQBm6oraoeeqjUW1UhE6+MVXBCspF4iP9e2QST8BC3ePebzGjsXQSASrLEMewiAABc1WYbTgBoFI4Be8kAH44jpjW7IVPF4HioCyWZ1AlZ1VSxyW3V+hUAktLkRj9hBK21R2yuqCPq5HgSSTAJq7M8B+eLTAGfTnlTkJVL54NfDY8dbN9V3dC8KU1t3T58/570N7QvubWUtZ2D54XCbA9MQ6CWShN/UuveAHC+UaW8UnpWkiti4jt6lUzfZkmtWrBp6gy4k+rdZ5gUxcJk3tXHiY41eBnSmslWnUi4yLU74Zy5qMZxrDU/Loz9i90i7g1FItJ4RoNnmaU0IiWGgiQJNUpmqRCyP+wnlDbxkUuZ0Yd/GnclLlW0/wcAAP//AwDlUg0f8wIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "8fd897b16e103c3ff00e975b477d94e8"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "be47ac8e9ed050eae0d96b800a3536e8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=qHy2vnW4RXEm6FUFL5v%2Br2wgDAH96E7CGzeaIC1hWBu3emI7%2FKBWtDfQ00Vo%2F0OvvKrbxn2YvIMn8PL6anARJUOsRlxEoPjaLHHxqIKMddT1aB91ehS5u11P7uuusl4bb5Ze5J9R%2FFJ4vf2YX8dML4WCeC%2BbLEftNX3NKA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e95fcb1443c4-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 949,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:58.946Z",
+        "time": 112,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 112
+        }
+      },
+      {
+        "_id": "8ea9378f88914c64c107f875015ae6a1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 864,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "864"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"164\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"206\",\"text\":\"test question updated\"}}],\"text\":\"test quiz updated\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
+        },
+        "response": {
+          "bodySize": 492,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 492,
+            "text": "[\"H4sIAAAAAAAAA4SSS2/CMBCE7/kVqz2j5gEkNDfUVlUPPVC1p6pCJt6GqMEJ8UbiIf575QCpE4o4ejyfZ7TevQOAUrDAGPYOAADWpRRMszrbtRoA6jpJSGuMgauaBmeZqqqojKrqPG/VdRcGwExiDOiHIxz8iUwbNjKTZjAMHLOlbVrXpDkrlO48aKJlSkb8tEToWBqbKiT10E6nwAutuGvdjh3+6dcC8zlvS1JiZdJwdiKwZzz0ySvck0ypyx6s05f9ypUXHgqlKOl2sNIvqGx39rWunuejXYw30nXOR//JjamQKfErWasEgMutrMTl92FSkRnktJnxo2B6z1Zkf/tp0j3DjYbPTYdpWeZZ0qQ2dZzz+BoMacOkdKcS5kVqTrhkLnXsumnKd3mmflxz4fpjL/QmbjhZDANB/iIKvO9oHMnAGw5H/uI+CkXg03m1kSuR0EuzXDcR08o5/AIAAP//AwANCntjhgMAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "6422201b505511a95cf698411a2f9c95"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "68b32ae1b720f757d203341b976a21e4"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=k08Niz3Sxxb57UxAXIO71ZjJ6pZWGaALEK5ZfvdT%2FuabHOPY1w78FBe0hkbg6xXKQtKVhBbyzaxFi93L1TLwFnj1qUhtG0ReSvGj0hZgeHbV46I2fhhrhUW1L8k9MEs3qnZI%2FaCeP3HaOAP3DZCoTASyVzwhVtZ0VRkTfg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e960cde617bd-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 943,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:59.102Z",
+        "time": 294,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 294
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasOne-relationship_3220970997/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasOne-relationship_3220970997/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update a single HasOne relationship",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "9d46ddfef89035ead8fc1689e3e2ec22",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 303,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "303"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 476,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"answer\",\"query\":\"query answer($id: GadgetID!) {\\n  answer(id: $id) {\\n    id\\n    text\\n    notification {\\n      id\\n      enabled\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"187\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "answer"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=answer"
+        },
+        "response": {
+          "bodySize": 384,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SRMW+DMBCFd37F6eaqkJSEwIZUqerQTt2jq30mVohB+KomivLfKwOl0CXj3b33/D35GgGgJiEs4BoBACA5/83dNAOg1VgArnYZPvyuhM8SlsJeYHB4+Go1Ces/lWvEGqtIbONmgVPkNpm0AMiOPmsOB0O159llv5dLy45OHFzv89RRdJveXGrLoUw002BFumJ541lpADxcdNdH+iWp6jiUKvu6zyT8YU88xx5b/xPc4XrpGcq2rcciPc6AGY025LOw8wskrJsqTHgQaX0Rx1Ulj7V1xzgc4tUm2Sa7WJmn1KgsS9PcbHJmMkbROt1lJleJXucjPkpHil/7r7hrCVTR7QcAAP//AwBhTWdfMAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:02 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "bad908f9b3145f52f39bb220a7ee18d0"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "cf34fc77449f59eeaffca2487f9c0d29"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=kCI99ixEh%2FiWgvDBnrbibh68B%2B4%2FB7OfNtHjbLRnDFFrIzFmctWR4UrTBnx4ITtYrAk%2FaPoDHultytmJfugyeMImDIqAE151cbGYSBSmcBZU%2FTDD6uILksR6z3unOcZC0QxlA7W0RynnKs3I2WhJfgajAmSoUDpXW0wTDQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e973cdbbc47c-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 949,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:02.145Z",
+        "time": 205,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 205
+        }
+      },
+      {
+        "_id": "6e3f264fc5f334d3e5356734eed272fe",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 765,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "765"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 482,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      notification {\\n        id\\n        enabled\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"notification\":{\"update\":{\"enabled\":false,\"id\":\"60\"}},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateAnswer"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateAnswer"
+        },
+        "response": {
+          "bodySize": 436,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 436,
+            "text": "[\"H4sIAAAAAAAAA4SSMW+DMBCFd37F6eaoJEoIiC1SpapDO1TtHBn7IKiOQfahJory3ysDpYYlI+/eOz4/+xYBoBIsMIdbBACAXasE08G4H7KTCoCuk5KcwxzYdrT6k8naxnrVdFpPqljGAbBWmANushRX/yLThb3M5BiGlIMBQYU+03Bd1lJw3ZjZ2mnxfh34PZgRhSY/KoV2NJsdj3xtyYgz+eR7uHuy3YO/z/1jN9HCt3B9BT1+kOs0D4nRj5VQFfEbBd0D4OmqbA/i5uVJS76SQ1/Ws2D6rM8UFjR2tjA8YHzpGQ5tq8fj9zgDZjTGkC5Mxs2QUDeV/8ITc+vyOK4qftK1+Y79IN4k6/06i4nSrCzTVOwSlRa7bbJPZCG32XZTFLKY3gGyFZJe+0t8GPFU0f0XAAD//wMAKGwLsbcCAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:02 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "bf1095c3d28f30d3bb39f7477e4e53dd"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "ee78ff77a45d7b43565cbc3831bbcb87"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=X1ooxEM98aPY9LV%2FeWcb%2F9YQA%2BVnHAWhvKfmsoLV0UsTaKb%2BYPFRYlIeWSD4vGYbdFxz3KLJtEVJBXeFG4oaW9qz2BL5SyoCOt766OCFuxtUAs565cmL%2B5SjHzliWwJWZq5g%2Bv8AW2Yh8OWnF6TSEtxrhw4qyUD%2Buu%2F5ew%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e9757ca643a3-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 955,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:02.410Z",
+        "time": 417,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 417
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-HasMany-relationships_3421995200/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-HasMany-relationships_3421995200/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update multiple HasMany -> HasMany relationships",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a119b60a21e70ca9bcd3586c6a784cfd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 619,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "619"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 474,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quiz\",\"query\":\"query quiz($id: GadgetID!) {\\n  quiz(id: $id) {\\n    id\\n    text\\n    questions {\\n      edges {\\n        node {\\n          id\\n          text\\n          answers {\\n            edges {\\n              node {\\n                id\\n                text\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"193\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
+        },
+        "response": {
+          "bodySize": 587,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 587,
+            "text": "[\"H4sIAAAAAAAAA+yWTU/CQBCG7/0Vkzmr/aAtlBtRYzx4MPFmDNl2h9IIbWmXyEf472YL1H4sEtADMR47O+87z05n0q41AORMMOzDWgMAwNk8WpVPABhx7AOaXgev9iFBCyGDgnIBMh/mKWeC+FfKbE65iJI4r1gBIPGQZOi1DEHluEiJE041UY3Dsp2ySHnU4NlW3jPBNZhtCYvzD8pyRaEDlGraY9QNerPXaaGob7Hl+/YOpXA4FMuUYjaVBDgolKhM3qg9lA73PCSVi9Ljh12xz+2KdTFdacXe2q5Kx9skjimQE9v0bXE19M+7Sa/rGqoDmuY9aqoTN9I9fSOty9lI59zZ6/zljXTP7Yr9v5G/tJGagvuAtk1c1mwpotU2Z5eBIeMhiSeq/AMA4HjJM6b4gAcZyRc9KCbgjgl6iaZUeeW4m4RGwhGqh4JhkKaTKCiqFjjavg2FDGkhKM5rSDhJQvmEYyHSvK/rYShuJlH8rssD3XQM1+jpnud3fdvvjnw=\",\"1zJMwwp44I1Mh5weJz/gwQ4fRcYCeiwW4KhEUmmbTwAAAP//AwC00fNNPwkAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:01 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "4112bc4408ca119eb4149aa430ef56e1"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "99b7b4b7fb620102cdc9f15e58debcdc"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=kJMvEC%2BM8BevpPtRn9rutoPWKsFtwecKxBa4j6Jqeh%2FxQx8IwUm%2FHw8gdiDGHjkW%2F0PLhD3VMxRl6ViA5ZwfAI%2Fd2V18yqRpeAAUsL7PoQLk3V3p8%2FtaGJ8iUsn%2F%2B2gCJwV3F97aTrskv%2BO7fsfC%2B%2Bo050504fiQKqKQ3Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e96f0d4d9dff-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 961,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:01.384Z",
+        "time": 157,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 157
+        }
+      },
+      {
+        "_id": "b8202c428e52811dc2e0d597ff65d16e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1430,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1430"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 481,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            answers {\\n              edges {\\n                node {\\n                  id\\n                  text\\n                  __typename\\n                }\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"193\",\"quiz\":{\"questions\":[{\"update\":{\"answers\":[{\"update\":{\"id\":\"183\",\"text\":\"test answer updated - 1\"}},{\"update\":{\"id\":\"184\",\"text\":\"test answer updated - 2\"}}],\"id\":\"245\",\"text\":\"test question updated - 1\"}},{\"update\":{\"answers\":[{\"update\":{\"id\":\"185\",\"text\":\"test answer updated - 3\"}},{\"update\":{\"id\":\"186\",\"text\":\"test answer updated - 4\"}}],\"id\":\"246\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
+        },
+        "response": {
+          "bodySize": 639,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 639,
+            "text": "[\"H4sIAAAAAAAAA+xWTU/jMBC951eM5sxuktYp3d4qWK32wIEVnBBCbjyEiOCE2BFf4r8jp03Ih61K0SIhwbGv7715M5qJ/OIBoOCa4wpePAAArArBNZ1W6XOLAaCq4piUwhXosqKDBqayzEuDyirLWvS+LwbAVOAKMPw1x4N3UNOjNrAmpcFoYFtbdEn3FSmd5lL1DE1pkZABLzog9Cg1TeaCBtJephmLOuVc2bYZmnzwA0KbiEv1QKWylnMmdiXf38Fwusu5JZS9o23SPf200qsr/VSQ5HcmB65rLTrory4fq8tvkZDdyeHzH6bEpk9p9ummZEEvbd5W36NcSorNZo/dLQkHHqe7qxhqR0qHbtzVQDnhlhdTbnn2GW85mr6l869zy4vpU2Lft/yht+w5unA42PJ3qo9U6XPDa1kDznn7kPlHqsr0lr9jY8JFQvqEOk8fALx5EiUfPzcwLsmszbrep2Ou6Sy9o+4zZbdXA8KehH/qDOuiyNK4rlrH8Zrx1TKkR01S9SJhlifmF95oXQ==\",\"qJXvJ4n+maXy1jd/+GEULIKlvxTX82jDZoc8YsQYuw42LAwCog2PQh43Xz3UJY/pb31QeyUmlff6BgAA//8DABYYH1w2CgAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:02 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "69d9379561317cb5a981769b874fc552"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "8df35b427a54e444f0b4100eeba51ac2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=v37mqhiYUkkD20sAziwAcnTGwWokM0WNumXhDWHu%2BxeBCKPaP3fCLn5SHh2PMyzwXrG3zf%2FLbZYYKQ0Ps9ypEEmtR%2F5mmvQnXrDsID%2FD2tBwIQ5Y5amvHPzkGb1gNGSOJXtZHfZBE2wAY5QwWPU9P2Yio7FGq55MRmJaQA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e97069b54405-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:01.602Z",
+        "time": 508,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 508
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update multiple HasMany relationships that are reordered",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "7dff9ab5ab10511ee8deb9137d277700",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 390,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "390"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 474,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quiz\",\"query\":\"query quiz($id: GadgetID!) {\\n  quiz(id: $id) {\\n    id\\n    text\\n    questions {\\n      edges {\\n        node {\\n          id\\n          text\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
+        },
+        "response": {
+          "bodySize": 456,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 456,
+            "text": "[\"H4sIAAAAAAAAA7yST0/CQBDF7/0Ukzmr7TbStNyIGuPBg4k3Y8janS4bYVvokPAnfHezS6ktSAgXb92Z9+t7M5ltAIBKssQhbAMAAJwvzaZ9AaBROAQUSYo3hxLTil2RqWZwelhWSjKpX8l8STWb0tadXwEgKU2u9NGWoNP2Elsq6kG9HLGIWpO2dZRn73zIBLcgTpHxmNcVWTlzXvjWMNiT7frUGeZJaepyPerK2cT1s8X/Olv7/fnLn2EfSmsp7zq3nieE2ew1jQK1VJr4lTp3CYCTtVrIP44qX5Bbxsjv6VEyvZsZddaCzbaOBBdSPfsMo6qamty7+jjBYQ0eQ1ox2boXCaeldi+cMFf1MAy15rupsd+ha4RiECVRGt4rUaRFnGbZV0SiSIo0Vmk+yEhSEWciaeIjL2ROL/48LiIuVbD7AQAA//8DAOnKHB7TAwAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "e229cf9ed4418dcd8d7eb75345aac42a"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "4d1f8f2899b0e1f6f82d8c59eaef2916"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=OUcaaWSSmDF%2BuGM2Xsgv5o%2FFdS1Lo8agtyybcZuwQ6wjPLBruO9amBCX8PyvPmTSeK4LIdu8jOSIqIX2trAb07dhUu6myywKWklUfYCvFNE0gqhbTOUfeQtmN57jdkE9Ry0PsZV0FzjBCAGalREovaGKEOr4EPmA3h3ydg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e9672a9d428f-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 943,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:00.126Z",
+        "time": 196,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 196
+        }
+      },
+      {
+        "_id": "3923eb5ee6ede8b5b4f0a52978e998a7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 927,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "927"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"210\",\"text\":\"test question updated - 1\"}},{\"update\":{\"id\":\"211\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
+        },
+        "response": {
+          "bodySize": 512,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 512,
+            "text": "[\"H4sIAAAAAAAAA8STTU+DQBCG7/yKyZyrsNgP5NaoMR481OjJmGbLTiiRAmWHpB/pfzdLAYHaNOnF4777PjvvTGb3FgAqyRJ92FsAAFhkSjLNimjXaACoiyAgrdEHzgsa1DLleZobNSniuFHXXRgAI4U+oBh7OPgVmTZsZCbNYBg41lZt07ogzVGa6M6DprQKyYifLRE6ltKWpIp6aCeTK5xWuXPZjhnqfHAD4i9oPudtRolcmYo4qyjsGQ998gz3pELqsj3yil7FNb26/9Jr6/TVfuXMCw9pklDQzdCqfkJFu9rXuHqej+YjvJEuYj76KzeGUoXEr9T6OgC43Kpcnq4rBjmZYU7LOT9KpvdoRe01r6bdM1xI+FxmmGZZHAVl1TKOVY+vxJA2TInuRMI4Dc0Jl8yZ9m07DPk2jpJv21zYYuSMHc927keOJ4ZjUq63GApHLYScOBMK7rzAndCiio+cy4BeygW7iJhU1uEHAAD//wMASsFCUXYEAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "2282de8eee98249f69ac5f7737138ae8"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "09508146ed28b410db1a707ec38c27eb"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=WCj6xp9y%2B2EQ2ZnqnD25NwgUECkoK3%2BrFeVOb8hbVNmq%2BBkpPmO9S7D%2BV7pXAPbr5WMr4%2FL8%2Bw%2FS5QR7qYzx9wEchkp6vVVUyKCxEiN%2Bf%2F%2BI5X%2FSRAVA0sn0OCPPgxnqjHqV9VvmpKSZUbjkNtb382Row12tGvJas6SpRg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e9688bc60fa8-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 961,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:34:00.343Z",
+        "time": 244,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 244
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update multiple HasMany relationships",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "7dff9ab5ab10511ee8deb9137d277700",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 390,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "390"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 474,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quiz\",\"query\":\"query quiz($id: GadgetID!) {\\n  quiz(id: $id) {\\n    id\\n    text\\n    questions {\\n      edges {\\n        node {\\n          id\\n          text\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
+        },
+        "response": {
+          "bodySize": 460,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 460,
+            "text": "[\"H4sIAAAAAAAAA7ySTW/CMAyG7/0Vls/b2pSvwg1t07TDDpN2myYUGi9Eg7RQI/Eh/vuUUEoLQ4jLbo39Pn1fW94GAKgkSxzANgAAwPnSbKoXABqFA0DRTfDuUGJasSsyFQxOD8tcSSZ1lMyXVLDJbFH7FQCS0uRKn1UJam0vsZmiBtTIEYuoMqlaJ3n2zodMcA/iHBmNeJ2TlTPnhe8lgw3ZrkldYJ6VpjrXoG6cTdw+W/yvs1XfX0f+AvuYWUtp3bnyPCPMZq8pFail0sRvVLtLAJys1UL+cVTpgtwyhn5PT5Lpw8yothYst3UiuJLqxWcY5vnUpN7VxwkOa/AY0orJFo1IOM20e+GEOS8GYag1P0yN/QldIxSdqBsloWrJOIrbot9J+mo8FoJ6cZvGUSsRrd53t1fGR17IlF79eVxFXKpg9wsAAP//AwAJLRWr0wMAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "89cc0c4aa8861ce5afc5b57ae88c0889"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "d3a202419589dbb11e724eb038137f67"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=UhS8y2sCeM6EuHUrZyoD%2B5JzFAt%2BrlSaOyP0xFdlGpLdHq2d4c5DryDT6T6aeYtkYk4MNiaih%2FvHhwB0XyFk4CVvC8oVbmhj3CKQ5GQivRKaqGmCAQkbWaWV%2Bq3tPr%2F53Zg4NFPOguF2H5g%2BbwpQiU8gwqujB73TafPUfw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e962cd854243-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 951,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:59.424Z",
+        "time": 204,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 204
+        }
+      },
+      {
+        "_id": "3923eb5ee6ede8b5b4f0a52978e998a7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 927,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "927"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"210\",\"text\":\"test question updated - 1\"}},{\"update\":{\"id\":\"211\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
+        },
+        "response": {
+          "bodySize": 512,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 512,
+            "text": "[\"H4sIAAAAAAAAA8STT0+DQBDF73yKyZyrQFFEbo0a48FDjZ6MaRZ2pEQKlB2S/onf3SyluFCbJr143Lfvt/NmMru1AFAKFhjC1gIAwLqUgmlap5tOA0BVxzEphSFwVdNoL1NVFZVW8zrLOnXZhwEwlRgCun6Ao1+RacVaZlIMmoFdbWmaljUpTotc9R7UpWVCWnw3ROhZGlteSBqgvUxj1zHKHcu2y7DPBxfg/gXNZrwuKRcLXRGnLYUD4/eQPMI9yIT67IA8o1f3nF7H/9KrcfowXznywl2R5xT3MxjVD6h0s/d1roHnrfsIL6TqjHf+1o2JkAnxMxlfBwDna1mJw3XFuCI9zEkz53vB9JouyFzzdtoDw4mEj02GSVlmadxUbeJY+/E1GNKKKVe9SJgViT7hnLlUoW0nCV9maf5l6wvbvXZ8J7Ajb+wEsSduAxE5jh/dRI4XB8L9JF9e+V7UxkeuRExPzYKdRHQq6/sHAAD//wMArArjEnYEAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:34:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "f9b0423d6e2d0f8b91a8ac8efdc95d61"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "b3208c3a98ab006b7b03c8a1fe6d463b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=sTwSEbm6JBc08z16pHU2bI%2F%2FTKc6WiirKmYINLRxFiol0mVt7xlLn1TYGKy%2F30Wo1U0xoPq4yPRAY%2B%2BfI2Wnm2fM0vs4a%2Fo5iLH0zztYJrQ6WO2kdqaGwsduaLKniLST%2BUF%2ByyekcUTtGZNTmU1TiRJRwJ8FYBrX8PAb%2Fw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e9647eaf727b-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 957,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:59.691Z",
+        "time": 411,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 411
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-even-if-nested_698860812/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-even-if-nested_698860812/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update root even if nested",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "72f3b4c5cbe8ff55b3c3b96a6a3c5e60",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 225,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "225"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 474,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quiz\",\"query\":\"query quiz($id: GadgetID!) {\\n  quiz(id: $id) {\\n    id\\n    text\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"163\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
+        },
+        "response": {
+          "bodySize": 348,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 348,
+            "text": "[\"H4sIAAAAAAAAA4SQQW/CMAyF7/0Vls9oaUcaoDekSdMOO0zaHYXEDRGlhNZIMNT/PiV0jE2advR7z36ffMkA0GrWWMElAwDAw9F/3CYA9BYrwEJNcfIlMZ04ikw9Q8zDMVjNZL8jqxWfA7V6RzH4Fm8ma7gm0GnriF/prhkAN2fbafb7tr9TAdB0FM8vU+uTZnr3O7qVAeDY/ysw+sMfVM+JYRlC401qTThXzGxcQzoxtf0PJGz2Lk64YQ59JYRz/ND4diuiIYoyV/lc2AXRfL1WRS0NSaNMKWup8tljsZDTsp6N+MidNvSSnvzvSqTKhk8AAAD//wMAJ5UzzbUBAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:58 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "1aac87134dd07108335879d59740fd17"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "d9ee8bb61f4ce4c6c54f4607219435f7"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=4LwYoIl5u2e9HjIlN9sqFxNTVWAC0hQP3PT6TGNUv6lFQ2qJ0zmOQCv1nxsi7ROSeuXk1nunQbASnUTWMaObGW%2FwPlMHWLF8Yn2xIzJ6J%2BD2K7TkxfIx3wzyVVCD606LavknP1FKxB4dttH7%2FG3CM%2Bl4jQMAN862zTOE1Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e95c898443a7-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:58.426Z",
+        "time": 187,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 187
+        }
+      },
+      {
+        "_id": "cc2fca976335b6034f9946efffb8de10",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 608,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "608"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"163\",\"quiz\":{\"text\":\"test quiz updated\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
+        },
+        "response": {
+          "bodySize": 388,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 388,
+            "text": "[\"H4sIAAAAAAAAA4SRwU6DQBCG7zzFZM6NgLKI3JqYGA8eNHpupuyEEreAu7NJa9N3NwuIxUuP+8/3Z77JniIA1CSEJZwiAAD0vSbhV998zxkAOl9V7ByWINbz6jdmazsb0tYbM6dfyzIANhpLwDS/w9VfKHyQEAs7gdCBcbe+hDYbOfbc0p4DOmhNw/O8b8l8zAe8sfNGRn6isSZds7zwxckAuDtqS9J0rVt6V5aD0HrwfCTh92bPl3qT8T/giuHT4LDue9NUw9ZBZ9SMphryQbh1CyU0XR1euBPpXRnHdS03pmk/4zCIU5XkSRFryuk+eeAio2q7zXKV3RZ5kiqlCs5VQpM+iqWKn4ePuVoJVtH5BwAA//8DAFDF9HQuAgAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:58 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "45318204ffcd6a46b38a0f2b7058d64d"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "da6a709e84acbb4654286015558e650a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=8sgDF%2Bn45JEgBwUc1I1VjV%2B138ECL0Of%2B39qKXaRcQbyH5J%2FpwmXJF1Mqn8sa9VJqx2NcwTbsx5jS4raHXxND7eovBoz%2BZ%2Buav4cbOsQvm3zBNtKh%2BTjZmCjI4lS%2FghL8wItxMTKn58jVnf8FeWuUN7BlNUbdAvuxTzjGA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e95def37c445-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 955,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:58.637Z",
+        "time": 277,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 277
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-object_3536142481/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-object_3536142481/recording.har
@@ -1,0 +1,344 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/can update root object",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "72f3b4c5cbe8ff55b3c3b96a6a3c5e60",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 225,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "225"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 474,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quiz\",\"query\":\"query quiz($id: GadgetID!) {\\n  quiz(id: $id) {\\n    id\\n    text\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"163\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
+        },
+        "response": {
+          "bodySize": 348,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 348,
+            "text": "[\"H4sIAAAAAAAAA4SQQU/DMAyF7/0Vls8TTRYaut4mISEOHJC4T1lisoiuC60nbUz97yhZGQMJcfR7z36ffCoA0Bk22MCpAADA9334uEwAGBw2gFIrnH1JTAdOItPAkPKwj84wue/IasXHSJ3ZUgo+p5vZGs8J9MZ54ie6agbAzdH1hsOuG65UALQ9pfPL3HpvmF7Cli5lADj1/wpM/vgH1UNmWMbYBptbM84Zs5jWkA5M3fADCdudTxNumOPQlKX3fNOG7q1MRikroUVdvjp5q5USd0IqVa8XlubVWtdaCmV1VdkJH7k3lh7zk/9dSVTF+AkAAP//AwBB2isWtQEAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 14 Dec 2023 22:33:58 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "7e484a28a47fb1ba1c92ad8d64d96c7a"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "fd146330701338b9ce25b686103c655c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=2KhqCxSHma4LvudKB1eq0ShfYzeqheu19mu5mZBGL8ONNqP7PSV6J8QgToDL%2BxKm08NQjHDNRbhPOaJmOESorZ8ouOq61cM90g%2FRqBo53RrRY%2F73PizegELI9jNUugcUaSTUoNUZQHzSVCdN2meEHEvbujF3DB%2FKtSfxFQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8359e959acd4c452-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 947,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-14T22:33:57.953Z",
+        "time": 150,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 150
+        }
+      },
+      {
+        "_id": "cc2fca976335b6034f9946efffb8de10",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 608,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "608"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"163\",\"quiz\":{\"text\":\"test quiz updated\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "updateQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
+        },
+        "response": {
+          "bodySize": 392,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 392,
+            "text": "[\"H4sIAAAAAAAAA4SRPW+DMBCGd37F6eaofAQTwhapUtWhQ6t2jhx8EFQC1D5LSaP898pAKXTJ6PeeV/ecfPUAUEmWmMHVAwBA2ynJ9Gqr7ykDQGPznIzBDFhbWv3GpHWrXdrYup7Sr2UZACuFGWCYrHH1FzKd2cVMhsF1YNit5tB+z5eOGnkih/Za4/A27VsyH9MBb2RszQM/0lhKVRK/0OxkADxelJZctY1ZeueanNCu93yUTO/VieZ6o/E/4I7hU++w67q6yvutvc6g6Y01pDNTYxZKWLele+GRuTOZ75clP9RV8+m7gR+KIAlS/0AiKgohQnmIE5GnFESCongbF+tNnIabUR9Zy5ye+4+5W3FW3u0HAAD//wMAo0AtQy4CAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 22 Dec 2023 17:24:02 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "c1fe6f273749cf5a9a9fa97bfa78ba1f"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "be52ff551ab465c8e025e2494f374817"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=02sq1a1DiSxCi8p7kJfHuIdF09afoK8c6Q926UOUora4V6bhYms1vA5xDqqVmXau8L0u4qUYRJ5F97GSI5ob%2FH9pq1aiBS%2F14e4T0Ylt1XLaOCRd9V%2BwP4a5xfZFHKyCSc0vMXgCRd7dCXO15X0BgwYQVS%2B%2BJevG0ICB7A%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "839a0e57ea2c0c7e-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 949,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-22T17:24:01.748Z",
+        "time": 378,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 378
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/when-no-referenceTypes-are-provided_1796353339/fetched-it-should-throw-an-error_2956595739/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/when-no-referenceTypes-are-provided_1796353339/fetched-it-should-throw-an-error_2956595739/recording.har
@@ -1,0 +1,179 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/with polly/when no referenceTypes are provided/fetched it should throw an error",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "5e1cb85c45ecc6b20b4cb3b41411934b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 648,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "648"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 480,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      createdAt\\n      id\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"text\":\"test question\"}}],\"text\":\"test quiz\"}}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "createQuiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
+        },
+        "response": {
+          "bodySize": 428,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxV2BWBcjNt0vTQQxtPvZgtOyIpAu4Oidb43xtWSqVJY4/75r2Zb2ZPHgBqxQpTOHkAAJgZUkwvbfE5aABo2ywjazEFNi1NvmUypjadWrVlOaj7cRgA12s+NlSpHWEK6JpPfqqXkXrJXVEGcj4VcirlSsSpDNNAzIIgfLsOFNo5o+haZDq4BkyWYf9rRNvof4zo/edhkzH3/XCaV7JtyRd/78Zc6Zz4ma6OCYDbozaKi7qy44uMdn5QTKtiR38SD4YbhI+OYdk0ZZG5qQ7ngun1MaQDU2VHSFjWeffCLXNjU9/Pc56VRfXhdwVfLIIoSHyRiM37XRyRlgltKI4ozBbxPJKxmCeLMOnxkY3K6Mn90c1IR+WdvwAAAP//AwCa/D5niAIAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 22 Dec 2023 17:24:01 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "1faa51e2c81da8249f8992e8520834e2"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "181fb976ed28efe76e4c573627138548"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "x-gadget-served-by",
+              "value": "nginx-green"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=P0yPefli0JBh0LJYBlGvHMEI1i%2Bn57CVoREDBPDOdNZ%2F3pV9m6029EgB9pmv%2FBvzHc3KR7%2BN2bjY71qf4DXDYFhoDO9ajfv6I%2FCz0MYA8toGXvQNNM%2FEiyHdSsuc21m6jnrIddlxv6QIE4Wu%2FjwJYzFBJYLI51rwGPp5FQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "839a0e41ba4c43d6-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 953,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-22T17:23:58.234Z",
+        "time": 3084,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3084
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/packages/react/spec/apis.ts
+++ b/packages/react/spec/apis.ts
@@ -2,8 +2,12 @@ import { Client as NoUserClient } from "@gadget-client/app-with-no-user-model";
 import { Client as BulkClient } from "@gadget-client/bulk-actions-test";
 import { Client as AuthClient } from "@gadget-client/full-auth";
 import { Client } from "@gadget-client/related-products-example";
+import { Client as NestedClient } from "@gadget-client/zxcv-deeply-nested";
+import { Client as SimpleClient } from "@gadget-client/zxcv-simple-relationship";
 
 export const relatedProductsApi = new Client({ environment: "Development" });
 export const bulkExampleApi = new BulkClient({ environment: "Development" });
 export const fullAuthApi = new AuthClient({ environment: "Development" });
 export const noUserModelApi = new NoUserClient({ environment: "Development" });
+export const nestedExampleApi = new NestedClient({ environment: "Development" });
+export const simpleExampleApi = new SimpleClient({ environment: "Development" });

--- a/packages/react/spec/polly.ts
+++ b/packages/react/spec/polly.ts
@@ -1,0 +1,26 @@
+import NodeHttpAdapter from "@pollyjs/adapter-node-http";
+import XHRAdapter from "@pollyjs/adapter-xhr";
+import type { PollyConfig } from "@pollyjs/core";
+import FSPersister from "@pollyjs/persister-fs";
+import path from "path";
+import { setupPolly } from "setup-polly-jest";
+
+export const startPolly = (config: PollyConfig) => {
+  const context = setupPolly({
+    adapters: [NodeHttpAdapter, XHRAdapter],
+    persister: FSPersister,
+
+    persisterOptions: {
+      fs: {
+        recordingsDir: path.resolve(__dirname, "__recordings__"),
+      },
+    },
+    recordIfMissing: true,
+  });
+
+  beforeEach(() => {
+    context.polly.configure(config);
+  });
+
+  return context;
+};

--- a/packages/react/spec/testWrappers.tsx
+++ b/packages/react/spec/testWrappers.tsx
@@ -26,6 +26,22 @@ export const MockClientWrapper =
     );
   };
 
+export const LiveClientWrapper =
+  (
+    api: AnyClient,
+    propOverrides?: {
+      auth?: Partial<GadgetAuthConfiguration>;
+      navigate?: (url: string) => void;
+    }
+  ) =>
+  (props: { children: ReactNode }) => {
+    return (
+      <Provider api={api} navigate={propOverrides?.navigate} auth={propOverrides?.auth}>
+        <Suspense fallback={<div>Loading...</div>}>{props.children}</Suspense>
+      </Provider>
+    );
+  };
+
 export const MockGraphQLWSClientWrapper = (api: AnyClient, auth?: Partial<GadgetAuthConfiguration>) => (props: { children: ReactNode }) => {
   jest.replaceProperty(api.connection, "baseSubscriptionClient", mockGraphQLWSClient as any);
 
@@ -36,5 +52,5 @@ export const MockGraphQLWSClientWrapper = (api: AnyClient, auth?: Partial<Gadget
   );
 };
 
-export { mockUrqlClient, mockGraphQLWSClient, createMockUrqlClient };
+export { createMockUrqlClient, mockGraphQLWSClient, mockUrqlClient };
 export type { MockUrqlClient };

--- a/packages/react/spec/useActionForm.spec.tsx
+++ b/packages/react/spec/useActionForm.spec.tsx
@@ -169,7 +169,6 @@ describe("useActionForm", () => {
   test("can be used with a create action", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -180,8 +179,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -189,7 +188,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -211,7 +209,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -261,7 +258,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -275,7 +271,6 @@ describe("useActionForm", () => {
   test("can be used with a create action with nested fields", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -286,8 +281,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -295,7 +290,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -317,7 +311,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -367,7 +360,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -378,10 +370,9 @@ describe("useActionForm", () => {
     expect(result.current.getValues("user.password")).toBe("secret");
   });
 
-  test("can be used with a gloabal action", async () => {
+  test("can be used with a global action", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -392,8 +383,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(bulkExampleApi) }
@@ -401,7 +392,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -421,7 +411,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -463,7 +452,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -476,7 +464,6 @@ describe("useActionForm", () => {
   test("can be used with a create action on an ambiguous model", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -487,8 +474,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -496,7 +483,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -518,7 +504,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -570,7 +555,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -584,7 +568,7 @@ describe("useActionForm", () => {
   test("can handle errors during a create action", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
+    let error: any = null;
 
     const { result } = renderHook(
       () =>
@@ -595,8 +579,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            error = e;
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -604,7 +588,7 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
+    expect(error).toBeFalsy();
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -627,7 +611,7 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
+    expect(error).toBeFalsy();
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -679,7 +663,9 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(true);
+    expect(error).toMatchInlineSnapshot(
+      `[ErrorWrapper: [GraphQL] Record is invalid, one error needs to be corrected. Email is not unique.]`
+    );
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -708,6 +694,7 @@ describe("useActionForm", () => {
     expect(result.current.getValues("user.email")).toBe("test@test.com");
     expect(result.current.getValues("user.password")).toBe("secret");
 
+    error = null;
     await act(async () => {
       (result.current as any).setValue("user.email", "foo@test.com");
       submitPromise = result.current.submit();
@@ -715,7 +702,7 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(true);
+    expect(error).toBeFalsy();
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -767,7 +754,8 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(true);
+    expect(error).toBeTruthy();
+    expect(error).toMatchInlineSnapshot(`[ErrorWrapper: [GraphQL] GGT_INVALID_EMAIL_PASSWORD: Invalid email or password.]`);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -789,6 +777,7 @@ describe("useActionForm", () => {
     expect(result.current.getValues("user.email")).toBe("foo@test.com");
     expect(result.current.getValues("user.password")).toBe("secret");
 
+    error = null;
     await act(async () => {
       (result.current as any).setValue("user.password", "Abc123123!");
       submitPromise = result.current.submit();
@@ -796,7 +785,7 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(true);
+    expect(error).toBeFalsy();
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -838,7 +827,8 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(true);
+    expect(error).toBeTruthy();
+    expect(error).toMatchInlineSnapshot(`[ErrorWrapper: [Network] Network error]`);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -858,6 +848,7 @@ describe("useActionForm", () => {
     expect(result.current.getValues("user.email")).toBe("foo@test.com");
     expect(result.current.getValues("user.password")).toBe("Abc123123!");
 
+    error = null;
     await act(async () => {
       (result.current as any).setValue("user.password", "Abc123123!");
       submitPromise = result.current.submit();
@@ -865,7 +856,7 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(true);
+    expect(error).toBeFalsy();
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -917,7 +908,7 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(true);
+    expect(error).toBeFalsy();
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -940,7 +931,7 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(true);
+    expect(error).toBeFalsy();
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -961,7 +952,7 @@ describe("useActionForm", () => {
   test("can handle an form error", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
+    let error: any;
 
     const { result } = renderHook(
       () =>
@@ -972,8 +963,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            error = e;
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -981,7 +972,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -996,9 +986,9 @@ describe("useActionForm", () => {
       await result.current.submit();
     });
 
+    expect(error).toBeDefined();
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(true);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
@@ -1026,7 +1016,6 @@ describe("useActionForm", () => {
   test("can only send certain fields in the action", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -1037,8 +1026,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
           send: ["user.email"],
         }),
@@ -1047,7 +1036,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1069,7 +1057,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1118,7 +1105,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -1132,7 +1118,6 @@ describe("useActionForm", () => {
   test("can be used with an update action when given an existing record as default values at the root level", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -1155,8 +1140,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -1164,7 +1149,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1186,7 +1170,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1239,7 +1222,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -1253,7 +1235,6 @@ describe("useActionForm", () => {
   test("can be used with an update action when given an existing record as default values at the record level", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -1275,8 +1256,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -1284,7 +1265,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1306,7 +1286,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1359,7 +1338,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -1373,7 +1351,6 @@ describe("useActionForm", () => {
   test("can be used with an update action when finding record by id", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -1385,8 +1362,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -1394,7 +1371,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(true);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1423,7 +1399,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1443,7 +1418,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1496,7 +1470,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -1512,7 +1485,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1816,7 +1788,6 @@ describe("useActionForm", () => {
   test("can be used with an update action when finding record by id on an ambiguous model", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -1828,8 +1799,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -1837,7 +1808,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(true);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1866,7 +1836,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1886,7 +1855,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -1945,7 +1913,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -1968,7 +1935,6 @@ describe("useActionForm", () => {
   test("can be used with an update action when finding record by email", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -1980,8 +1946,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -1989,7 +1955,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(true);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -2030,7 +1995,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -2050,7 +2014,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -2103,7 +2066,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);
@@ -2117,7 +2079,6 @@ describe("useActionForm", () => {
   test("can be used with an update action when finding record by id and specifying a selection", async () => {
     let submitted = false;
     let success = false;
-    let error = false;
 
     const { result } = renderHook(
       () =>
@@ -2130,8 +2091,8 @@ describe("useActionForm", () => {
           onSuccess: () => {
             success = true;
           },
-          onError: () => {
-            error = true;
+          onError: (e) => {
+            expect(e).toBeUndefined();
           },
         }),
       { wrapper: MockClientWrapper(relatedProductsApi) }
@@ -2139,7 +2100,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(true);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -2173,7 +2133,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(false);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -2193,7 +2152,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(false);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(false);
     expect(result.current.formState.isSubmitSuccessful).toBe(false);
@@ -2246,7 +2204,6 @@ describe("useActionForm", () => {
 
     expect(submitted).toBe(true);
     expect(success).toBe(true);
-    expect(error).toBe(false);
     expect(result.current.formState.isLoading).toBe(false);
     expect(result.current.formState.isSubmitted).toBe(true);
     expect(result.current.formState.isSubmitSuccessful).toBe(true);

--- a/packages/react/spec/useActionFormNested.spec.tsx
+++ b/packages/react/spec/useActionFormNested.spec.tsx
@@ -1,0 +1,1673 @@
+import { MODE } from "@pollyjs/core";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useActionForm, useFieldArray } from "../src/useActionForm.js";
+import { useFindFirst } from "../src/useFindFirst.js";
+import { bulkExampleApi, nestedExampleApi } from "./apis.js";
+import { startPolly } from "./polly.js";
+import { LiveClientWrapper, MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
+
+describe("useActionFormNested", () => {
+  describe("with polly", () => {
+    startPolly({
+      mode: (process.env.POLLY_MODE ?? "replay") as MODE,
+      recordFailedRequests: true,
+    });
+
+    test("can create a single HasMany relationship", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create multiple HasMany relationships", async () => {
+      let returnedData: any;
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              returnedData = actionResult;
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.text", "test question - 2");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create a single HasMany -> HasMany relationship", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer - 1");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create multiple HasMany -> HasMany relationships", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer - 1");
+
+        (useActionFormHook.current as any).setValue("quiz.questions.1.text", "test question - 2");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.answers.0.text", "test answer - 2");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create a single HasMany -> HasMany -> HasOne relationship", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.notification.enabled", true);
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create multiple HasMany -> HasMany -> HasOne relationships", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.notification.enabled", true);
+
+        (useActionFormHook.current as any).setValue("quiz.questions.1.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.answers.0.text", "test answer - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.answers.0.notification.enabled", true);
+      });
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create a single HasMany -> HasMany -> HasOne -> BelongsTo relationship", async () => {
+      const { result: useFindFirstHook } = renderHook(() => useFindFirst(nestedExampleApi.shopifyProduct), {
+        wrapper: LiveClientWrapper(nestedExampleApi),
+      });
+
+      await waitFor(() => expect(useFindFirstHook.current[0].fetching).toBe(false), { timeout: 3000 });
+
+      expect(useFindFirstHook.current[0].data).toMatchInlineSnapshot(`
+              {
+                "__typename": "ShopifyProduct",
+                "body": "example value for body",
+                "compareAtPriceRange": null,
+                "createdAt": "2023-12-12T16:22:25.001Z",
+                "handle": null,
+                "id": "123",
+                "productCategory": null,
+                "productType": null,
+                "publishedAt": null,
+                "publishedScope": null,
+                "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
+                "shopifyUpdatedAt": null,
+                "status": null,
+                "tags": null,
+                "templateSuffix": null,
+                "title": null,
+                "updatedAt": "2023-12-12T16:22:25.001Z",
+                "vendor": null,
+              }
+          `);
+
+      const productSuggestionId = useFindFirstHook?.current[0]?.data?.id;
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer - 1");
+        (useActionFormHook.current as any).setValue(
+          "quiz.questions.0.answers.0.recommendedProduct.productSuggestion.id",
+          productSuggestionId
+        );
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create a single HasMany -> HasMany -> HasOne -> multiple BelongsTo relationship", async () => {
+      const { result: useFindFirstHook } = renderHook(() => useFindFirst(nestedExampleApi.shopifyProduct), {
+        wrapper: LiveClientWrapper(nestedExampleApi),
+      });
+
+      await waitFor(() => expect(useFindFirstHook.current[0].fetching).toBe(false), { timeout: 3000 });
+
+      expect(useFindFirstHook.current[0].data).toMatchInlineSnapshot(`
+              {
+                "__typename": "ShopifyProduct",
+                "body": "example value for body",
+                "compareAtPriceRange": null,
+                "createdAt": "2023-12-12T16:22:25.001Z",
+                "handle": null,
+                "id": "123",
+                "productCategory": null,
+                "productType": null,
+                "publishedAt": null,
+                "publishedScope": null,
+                "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
+                "shopifyUpdatedAt": null,
+                "status": null,
+                "tags": null,
+                "templateSuffix": null,
+                "title": null,
+                "updatedAt": "2023-12-12T16:22:25.001Z",
+                "vendor": null,
+              }
+          `);
+
+      const productSuggestionId = useFindFirstHook?.current[0]?.data?.id;
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer - 1");
+        (useActionFormHook.current as any).setValue(
+          "quiz.questions.0.answers.0.recommendedProduct.productSuggestion.id",
+          productSuggestionId
+        );
+        (useActionFormHook.current as any).setValue(
+          "quiz.questions.0.answers.0.recommendedProduct.anotherProductSuggestion.id",
+          productSuggestionId
+        );
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create a single HasMany -> HasMany -> HasOne -> BelongsTo relationship with support for Id prefix", async () => {
+      const { result: useFindFirstHook } = renderHook(() => useFindFirst(nestedExampleApi.shopifyProduct), {
+        wrapper: LiveClientWrapper(nestedExampleApi),
+      });
+
+      await waitFor(() => expect(useFindFirstHook.current[0].fetching).toBe(false), { timeout: 3000 });
+
+      expect(useFindFirstHook.current[0].data).toMatchInlineSnapshot(`
+              {
+                "__typename": "ShopifyProduct",
+                "body": "example value for body",
+                "compareAtPriceRange": null,
+                "createdAt": "2023-12-12T16:22:25.001Z",
+                "handle": null,
+                "id": "123",
+                "productCategory": null,
+                "productType": null,
+                "publishedAt": null,
+                "publishedScope": null,
+                "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
+                "shopifyUpdatedAt": null,
+                "status": null,
+                "tags": null,
+                "templateSuffix": null,
+                "title": null,
+                "updatedAt": "2023-12-12T16:22:25.001Z",
+                "vendor": null,
+              }
+          `);
+
+      const productSuggestionId = useFindFirstHook?.current[0]?.data?.id;
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer - 1");
+        (useActionFormHook.current as any).setValue(
+          "quiz.questions.0.answers.0.recommendedProduct.productSuggestionId",
+          productSuggestionId
+        );
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can create a single HasMany -> HasMany -> HasOne -> multiple BelongsTo relationship with support for Id prefix", async () => {
+      const { result: useFindFirstHook } = renderHook(() => useFindFirst(nestedExampleApi.shopifyProduct), {
+        wrapper: LiveClientWrapper(nestedExampleApi),
+      });
+
+      await waitFor(() => expect(useFindFirstHook.current[0].fetching).toBe(false), { timeout: 3000 });
+
+      expect(useFindFirstHook.current[0].data).toMatchInlineSnapshot(`
+              {
+                "__typename": "ShopifyProduct",
+                "body": "example value for body",
+                "compareAtPriceRange": null,
+                "createdAt": "2023-12-12T16:22:25.001Z",
+                "handle": null,
+                "id": "123",
+                "productCategory": null,
+                "productType": null,
+                "publishedAt": null,
+                "publishedScope": null,
+                "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
+                "shopifyUpdatedAt": null,
+                "status": null,
+                "tags": null,
+                "templateSuffix": null,
+                "title": null,
+                "updatedAt": "2023-12-12T16:22:25.001Z",
+                "vendor": null,
+              }
+          `);
+
+      const productSuggestionId = useFindFirstHook?.current[0]?.data?.id;
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.create, {
+            defaultValues: {
+              quiz: {
+                text: "",
+                questions: [{}],
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      expect(useActionFormHook.current.getValues()).toMatchInlineSnapshot(`
+              {
+                "quiz": {
+                  "questions": [
+                    {},
+                  ],
+                  "text": "",
+                },
+              }
+          `);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer - 1");
+        (useActionFormHook.current as any).setValue(
+          "quiz.questions.0.answers.0.recommendedProduct.productSuggestionId",
+          productSuggestionId
+        );
+        (useActionFormHook.current as any).setValue(
+          "quiz.questions.0.answers.0.recommendedProduct.anotherProductSuggestionId",
+          productSuggestionId
+        );
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update root object", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "163",
+            select: {
+              id: true,
+              text: true,
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("quiz");
+      expect(formValues).toBeDefined();
+      expect(formValues?.text).toBeDefined();
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("text", "test quiz updated");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update root even if nested", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "163",
+            select: {
+              id: true,
+              text: true,
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("quiz");
+      expect(formValues).toBeDefined();
+      expect(formValues?.text).toBeDefined();
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz updated");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update a single HasMany relationship", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "164",
+            select: {
+              id: true,
+              text: true,
+              questions: {
+                edges: {
+                  node: {
+                    id: true,
+                    text: true,
+                  },
+                },
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("quiz");
+      expect(formValues).toBeDefined();
+      expect(formValues?.text).toBeDefined();
+      expect(formValues?.questions).toBeDefined();
+      expect(formValues?.questions?.length).toBe(1);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz updated");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question updated");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update multiple HasMany relationships", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "168",
+            select: {
+              id: true,
+              text: true,
+              questions: {
+                edges: {
+                  node: {
+                    id: true,
+                    text: true,
+                  },
+                },
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("quiz");
+      expect(formValues).toBeDefined();
+      expect(formValues?.text).toBeDefined();
+      expect(formValues?.questions).toBeDefined();
+      expect(formValues?.questions?.length).toBe(2);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz updated");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.text", "test question updated - 2");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update multiple HasMany relationships that are reordered", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "168",
+            select: {
+              id: true,
+              text: true,
+              questions: {
+                edges: {
+                  node: {
+                    id: true,
+                    text: true,
+                  },
+                },
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("quiz");
+      expect(formValues).toBeDefined();
+      expect(formValues?.text).toBeDefined();
+      expect(formValues?.questions).toBeDefined();
+      expect(formValues?.questions?.length).toBe(2);
+
+      const { result: questionsFieldArrayHook } = renderHook(() =>
+        useFieldArray({ control: useActionFormHook.current.control, name: "quiz.questions" })
+      );
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz updated");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.text", "test question updated - 2");
+
+        questionsFieldArrayHook.current.move(0, 1);
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update a single HasMany -> Multiple HasMany relationship", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "192",
+            select: {
+              id: true,
+              text: true,
+              questions: {
+                edges: {
+                  node: {
+                    id: true,
+                    text: true,
+                    answers: {
+                      edges: {
+                        node: {
+                          id: true,
+                          text: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("quiz");
+      expect(formValues).toBeDefined();
+      expect(formValues?.text).toBeDefined();
+      expect(formValues?.questions).toBeDefined();
+      expect(formValues?.questions?.length).toBe(2);
+      expect(formValues?.questions?.[0]?.answers?.length).toBe(2);
+      expect(formValues?.questions?.[1]?.answers?.length).toBe(0);
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz updated");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.text", "test question updated - 2");
+
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.1.text", "test answer updated - 2");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update a single HasOne relationship", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.answer.update, {
+            findBy: "187",
+            select: {
+              id: true,
+              text: true,
+              notification: {
+                id: true,
+                enabled: true,
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("answer");
+      expect(formValues).toBeDefined();
+      expect(formValues?.notification).toBeDefined();
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("answer.text", "test answers updated");
+        (useActionFormHook.current as any).setValue("answer.notification.enabled", false);
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update a single BelongsTo relationship", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.answer.update, {
+            findBy: "187",
+            select: {
+              id: true,
+              text: true,
+              question: {
+                id: true,
+              },
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("answer");
+      expect(formValues).toBeDefined();
+      expect(formValues?.question).toBeDefined();
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("answer.text", "test answers updated");
+        (useActionFormHook.current as any).setValue("answer.question.id", 123);
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+
+    test("can update a single BelongsTo relationship with support for Id prefix test", async () => {
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.answer.update, {
+            findBy: "187",
+            select: {
+              id: true,
+              text: true,
+              questionId: true,
+            },
+            onSuccess: (actionResult) => {
+              expect(actionResult.id).toBeDefined();
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: LiveClientWrapper(nestedExampleApi),
+        }
+      );
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("answer");
+      expect(formValues).toBeDefined();
+
+      await act(async () => {
+        useActionFormHook.current.setValue("answer.text", "test answers updated");
+        (useActionFormHook.current as any).setValue("answer.questionId", 123);
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      await act(async () => {
+        await useActionFormHook.current.submit();
+      });
+    });
+  });
+
+  describe("with mocking", () => {
+    test("when no referenceTypes are provided/fetched it should throw an error", async () => {
+      const { result: useActionFormHook } = renderHook(() => useActionForm(bulkExampleApi.widget.create), {
+        wrapper: MockClientWrapper(bulkExampleApi),
+      });
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false));
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question");
+      });
+
+      await act(async () => {
+        await expect(useActionFormHook.current.submit).rejects.toThrowError(
+          "No Gadget model metadata found -- please ensure you are using the latest version of the API client for your app"
+        );
+      });
+    });
+
+    test("can update multiple HasMany -> HasMany relationships", async () => {
+      const queryResponse = {
+        data: {
+          quiz: {
+            __typename: "Quiz",
+            id: "193",
+            text: "quiz title",
+            questions: {
+              edges: [
+                {
+                  node: {
+                    id: "1",
+                    text: "question text - 1",
+                    answers: {
+                      edges: [
+                        {
+                          node: {
+                            id: "1",
+                            text: "answer text - 1",
+                            __typename: "Answer",
+                          },
+                        },
+                        {
+                          node: {
+                            id: "2",
+                            text: "answer text - 2",
+                            __typename: "Answer",
+                          },
+                        },
+                      ],
+                    },
+                    __typename: "Question",
+                  },
+                  __typename: "QuestionEdge",
+                },
+                {
+                  node: {
+                    id: "2",
+                    text: "question text - 2",
+                    __typename: "Question",
+                    answers: {
+                      edges: [],
+                    },
+                  },
+                  __typename: "QuestionEdge",
+                },
+              ],
+              __typename: "QuestionConnection",
+            },
+          },
+        },
+      };
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "193",
+            select: {
+              id: true,
+              text: true,
+              questions: {
+                edges: {
+                  node: {
+                    id: true,
+                    text: true,
+                    answers: {
+                      edges: {
+                        node: {
+                          id: true,
+                          text: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: MockClientWrapper(nestedExampleApi),
+        }
+      );
+
+      expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+      mockUrqlClient.executeQuery.pushResponse("quiz", {
+        stale: false,
+        hasNext: false,
+        data: queryResponse.data,
+      });
+
+      await waitFor(() => expect(useActionFormHook.current.formState.isLoading).toBe(false), { timeout: 3000 });
+
+      const formValues = useActionFormHook.current.getValues("quiz");
+      expect(formValues).toBeDefined();
+      expect(formValues?.text).toBeDefined();
+      expect(formValues?.questions).toBeDefined();
+      expect(formValues?.questions?.length).toBe(2);
+      expect(formValues?.questions?.[0]?.answers?.length).toBe(2);
+      expect(formValues?.questions?.[1]?.answers?.length).toBe(0);
+
+      const { result: questionsFieldArrayHook } = renderHook(() =>
+        useFieldArray({ control: useActionFormHook.current.control, name: "quiz.questions" })
+      );
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz updated");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.text", "test question updated - 2");
+
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "test answer updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.1.text", "test answer updated - 2");
+
+        (useActionFormHook.current as any).setValue("quiz.questions.1.answers.0.text", "test answer updated - 3");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.answers.1.text", "test answer updated - 4");
+      });
+
+      expect(useActionFormHook.current.formState.errors).toEqual({});
+
+      let submitPromise: Promise<any>;
+
+      await act(async () => {
+        submitPromise = useActionFormHook.current.submit();
+      });
+
+      expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
+
+      mockUrqlClient.executeMutation.pushResponse("updateQuiz", {
+        data: {
+          quiz: {
+            __typename: "Quiz",
+            createdAt: "2023-12-12T15:20:11.728Z",
+            id: "193",
+            text: "test quiz",
+            updatedAt: "2023-12-12T15:20:11.728Z",
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      await act(async () => {
+        await submitPromise;
+      });
+
+      const submitResult = mockUrqlClient.executeMutation.mock.calls[0][0].variables;
+      expect(submitResult.quiz.questions.length).toBe(2);
+
+      expect(submitResult.quiz.questions[0].update.answers.length).toBe(2);
+      expect(submitResult.quiz.questions[0].update.answers[0].update.id).toBe("1");
+      expect(submitResult.quiz.questions[0].update.answers[1].update.id).toBe("2");
+
+      expect(submitResult.quiz.questions[1].update.answers.length).toBe(2);
+      expect(submitResult.quiz.questions[1].update.answers[0].create).toBeDefined();
+      expect(submitResult.quiz.questions[1].update.answers[1].create).toBeDefined();
+    });
+
+    test("can update HasMany relationships that are reordered and one is deleted", async () => {
+      const queryResponse = {
+        data: {
+          quiz: {
+            __typename: "Quiz",
+            id: "168",
+            text: "quiz title",
+            questions: {
+              edges: [
+                {
+                  node: {
+                    id: "1",
+                    text: "question text - 1",
+                    __typename: "Question",
+                  },
+                  __typename: "QuestionEdge",
+                },
+                {
+                  node: {
+                    id: "2",
+                    text: "question text - 2",
+                    __typename: "Question",
+                  },
+                  __typename: "QuestionEdge",
+                },
+                {
+                  node: {
+                    id: "3",
+                    text: "question text - 3",
+                    __typename: "Question",
+                  },
+                  __typename: "QuestionEdge",
+                },
+              ],
+              __typename: "QuestionConnection",
+            },
+          },
+        },
+      };
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "168",
+            select: {
+              id: true,
+              text: true,
+              questions: {
+                edges: {
+                  node: {
+                    id: true,
+                    text: true,
+                  },
+                },
+              },
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: MockClientWrapper(nestedExampleApi),
+        }
+      );
+
+      expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+      mockUrqlClient.executeQuery.pushResponse("quiz", {
+        stale: false,
+        hasNext: false,
+        data: queryResponse.data,
+      });
+
+      let formValues: any;
+
+      await act(async () => {
+        formValues = useActionFormHook.current.getValues();
+      });
+
+      expect(formValues.quiz).toBeDefined();
+      expect(formValues.quiz.text).toBeDefined();
+      expect(formValues.quiz.questions).toBeDefined();
+      expect(formValues.quiz.questions.length).toBe(3);
+
+      const { result: questionsFieldArrayHook } = renderHook(() =>
+        useFieldArray({ control: useActionFormHook.current.control, name: "quiz.questions" })
+      );
+
+      await act(async () => {
+        useActionFormHook.current.setValue("quiz.questions.0.text", "test quiz updated");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.1.text", "test question updated - 2");
+        (useActionFormHook.current as any).setValue("quiz.questions.2.text", "test question updated - 3");
+
+        questionsFieldArrayHook.current.move(0, 1);
+        questionsFieldArrayHook.current.remove(2);
+      });
+
+      let submitPromise: Promise<any>;
+
+      await act(async () => {
+        submitPromise = useActionFormHook.current.submit();
+      });
+
+      expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
+
+      mockUrqlClient.executeMutation.pushResponse("updateQuiz", {
+        data: {
+          quiz: {
+            __typename: "Quiz",
+            createdAt: "2023-12-12T15:20:11.728Z",
+            id: "21",
+            text: "test quiz",
+            updatedAt: "2023-12-12T15:20:11.728Z",
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      await act(async () => {
+        await submitPromise;
+      });
+
+      const submitResult = mockUrqlClient.executeMutation.mock.calls[0][0].variables;
+
+      expect(submitResult.quiz.questions.length).toBe(3);
+      expect(submitResult.quiz.questions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            update: {
+              id: "1",
+              text: "test question updated - 1",
+            },
+          }),
+          expect.objectContaining({
+            update: {
+              id: "2",
+              text: "test question updated - 2",
+            },
+          }),
+          expect.objectContaining({
+            delete: {
+              id: "3",
+            },
+          }),
+        ])
+      );
+    });
+
+    test("can update HasMany -> HasMany relationships that are reordered and one is deleted", async () => {
+      const queryResponse = {
+        data: {
+          quiz: {
+            __typename: "Quiz",
+            id: "168",
+            text: "quiz title",
+            questions: {
+              edges: [
+                {
+                  node: {
+                    id: "1",
+                    text: "question text - 1",
+                    answers: {
+                      edges: [
+                        {
+                          node: {
+                            id: "1",
+                            text: "answer text - 1",
+                          },
+                        },
+                        {
+                          node: {
+                            id: "2",
+                            text: "answer text - 2",
+                          },
+                        },
+                        {
+                          node: {
+                            id: "3",
+                            text: "answer text - 3",
+                          },
+                        },
+                      ],
+                    },
+                    __typename: "Question",
+                  },
+                  __typename: "QuestionEdge",
+                },
+              ],
+              __typename: "QuestionConnection",
+            },
+          },
+        },
+      };
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.quiz.update, {
+            findBy: "168",
+            select: {
+              id: true,
+              text: true,
+              questions: {
+                edges: {
+                  node: {
+                    id: true,
+                    text: true,
+                    answers: {
+                      edges: {
+                        node: {
+                          id: true,
+                          text: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: MockClientWrapper(nestedExampleApi),
+        }
+      );
+
+      expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+      mockUrqlClient.executeQuery.pushResponse("quiz", {
+        stale: false,
+        hasNext: false,
+        data: queryResponse.data,
+      });
+
+      let formValues: any;
+
+      await act(async () => {
+        formValues = useActionFormHook.current.getValues();
+      });
+
+      expect(formValues.quiz).toBeDefined();
+      expect(formValues.quiz.text).toBeDefined();
+      expect(formValues.quiz.questions).toBeDefined();
+      expect(formValues.quiz.questions.length).toBe(1);
+      expect(formValues.quiz.questions[0].answers.length).toBe(3);
+
+      const { result: questions0AnswersFieldArrayHook } = renderHook(() =>
+        useFieldArray({ control: useActionFormHook.current.control, name: "quiz.questions.0.answers" })
+      );
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("quiz.text", "test quiz updated");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.text", "test question updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.0.text", "answer updated - 1");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.1.text", "answer updated - 2");
+        (useActionFormHook.current as any).setValue("quiz.questions.0.answers.2.text", "answer updated - 3");
+
+        questions0AnswersFieldArrayHook.current.move(0, 2);
+        questions0AnswersFieldArrayHook.current.remove(2);
+      });
+
+      let submitPromise: Promise<any>;
+
+      await act(async () => {
+        submitPromise = useActionFormHook.current.submit();
+      });
+
+      expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
+
+      mockUrqlClient.executeMutation.pushResponse("updateQuiz", {
+        data: {
+          quiz: {
+            __typename: "Quiz",
+            createdAt: "2023-12-12T15:20:11.728Z",
+            id: "21",
+            text: "test quiz",
+            updatedAt: "2023-12-12T15:20:11.728Z",
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      await act(async () => {
+        await submitPromise;
+      });
+
+      const submitResult = mockUrqlClient.executeMutation.mock.calls[0][0].variables;
+
+      expect(submitResult.quiz.questions.length).toBe(1);
+      expect(submitResult.quiz.questions[0].update.answers.length).toBe(3);
+      expect(submitResult.quiz.questions[0].update.answers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            delete: {
+              id: "1",
+            },
+          }),
+          expect.objectContaining({
+            update: {
+              id: "2",
+              text: "answer updated - 2",
+            },
+          }),
+          expect.objectContaining({
+            update: {
+              id: "3",
+              text: "answer updated - 3",
+            },
+          }),
+        ])
+      );
+    });
+
+    test("can update multiple HasOne -> BelongsTo relationships", async () => {
+      const queryResponse = {
+        data: {
+          answer: {
+            __typename: "Answer",
+            id: "123",
+            text: "answer text",
+            notification: {
+              __typename: "Notification",
+              id: "1",
+              enabled: false,
+              answer: {
+                id: "123",
+              },
+            },
+            recommendedProduct: {
+              __typename: "RecommendedProduct",
+              id: "1",
+              answer: {
+                id: "123",
+              },
+            },
+          },
+        },
+      };
+
+      const { result: useActionFormHook } = renderHook(
+        () =>
+          useActionForm(nestedExampleApi.answer.update, {
+            findBy: "168",
+            select: {
+              id: true,
+              text: true,
+              notification: {
+                id: true,
+                enabled: true,
+                answer: {
+                  id: true,
+                },
+              },
+              recommendedProduct: {
+                id: true,
+                answer: {
+                  id: true,
+                },
+              },
+            },
+            onError: (error) => {
+              expect(error).toBeUndefined();
+            },
+          }),
+        {
+          wrapper: MockClientWrapper(nestedExampleApi),
+        }
+      );
+
+      expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+      mockUrqlClient.executeQuery.pushResponse("answer", {
+        stale: false,
+        hasNext: false,
+        data: queryResponse.data,
+      });
+
+      let formValues: any;
+
+      await act(async () => {
+        formValues = useActionFormHook.current.getValues();
+      });
+
+      expect(formValues.answer).toBeDefined();
+
+      await act(async () => {
+        (useActionFormHook.current as any).setValue("answer.notification.answer.id", "999");
+        (useActionFormHook.current as any).setValue("answer.recommendedProduct.answer.id", "999");
+      });
+
+      let submitPromise: Promise<any>;
+
+      await act(async () => {
+        submitPromise = useActionFormHook.current.submit();
+      });
+
+      expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
+
+      mockUrqlClient.executeMutation.pushResponse("updateAnswer", {
+        data: {
+          answer: {
+            __typename: "Answer",
+            createdAt: "2023-12-12T15:20:11.728Z",
+            id: "123",
+            text: "test answer",
+            updatedAt: "2023-12-12T15:20:11.728Z",
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      await act(async () => {
+        await submitPromise;
+      });
+
+      const submitResult = mockUrqlClient.executeMutation.mock.calls[0][0].variables;
+      expect(submitResult.answer.notification.update.answer._link).toBe("999");
+      expect(submitResult.answer.recommendedProduct.update.answer._link).toBe("999");
+    });
+  });
+});

--- a/packages/react/spec/useFetch.spec.tsx
+++ b/packages/react/spec/useFetch.spec.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment ./spec/jsdom-environment.ts
+ */
+
 import { act, render, renderHook, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { IsExact } from "conditional-type-checks";

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -57,6 +57,7 @@ export const useFindOne = <
 
   const result = useMemo(() => {
     const dataPath = [manager.findOne.operationName];
+
     let data = rawResult.data && get(rawResult.data, dataPath);
     if (data) {
       data = hydrateRecord(rawResult, data);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,17 +22,23 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@gadget-client/related-products-example':
-        specifier: ^1.854.0
-        version: 1.854.0
+        specifier: ^1.859.0
+        version: 1.859.0
+      '@gadget-client/zxcv-deeply-nested':
+        specifier: ^1.207.0
+        version: 1.207.0
+      '@gadget-client/zxcv-simple-relationship':
+        specifier: ^1.17.0
+        version: 1.17.0
       '@gadgetinc/api-client-core':
         specifier: workspace:*
         version: link:packages/api-client-core
       '@gadgetinc/eslint-config':
         specifier: ^0.6.1
-        version: 0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.39.0)(jest@29.7.0)(lodash@4.17.21)(typescript@5.0.4)
+        version: 0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.39.0)(jest@29.7.0)(lodash@4.17.21)(typescript@5.2.2)
       '@gadgetinc/prettier-config':
         specifier: ^0.4.0
-        version: 0.4.0(prettier@2.8.8)(typescript@5.0.4)
+        version: 0.4.0(prettier@2.8.8)(typescript@5.2.2)
       '@gadgetinc/react':
         specifier: workspace:*
         version: link:packages/react
@@ -80,10 +86,10 @@ importers:
         version: 7.3.8
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@swc/core@1.3.90)(@types/node@16.11.7)(typescript@5.0.4)
+        version: 10.9.1(@swc/core@1.3.90)(@types/node@16.11.7)(typescript@5.2.2)
       typescript:
-        specifier: 5.0.4
-        version: 5.0.4
+        specifier: 5.2.2
+        version: 5.2.2
       zx:
         specifier: ^7.1.1
         version: 7.1.1
@@ -207,6 +213,21 @@ importers:
       '@n1ru4l/json-patch-plus':
         specifier: ^0.2.0
         version: 0.2.0
+      '@pollyjs/adapter-fetch':
+        specifier: ^6.0.6
+        version: 6.0.6
+      '@pollyjs/adapter-node-http':
+        specifier: ^6.0.6
+        version: 6.0.6
+      '@pollyjs/adapter-xhr':
+        specifier: ^6.0.6
+        version: 6.0.6
+      '@pollyjs/core':
+        specifier: ^6.0.6
+        version: 6.0.6
+      '@pollyjs/persister-fs':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -231,6 +252,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.4
         version: 18.2.4
+      '@types/setup-polly-jest':
+        specifier: ^0.5.5
+        version: 0.5.5
       '@urql/core':
         specifier: ^4.0.10
         version: 4.0.10(graphql@16.8.1)
@@ -252,6 +276,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      setup-polly-jest:
+        specifier: ^0.11.0
+        version: 0.11.0(@pollyjs/core@6.0.6)
       wonka:
         specifier: ^6.3.2
         version: 6.3.2
@@ -1195,13 +1222,25 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/related-products-example@1.854.0:
-    resolution: {integrity: sha1-yEytaM9x8otBV06i0Cw/F6zsglo=, tarball: https://registry.gadget.dev/npm/_/tarball/1268/1361/5562}
+  /@gadget-client/related-products-example@1.859.0:
+    resolution: {integrity: sha1-nb14pOPLAMiw0Yz7IiLFBLedUu0=, tarball: https://registry.gadget.dev/npm/_/tarball/1268/1362/6228}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadgetinc/eslint-config@0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.39.0)(jest@29.7.0)(lodash@4.17.21)(typescript@5.0.4):
+  /@gadget-client/zxcv-deeply-nested@1.207.0:
+    resolution: {integrity: sha1-bXcspYSq+sVyQiQ3AoqiWT5CSnc=, tarball: https://registry.gadget.dev/npm/_/tarball/76013/150608/6227}
+    dependencies:
+      '@gadgetinc/api-client-core': link:packages/api-client-core
+    dev: true
+
+  /@gadget-client/zxcv-simple-relationship@1.17.0:
+    resolution: {integrity: sha1-FRYfc5QiRRNZtlbEI8YO9VVxIo4=, tarball: https://registry.gadget.dev/npm/_/tarball/79412/157406/6169}
+    dependencies:
+      '@gadgetinc/api-client-core': link:packages/api-client-core
+    dev: true
+
+  /@gadgetinc/eslint-config@0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.39.0)(jest@29.7.0)(lodash@4.17.21)(typescript@5.2.2):
     resolution: {integrity: sha512-RFxEUYbQS9feOikGDphXWdHTkMHtO3g8x6XYwo9FPRK1VuzRpRhsiU1QXA1yU+KEGW5kMNU02t/iCFLoXkdl3g==}
     peerDependencies:
       '@gadgetinc/prettier-config': '>=0'
@@ -1209,22 +1248,22 @@ packages:
       lodash: '>=4'
       typescript: '>=2.8.0'
     dependencies:
-      '@gadgetinc/prettier-config': 0.4.0(prettier@2.8.8)(typescript@5.0.4)
-      '@typescript-eslint/eslint-plugin': 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@gadgetinc/prettier-config': 0.4.0(prettier@2.8.8)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.2.2)
       eslint: 8.39.0
       eslint-config-prettier: 8.8.0(eslint@8.39.0)
       eslint-plugin-baseui: 10.12.1(eslint@8.39.0)
       eslint-plugin-cypress: 2.12.1(eslint@8.39.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)
-      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.59.2)(eslint@8.39.0)(jest@29.7.0)(typescript@5.0.4)
+      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.59.2)(eslint@8.39.0)(jest@29.7.0)(typescript@5.2.2)
       eslint-plugin-jsdoc: 39.9.1(eslint@8.39.0)
       eslint-plugin-lodash: 7.4.0(eslint@8.39.0)
       eslint-plugin-react: 7.32.2(eslint@8.39.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.39.0)
       eslint-plugin-workspaces: 0.7.0
       lodash: 4.17.21
-      typescript: 5.0.4
+      typescript: 5.2.2
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -1232,13 +1271,13 @@ packages:
       - supports-color
     dev: true
 
-  /@gadgetinc/prettier-config@0.4.0(prettier@2.8.8)(typescript@5.0.4):
+  /@gadgetinc/prettier-config@0.4.0(prettier@2.8.8)(typescript@5.2.2):
     resolution: {integrity: sha512-a5jSbHlFjg3WojaDONSGPPvwJdToqpSAixHpLOJ55xMqnfOTRxY2Qr41lPDmLryfch0vD8v/Fnue3/pkwZKVdQ==}
     peerDependencies:
       prettier: ^2.8.1
     dependencies:
       prettier: 2.8.8
-      prettier-plugin-organize-imports: 3.2.2(prettier@2.8.8)(typescript@5.0.4)
+      prettier-plugin-organize-imports: 3.2.2(prettier@2.8.8)(typescript@5.2.2)
     transitivePeerDependencies:
       - '@volar/vue-language-plugin-pug'
       - '@volar/vue-typescript'
@@ -1630,6 +1669,108 @@ packages:
       fastq: 1.13.0
     dev: true
 
+  /@offirgolan/nise@4.1.0:
+    resolution: {integrity: sha512-7GEUt4YBlYdQM3D5cyQTUiupvBtSNapNiplkz1AI9hJETjFOemUPUHJq0+NmlaBt3WjdHGq8zg+FfKwjYTSQcw==}
+    dependencies:
+      '@sinonjs/commons': 1.8.6
+      '@sinonjs/fake-timers': 6.0.1
+      '@sinonjs/text-encoding': 0.7.2
+      just-extend: 4.2.1
+      path-to-regexp: 1.8.0
+    dev: true
+
+  /@pollyjs/adapter-fetch@6.0.6:
+    resolution: {integrity: sha512-euWzM5TnA2jptdJgjIkEd/Q2hNFB652XivPKerWpLMFB13IKlrERX9wn2Dw3pquDAP0LvXH1qVBZt5DK0Xhzyg==}
+    dependencies:
+      '@pollyjs/adapter': 6.0.6
+      '@pollyjs/utils': 6.0.6
+      detect-node: 2.1.0
+      to-arraybuffer: 1.0.1
+    dev: true
+
+  /@pollyjs/adapter-node-http@6.0.6:
+    resolution: {integrity: sha512-jdJG7oncmSHZAtVMmRgOxh5A56b7G8H9ULlk/ZaVJ+jNrlFXhLmPpx8OQoSF4Cuq2ugdiWmwmAjFXHStcpY3Mw==}
+    dependencies:
+      '@pollyjs/adapter': 6.0.6
+      '@pollyjs/utils': 6.0.6
+      lodash-es: 4.17.21
+      nock: 13.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@pollyjs/adapter-xhr@6.0.6:
+    resolution: {integrity: sha512-S/2RVZvCe460BWz5fYVg9dfVZ0yZobA54vqReF17A2fkvAjrPXT3jk2tRLhULccrsbEAnBdxE0/w+aKOBUjXbw==}
+    dependencies:
+      '@offirgolan/nise': 4.1.0
+      '@pollyjs/adapter': 6.0.6
+      '@pollyjs/utils': 6.0.6
+      to-arraybuffer: 1.0.1
+    dev: true
+
+  /@pollyjs/adapter@6.0.6:
+    resolution: {integrity: sha512-szhys0NiFQqCJDMC0kpDyjhLqSI7aWc6m6iATCRKgcMcN/7QN85pb3GmRzvnNV8+/Bi2AUSCwxZljcsKhbYVWQ==}
+    dependencies:
+      '@pollyjs/utils': 6.0.6
+    dev: true
+
+  /@pollyjs/core@6.0.6:
+    resolution: {integrity: sha512-1ZZcmojW8iSFmvHGeLlvuudM3WiDV842FsVvtPAo3HoAYE6jCNveLHJ+X4qvonL4enj1SyTF3hXA107UkQFQrA==}
+    dependencies:
+      '@pollyjs/utils': 6.0.6
+      '@sindresorhus/fnv1a': 2.0.1
+      blueimp-md5: 2.19.0
+      fast-json-stable-stringify: 2.1.0
+      is-absolute-url: 3.0.3
+      lodash-es: 4.17.21
+      loglevel: 1.8.1
+      route-recognizer: 0.3.4
+      slugify: 1.6.6
+    dev: true
+
+  /@pollyjs/node-server@6.0.6:
+    resolution: {integrity: sha512-nkP1+hdNoVOlrRz9R84haXVsaSmo8Xmq7uYK9GeUMSLQy4Fs55ZZ9o2KI6vRA8F6ZqJSbC31xxwwIoTkjyP7Vg==}
+    dependencies:
+      '@pollyjs/utils': 6.0.6
+      body-parser: 1.20.2
+      cors: 2.8.5
+      express: 4.18.2
+      fs-extra: 10.1.0
+      http-graceful-shutdown: 3.1.13
+      morgan: 1.10.0
+      nocache: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@pollyjs/persister-fs@6.0.6:
+    resolution: {integrity: sha512-/ALVgZiH2zGqwLkW0Mntc0Oq1v7tR8LS8JD2SAyIsHpnSXeBUnfPWwjAuYw0vqORHFVEbwned6MBRFfvU/3qng==}
+    dependencies:
+      '@pollyjs/node-server': 6.0.6
+      '@pollyjs/persister': 6.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@pollyjs/persister@6.0.6:
+    resolution: {integrity: sha512-9KB1p+frvYvFGur4ifzLnFKFLXAMXrhAhCnVhTnkG2WIqqQPT7y+mKBV/DKCmYFx8GPA9FiNGqt2pB53uJpIdw==}
+    dependencies:
+      '@pollyjs/utils': 6.0.6
+      '@types/set-cookie-parser': 2.4.7
+      bowser: 2.11.0
+      fast-json-stable-stringify: 2.1.0
+      lodash-es: 4.17.21
+      set-cookie-parser: 2.6.0
+      utf8-byte-length: 1.0.4
+    dev: true
+
+  /@pollyjs/utils@6.0.6:
+    resolution: {integrity: sha512-nhVJoI3nRgRimE0V2DVSvsXXNROUH6iyJbroDu4IdsOIOFC1Ds0w+ANMB4NMwFaqE+AisWOmXFzwAGdAfyiQVg==}
+    dependencies:
+      qs: 6.11.2
+      url-parse: 1.5.10
+    dev: true
+
   /@repeaterjs/repeater@3.0.4:
     resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
     dev: false
@@ -1664,6 +1805,17 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
+  /@sindresorhus/fnv1a@2.0.1:
+    resolution: {integrity: sha512-suq9tRQ6bkpMukTG5K5z0sPWB7t0zExMzZCdmYm6xTSSIm/yCKNm7VCL36wVeyTsFr597/UhU1OAYdHGMDiHrw==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /@sinonjs/commons@1.8.6:
+    resolution: {integrity: sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
   /@sinonjs/commons@3.0.0:
     resolution: {integrity: sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==}
     dependencies:
@@ -1674,6 +1826,16 @@ packages:
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
     dependencies:
       '@sinonjs/commons': 3.0.0
+    dev: true
+
+  /@sinonjs/fake-timers@6.0.1:
+    resolution: {integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==}
+    dependencies:
+      '@sinonjs/commons': 1.8.6
+    dev: true
+
+  /@sinonjs/text-encoding@0.7.2:
+    resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: true
 
   /@swc/core-darwin-arm64@1.3.78:
@@ -2121,6 +2283,20 @@ packages:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
     dev: true
 
+  /@types/set-cookie-parser@2.4.7:
+    resolution: {integrity: sha512-+ge/loa0oTozxip6zmhRIk8Z/boU51wl9Q6QdLZcokIGMzY5lFXYy/x7Htj2HTC6/KZP1hUbZ1ekx8DYXICvWg==}
+    dependencies:
+      '@types/node': 18.11.18
+    dev: true
+
+  /@types/setup-polly-jest@0.5.5:
+    resolution: {integrity: sha512-kbuM19M8EAkbgzCG3kuXo+IoxrQcgIPHm54WmxcqlHgOy9A7esTFfrUwu/WiOsUcoUiZSzm3F3aQJuihR09wAA==}
+    dependencies:
+      '@pollyjs/adapter': 6.0.6
+      '@pollyjs/core': 6.0.6
+      '@pollyjs/persister': 6.0.6
+    dev: true
+
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
@@ -2155,7 +2331,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.2.2):
     resolution: {integrity: sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2167,23 +2343,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 5.59.2
-      '@typescript-eslint/type-utils': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 5.59.2(eslint@8.39.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.39.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.2(eslint@8.39.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@5.59.2(eslint@8.39.0)(typescript@5.2.2):
     resolution: {integrity: sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2195,10 +2371,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.2
       '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.39.0
-      typescript: 5.0.4
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2211,7 +2387,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.2
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.2(eslint@8.39.0)(typescript@5.0.4):
+  /@typescript-eslint/type-utils@5.59.2(eslint@8.39.0)(typescript@5.2.2):
     resolution: {integrity: sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2221,12 +2397,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.39.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2236,7 +2412,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.2(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@5.59.2(typescript@5.2.2):
     resolution: {integrity: sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2251,13 +2427,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.2(eslint@8.39.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@5.59.2(eslint@8.39.0)(typescript@5.2.2):
     resolution: {integrity: sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2268,7 +2444,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.59.2
       '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.2.2)
       eslint: 8.39.0
       eslint-scope: 5.1.1
       semver: 7.5.0
@@ -2317,6 +2493,14 @@ packages:
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    dev: true
+
+  /accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
     dev: true
 
   /acorn-globals@6.0.0:
@@ -2445,6 +2629,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
       is-array-buffer: 3.0.2
+    dev: true
+
+  /array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
     dev: true
 
   /array-includes@3.1.6:
@@ -2598,6 +2786,13 @@ packages:
     resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
     engines: {node: '>=6.0.0'}
 
+  /basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      safe-buffer: 5.1.2
+    dev: true
+
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -2608,6 +2803,54 @@ packages:
 
   /bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+    dev: true
+
+  /blueimp-md5@2.19.0:
+    resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
+    dev: true
+
+  /body-parser@1.20.1:
+    resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.1
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /body-parser@1.20.2:
+    resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /bowser@2.11.0:
+    resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
     dev: true
 
   /brace-expansion@1.1.11:
@@ -2655,6 +2898,11 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: true
+
+  /bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
     dev: true
 
   /call-bind@1.0.2:
@@ -2810,6 +3058,18 @@ packages:
     resolution: {integrity: sha512-3vyi+yNcmKq+xl1sTX7Ta+4pUvjusMYbC6FSbrS6YJV8TI51wiRn24u4bfdFVhDKKH5GtpKQzxW7bqXbPWllgQ==}
     dev: true
 
+  /content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /convert-source-map@1.8.0:
     resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
     dependencies:
@@ -2818,6 +3078,23 @@ packages:
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    dev: true
+
+  /cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    dev: true
+
+  /cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
     dev: true
 
   /create-jest@29.7.0(@types/node@16.11.7)(ts-node@10.9.1):
@@ -2911,6 +3188,17 @@ packages:
       whatwg-url: 11.0.0
     dev: true
 
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: true
+
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -2994,9 +3282,23 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dev: true
+
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
     dev: true
 
   /diff-sequences@29.6.3:
@@ -3052,6 +3354,10 @@ packages:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
 
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: true
+
   /electron-to-chromium@1.4.140:
     resolution: {integrity: sha512-NLz5va823QfJBYOO/hLV4AfU4Crmkl/6Hl2pH3qdJcmi0ySZ3YTWHxOlDm3uJOFBEPy3pIhu8gKQo6prQTWKKA==}
     dev: true
@@ -3063,6 +3369,11 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
+  /encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
     dev: true
 
   /end-of-stream@1.4.4:
@@ -3211,6 +3522,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: true
+
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -3279,7 +3594,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.2.2)
       debug: 3.2.7
       eslint: 8.39.0
       eslint-import-resolver-node: 0.3.7
@@ -3315,7 +3630,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.2.2)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -3338,7 +3653,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.59.2)(eslint@8.39.0)(jest@29.7.0)(typescript@5.0.4):
+  /eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.59.2)(eslint@8.39.0)(jest@29.7.0)(typescript@5.2.2):
     resolution: {integrity: sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3351,8 +3666,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.2.2)
       eslint: 8.39.0
       jest: 29.7.0(@types/node@16.11.7)(ts-node@10.9.1)
     transitivePeerDependencies:
@@ -3542,6 +3857,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /event-stream@3.3.4:
     resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
     dependencies:
@@ -3583,6 +3903,45 @@ packages:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+    dev: true
+
+  /express@4.18.2:
+    resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
+    engines: {node: '>= 0.10.0'}
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.1
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.5.0
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.11.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.18.0
+      serve-static: 1.15.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /fast-deep-equal@3.1.3:
@@ -3642,6 +4001,21 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
+  /finalhandler@1.2.0:
+    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3690,6 +4064,16 @@ packages:
     engines: {node: '>=12.20.0'}
     dependencies:
       fetch-blob: 3.1.5
+    dev: true
+
+  /forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
     dev: true
 
   /from@0.1.7:
@@ -3979,6 +4363,26 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
+  /http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+    dev: true
+
+  /http-graceful-shutdown@3.1.13:
+    resolution: {integrity: sha512-Ci5LRufQ8AtrQ1U26AevS8QoMXDOhnAHCJI3eZu1com7mZGHxREmw3dNj85ftpQokQCvak8nI2pnFS8zyM1M+Q==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -4003,6 +4407,13 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+    dev: true
+
+  /iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
     dev: true
 
   /iconv-lite@0.6.3:
@@ -4079,6 +4490,16 @@ packages:
       get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
+    dev: true
+
+  /ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: true
+
+  /is-absolute-url@3.0.3:
+    resolution: {integrity: sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==}
+    engines: {node: '>=8'}
     dev: true
 
   /is-array-buffer@3.0.2:
@@ -4249,6 +4670,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-docker: 2.2.1
+    dev: true
+
+  /isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
     dev: true
 
   /isexe@2.0.0:
@@ -4423,7 +4848,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.90)(@types/node@16.11.7)(typescript@5.0.4)
+      ts-node: 10.9.1(@swc/core@1.3.90)(@types/node@16.11.7)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4464,7 +4889,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.90)(@types/node@16.11.7)(typescript@5.0.4)
+      ts-node: 10.9.1(@swc/core@1.3.90)(@types/node@16.11.7)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4935,6 +5360,10 @@ packages:
       object.assign: 4.1.4
     dev: true
 
+  /just-extend@4.2.1:
+    resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
+    dev: true
+
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -4994,6 +5423,10 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: true
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -5008,6 +5441,11 @@ packages:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+    dev: true
+
+  /loglevel@1.8.1:
+    resolution: {integrity: sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==}
+    engines: {node: '>= 0.6.0'}
     dev: true
 
   /loose-envify@1.4.0:
@@ -5049,9 +5487,18 @@ packages:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
     dev: true
 
+  /media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
+    dev: true
+
+  /merge-descriptors@1.0.1:
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
     dev: true
 
   /merge-stream@2.0.0:
@@ -5061,6 +5508,11 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
     dev: true
 
   /micromatch@4.0.5:
@@ -5081,6 +5533,12 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: true
+
+  /mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
     dev: true
 
   /mimic-fn@2.1.0:
@@ -5113,6 +5571,23 @@ packages:
     hasBin: true
     dev: true
 
+  /morgan@1.10.0:
+    resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      basic-auth: 2.0.1
+      debug: 2.6.9
+      depd: 2.0.0
+      on-finished: 2.3.0
+      on-headers: 1.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: true
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -5134,8 +5609,18 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
+  /negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+    dev: true
+
+  /nocache@3.0.4:
+    resolution: {integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /nock@13.2.9:
@@ -5294,6 +5779,25 @@ packages:
       es-abstract: 1.21.2
     dev: true
 
+  /on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: true
+
+  /on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: true
+
+  /on-headers@1.0.2:
+    resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
@@ -5426,6 +5930,11 @@ packages:
       entities: 4.4.0
     dev: true
 
+  /parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -5448,6 +5957,16 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /path-to-regexp@0.1.7:
+    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+    dev: true
+
+  /path-to-regexp@1.8.0:
+    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
+    dependencies:
+      isarray: 0.0.1
     dev: true
 
   /path-type@3.0.0:
@@ -5527,7 +6046,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-organize-imports@3.2.2(prettier@2.8.8)(typescript@5.0.4):
+  /prettier-plugin-organize-imports@3.2.2(prettier@2.8.8)(typescript@5.2.2):
     resolution: {integrity: sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==}
     peerDependencies:
       '@volar/vue-language-plugin-pug': ^1.0.4
@@ -5541,7 +6060,7 @@ packages:
         optional: true
     dependencies:
       prettier: 2.8.8
-      typescript: 5.0.4
+      typescript: 5.2.2
     dev: true
 
   /prettier@2.8.8:
@@ -5589,6 +6108,14 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
+  /proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: true
+
   /ps-tree@1.2.0:
     resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
     engines: {node: '>= 0.10'}
@@ -5617,12 +6144,51 @@ packages:
     resolution: {integrity: sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==}
     dev: true
 
+  /qs@6.11.0:
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: true
+
+  /qs@6.11.2:
+    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: true
+
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
     dev: true
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
+  /range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /raw-body@2.5.1:
+    resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+    dev: true
+
+  /raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
     dev: true
 
   /react-dom@18.2.0(react@18.2.0):
@@ -5814,6 +6380,10 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /route-recognizer@0.3.4:
+    resolution: {integrity: sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==}
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -5886,6 +6456,55 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
+  /send@0.18.0:
+    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /serve-static@1.15.0:
+    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /set-cookie-parser@2.6.0:
+    resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
+    dev: true
+
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: true
+
+  /setup-polly-jest@0.11.0(@pollyjs/core@6.0.6):
+    resolution: {integrity: sha512-3ywsCFGfCvfi3ZpwYyDc4YDPNiB70QtjODoKFD5hbhza1GMOh0ZzAYUZO9OBmo/1isasynxcS5WzKYMyDJUeZw==}
+    peerDependencies:
+      '@pollyjs/core': '*'
+    dependencies:
+      '@pollyjs/core': 6.0.6
+    dev: true
+
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
     engines: {node: '>=0.10.0'}
@@ -5943,6 +6562,11 @@ packages:
   /slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
+    dev: true
+
+  /slugify@1.6.6:
+    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
+    engines: {node: '>=8.0.0'}
     dev: true
 
   /source-map-js@1.0.2:
@@ -6003,6 +6627,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       escape-string-regexp: 2.0.0
+    dev: true
+
+  /statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
     dev: true
 
   /stream-combiner@0.0.4:
@@ -6186,6 +6815,10 @@ packages:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
     dev: true
 
+  /to-arraybuffer@1.0.1:
+    resolution: {integrity: sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==}
+    dev: true
+
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -6196,6 +6829,11 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+    dev: true
+
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
     dev: true
 
   /tough-cookie@4.1.3:
@@ -6250,6 +6888,38 @@ packages:
       yn: 3.1.1
     dev: true
 
+  /ts-node@10.9.1(@swc/core@1.3.90)(@types/node@16.11.7)(typescript@5.2.2):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@swc/core': 1.3.90
+      '@tsconfig/node10': 1.0.8
+      '@tsconfig/node12': 1.0.9
+      '@tsconfig/node14': 1.0.1
+      '@tsconfig/node16': 1.0.2
+      '@types/node': 16.11.7
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.2.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -6267,14 +6937,14 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
 
-  /tsutils@3.21.0(typescript@5.0.4):
+  /tsutils@3.21.0(typescript@5.2.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 5.2.2
     dev: true
 
   /type-check@0.3.2:
@@ -6311,6 +6981,14 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
+  /type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+    dev: true
+
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
@@ -6322,6 +7000,12 @@ packages:
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 
@@ -6342,6 +7026,11 @@ packages:
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+    dev: true
+
+  /unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
     dev: true
 
   /uri-js@4.4.1:
@@ -6369,8 +7058,17 @@ packages:
       - graphql
     dev: false
 
+  /utf8-byte-length@1.0.4:
+    resolution: {integrity: sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==}
+    dev: true
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
+
+  /utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
     dev: true
 
   /uuid@8.3.2:
@@ -6396,6 +7094,11 @@ packages:
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
+    dev: true
+
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
     dev: true
 
   /vite@4.2.2(@types/node@16.11.7):

--- a/recordings/useActionFormNested_1974165259/should-record_255246347/recording.har
+++ b/recordings/useActionFormNested_1974165259/should-record_255246347/recording.har
@@ -1,0 +1,175 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/should record",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "facdf77e90ec230c8ef1835f2b48047c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 577,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "577"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 477,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quizzes\",\"query\":\"query quizzes($after: String, $first: Int, $before: String, $last: Int) {\\n  quizzes(after: $after, first: $first, before: $before, last: $last) {\\n    pageInfo {\\n      hasNextPage\\n      hasPreviousPage\\n      startCursor\\n      endCursor\\n      __typename\\n    }\\n    edges {\\n      cursor\\n      node {\\n        __typename\\n        createdAt\\n        id\\n        text\\n        updatedAt\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quizzes"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quizzes"
+        },
+        "response": {
+          "bodySize": 863,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 863,
+            "text": "[\"H4sIAAAAAAAAA7yXTW+bQBCG7/4Vqz03eD/5WCmHyI0qV0qVSM6hqapoBQOhcYDCurUT5b9XkGCDY+SoInuD2Xf2nXkEq52nCUI40kZjhZ4mCCGEf6/Sx0eotgGEcKETmGdx3okhhO909Q3W5lIngBWK9bKCT73VyxL+pPmqGlBURpdmtiqrvMQKYdh8LW5mc3f+a57GV6enuCOFLDokPN/MM9IT3t6aTQGZfqgN8WVb96vguVViiJKmxR/b1F1jCOHwPVUhhLM8gh6UA0VcrdLHXla9fwnaQHRmagEjjJ9QdkK8BQ0UF4oFjueKm/2kNGrU+2ED62abBVQG1Wbouojq3feFq5fwIVPhK8IcQf0b3Ml57vX6tqvzKIGdvqM+yvLCAkvGlWSKMyfw2QBLfpTlexn2zawwvLLGUDJHeHyAoRiZYWtmheG1JYZcEe4Q4g8wlKMy3JlZYfj9wxn6CyqVDOojSvKh79AdieG+mRWGoTWGlDqeJAMMvZEZtmZWGCbWGArPof7Qv+yPzLA1s8Lw3hpD6TrclQMMg5EZtmZWGJ7/3Q==\",\"u5R+BENX0UBJ4QjPG2BIyXgQe252IK6tQGREEeHIYOhApHRMiB03OxA3tiBS3wnE0IlI2cgQW7f/h/j69HM7D77NmOVZBqFJ8+wl79UBJzpKwFxAZ2Sup91NVOpaXPVn5B62z9rAIn2A7sDa63QreDOv9uv70tRwVhTLNGxcm3ImbWtNGoa1gazqlYSXeVK/4TtjikpNp0linGWa3U/rhSmVxCX+1PXDQMSuJH4cxdyNvYiGAXANgvpBzNqhCZtShzB/uXwdS6mrmjz/AwAA//8DAJXEpN1uEAAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 08 Dec 2023 23:08:12 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "98771173d73b8944fd300454698c005a"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "68c94f6508fdf36f7d1c9e3ae4189f23"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=qcIht0KmyR3KGt6FwEAY6ZH%2FNcHRSKUl6DZnF%2BzTS802dLy%2FmrjKbpOhDXGcqnF0lrYZ4w%2B5Sac63zkARF35XLIa2P2ZPHlgU6Mm8JF3HKNUKl%2BD%2FDlRNsylJmI3NU9F2ZbQ5szVWgFx%2BvOzcjSFqgL1%2FGVjP%2BCss5%2FhOw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8328ab3f7e5c0c76-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 926,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-08T23:08:11.960Z",
+        "time": 253,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 253
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/useActionFormNested_1974165259/update-HasMany-HasMany-HasOne-HasOne-BelongsTo_2250701809/recording.har
+++ b/recordings/useActionFormNested_1974165259/update-HasMany-HasMany-HasOne-HasOne-BelongsTo_2250701809/recording.har
@@ -1,0 +1,175 @@
+{
+  "log": {
+    "_recordingName": "useActionFormNested/update HasMany -> HasMany -> HasOne -> HasOne -> BelongsTo",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b69a62c6ea7ef9f7b0bc26035cbe7636",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 254,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-gadget-environment",
+              "value": "Development"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "254"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "zxcv-deeply-nested--development.gadget.app"
+            }
+          ],
+          "headersSize": 474,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"operationName\":\"quiz\",\"query\":\"query quiz($id: GadgetID!) {\\n  quiz(id: $id) {\\n    __typename\\n    createdAt\\n    id\\n    text\\n    updatedAt\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"12\"}}"
+          },
+          "queryString": [
+            {
+              "name": "operation",
+              "value": "quiz"
+            }
+          ],
+          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
+        },
+        "response": {
+          "bodySize": 376,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 376,
+            "text": "[\"H4sIAAAAAAAAA4yQT2+DMAzF73wKy+e2JIEgyq3SpGmHHSZx2qXKiEejUcrAldpVfPeJlNE/mrQd7fee/bNPAQBawwYzOAUAAPi5d19TBYDrNR8bqs2WMAN8GdTZj1a0ZJjsigdJCRXNpZqLNJdJpkQm08UyTl8vdmcHn1SXDtPBZ3PqGG5n7xv7j9ne3Z9DWBpbEj/T1TkAuDna1rDb1d1V9x7+wTDlbkvT/nuCyTDq/ez3Bz16hlXTVK7wWz3OGTMYY0gHprq7QcJqVw4VbpibLgvDsuRF5eqPcBBCqUUi0tAUIopFQklCkdbC6jf9rq2KYquWUpEc8ZFbU9CTf/efkYEq6L8BAAD//wMAaQMtbwoCAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 08 Dec 2023 23:08:12 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-set-authorization, x-gadget-environment"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "2249"
+            },
+            {
+              "name": "x-request-id",
+              "value": "45a76658d67c40c366dc64f4b179d2ce"
+            },
+            {
+              "name": "x-trace-id",
+              "value": "ac03406e66e3550d5b5f5d234d2912e1"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=15724800; includeSubDomains"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=XTYTLlWvgpdf%2FElO8SDIqjlxKjWZhMXDiozcg%2F1MvQ7Hadl9SSe%2BFARM%2BqB%2F5XP6iRUBr38dMzD0NGIeB8X9qf75o36TmyRNwMc9qc7T%2FM2rKKvUdEn%2Ffv9V45t3PYyGhAqsiKr65lbAXubov0M2wzBpTXFEth1d3d7MwA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "8328ab411dee41e3-EWR"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 920,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-08T23:08:12.269Z",
+        "time": 287,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 287
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
One of the big drawbacks of `useActionForm` is that it didn't support nested relationships. Hopefully with this PR we can fix that.

We achieve this in a few steps:

When fetching data, unwind the edges and node to adhere to a simpler more usable structure for `react-hook-forms`

Afterwards on submit:

1. fetch the relationship(s) meta data that exists on the client
2. Create a map of updates that existed on the default values
3. Traverse through the data structure, transform anything to match our GraphQL api.

For 🎩:

Make sure you replace `gadget-react` in your package json with: `"@gadgetinc/react": "github:gadget-inc/js-clients#@gadgetinc/react-v0.15.0-gitpkg-b07ca84"`

Best thing to do for tophatting would be to try to build a mini app with complex nested relationships. `HasMany -> HasMany -> BelongsTo`, `HasOne -> HasOne -> HasMany` anything you can really think of.

Incase there's a need for a working example: https://zxcv-product-quiz-v5.gadget.app/

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
