### PR TITLE
Added model relationships to AnyClient interface for upcoming support of nested relationships

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.12",
+  "version": "0.15.13",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/src/AnyClient.ts
+++ b/packages/api-client-core/src/AnyClient.ts
@@ -2,6 +2,8 @@ import type { GadgetConnection } from "./GadgetConnection.js";
 import type { GadgetTransaction } from "./GadgetTransaction.js";
 import type { InternalModelManager } from "./InternalModelManager.js";
 
+export const $modelRelationships = Symbol.for("gadget/modelRelationships");
+
 /**
  * An instance of any Gadget app's API client object
  */
@@ -13,6 +15,7 @@ export interface AnyClient {
   internal: {
     [key: string]: InternalModelManager;
   };
+  [$modelRelationships]?: { [modelName: string]: { [apiIdentifier: string]: { type: string; model: string } } };
 }
 
 /**


### PR DESCRIPTION
Small PR to merge in the required changes for handling nested relationships in the `react` library.

Going forward all clients have baked in relationship metadata that we use in the `react` library to reshape the data when passing it on to graphql.

## PR Checklist

- [x] Important or complicated code is tested
- [x] Any user facing changes are documented in the Gadget-side changelog
- [x] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [x] Versions within this monorepo are matching and there's a valid upgrade path
