### PR TITLE
Update client packages to use new dev format

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "preinstall": "npx only-allow pnpm"
   },
   "devDependencies": {
-    "@gadget-client/app-with-no-user-model": "^1.5.0",
-    "@gadget-client/bulk-actions-test": "^1.104.0",
-    "@gadget-client/full-auth": "^1.4.0",
-    "@gadget-client/related-products-example": "^1.859.0",
-    "@gadget-client/zxcv-deeply-nested": "^1.207.0",
-    "@gadget-client/zxcv-simple-relationship": "^1.17.0",
+    "@gadget-client/app-with-no-user-model": "1.6.0-development.5",
+    "@gadget-client/bulk-actions-test": "1.108.0-development.111",
+    "@gadget-client/full-auth": "1.5.0-development.4",
+    "@gadget-client/related-products-example": "1.860.0-development.859",
+    "@gadget-client/zxcv-deeply-nested": "1.208.0-development.207",
+    "@gadget-client/zxcv-simple-relationship": "1.18.0-development.17",
     "@gadgetinc/api-client-core": "workspace:*",
     "@gadgetinc/eslint-config": "^0.6.1",
     "@gadgetinc/prettier-config": "^0.4.0",

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship-with-support-for-Id-pre_1709343723/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship-with-support-for-Id-pre_1709343723/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "cf3c4a593907da2a1d1b4e65688bb5e9",
+        "_id": "b9ed681363c960ad8fb701ab79e4e003",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 747,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twEgVKboitVlTqCi3spdWqGuJJ8G6wLdtBRBX/vkoaaEITyi3KvPdm3vPYbwNCKAcHNCJvA0IIoXartEiKpVE8j509FwihGlJcyEQ1/hFCt2B/4sEtIUUakQQyi99a1aXBvVC57UFYB8bNc2OVoRGhWDzq5/livPj7UDwVj1PagKLktwFfX12hUcKubEiXp7lrwPGEpMhTLC2+nKkfxgih8S3NCKFScWyF0jHEqpVri08I3SheVH0OsNMZkj1kOZJEGVJVLtCx2mkwOHNLI2L8BbIKVuZZdgk0CA75zJXaPvODO8+/8/y1N458P/LDIWPe86X6FiTPegQFL5U8P7gk6Xdfc3CYKlN0s2vQutA98jrfZMJu64mvAVax6hOpN3je5Z15axZGjEWMDRljn7zX3N+an7ldHRy43HbXHKR9FdzpDByu8iQRhx6McH3R542Zbj7LPUpebXAp2CgdW/t7bVMfeIr0DD7WX3/OV+gad66kxNgJJd8V6g==\",\"rjQFnqJ7wsa7U+5dwQ2UYNt+YLrO8zs4XIsdNi99e3k6IfFXGq2QuwAdC/KB+/S+tMP5UdmeaZ2JuDJaJTA45VrRKB4cSttKgWaq2im6dU7baDRKUzfMhPw3KgsjL2Rjdj8KQi/YsCAJN+NJHIT3fjBhU5zCxBtPAT2/dkGdgRgX1T3+klJONTj+BwAA//8DAK3C9bwmBgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4xU0W7aMBR95yssP6/gBAJr3hCrJip1QoO9dJqqi30TsgXbsh1EVPHvU9KQJjShvEW555x7z/G1XweEUAEOaEheB4QQQu1O6STKV0aJjDtbFwihGmJcykg1/hFCd2B/4NGtIEYakghSi19a1ZXBQ6Iy24OwDoxbZMYqQ0NCMX/Uz4vldPn3IX/KH+9pA4pS3AZ8eXG5Rgn7oiFdneeuAKczkqKIsbD4u6a+GyOE8luaEUKlEtgKpWOIdSvXFp8QulUiL/scYa9TJAdIMySRMqSsXKC52mswOHcrk3D8CbIMVmZpegk0CA7F3BXaPvPHd55/5/kbbxr6fugHQ8a850v1HUiR9ggmolDy/PElSb/5WoDDWJm8m12BNrnukdfZNk3srpr4GmDNVZ9ItcGLLu/M27AgZCxkbMgY++C94v7SouZ2dXDgMttdcxD3VXCvU3C4zqIoOfZgEtcXfdaY6eazPKAU5QYXgo3SqbW/1zb1QcRIa/Cp+vo=\",\"U1+ha9yFkhK5S5R8U6i60hhEjO4JG+9OsXe5MFCAbfuB6TrPb+Bwk+yxeenby9MJ4Z9ptELuAnQsyDvuw/vSDud7aXuudZrw0miZwOCca0mjeHQobSsFmqpyp+jOOW3D0SiO3TBN5L9RURh5AZuyr6OZNwnGzGezCAS/ZxM2gemMexMIEHiwFZUL6gxwXJb3+FNKMdXg9B8AAP//AwABVQyYJgYAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:57 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:37 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "7d842e9dfdc244ffe5b1d849a5db2955"
+              "value": "6726f31c817a5b91917c84c51170489a"
             },
             {
               "name": "x-trace-id",
-              "value": "3513b03f5b67c35823709e9a7169ae12"
+              "value": "714530207fadc90404a67c14a5eac5bd"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=Il4pJv%2Fyc0%2FNtBq8E6dAlCRh3G5OyJz9z%2B2v6DaQJUvOC30NZj5FHywM2LY9kgqZAn6ZhtMZJ5ZMX0yAUrtF4gP1MoCMagPqEzkyYHT3Kr8nLLa7blQ48%2FmlL5fhOaVa2JQygnZ24bPTd426i8t6voYKqLgFJm3rbyRIFA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=LoHHhlCwQWIYwI4VBDK94EhvL%2BmRxKqIBw7JNXMhvE%2Bz%2F9SF7Pf%2BStWrzqnkWIYOLemXuSnwsNbutrjQFVl%2BbnrFdH8bSltOAGO8KTpTNePViUshPdRncQVkcR%2FhVenfA%2BNw%2B%2F28KTs7MpShCCnE%2FJyyS4YmJKKmSs9%2BEQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,20 +147,20 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e953898fc356-EWR"
+              "value": "8479e4f4db49443e-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 961,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:56.967Z",
+        "startedDateTime": "2024-01-18T21:22:36.873Z",
         "time": 141,
         "timings": {
           "blocked": -1,
@@ -173,7 +173,7 @@
         }
       },
       {
-        "_id": "be0fd31a4adea3fe07ef99136eeacddd",
+        "_id": "443221dc3f90cfa2ffb770d764f4e7b9",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -237,18 +237,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 424,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVYFEQbqZNmh56aOOpF7OyA5Ii4O6QaI3/vWGlVJo09rhv3pv5ZvbsAKCSLDGBswMAgKkmyfTaFp+DBoCmTVMyBhNg3dLkWyata92pVVuWg3oYhwFws+FTQ5XcEyaAtvnkp3odqVbcFYUngqkvpv58LUQSBMkimgWReL8NFMo6w/mtyHS0DZgMw+HXiLZR/xjR+y/DJmPuh+E0b2Takq/+3o25VDnxC90cEwB3J6UlF3VlxhcZ7fwomdbFnv4kHgx3CJ8sw6ppyiK1Uy3OFdPpY0hHpsqMkLCs8+6FO+bGJK6b5zwri+rD7Qquv/BCb+lmIhIUx/PY20a0DZdLFYVZrDLfi7Mw9WWPj6xlSs/2j+5GOirn8gUAAP//AwDqaRb/iAIAAA==\"]"
+            "size": 424,
+            "text": "[\"H4sIAAAAAAAAA4yRT0/DMAzF7/0Uls/b2oT1D71NICEOHEA7cZmixusquq5LXGlj2ndHTUtpkdA45vk9+2fn4gGgVqwwhYsHAICZIcX02hSfgwaAtskyshZTYNPQ7FsmYw6mVaumLAf1OA0D4GbD55oqtSdMAV3z2U+1G6lX3BZlIJfzQMxFspYilTK9ixcyvH8fBwrtnHE4FplOrgGTZTj+GtHU+h8jev912GTK/TCc5o1sU3Ln792YK50Tv9DomAC4O2ujuDhUdnqRyc6Pimld7OlP4sFwg/DJMazquiwyN9XhdJheH0M6MVV2goTlIW9fuGOuber7ec6Lsqg+/LbgizCIgsRPVCJFnJAIo2Wol5EIVKS0oFhvw0hugx4f2aiMnt0f3Yy0VN71CwAA//8DAPvKPouIAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:57 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:37 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "5acae61dd4ac99a53445b8098b27d17b"
+              "value": "5e8d3bf98e44fcd460735bc860c8c1d0"
             },
             {
               "name": "x-trace-id",
-              "value": "f272e99490b7eb688d76f9df109f6c1a"
+              "value": "8a82178e15645d4610a6ad1e7df562f0"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=MD5KTZr0xpbdri3uNiMfKpqrRng385WtclDl%2F2K9KmZt0MKtylvU4OA9cgqpKDa3pZGn30RD2b5Kq%2BcuK34Ou3uBEvGBSrlDtGiPY1ONQMKaQVoN0PhU7mBD5ZI1RA3Tf0qRpXCeQZQxHztRO6N9eKHYzSVR%2BlQesYvj%2BA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=9prXI%2Bvu48zlWXpVh1KJC1gJRdqmNcbWH29nj7DDTDb%2Bm80OYBdKDmmZPXPJXNQhzcfByYEJm%2FBpW9DKPX5mPo%2B33vxwBqcO7cpb9NVF6lNB35nqwGRqV5WK4R5YAID5CBVEXn%2BFiiypuSsc9Plmy1aXchUEM4vGqamwwA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e954992d0f8c-EWR"
+              "value": "8479e4f5cfd4424c-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:57.141Z",
-        "time": 306,
+        "startedDateTime": "2024-01-18T21:22:37.029Z",
+        "time": 340,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 306
+          "wait": 340
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship_3235963512/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship_3235963512/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "cf3c4a593907da2a1d1b4e65688bb5e9",
+        "_id": "b9ed681363c960ad8fb701ab79e4e003",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 747,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twQkGQG2KrFZW6Qgt7abWqBnsSsmtsy3YQUcW/r5IGmtCEcosy772ZeX72W48QKsADjchbjxBCqNtqk8b50mqRce/OBUKogQQXKta1f4TQLbifePBLSJBGJAbp8FujurS4T3XmOhDOg/XzzDptaUQo5o/meb4YL/4+5E/545TWoKjEbcDXV58bVLArGtLlae4KcDwhKYoEixVfztSPxQih/JZmhFClBTZMaRli1fC1wSeEbrTIyz4H2BmJZA8yQxJrS8rKBZrrnQGLM7+0KcdfoEpjVSblJdAieBQzX2iHLBzeBeFdEK6DcRSGUTjqMxY8X6pvQQnZIZiKQikIh5ck877XHDwm2ubt7Aq0zk2HvMk2MnXbauJrgBXXXSJVgudtu7NgzUYRYxFjfcbYp90r7m8jzty2Dh585tprHpKuCu6MBI+rLI7TQwcm9V3WZ7WZbj7LPSpRJrgQrJWOjfxeS+qDSJCewcfq68/5Cl3jzrVSyH2q1bs=\",\"QtWVJiAS9E9Ye3eK3OXCQgF2zQem7Ty/g8d1usP6pW+GpxXCv9JomNwGaAnIB+7T+9I050e59swYmfJy0dKB3snXkkbx4FG5hgtU6jJTdOu9cdFgkCS+L1P1b1AUBsGIjdlkEE/v78PJKBYceDANJ2OOHNg0HAWb6XDDTzeWegscF+U9/pJSTNU7/gcAAP//AwDAFcFCJgYAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twnA2wuSFarajUFVropatV5caTkG6wLXuCiCr+fZU00IQmlFuUee/NvOex3waEUClQ0JC8DQghhLqNNmlcLK2WeYTuVCCEGpHAQsW68Y8QuhHuF+xxKRKgIYlF5uBbq7q0sEt17noQDoXFeW6dtjQkFIp78zRfjBevd8VDcf+DNqCg5HXA52csDCixLRvS5XHuGnA4IinIBEqLf07UD2OE0OiaZoRQpSW0QukYYtXKtcUnhL5oWVR99mJrMiA7keVAYm1JVTlDR3prhIUZLm0awW+hqmBVnmXnQAsCQc6w1OaM+zcev/H42huHnIc8GDLmPZ2rb4SSWY9gKkslj/vnJPPuay4QEm2LbnYNWhemR97kL1nqNvXElwCrSPeJ1Bs87/LOvDULQsZCxoaMsU/ea+6jkSduVwcUmLvuGoqkrwJbkwmEVR7H6b4Hk2Jf9HljpqvPcgdKVhtcCjZKh9b+XtrUO5kAPYEP9dff0xW6xJ1rpSDC\",\"VKt3hborTYRMAB+g8e6Ue1dIK0qwaz8wXed5KxDW6Raal769PJ2Q6CuNVshdgI4F+cB9el/a4fysbM+MydKoMlolMDjmWtEo7BGUa6VAM13tFN0gGheORkmCwyxV/0ZlYeQFbMymo4DLCZtEU8ljbxLwsc8D7nvj71Pug8+ioHZB0YoIFtU9/pJSTjU4/AcAAP//AwCUbAZmJgYAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:55 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:11 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "143be2b9f4327af7b618f2ae3d2ba1ca"
+              "value": "9cf3c8c236ece8822b3681efc0ae183d"
             },
             {
               "name": "x-trace-id",
-              "value": "f944285fdcac19286ceca09251b93bc3"
+              "value": "52d707c8d2f1752632523164823e30c5"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=ZylCK2XuRsxQ5WAnowwcyFWdlo3FKxq4tkxUsQ%2Fn4sobvR8Mf3AFQIiiI9Az6DxnjxY77sgpWw6WqiRwAhSrTK8j%2FvPpVn3BTg0IcM6IBR%2FtcI1UKABlB1WJYF%2BFGhIGaO20pKZ1U4gTMf1fJuwGdcNtP%2BsBe0YtjwAhWA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=RQ1%2BiLKwmo2De9madbKdA47pHhWeMr3VdImhl9UHK8%2BNKl7KkdNFbmFdd7HBSNyQ9ukRbRgSLhbVZ%2FFfrPamBt3m%2BdNeUlLIsY%2BaPFI1P87ckYG2LdORzoLSxoJkBj7mTTPtJLEtb3WIhnp6tS%2Fs0UBMhjwsQQZEeZBAEQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e94c2c658cd4-EWR"
+              "value": "8479e454c82e4316-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:55.800Z",
-        "time": 144,
+        "startedDateTime": "2024-01-18T21:22:11.171Z",
+        "time": 452,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 144
+          "wait": 452
         }
       },
       {
-        "_id": "be0fd31a4adea3fe07ef99136eeacddd",
+        "_id": "443221dc3f90cfa2ffb770d764f4e7b9",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -242,13 +242,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9AkxRK1xvapGmHHTZx2gVljSnVSimJK8EQ/31q6Do6aWLHPL9nf3ZOAQAazRpTOAUAAJhZ0kwvTfHZawDomiwj5zAFtg2NvmWydmdbtWrKslf3wzAArlZ8rKnSW8IU0Dcf/VQvI82C26ISKhpLNZbTpVJpFKWzeBLNkrfrQGG8M1bXItPBN2ByDPtfI5ra/GNE5z/3mwy57/vTvJJrSr74Ozfm2uTEz3R1TADcHI3VXOwqN7zIYOcHzbQstvQncW+4QfjoGRZ1XRaZn+pxLphBF0M6MFVugITlLm9fuGGuXRqGec6Tsqg+wrYQypmIRRLG0+xurt9jmUg5XydSqLkW8dqQNkKsSXb4yFZn9OT/6GakpQrOXwAAAP//AwDK+TbviAIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9Am0Bp1RvapGmHHTZx2gVliSnVSimJK8EQ/31q6DqKNLFjnt+zPzunAACNYoUZnAIAANSWFNNrU3z1GgC6RmtyDjNg29DoRyZrd7ZVq6Yse3U/DAPgasXHmiq1JcwAffPRb/Uy0iy4LcpIzsaRGIt0KUUmZTaNJ+kseb8OFMY7k+m1yHTwDZgcw/5mRFObf4zo/Od+kyH3Q3+aN3JNyRd/58ZcmZz4ha6OCYCbo7GKi13lhhcZ7PyomJbFlv4k7g13CJ88w6Kuy0L7qR7nghl0MaQDU+UGSFju8vaFG+baZWGY5zwpi+ozbAuhiKN5lIZzI6VYx1GS6nS6jkgYGUczIeKPNIlVojt8ZKs0Pfs/uhtpqYLzNwAAAP//AwAryxZbiAIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:56 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:35 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "4210084abc8d4500c716b4d4697cb75f"
+              "value": "08fa24607ccf7cef191225f5abd460d3"
             },
             {
               "name": "x-trace-id",
-              "value": "64c97ab618117f81027a06fdead00fe1"
+              "value": "6d221f5078c83f0e1d2504115b875a7c"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=vbb4PiMm86gS5xb7V0nRuOg2Lss4yU5R3DGeSlbADGfX63hIuD0Svb6f8VxVwPeiIaUjadRGlEBCWn3TQn34Dcl%2FOHzDTGiQTOALkz9UhFVnRlDxHw%2FgG5pUHwp5FL2D0Gg0kNafUl2FXWQMOcrnikwd5D9%2BoPh3ZjQ3%2BA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=sFVg08p67Szo6KIsMCeus6lYuE4bm%2F91fv5PQOWiS2XRxlNvi%2BDtJgU5Cq2a1qwowhXxFFMrSkLSlq4d8kFM2VcDtqcF6SIT908zXApERKLhNzeJc69p0JC6CnT%2Fj1p4QapZBGbbnqwjTlqmWTU%2Fsu%2FFRfSDh9oNj3%2BKLg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e94d8e7b426d-EWR"
+              "value": "8479e4ed4b2e41bb-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:56.021Z",
-        "time": 408,
+        "startedDateTime": "2024-01-18T21:22:35.666Z",
+        "time": 253,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 408
+          "wait": 253
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship-with-support-f_3501493881/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship-with-support-f_3501493881/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "cf3c4a593907da2a1d1b4e65688bb5e9",
+        "_id": "b9ed681363c960ad8fb701ab79e4e003",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -72,18 +72,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
         },
         "response": {
-          "bodySize": 743,
+          "bodySize": 747,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 743,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twwoIgN8RWFZW6Qgt76WpVDfEkpBtsy54goop/XyUNNKEJ5RZl3nsz73nstx5jXAIBD9hbjzHGuNtqk0T50mqZheTOBca4gRgXKtK1f4zxLbifeKAlxMgDFkHq8FujurS4T3TmOhCOwNI8s05bHjCO+aN5ni/Gi9f7/Cl/nPIaFJW8DfjyQrlBBbuiIV+e5q4AxxOSo4yxsPjnTP0wxhgPb2nGGFdaYiOUliFWjVwbfMb4Rsu87HOAnUmR7SHNkEXasrJygQ71zoDFGS1tEuIvUGWwKkvTS6BFIJQzKrR94Q/vPP/O89feOPD9wB/1hfCeL9W3oGTaIZjIQsnzh5ck8+5rDoSxtnk7uwKtc9Mhb7JNmrhtNfE1wCrUXSLVBs/bvAtvLUaBEIEQfSHEJ+8V97eRZ25bBwLKXHuNIO6q4M6kQLjKoig5dGAS6oo+q81081nuUclygwvBWunY2N9rm3ovY+Rn8LH6+nu+Qte4c60UhpRo\",\"9a5QdeUxyBjpCWvvTrF3ubRQgF3zgWk7zx9AuE52WL/0zeVphYRfaTRCbgO0LMgH7tP70gznobQ9MyZNwtJomUDvlGtJ43ggVK6RAk91uVN8S2RcMBjEMfXTRP0bFIWBNxJjMRkMN1M5nUTRdx/QH4koDBGEHG+kPxwjbiaVC04WQlyU9/hLSjFV7/gfAAD//wMA0R3SfyYGAAA=\"]"
+            "size": 747,
+            "text": "[\"H4sIAAAAAAAAA4xU0W7aMBR95yssP6/gBMhK3hCrJip1Qit76TRVjn0TsgXbsm8QUcW/TwmBJjShvEW555x7z/G13waEUMmR05C8DQghhLqNNmlcrKyWuUB3LhBCDU9gqWLd+EcI3XD3A/a44gnQkMQ8c/ClVV1Z2KU6dz0Ih9ziIrdOWxoSCsWjeVksg+Xfh+KpeJzRBhSUvA34+oqFAcW3ZUO6Os1dAw4nJAWZQGnx95n6bowQKm5pRghVWkIrlI4hnlu5tviE0EjLouqz51uTAdnxLAcSa0uqygVa6K3hFua4sqmAn1xVwao8yy6BFjiCnGOp7TN/fOf5d56/9oLQ90N/OmTMe7lU33Alsx7BVJZKnj++JJmjrwVHSLQtutk1aF2YHnmTR1nqNvXE1wDPQveJ1Bu86PLOvDWbhoyFjA0ZYx+819xfRp65XR2QY+66a8iTvgpsTcYRnvM4Tvc9mBT7os8bM918ljtQstrgUrBROrT299qmPsgE6Bl8qL/+nK/Q\",\"Ne5CKwUCU62OCnVXmnCZAD5B490p966Qlpdg135gus7zG0dYp1toXvr28nRCxGcarZC7AB0L8o778L60w/le2Z4bk6WiMlolMDjlWtEo7BGUa6VAM13tFN0gGheORkmCwyxV/0ZlYeRNWcDuR97Un3lBJHw2leOZkJNg8jWeQHAfRWMeyah2QdFyAcvjPf6MUk41OPwHAAD//wMAKUnx7yYGAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:57 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:37 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "086962d1925cf28f2a6a45a9cd6932a1"
+              "value": "303ca8d700f2b7ff7a37975eebc5253f"
             },
             {
               "name": "x-trace-id",
-              "value": "3b9d98ff42ae250fccea0d6bd236eeb8"
+              "value": "152916bc205d39cd4647f4e68bb3abdb"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=hwyOuMywrvUv3njL5Vxhmz38hvgservqWOU%2BEDx6VO%2ByhUDvNwM2zvO895dJVyemvfLMbr7Q5iQeDbFZg4w6yOA8zcfYd07U%2BTsrjQJh9DAhxsM8uu9xuyF%2Bz%2BcesRs3owyMa8iwG5ddPhmrsLPCavRbzyBpBJFu6DQA%2Fg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=lFR%2B2eWgtpkY072%2Fv%2BQ2%2BSLLrlr%2BeQb5XkXqH5cxat%2Fe%2Foks6tI0xjkDFc5PJqK9%2Bw5clLpWUQzbSssbcM4YOGbFW5NPYzLO2Af4SZR4eTpY%2FzQ0waLRPenmvT9AeN6mvvJWbZ6hxPVFWbnsj7qp2Zo7jezrCS9UxoXt1w%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e956ae1fc324-EWR"
+              "value": "8479e4f8097517ad-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 957,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:57.478Z",
-        "time": 143,
+        "startedDateTime": "2024-01-18T21:22:37.386Z",
+        "time": 140,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 143
+          "wait": 140
         }
       },
       {
-        "_id": "f682894f147ce2bebf571d95cd5c59a7",
+        "_id": "80e367b3ab417eaa93efda92c5798ea7",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -237,18 +237,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 424,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9Aaej/G9qkaYcdNnHaBUWNW6qVtiSuBEN896mh6+ikiR3z/J79s3N2AFBJlpjC2QEAwEyTZHrtys9RA0DTZRkZgymw7mj2LZPWje7VuquqUT1MwwC43fKppVruCVNA23z2U72OVGvui2IpVnNPzD1/I0S6WqVBtIij8P02UCrrDINbkeloGzAZhsOvEV2r/jFi8F/GTabcD+Np3sh0FV/9gxsLqQriF7o5JgDuTkpLLpvaTC8y2flRMm3KPf1JPBruED5ZhnXbVmVmp1qcK6YzxJCOTLWZIGHVFP0Ld8ytSV23KHhRlfWH2xdcL1iGy9glPw78MAnzXOW5kmGce5GfiNjP/MQTUTLgI2uZ0bP9o7uRnsq5fAEAAP//AwAQv+miiAIAAA==\"]"
+            "size": 424,
+            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9A05TR0hvapGmHHTZx2gWFxJRqpZTElWCI/z41QEcnTeyY5/fsz84xAECjWGEGxwAAALUlxfTWFF+dBoCu0ZqcwwzYNjS4ymTt1rZq1ZRlp+76YQBcLPhQU6U2hBmgbz74qZ5Hmhm3RSnkeCiiYZTOZZRJmcXJKI3kx22gMN6ZTG5Fpr1vwOQYdr9GNLX5x4iL/9Rt0ud+7E7zTq4p+ey/uDFXJid+pZtjAuD6YKziYlu5/kV6Oz8ppnmxoT+JO8MdwmfPMKvrstB+qsc5YwaXGNKeqXI9JCy3efvCNXPtsjDMcx6VRfUZtoUwehATkYZGRFoqiiMRT6c6XomEErNMV5PUJMvx6oqPbJWmF/9HdyMtVXD6BgAA//8DAHM/0jeIAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:57 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:37 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "05dbf9ba5f87c5d526cd3e75e90c2190"
+              "value": "a9bde5000f35db7fdcb33ef026950330"
             },
             {
               "name": "x-trace-id",
-              "value": "e4854696ffdffda68f1749284c491279"
+              "value": "d01c2ae310399c3f07e7db8f68d7b4fe"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=sPbc6%2BY%2BctasnKQE2P6ORyRo%2F4KBd9%2FEkL0%2FhCK57rNN15XnSToHNrog3%2FGpJEqR8j2Zku8troVHobDo0ARGNE7sbQAJfnalC02Wt9LfIG5qefAldm%2BZSXEy7iQ4kM4MQCqSOB8IvIcpTby9ht5s6aPFDGWdCZfwX3fI9g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=3NuCm%2BFLrgu1STld%2FTMkH1CnSkhdNU8ZIvqAVhA%2FWXJjK6KQBusITUO2bflyi2oaBhqm9B5pfCIzxebfYgYrvgHsyJuuLsPfOJ176KiHVEItklc%2BsWUESEPo%2FSnIuZQIgr7ANFbDKXV7eAUG5eU19DSiAB09xSyees4UkQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e957a9798c11-EWR"
+              "value": "8479e4f8fe5f8c15-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 953,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:57.642Z",
-        "time": 282,
+        "startedDateTime": "2024-01-18T21:22:37.541Z",
+        "time": 442,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 282
+          "wait": 442
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship_1667904710/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship_1667904710/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "cf3c4a593907da2a1d1b4e65688bb5e9",
+        "_id": "b9ed681363c960ad8fb701ab79e4e003",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 747,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWzy04gYRtbohWKyp1hRb20tWqcuNJyK6xLXuCiCr+fZU00IQmlFuUee/NvOex3waEUMGR04i8DQghhLqNNllSLK0WeYzuVCCEGp7CQiW68Y8QuuHuB+xxyVOgEUm4dHDTqi4t7DKdux6EQ25xnlunLY0IheLRPM8X4eLvQ/FUPN7RBhSUuA748oKFAcW3ZUO6PM5dAw5HJAWRQmnx94n6YYwQGl/TjBCqtIBWKB1DrFq5tviE0FctiqrPnm+NBLLjMgeSaEuqyhk61lvDLcxwabMYfnJVBatyKc+BFjiCmGGp7TN/fOv5t56/9sLI9yM/GDLmPZ+rb7gSskcwE6WS54/PSebd15wjpNoW3ewatC5Mj7zJX2XmNvXElwCrWPeJ1Bs87/LOvDULIsYixoaMsU/ea+4vI07crg7IMXfdNeRpXwW2RnKEVZ4k2b4Hk2Ff9HljpqvPcgdKVBtcCjZKh9b+XtrUB5ECPYEP9def0xW6xJ1rpQ==\",\"IMZMq3eFuitNuUgBn6Dx7pR7VwjLS7BrPzBd53nPEdbZFpqXvr08nZD4K41WyF2AjgX5wH16X9rhfK9sz4yRWVwZrRIYHHOtaBT2CMq1UqBSVztFN4jGRaNRmuJQZurfqCyMvICF7NsonI6TMLgLJkkcTAN/wpKp8GGShAAMwiCuXVC0PIZFdY+/pJRTDQ7/AQAA//8DALiSTGEmBgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4xU0W7aMBR95yssP6/ghJKRvCFWTVTqhAZ76TRVl/gmZDO2ZTuIqOLfp6SBJjShvEW555x7z/G1XweEUA4OaEReB4QQQu1W6SwplkbxPHb2XCCEakhxIRPV+EcI3YL9gQe3hBRpRBIQFr+0qkuD+0zltgdhHRg3z41VhkaEYvGon+eLYPH3oXgqHkPagKLktwFfXlyhUcKubEiXp7lrwPGEpMhTLC3+PlPfjRFC41uaEUKl4tgKpWOIVSvXFp8QulG8qPocYKcFkj2IHEmiDKkqF+hY7TQYnLmlyWL8CbIKVuZCXAINgkM+c6W2z/zxneffef7aCyLfj/zJkDHv+VJ9C5KLHsGMl0qeP74k6Tdfc3CYKlN0s2vQutA98jrfiMxu64mvAVax6hOpN3je5Z15azaJGIsYGzLGPnivub80P3O7Ojhwue2uOUj7KrjTAhyu8iTJDj2YzPVFnzdmuvks9yh5tcGlYKN0bO3vtU194CnSM/hYf/05X6Fr3LmSEmOX\",\"KfmmUHelKfAU3RM23p1y7wpuoATb9gPTdZ7fwOE622Hz0reXpxMSf6bRCrkL0LEg77gP70s7nO+V7ZnWIosro1UCg1OuFY3iwaG0rRSoUNVO0a1z2kajUZq6ocjkv1FZGHkTFrDpaDoOY/D8ED1MIPDDIGTB/dQLfB5+DTf3ULugzkCMi+oef0oppxoc/wMAAP//AwBUeYR5JgYAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:56 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:36 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "30f7f42855adf9d690f47c4b8d489e7a"
+              "value": "39c38fab7d5019e4d6ce40c041f879db"
             },
             {
               "name": "x-trace-id",
-              "value": "673f65954fc575240f7d2e4f6ee0e65c"
+              "value": "839ca129e1efa629690648162d979b4a"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=Tc5AfxCnb%2FNZ5NYwNR4ff%2FSYgXX7oaJ%2BRSmFDfMIZ0z4Lu8iGPk515gz5gWXm9zyWJ4ixD8bW%2B3bpNp%2Fu484LdUAmNYzhLca0b%2F7bwre3glMZ1%2Bvm3qkfLoB9wIc7CgDOPzDMrUkNntnASLleutNmigNioX5BuV02zIFoA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=3cqHE55OJ%2B3a5vCpYD%2BvVDZ7IMUsiOGCwubIIKSsGR1ovPGO3QC3W8rtemswNXyNbvofWLTPqLND8mCjZ0O7Ghd%2BApKR5NDV41JEnIC4%2Bea%2FbepDRZHQnuqpHE3FdCwOaUtVJ2INH3EdsIc%2F5WEBy5gxNWmex8aoud3EMQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e9504a0f41af-EWR"
+              "value": "8479e4ef0b3717e5-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 953,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:56.461Z",
-        "time": 216,
+        "startedDateTime": "2024-01-18T21:22:35.942Z",
+        "time": 405,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 216
+          "wait": 405
         }
       },
       {
-        "_id": "f682894f147ce2bebf571d95cd5c59a7",
+        "_id": "80e367b3ab417eaa93efda92c5798ea7",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -237,18 +237,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 424,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVFhAUbqZNmh56aOOpF7PuTpEUEXeHRGv87w0rpWLS2OO+eW/mm9mTB4BassQMTh4AACpDkum1Kb56DQBtoxRZixmwaWj0I5MxO9OqVVOWvbofhgFwteJjTZXcEmaArvnot3oZqRfcFkMRRuMgHAfTZRhmUZTFySQVwft1oNDOmUTXItPBNWCyDPubEU2t/zGi85/7TYbcD/1p3sg2JV/8nRtzqXPiF7o6JgBujtpILnaVHV5ksPOjZFoWW/qTuDfcIXxyDIu6LgvlpjqcC6bXxZAOTJUdIGG5y9sXbphrm/l+nvOkLKpPvy34QSwSMffnwToRcZrSOhVxHH+Qmgo9EyoKp3pGybrDRzZS0bP7o7uRlso7fwMAAP//AwBEFxzjiAIAAA==\"]"
+            "size": 424,
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVYEUw3EybND300MZTL2bdHZEUEXeHRGv87w0LpdCkscd9897MN7NXDwC1ZIkpXD0AAFSGJNNrnX/2GgDaWimyFlNgU9PkWyZjjqZRy7ooevU0DgPgZsOXikp5IEwBXfPJT7UdqVfcFEUgomkQTsPlWoSpEOk8nsVR/D4M5No5k2goMp1dAybLcPo1oq70P0Z0/lu/yZj7oT/NG9m64NbfuTGTOiN+ocExAXB/0UZyfizt+CKjnR8l0zo/0J/EveEO4ZNjWFVVkSs31eG0mF4XQzozlXaEhMUxa164Z65s6vtZxrMiLz/8puCHiyAOlr6OF0G8jUgst4lSSUK73VxLIRYi0HouZIePbKSiZ/dHdyMNlXf7AgAA//8DAOel4nuIAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:56 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:36 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "dcffef91a3d737fc2b375b2048b0e3d1"
+              "value": "e2d05f8e9e794a4917504b1eee2b08f6"
             },
             {
               "name": "x-trace-id",
-              "value": "81b60599eb90555fec40d70c324d7e6b"
+              "value": "d6506b4e28b7cc77eff3da22520dd32a"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=ry%2BeY7kQp5oYj8CzE2HzK3CLg4C%2BTKYMH6p4cClMeiX%2Bvp8iO6wO46ktyfxSjLZC2b8oOX2ftHzrQz8EkBJMwITo9Muj1G49bZo%2Fj3kmYuKyHHnrTwqohuCroAhizXw%2BNH5JKdR20ESPyRP3Tyk5%2Bulb2XYvbsz7tPCPnQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=F0U3QGP%2F1i0hTnNTpF2RSMt%2BQIIi3%2B2hDNB0SpopXIYr9BDPn4esgG7etp5uSrYC%2FkvGHfk%2FEm7rvbwzSaLdGyAPiqRmEyOYkRjZ%2F78OXAUnLlJlqUc98vdJyibPPplYFlOFRixAfPXGanWlkWbHLhoyYD5Y4KaYteI%2BGA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e9520a811845-EWR"
+              "value": "8479e4f1ddcb0f79-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 953,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:56.734Z",
-        "time": 210,
+        "startedDateTime": "2024-01-18T21:22:36.404Z",
+        "time": 454,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 210
+          "wait": 454
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-relationship_933332662/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-relationship_933332662/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "e07b2c757d353088f440046b49aea44d",
+        "_id": "de663f091ed881d9fba76db496332f80",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -72,18 +72,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 424,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVWBBKuZk2aXrooY2nXsyyOyIpIu4Oidb43xtWpWLS2OO+eW/mm9mDB4BassQMDh4AACpDkum9Lb97DQBtqxRZixmwaWl0kcmYjenUuq2qXt0OwwC4WPC+oVquCTNA13z0Wz2N1DPuimEQRmMRjsV0HoZZFGVxPBFp+HkdKLVzJsG1yLRzDZgsw/ZmRNvof4w4+4/9JkPup/40H2Tbik/+sxsLqQviN7o6JgCu9tpILje1HV5ksPOzZJqXa/qTuDfcIXxxDLOmqUrlpjqcE6Z3jiHtmGo7QMJqU3QvXDE3NvP9ouBJVdZfflfwRRwkQeqniV4+Lh9iGYgk0dNcyVyISKcqznWUxxd8ZCMVvbo/uhvpqLzjDwAAAP//AwCeGyXwiAIAAA==\"]"
+            "size": 424,
+            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9AmxRY1xvapGmHHTZx2gWFxC3VSimJK8EQ/31q6Do6aWLHPL9nf3ZOAQAaxQpTOAUAAKgtKabXpvjsNQB0jdbkHKbAtqHRt0zW7myrVk1Z9up+GAbA1YqPNVVqS5gC+uajn+plpFlwW5SRnI4jMRbJUopUyjSeTu5l8n4dKIx33olrkengGzA5hv2vEU1t/jGi85/7TYbcD/1p3sg1JV/8nRtzZXLiF7o6JgBujsYqLnaVG15ksPOjYloWW/qTuDfcIHzyDIu6Lgvtp3qcC2bQxZAOTJUbIGG5y9sXbphrl4ZhnvOkLKqPsC2EYhbNoyTM5jKL73SSxJlJ1ppoLeVMxEbMhdAyMx0+slWanv0f3Yy0VMH5CwAA//8DANopY5CIAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:55 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:35 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "de5ee7fa696921261182ae85d1772a1f"
+              "value": "2ac84706d1f2c171deacfe5b1694effd"
             },
             {
               "name": "x-trace-id",
-              "value": "86df9f75a0166d4bcab113d8c5bd3b5e"
+              "value": "f62f37c883fd8bceeb22513d1611c2fd"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=ajgg7nyDMux0OjvXYyeCDxAbhjY9X30uFJmpmRc1AmMqk0ULcInpr%2FzJpT%2Fzly4ALNvklHvKLDjR7GXc0fuIflcR%2FGfGm73Kqp4ROhk5eL1qBGbW1KpjNaVtL7YAMsc3YPW06TzHdweBdFWE9v9EUt8HaZWeX%2B9gZ%2BFKXA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=wufHxPR61KylNdSuOLXRYqtNi0aKCW%2B4YVCEpST5wlIXhEf%2BXVSplEWYmtjrXqt3gpecV6b2gls7xcpGNipEFuP4vZs94kIHD85XsiBBlFCH4YyrZNCILcRU57Y2URJuWymgxIhZU9%2Fbat42CIIxZmaKDv0d6cwwpofNZw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e946ce951791-EWR"
+              "value": "8479e4e6a83c7271-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 945,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:54.939Z",
-        "time": 303,
+        "startedDateTime": "2024-01-18T21:22:34.601Z",
+        "time": 621,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,7 +169,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 303
+          "wait": 621
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-relationship_2952094097/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-relationship_2952094097/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "69bf5cde0c38a7c44872426973698910",
+        "_id": "2cdbff2aed36d3391929b7a1eec454de",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -72,18 +72,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 424,
+          "bodySize": 428,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 424,
-            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9A2zTtWG9ok6YddtjEaRcUEqtUK6UkrgRD/PepATo6CbFjnt+zPzuHAACNYoU5HAIAANSWFNN7W373GgC6VmtyDnNg29LoIpO1G9updVtVvbodhgFwseB9Q7VaE+aAvvnot3oaaWbcFUUkknEsxrGcC5EnSZ7KiZTR53WgNN6ZTq9Fpp1vwOQYtn9GtI35x4iz/9hvMuR+6k/zQa6t+OQ/u7FQpiB+o6tjAuBqb6ziclO74UUGOz8rpnm5ppvEveEO4YtnmDVNVWo/1eOcMINzDGnHVLsBElabonvhirlxeRgWBU+qsv4Ku0IYp1EWTUP9IIVcplIaOY1jTeIx01Eis2WSZGapLvjIVml69X90N9JRBccfAAAA//8DAJvCU7GIAgAA\"]"
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9Ak1Io9IY2adphh02cdkFpYkq1UkriSjDEf58aWEcnTeyY5/fiz/YpAECjWGEKpwAAALUlxfTaFJ+dBoCu0ZqcwxTYNjT4lsnanW3VqinLTt33wwC4WvGxpkptCVNA//ngp3ppaRbcFiMRxUMhh3K2jGQaRek4HgkRv98GCuOd0/mtyHTwHzA5hv2vFk1t/tHi6j93k/S5H7rVvJFrSr74r27MlcmJX+hmmQC4ORqruNhVrr+R3syPimlZbOlP4s5wh/DJMyzquiy07+pxLpjBNYZ0YKpcDwnLXd6+cMNcuzQM85xHZVF9hG0hlBMxFbMwyzIT60TJcUJKzs1UJDKbzGWyXo9nWn5fA9kqTc/+RncjLVVw/gIAAP//AwD5k4OJiAIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:54 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:34 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "edd7dda4f2a372cd5a2a452d6ea8ac76"
+              "value": "7a48b8b3e93a4ddf1760cc07a9c14458"
             },
             {
               "name": "x-trace-id",
-              "value": "c7424b544d4811ce296c0346b336dbae"
+              "value": "bbbd4c7a137ea19d6071b5917ff38c19"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=xVnljyhnhHS%2BAY2V%2BnHTPR55ftsFnm0Cw16vBIxcmsYIajJ3eqkHQNx94%2BOMnmzU9pXa7UOSxc5pF32AFKm41RCj%2Brgi0BlZ%2FgHzgvUysBsHPb0utDlvHBRy04v%2Ft%2Fa7RAt2OAwSW4T5oms7BuxLVaBXoYwBgRCfJMD97Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=Fjeca%2F6hayNNjtc%2BmA5wmTu218bTLgmrkl67%2FgTa%2Fr9HLNNP6mNjF2wh6YTuAePDFmXe2jVYKh4VHsBKWYOIk4af8p%2BDL5PxF9gFf2%2F6tH0jmjsMpo0bWGgSrC7p2OfHBK1mHkxnqncEhzYyuFG%2Bb7wYIg1c38FhsivCWw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,7 +147,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e941fb6f32d3-EWR"
+              "value": "8479e4e0ef7a41b2-EWR"
             },
             {
               "name": "content-encoding",
@@ -160,8 +160,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:54.168Z",
-        "time": 325,
+        "startedDateTime": "2024-01-18T21:22:33.643Z",
+        "time": 439,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,7 +169,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 325
+          "wait": 439
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-relationship_3875503635/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-relationship_3875503635/recording.har
@@ -8,172 +8,7 @@
     },
     "entries": [
       {
-        "_id": "24aca3aa6395eada79beed11b646c7df",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 87,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "x-gadget-environment",
-              "value": "Development"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "87"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "zxcv-deeply-nested--development.gadget.app"
-            }
-          ],
-          "headersSize": 479,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"query\":\"{\\n  gadgetMeta {\\n    allHydrations\\n    __typename\\n  }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "operation",
-              "value": "gadgetMeta"
-            }
-          ],
-          "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=gadgetMeta"
-        },
-        "response": {
-          "bodySize": 851,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json; charset=utf-8",
-            "size": 851,
-            "text": "[\"H4sIAAAAAAAAA8xYTW+jMBC98yssn6OFpEnU5tbtSs0eolab7rly8ECsBZtio1226n9fmZAuEAMNH1FviRm/mXnzxh54tRDClCiCV+jVQggh7BPqg9pAYQ0hTIJgndKYKCa4LDxACEuQkgleWtTLexFV1hDCKo0ArxD+CoHgvnwSeFI2CAWFQFvo/cxLtxqmYPJWtMduDEQBvVV6xzei4ImFUILESUQNJpYBD78k7G81jc4eSiYvCUhNHdkFIOtZWRO5ITyt5aQIU0/K0WoARyUnNZzllhXeCJe/Ie4RwgFghNJXuDop+Vkqzfa3kpTnUqGohroz/RsKNQJPXCjmMZc0x7sm8oFDbbAlkFb5ZiIfgJrmZonBFWEInAJ9jAVNXNU5PQNUqzJa3ePosLxNfL+/XMY9VCenB0CfYNtOAMKF2kP8eAmCjMVraAosgdOHRGlu6jkavjc3ICXxYZAWPWI1FGCEErcybU5xFC4VKc1GHRI04tUS+rFT9jyv55JrzHk8pfaYENq0akw2b/B7GsU/ILs=\",\"IsZJdazxtympmhskf3rXnleU7AIm981Gw/HDvPTn52Rye+oTy5S7PdR6RE65W38A5Jd9fzemAWTSTRT+/1bpH1ex70YeQD6usNMhrEeiXabAojYMqtsy7sIlGvJibdYw4w//SjbacDvs261V/fUeOH5+1richBn2ffaF5jaKgsKlfYDSW7NtGP4o4LL0FQAHwtf/8F6pSK5s2/fVl4DxX7Z+YE8XztK5tnfLKV3c0OV0Nqczb3FzDTOgy8X8yrmazh3Hy1PCKiYufKcar3WLjsp6+wcAAP//AwAW7AqJbRIAAA==\"]"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "vary",
-              "value": "Origin"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-expose-headers",
-              "value": "x-set-authorization, x-gadget-environment"
-            },
-            {
-              "name": "x-rate-limit-remaining",
-              "value": "2249"
-            },
-            {
-              "name": "x-request-id",
-              "value": "35b462666a9e6c865d0399232c0a22fb"
-            },
-            {
-              "name": "x-trace-id",
-              "value": "b61d59d6124d2f598e2ed6543031400f"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=15724800; includeSubDomains"
-            },
-            {
-              "name": "x-gadget-served-by",
-              "value": "nginx-green"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=F7ZcosgyKaKdZuOYKbi0skg4PETH9GaCYm7quvHEDHAY00pn2iofkqaQH5iwgHBQQUPS0hZabhxKOb1we%2FhZn1waOUIXXvt9kJItQLYnKnz8hjek8bvu14d7d6gaucjSVGhW0L0ru1UzMTOkb1f5ZnB%2FMX2nBJvCoXNq2g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "8359e93c79d11809-EWR"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 943,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-14T22:33:53.262Z",
-        "time": 140,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 140
-        }
-      },
-      {
-        "_id": "5e1cb85c45ecc6b20b4cb3b41411934b",
+        "_id": "0152bbab561f12b48da1cd31082df08c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -242,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRT0+DQBDF73yKyZzb8neRcms0MR48aHry0mzZkRIppbtD0tr0uxsWRDAx9bhv3pv5zezFAUAlWWIKFwcAADNNkumlKT4HDQBNk2VkDKbAuqHZt0xaH3SrVk1ZDupxGgbAzYbPNVVyT5gC2uazn2o3Uq24LQZeEM79YO5H6yBIwzAV4eJORG/jQKGsU8RjkelkGzAZhuOvEU2t/jGi91+HTabc98NpXsk0JXf+3o25VDnxM42OCYC7s9KSi0NlpheZ7PwgmdbFnv4kHgw3CB8tw6quyyKzUy1Oh+n0MaQTU2UmSFge8vaFO+bapK6b57woi+rDbQuuL7zYS9wkin2xTShKPE8tM7mNlVpG70IEoQp9sezxkbXM6Mn+0c1IS+VcvwAAAP//AwCNw6GTiAIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9A05Q/WW9ok6YddtjEaRcUGlOqlVISV4IhvvvU0HUUaWLHPL9n/+ycAgA0mjUmcAoAADC1pJne6vyr0wDQ1WlKzmECbGsa/Mhk7c42alkXRafu+2EAXC75WFGpt4QJoG8++K1eRpo5N0Up5HgoomGkFjJKpExiOXpQ6uM6kBvvnM6uRaaDb8DkGPY3I+rK/GNE6z93m/S5H7vTvJOrC774Wzdm2mTEr3R1TADcHI3VnO9K179Ib+cnzbTIt/QncWe4Q/jsGeZVVeSpn+pxLphBG0M6MJWuh4TFLmteuGGuXBKGWcajIi8/w6YQRhMxFSpUUapmlMaz6WS9WscrKcSYYr0eKzKRiE2Lj2x1Si/+j+5GGqrg/A0AAP//AwBGNWA7iAIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:53 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:33 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "72aaf32f9c6dd36a2f7487608f260270"
+              "value": "4e261fbc76f1197bf881dc759091cfa7"
             },
             {
               "name": "x-trace-id",
-              "value": "84615b8e4800d9cab6dd94f5523d3159"
+              "value": "81c87ec3765fbf3b2004e3af48ed103d"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=QA%2B3tEGsqQqXlG1TBGfr9W7doEUSSujGLQ56Gf93AQrrAY1fWw16DZ%2BEilTdmhYL2KysTS%2BrKyXwueo4Z5AESd69FSsE0lrF%2BybODBObk3Zxzwz1eIf6bqKWh5Ru41cg4h0%2FZUFKsfkBPRSLeC31acULknTRLeMPpShhew%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=tjwzs23MaC7I9q%2FNkH96wcX5U3fMsYhHjDO7208TI57aVcFZuH10iIYYckwh%2BEMaJ%2Bwsg94Vk4k91pkQg55FjfAot1nlPGWoOc7bcp3oG3nIgAYLuIsAduLzTlkHp%2BYSxU1PbnXfT5s87kNjxjBjJ9YPsS1GGTCNglheWg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e93d69e75e76-EWR"
+              "value": "8479e4cdddb00fa1-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:53.445Z",
-        "time": 364,
+        "startedDateTime": "2024-01-18T21:22:30.595Z",
+        "time": 2467,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +169,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 364
+          "wait": 2467
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-HasOne-relationships_2856696492/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-HasOne-relationships_2856696492/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "44c1446218c7c6dd25a52edbe0aad455",
+        "_id": "78977f79a8b907618b737874df31625a",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9A29A/rDe0SdMOO2zitAvKElOqlbYkrgRDfPepoevopIkd8/ye/bNz8gBQS5aYwckDAEBlSDK9tMXnoAGgbZUiazEDNi1NvmUypjadWrVlOaj7cRgA12s+NlTJHWEG6JpPfqqXkXrJXVEEYj4NxTSMVkJk83kWx7N4kb5dBwrtnEl4LTIdXAMmy7D/NaJt9D9G9P7zsMmY+344zSvZtuSLv3djLnVO/ExXxwTA7VEbyUVd2fFFRjs/SKZVsaM/iQfDDcJHx7BsmrJQbqrDuWB6fQzpwFTZERKWdd69cMvc2Mz385xnZVF9+F3BD+MgCRa+VtFmIyOVSpUKGUd3lAgdpWGSLN6TMIh6fGQjFT25P7oZ6ai88xcAAAD//wMAEUqWJogCAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRTW+CQBCG7/yKyZxV2JUP5WbapOmhhzaeejELTJEUAXeHRGv87w0fpWDS2OO+874zz8xeLABMFCsM4WIBAGCsSTG91tnXoAGgqeOYjMEQWNc0+5FJ61I3alHn+aAep2EA3O34XFGhDoQhYNt89lvtRiYbborSke7cEXOx2koRShkuvYUnxPs4kCWtM5BjkenUNmAyDMebEXWV/GNE778Om0y5H4bTvJGpc+78vRtTlaTELzQ6JgDuz4lWnJWFmV5ksvOjYtpmB/qTeDDcIXxqGTZVlWdxO7XF6TCtPoZ0YirMBAnzMm1euGeuTGjbacqLPCs+7aZgC8/xnZUtVbBeup7vriLXUSKI1r6iIAp89SHJW/o9PrJWMT13f3Qv0lBZ128AAAD//wMAbzYxX4gCAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:55 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:35 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "6edffaacd72bcf34d1f1be3011c628eb"
+              "value": "2f6f7912be5d7e5245bbf3c837070098"
             },
             {
               "name": "x-trace-id",
-              "value": "dc4ffa4c7ac72a549e62d471668b6104"
+              "value": "2a79345648b40a17b96ae7b76af2e536"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=1TVUKfsH9a14KIzHFe6rzBM%2FyrilqUuwaC1%2FXQKOGj0%2FfA1bgwK%2FbzCW5S%2FV7RME8ansIwYzISGtH1dHj7eO3B8EV%2BEJjd239X139bWm3BuN2%2B1VRhjw5XRttfHtDPATJAIllmBI%2FqCvR1SOWPhCeavFhI0LnrNLha4YNA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=TzUwU7llBasrq9ABjmm5egPPo3qStrC%2BAQxBXwOvT8E6kXSp5hBhjt3wACR068i5obUYJmH7J%2FhGPYY4%2FO0xKM4qkIctmDNZmCpk8K9SSTc%2B6N3d%2BsTh%2F%2FJxt3DULupDAmYjQKW3b8Tv%2FxqfU3GsqNdaCVQ%2Bp4yfgHs5Ww%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e948eb26435b-EWR"
+              "value": "8479e4eaaba80c7c-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 955,
+          "headersSize": 957,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:55.277Z",
-        "time": 492,
+        "startedDateTime": "2024-01-18T21:22:35.251Z",
+        "time": 339,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,7 +169,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 492
+          "wait": 339
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-relationships_3250074585/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-relationships_3250074585/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "3d0dbc97120f68c8fa9edf99fd49921b",
+        "_id": "f7ba9e5bc7b53e2bad64a931da393a9b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW/CMAyF7/0Vls9A2zSZWG9ok6YddtjEaReUJqZUK6UkrgRD/PeppevopIkd8/ye/dk5BQBoNWtM4RQAAKBxpJlem+Jz0ADQN8aQ95gCu4Ym3zI5t3OtWjVlOaj7cRgAVys+1lTpLWEK2DWf/FQvI+2C26KIRDKNxTSWSyHSJEmVnM2j6P06UNjOqe6vRaZD14DJM+x/jWhq+48Rvf88bDLmfhhO80a+Kfni792Ya5sTv9DVMQFwc7ROc7Gr/Pgio50fNdOy2NKfxIPhBuFTx7Co67Iw3dQO54IZ9DGkA1PlR0hY7vL2hRvm2qdhmOc8K4vqI2wLYayiu2geylhkJouNVGtj5d1aKGXVXCZJJLPM6LjHR3ba0HP3RzcjLVVw/gIAAP//AwDgECPviAIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVdgERuJk2aXrooY2nXszKTpAUEXeHRGv87w0rpdKkscd9897MN7NnDwC1YoUZnD0AAMwNKabXtvwcNAC0bZ6TtZgBm5Ym3zIZszedWrdVNaiHcRgA12s+NVSrHWEG6JpPfqrXkXrJXTEQQTQVciqTVSCzIMjCaBYli/fbQKmdcyFuRaaja8BkGQ6/RrSN/seI3n8ZNhlzPwyneSPbVnz1924slC6IX+jmmAC4PWmjuNzXdnyR0c6PimlV7uhP4sFwh/DJMSybpipzN9XhXDG9PoZ0ZKrtCAmrfdG9cMvc2Mz3i4JnVVl/+F3Bl3MRi8SPhQw3SRhpQSoOcyFTmabpPIzTMBGbSPb4yEbl9Oz+6G6ko/IuXwAAAP//AwBLlFHpiAIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:54 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:34 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "2a7dff7a001421b2f68e71e8b9006d87"
+              "value": "0e89ac00c5c9dd60fa9bfbbc257fceea"
             },
             {
               "name": "x-trace-id",
-              "value": "412bcb1c45fcd46f255d5843304bbca1"
+              "value": "6013b834d0ea63c01919995369380b41"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=xjO9xwLAIp7pkkymOTJYALyvJgDoBnn3259C2xz56kq%2Bj1bytiFfbdM1xuVU8kmNQBp%2BVVR6zeSELasytne0DO1sawVpk%2FeQsM%2Fwdqup0Qpk2%2BLvrQ8KIOlDLPlAlgCPIO%2Fz3F3ZLR1fqGGlBTA2RUSJRZ96Q6Yu0RKpLw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=gSE4DOif8XKy%2BiPiLN7tOhrdg6CbO32Q8redIh9tdVDGPT5MrYloybErZ9pERq0k2pxfZZWmbxe1yjjKwl7Fg5nH%2F5iW2bxznQmxdaS4rVy0HJ%2BY7Vrpyar139xlCjXI7KivOlp%2Fw%2BUG9TKqWXUpbZHCgMmzuaC8xay31A%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e94428d442ab-EWR"
+              "value": "8479e4e3b85f4207-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:54.527Z",
-        "time": 383,
+        "startedDateTime": "2024-01-18T21:22:34.104Z",
+        "time": 475,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,7 +169,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 383
+          "wait": 475
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-relationships_2510062961/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-relationships_2510062961/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4377f7651cadafe8c37232abd47c644f",
+        "_id": "50b54ae79367b7bdbdd8882bd676c275",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9A04b+WW9ok6YddtjEaReUNV6pVkpJXAmG+O5TQ9dRpIkd8/ye/bNz9ABQK1aYwdEDAMDckGJ6acuvQQNA2+Y5WYsZsGlp8iOTMVvTqXVbVYO6G4cBcLXiQ0O12hBmgK755Ld6HqkX3BVDEcppEE6D+TIMMymzaD4Tafp2GSi1c0bJpci0dw2YLMPuakTb6H+M6P2nYZMx9/1wmleybcVnf+/GQumC+JkujgmA64M2isttbccXGe38oJiW5Yb+JB4MNwgfHcOiaaoyd1MdzhnT62NIe6bajpCw2hbdC9fMjc18vyh4VpX1p98V/CASsUh9nVMSh3OpZXQXC50EgVCBklomH0JF9N7jIxuV05P7o5uRjso7fQMAAP//AwD9gMqliAIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRMU/DMBCF9/yKk+e2iR3shGwVSIiBAdSJpTLxkUakSWpfpJaq/x3FDaFBQmX0u/fuvjsfAwBmNGmWwTEAAGC5RU343JWfowbAXJfn6BzLgGyHs28ZrW1sr9ZdVY3qbhoGYOs1HVqs9RZZBsw3n/1UzyPNkvqiiMTNPOJznq4Ez4TI4nghefJ6GSiNd6r0UiTc+waEjmD3a0TXmn+MGPyncZMp9914mhd0XUVn/+BmhTYF0hNeHBOAbQ7Gaiqb2k0vMtn5XhOuyi3+STwarhA+eIZl21Zl7qd6nDNmMMQY7glrN0FiVVP0L7Yhal0WhkVBi6qsP8K+EHIZqSgN341KbpOYxyqVSsoEBU+klnHOI6GUeBvwGVmd46P/o6uRnio4fQEAAP//AwD1S0mHiAIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:54 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:33 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "705e50f8b8214abee023b80547f221ba"
+              "value": "56d6b66cb8fb7cd7d34c75343f4e1372"
             },
             {
               "name": "x-trace-id",
-              "value": "dce76243d35960d7110a1a3d37f0a5eb"
+              "value": "fd67973136856557e2175a53c102662b"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=KgBtdNzfYbp7DxRzfwNqZbGbG%2Fv4weYgk0bMhoXifaF3wnyD7CqsjOc2S4Pd01yQtejCkSh9ar%2BXl2PWiB3fPCRjcwmib6lZw5BU552FavNBtWLSmLYfuYMXT7S2nXO6CI9Zy%2B2tdFTCbeJb76OObBs4ClnCMt5H2GOzkQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=nH0GpDO5NK%2BwZ1sZsBkSqIPW0p8%2BRZFfAoEqG%2BuEwBSETdv%2BjBgLpGv8IU5YYGg5kVV10lBRKCVtliGHc3oad%2BaFLEvmMQqXulERKIUux13iGz4i73J2vilC%2BuUpNkR5Oaplnb9LVvs6dOmFI7PbpetqzgBVpunljYcRdw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e93ff8858cca-EWR"
+              "value": "8479e4dd580143c8-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:53.846Z",
-        "time": 288,
+        "startedDateTime": "2024-01-18T21:22:33.090Z",
+        "time": 530,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,7 +169,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 288
+          "wait": 530
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship-with-support-for-Id-prefix-test_2503398001/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship-with-support-for-Id-prefix-test_2503398001/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4b94e5d5c308b4860c9c86ce369397c0",
+        "_id": "93162a24c367a265f0c308431ace695f",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 360,
-            "text": "[\"H4sIAAAAAAAAA4SQzWrDQAyE734KoXPo2jGJf26GQuiht96D1qs6SxzH9So0Ifjdy3rdJC2UHjWj0XzoGgGgISEs4RoBACB17pOH2wyA1mAJmOQZLr4l4bN4UdgJhISDU29I2Ny3Pk7sxB67l3Bgmd6t7VYuPXd0YG9VoXMyx7CDDZmG5ZUf2ABwdzED+ZvuQQXAemDfXU1UzyT8Zg98qwPAGe7XwuyPf3BtJoaq71tbT60TTsCM5hjyWbhzP5CwPTZ+wp1I70qlmkaeWtvtlTdUsorXca50bLiIc52lNaXLWr9nrA2tC80FJZStZnyUgWoOP/w34qmi8QsAAP//AwCAWudA1wEAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQzWrDMBCE736KZc+l8k8du74ZCqGH3noPsrVWRB3HsTY0IfjdiyQ3SQulx53Z2fnYSwSASrLECi4RAADKwX7SdJ0B0CisAJOywIdvienETmSyDCFh4TgqyaRuW4cjWTb74TUcSLObtdnweaRB7shZdej05hx2UEulid/ojg0At2c1SXfT3qkA2E7kumtP9SKZ3s2OrnUAuMD9Wlj8+Q+utWeox7E3rW/1OAEzWmJIJ6bB/kDCfq/dhFvm0VZCaM2PvRk+hDNEkseruBRNUVJTNt2qabsiVTKJ8y7Nn8siy4onSpIFH3mSLYUf/htxVNH8BQAA//8DAMkLlxDXAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:03 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:13 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "6e5fd58ce76f4bbef6ad9476cc174e03"
+              "value": "5ac6fecbb9193cfc83206185348dd522"
             },
             {
               "name": "x-trace-id",
-              "value": "b0de908b73ca32cbf7ebda69be9a1a75"
+              "value": "b78eb8bf6bcf72da105f259873374e11"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=Z1p6n2VAe2gDzLIXq34H0jc1VNBIpouIMH3YXUPO26uufI86kn84EoRyxhFb9UmjUFb9fqq07cgGyawz7a4CcFa7dd3tNebuBWQl9Q40NDao7LSWdtJUe6mf7gATKAk%2BIWhp1YvUeV5AmKSukRT28ZKVcNlS0LSqo6Ty%2Bg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=8HBNnHaEMtQVjB50LHZcJJTB3eSqiQ0hQjaXQWmq0RMF1%2B8PgJzK3DyWUebyQsZ%2BkwYjMHAT6E6Xi0jRlDd01Zc368A05TJptCilsBxNaYZuCf6IM8yWWOc%2BnV51LRQiIAT2rgD%2B9URVCGt28nfGK19C3rls0F5S4k8dOQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e97ba9e61a44-EWR"
+              "value": "8479e460b8cc0f73-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 943,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:03.393Z",
-        "time": 206,
+        "startedDateTime": "2024-01-18T21:22:13.172Z",
+        "time": 138,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 206
+          "wait": 138
         }
       },
       {
-        "_id": "a757901f9b650e6bcb328f24bf1a6e71",
+        "_id": "d89eef607ce1e91c519a90da519b43d5",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -242,13 +242,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 404,
-            "text": "[\"H4sIAAAAAAAAA4SQu26DQBBFe75iNLUVHuZh0yFFilKkiZLaWrMDRsZAdgfFluV/j5bFBNy45D6Wc+fqAKAULDCFqwMAgH0nBVPW6F9SkwqAus9z0hpTYNXT6i6TUq0yatPX9aSKxzoAVhJTQH+T4OpfZDqzkZk0g21psAhynvvpSXPVNu/2kWA9N3c7vnTUiBMZc0Qf7dvEtEx9z2Z+ku5rto0xj6WQJfEHzU4DgIeLVMJw6OW2XJEhzoYtr4LpqzrRHHGc9BB4wvg2MGRdV1f58NcBx2I6Yw3pzNToBRLWbWm+8MDc6dR1y5Jf6qo5usZw/ciLvY0bFkWUFMFWxnGy9r292G9lQXEow0AIP7pfGFmJnOzdn1YMlXP7AwAA//8DAJQhszJWAgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQTU+DQBCG7/yKyZwbASvycSMxMR68GD03IztQIgXcHWKbpv/dLKwIvfS478fu8+7ZA0BFQpjB2QMAwKFXJJy35of1rAKgGYqCjcEMRA+8+ZNZ605btR2aZlbpug6AtcIMMExi3PyLwkexsrARmFoGJgS1zH0PbKTu2pfpkvvt0tzt5NRzSwe2pkN39mVmWqc+FjPf2AyNTA2Xx4pUxfLKi68BwP1JabIcZr2t0GyJ83HLEwm/1wdeIrpJV4EbjM8jQ973TV2Mr444E6bnashH4daskLDpKnvCvUhvMt+vKrlr6vbLt4YfRsFjkPjhQ1CmYaI4ps8oTCMKtmUZUJzGpDilwOGjaCrY/futiqXyLr8AAAD//wMAxqMrdVYCAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:03 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:41 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "23e5f9abfed7b4f26b691a0451f3eb58"
+              "value": "815ee7b4ec83183d5073e8190517e899"
             },
             {
               "name": "x-trace-id",
-              "value": "4ff57f29d667310bab9dfe64d42aa153"
+              "value": "140f918de7ab5195a03ff0a797ade9a0"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=M25rkmlMtMg3VG0uWdmbD3Oee5WluYgpNUo4vq%2F%2FupbsYUqUsq0fj5bcLauKuC3WbzU4znfLGi5TXNtXuQDwIcaHuvKIPL4oIS4xBWggmqhxAERtj178aKh3obUecoaUbfpmie%2BCAYLn0GBHaFYhlJnfLbm3oHki2niT9Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=oUj0hX1kDMGcR1lqvKe5hEERbnWdePUAtI6qHLTPTZN9N76ZVy8Dzy33aHET5PKoTStUXnQ2%2Flsk0N3xyQ6jnmP42DlFd40QyOE%2FI945PFRJQiut3sNqJolwwAIhU0Og0VZPEDIl3UJw4YFjnb%2Bm1CQQ1YY2y1rUqyXC2g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,7 +312,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e97d49e54405-EWR"
+              "value": "8479e50e6af44251-EWR"
             },
             {
               "name": "content-encoding",
@@ -325,8 +325,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:03.658Z",
-        "time": 272,
+        "startedDateTime": "2024-01-18T21:22:40.963Z",
+        "time": 221,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 272
+          "wait": 221
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "4df2ca4801a9a1bd4ec0b93515476da0",
+        "_id": "0821bb282207dc88fc9692e216159c84",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 368,
-            "text": "[\"H4sIAAAAAAAAA4SQMW/CMBCFd/+K081VHRMMNFukSqhDh0rdkRMfIWoIIT5UEOK/V3ZCSLow3t17z9/zVQCgNWwwgasAAEBTu19qhxkAS4sJoFot8eW+YjqzXzI5hs7h4NRYw2QfquOJHJeHehT2iJvFgxAANxu+NFSbPfnj193YC25D5FSXdqxipMHC2IL4k0adAHB3sa3xkW4Kk7fkmdPQ5t0wfZd7GoP1pf4JnnCtA0PaNFWZh1cDTocpehvSmal2EySsDoWfcMfcuETKouDXqqx/pD9IpaNFtJI5aaPnimK9zBYzq6I81vOYaKu2WRa/qR4fuTU5fYTffmrxVOL2BwAA//8DAP4lhVEPAgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQQW+CQBCF7/yKyZybrmu1AjeSJqaHHpr0bgZ2wI2IyI6pxvjfmwVE6MXjzLz39nt7DQDQkBDGcA0AAJAq98vNMAOgNRgD6nCFL/eV8Fn8UtgJdA4Hp9qQsHmojid2Yg/VKOwRN38bhAC42cil5or27I/fd2MvuA2RU13SsQYjDRZkCpYvHnUCwO3FNOQj3RQma9gzJ22bDxL+sXseg/Wl/gmecK1bhqSuS5u1r7Y4HWbQ25DPwpWbIGF5KPyEW5HaxUoVhbyWttopf1B6OXufhYrImDSdLyknrdNokYercKFziqI8JR1lPT5KQxl/tr/91OKpgtsfAAAA//8DANf5K1sPAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:03 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:13 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "bebeb068104fdfc54f7e19dd67f0e424"
+              "value": "3130c81e4ece368063cc7e156e25be7c"
             },
             {
               "name": "x-trace-id",
-              "value": "ce5a541e357b62d10c3543eef1fbb391"
+              "value": "aaddbb25afa11b94f87841fa99fba19c"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=iz%2FSpLxJBKIBLWohFb2EYXje5V7QRoYUhPZy%2BTzksfG8Ez2owW3xOw0h6IlCQ0TxeZK3IS5tyCgxTCVTuizDcT1QSpABkoNsvJpvrH%2Fy8kh7wMsI9JHiORvmHA0qPE6PdCK%2FESxpWYQzqSgqPPcIBO%2BM%2FJHES1mF0H0lIQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=00utKd24hwBjWCLElW69KwxoObEEmlABCIps%2B4qcOpo5CkpJJD0xf3TH5CvmCyuQ4Sve20rw3ksjZ%2FkcKqKTvReQg1qsDwEk6TgdHvtkqtlfWftF7V%2FM%2FF2z8tylaxKbFtaPJNezcYFAVN7InVLYazrTP2oCyXYa%2FAKe4A%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e9784f95c34a-EWR"
+              "value": "8479e45faad719b6-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:02.861Z",
-        "time": 299,
+        "startedDateTime": "2024-01-18T21:22:13.011Z",
+        "time": 140,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 299
+          "wait": 140
         }
       },
       {
-        "_id": "9e4318fcbb5299c65cc74ceb38676db4",
+        "_id": "62fca7c9d0ae70b329f04df739e8b0ba",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -242,13 +242,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 424,
-            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9R+ROFcEOqVPXQQ6v2HBl7Q1AJUHtRE0V598pACHDJ0eOZ9bfjiwOASrDAFC4OAAB2rRJMWW3+SE8qAJpOSjIGU2Dd0eYmk9aNtmrdVdWkinUcAEuFKaCfxLi5i0wntjKTYRhSBgYENff9dmS4bOrFyPvQIJyZAXC343NLtTiSvf64hSfLdTZ66R0Xd1a+let7VtInma7iITH6sRCqIH6nWbEAeDgrLSyIWTYjNdl9s76JF8H0VR5pvv1YyMrwgPG1Z8jatipl/2qPM2A6YwzpxFSbBRJWTWFPeGBuTeq6RcFPVVn/uPbC9SPv2UtcFVPkJUruxX4bBoEXyzz0ExFGeezl21yM+MhaSHrrf+lhxFI5138AAAD//wMAwK2g2pQCAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRMW+DMBCFd37F6eao4DZpCBtSpapDh1btHDn4IKgEqH1WE0X575XBIcCS0c/vnb97PgcAqCRLTOAcAACgbZVkSmvzR3pQAdDYLCNjMAHWlhZXmbRutFNrW1WDKudxACwVJoAiXuPiJjId2clMhqFPGegR1Nj3a8lw2dSTkbehj08jMwBut3xqqZYHctcf1/BguYxGT71+8WDmm7m+RyV9krEV9wnvx0KqgvidRsUC4P6ktHQgZtpMpsntm3ZNvEimr/JA4+19ITPDHcbXjiFt26rMulc7nB4z8DGkI1NtJkhYNYU74Z65NUkYFgU/VGX9E7qLUKyi5ygORZznG1pSLuOVEJESKhdql+e79WpJUkYeH1nLjN7819+JOKrg8g8AAP//AwD8yfnklAIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:03 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:40 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "59f7cbef465403bc6df6e92d6470d77c"
+              "value": "5a89ad4ed95268c09058fa97ae07249a"
             },
             {
               "name": "x-trace-id",
-              "value": "d7e508dcfaf932207cb318a35b70b9ba"
+              "value": "18ff9e4efa85110d1df1dbffb754eaa0"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=%2BCV%2BUORFbTwyxl%2BvSS8FGdfsXyjDLY6PXHa%2BxY%2FeQy6yoyLddi6EAFzO%2F02JKxr3o33XL6KZCxGEaeClRiXg%2Btk0j8q62KGhNxvAIJ%2FRZbyamxhzuC9IYGH6dFHl2jnppC6okZItRkNOG%2BLrKpyI4nHlIlFPJ%2B4mUltWyQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=gkv3KtqPOpOx02%2Bzh5ek52ENdmw3DHX7PYHto5%2B4QHeJZ7htyHdRBphM1NkWHnbW%2BY0%2Fy1ZigoA4ZX1GtdZB241crvAcbNyFxWFJ1JkHkcx34scHg5LUKZ6CbgDHRXIgXffz9k4WrBSS6Q6iM7U2MTsBTdymS2tGTCCp3Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e97a4e95c42f-EWR"
+              "value": "8479e50c3d4c32d9-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 959,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:03.177Z",
-        "time": 191,
+        "startedDateTime": "2024-01-18T21:22:40.612Z",
+        "time": 278,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 191
+          "wait": 278
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "c8c651eded1e5525c16e3e822995c87c",
+        "_id": "625ddbb735ad192faf1c452290b47699",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -72,18 +72,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 559,
+          "bodySize": 563,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 559,
-            "text": "[\"H4sIAAAAAAAAA9SUTU+DQBCG7/yKyZxVYFsI7a1RYzx4MPFmTLOyAyW2QGEb+5H+d7NAkY+tTetFjzs77zvPzuzuzgBAwSXHMewMAABcrqJtvQLASOAY0B4xvDqEJK2lCkrKJah8WKWCSxLfKcsV5TJK4rxhBYAkQlKh1zoEje0iJU4EtUQtDjYc1EXqrQ5PWfnABNdg9yU8zj8pyzWFjlDqaU9Rd+htr4+iP0XJ9+MZauF0KjcpxXyhCHBSKFGbvNd7aB3uRUg6F63HL7vCLu0K+zNd6cXe+q5ax9skjslXN7br2+Pq6J+rm97WdVRHNN1ztFRnvsjh+S+SXfoi/1lXDc1tOKLtE9c1e4poW+ZUGRhyEZJ8osY/DoCzjci45hP2M1JjmBQTuuOSXqIFNQaC1Zw6CSeoHgqGSZrOI7+oWuAYhzYUMqS1pDhvIeE8CdUKZ1Km+dg0w1DezKP4w1Qbpu1YruWZzBs4dhA4Lg2Dd0YDlweWazkjm4184TG/wkeZcZ8ey4t5SqKo\",\"jP0XAAAA//8DAGEntsMDBwAA\"]"
+            "size": 563,
+            "text": "[\"H4sIAAAAAAAAA9SVTU/CQBCG7/0VkzmrpS1F4EbUGA8eTLwZQ5butDTCtrRL5CP8d7MLrf1YJOBFj52d951nZ3a3WwsAOZMMh7C1AABwsYw35RcAxhyHgM7AxasiJGklVVBSLkHlwzLlTBL/TlksKZdxIvKKFQASj0iF3soQVJZ1ikg41UQ1DrfrlUXKpQbPvnLBBNfgtCVM5J+U5YZCRyjNtKeoG/ROv41i3sWe78c9lMLxWK5TEmyuCHCklWhM3pk9jA4PPCKTi9Hjl11xL+2K+2e60oq9t12NjneJEBSoE9v0bXE19C+Hk17XNVRHNM191FRn3sju+TfSvfRG/rOuWobTcETbJi5rthTxZp9zyMCI8YjkM1XecQCcrnnGDI9wkJEaw0hP6J5Jeo3nVBkIHubUSDhB9agZRmk6iwNdVeNYRRu0DGklSeQ1JJwlkfrCqZRpPrTtKJI3s1h82GrBdvxOr9O32e0k8Dy/w0KfexQ67Nb32MAPvcFkErq94qeAMmMBPemDeVKiqKw=\",\"3RcAAAD//wMACOMeTAMHAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:00 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:12 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "d5bfcb6bd7b0841ab434db6b8b8ca44f"
+              "value": "04a956ed9a60c3b9cfc5d96ccff14e12"
             },
             {
               "name": "x-trace-id",
-              "value": "28351ff56e4fb2e36af06059129cd82c"
+              "value": "a7bc3350af5d3ef1a753a95f39bbf263"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=BKWWrnpKgBP%2BzjQH5EVyX1uc74CZnxwt8c%2FreohTAevTYNGS9X%2B9XuqDDhVt7kOSK6sOWkPXoJ74oHTXLApMsn33ok2F2H0lE0QJVlIVx%2BvxmEfcasmY5NK2aKIu9A0QjkvGcl2g35%2FlggqkAPzqWsAKkT7M3OacW%2F3jDA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=Ug%2FS5ph%2BP7bgTb%2F5XPqqbWjT3b8EtlRttdCA7%2B4R4WeiLJTSqy9jR%2FSS0q8HQbhu4sbQDpwhpYgKKmcPezBSCGDqvBhKvTXjKLZzouIYaDCTtJCeDdJVFmvZoeqMJxHMe7V1Bjg5FbFWXKJdu7GxhxclNKEbXQi68c1G2Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e96a3f475e76-EWR"
+              "value": "8479e45c6e6ac35d-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:00.609Z",
-        "time": 234,
+        "startedDateTime": "2024-01-18T21:22:12.490Z",
+        "time": 209,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 234
+          "wait": 209
         }
       },
       {
-        "_id": "888e8ea49ddeea7721179d6e14fdcdce",
+        "_id": "95d73f07d31fde4cb818366a72a3a7f5",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -237,18 +237,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 611,
+          "bodySize": 619,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 611,
-            "text": "[\"H4sIAAAAAAAAA9RVy07DMBC85ytWewbShrZAbxUgxIEDCE4IITfephGpE+KNeIl/R06bkIetSoUDHDudmZ1de+MPDwClYIFT+PAAALDIpGC6LuL3GgNAXYQhaY1T4LygvQqmPE9zg6oiSWr0uS0GwFjiFHB4EuDeN8j0ygZm0gxGA+vaskl6LkhznCrdMjSlZUQGvG+A0KKUNJVK6khbmYLRYaOcK9s6Q5UP9mFoEwmlXyjX1nLOxK7k2zvoTvfYFsre0Trpln5q6eMjv2WkxMrkwFmpRQf90+VjdTmXEdmdHD6/MKVg9ykFf25KFvTB5m31PU2VotDc7L67JWHH43qzFV1tT+nQ9bvqKHfY5dEuuxz8ZJf/8bQ9x51xONjyN6r3VPF7xatZHc5d/dTckC4SXvM3bIyEjIivqPE4AeDyTeai/yBgmJM5zll50meC6TZeUfMh2Zx3h7Al4UWZYZZlSRyWVcs4XjW+Uob0yqR0KxImaWR+4ZI501PfjyI+SGL15Js//OF4MBkc\",\"++PFfD4ZHYnFCYXzgQzni9F4MjkMRDAcBwtZfZORcxHSZXnFt0pMKu/zCwAA//8DAAmgrFPYBwAA\"]"
+            "size": 619,
+            "text": "[\"H4sIAAAAAAAAA9RVTU/cMBC951eM5gxkE0JI97Zqq4oDB1B7qhBy7dkQNTghnogv8d8rZ3fTfNhaacuBHvPy3ps3Y4/8GgCgEixwCa8BAAC2tRJMV23x0mMAaFopyRhcAjctHe1gapqqsahuy7JHH8ZiACwULgGjTzEe/QWZntjCTIbBamBTWw1JDy0ZLiptRoa2tMrJgj8HIIwoHU1XiibSUaY4OR2U82XbZNjlg2OIXCKhzSM1xlnOm9iXfH8H0+lmrlDujjZJ9/TTS29v+bkmLe5tDlx1WvTQ33w+TpevKie3k8fnHaYUHz6l+MNNyYHeuLydvp8rrUnamz13dySceFxtt2KqnSk9unlXE+UBu5wcssvxv+zyfzztwHNnPA6u/IPqM1XxsuP1rAnnR//UXJNpS97wt2zMhcqJL2nwOAHg3bNqxPxBQNmQPc5Vd9JfBNP34p6GD8n2vCeEPQm/dRlWdV0WsqvaxQl24+tkSE9M2owiYVnl9gvvmGuzDMM855Oy0L9D+yOMzhbpIg==\",\"C0/Fei3TXyJKKUvjsziVMkmTLEriRbaW54ttfORGSLrorvheiU0VvP0BAAD//wMAFTVEstgHAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:01 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:40 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "b32fb3fffc047bf4c0c1df4da2376222"
+              "value": "11ff2f04d4abc1859433f50ff810d04a"
             },
             {
               "name": "x-trace-id",
-              "value": "5fbb647af9ecb0dcbf456632a2152fd1"
+              "value": "3affc6ba16e862526cc464814208fc70"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=k1Y1EC1zgmjD3zfE9ePCsQWqNL9xyielD6%2Bx%2B5YqbBiHLS%2FFGM8h0DyNHz4seCNpL2lXRHvgorhpdlOfPPmdxBZKKUKvAF%2BoxwmRqzv46M6NHxnzHiUux5RVj3POs%2BIjO2v4EvSytxJ%2B89rY3cscBofw9kidSVmoM6DTCw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=XfZetp3kNZvcsntqsyOJAkZfJQGBaqaGn7giT%2BUo0bVIyRw6fFiaP7mS3Ubi1shI4v6o2Jjo%2FJRcfPl9N0lPYeB4nRuXVZBXCibggdExzKCluMXgm6All5lEhV8v4EAjy7fG%2BHkApYLvWqeWNTQkcaoxvgZPqpYcDI%2BZ7A%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e96becec5e6a-EWR"
+              "value": "8479e5074a29423f-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:00.877Z",
-        "time": 475,
+        "startedDateTime": "2024-01-18T21:22:39.826Z",
+        "time": 413,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 475
+          "wait": 413
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "28ef470ca9b07e9dac36797891532f24",
+        "_id": "c2e80d43b0b63cc05b19bdbbc5cf523e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 436,
-            "text": "[\"H4sIAAAAAAAAA4SSS2/CMBCE7/kVqz1XjSmQBm6oraoeeqjUW1UhE6+MVXBCspF4iP9e2QST8BC3ePebzGjsXQSASrLEMewiAABc1WYbTgBoFI4Be8kAH44jpjW7IVPF4HioCyWZ1AlZ1VSxyW3V+hUAktLkRj9hBK21R2yuqCPq5HgSSTAJq7M8B+eLTAGfTnlTkJVL54NfDY8dbN9V3dC8KU1t3T58/570N7QvubWUtZ2D54XCbA9MQ6CWShN/UuveAHC+UaW8UnpWkiti4jt6lUzfZkmtWrBp6gy4k+rdZ5gUxcJk3tXHiY41eBnSmslWnUi4yLU74Zy5qMZxrDU/Loz9i90i7g1FItJ4RoNnmaU0IiWGgiQJNUpmqRCyP+wnlDbxkUuZ0Yd/GnclLlW0/wcAAP//AwDlUg0f8wIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SSzW7CMBCE73mK1Z6rJk5KaLmhtqp66KFSb1WFTLwYq+AEskj8iHevbIJJoIhbvPtNZjT2LgJAJVniAHYRAAAuVmYbTgBoFA4ARf6Ad8cR05rdkKlmcDysKiWZ1AlZrKhmU9q69SsAJKXJjb7DCFprj9hSUUfUyZEmeTAJq7M8B+eLTAEfjXhTkZVz54OfDY8dbN9VXdG8Kk1t3T58/5z0V7TPpbVUtJ2D54XCbA9MQ6CWShN/UOveAHC6UUv5T+nFklwRQ9/Ri2T6MnNq1YJNU2fAjVRvPsOwqmam8K4+TnSswcuQ1ky27kTCWandCafMVT2IY635fmbsb+wWseglefIYZ4r6Mk0ehRD5OH+ijER/QmlvPCGVZalo4iMvZUHv/mnclLhU0f4PAAD//wMAikCez/MCAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:59 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:12 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "8fd897b16e103c3ff00e975b477d94e8"
+              "value": "dd9aad9acbd1bcaad7e7fa401ae53764"
             },
             {
               "name": "x-trace-id",
-              "value": "be47ac8e9ed050eae0d96b800a3536e8"
+              "value": "3de7a2081116b69e3e17fe25bfed3321"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=qHy2vnW4RXEm6FUFL5v%2Br2wgDAH96E7CGzeaIC1hWBu3emI7%2FKBWtDfQ00Vo%2F0OvvKrbxn2YvIMn8PL6anARJUOsRlxEoPjaLHHxqIKMddT1aB91ehS5u11P7uuusl4bb5Ze5J9R%2FFJ4vf2YX8dML4WCeC%2BbLEftNX3NKA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=BukiAKu%2BLl43BnR%2FTIlZMfZ3NrByiQvjwkO1%2BC1RaSp%2FCqD%2FU2%2FJpx43VcEp%2BnY%2BNe1kwlk56d5WPO9XJV47lQx6hstfzwpQh%2BTHJjotLl2m9huZuG9bGetnxJAn5voKlpAoVsbOmDbviLfbsqnEgTsIJONlFD0flTA4yw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e95fcb1443c4-EWR"
+              "value": "8479e4594a741859-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 957,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:58.946Z",
-        "time": 112,
+        "startedDateTime": "2024-01-18T21:22:11.986Z",
+        "time": 298,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 112
+          "wait": 298
         }
       },
       {
-        "_id": "8ea9378f88914c64c107f875015ae6a1",
+        "_id": "d0e1292eaea6b4749720a7debd3cc45b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -237,18 +237,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 492,
+          "bodySize": 488,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 492,
-            "text": "[\"H4sIAAAAAAAAA4SSS2/CMBCE7/kVqz2j5gEkNDfUVlUPPVC1p6pCJt6GqMEJ8UbiIf575QCpE4o4ejyfZ7TevQOAUrDAGPYOAADWpRRMszrbtRoA6jpJSGuMgauaBmeZqqqojKrqPG/VdRcGwExiDOiHIxz8iUwbNjKTZjAMHLOlbVrXpDkrlO48aKJlSkb8tEToWBqbKiT10E6nwAutuGvdjh3+6dcC8zlvS1JiZdJwdiKwZzz0ySvck0ypyx6s05f9ypUXHgqlKOl2sNIvqGx39rWunuejXYw30nXOR//JjamQKfErWasEgMutrMTl92FSkRnktJnxo2B6z1Zkf/tp0j3DjYbPTYdpWeZZ0qQ2dZzz+BoMacOkdKcS5kVqTrhkLnXsumnKd3mmflxz4fpjL/QmbjhZDANB/iIKvO9oHMnAGw5H/uI+CkXg03m1kSuR0EuzXDcR08o5/AIAAP//AwANCntjhgMAAA==\"]"
+            "size": 488,
+            "text": "[\"H4sIAAAAAAAAA4SSzU7DMBCE73mK1Z4rklCStrlVgBAHDkVwQqgy9pJGpE4ab6T+qO+OnLbBSal69Hg+z2i9Ow8AlWCBCew8AACsSyWYZnW2bTUANLWUZAwmwFVNg5NMVVVUVtV1nrfqqgsDYKYwAQzjOxz8iUxrtjKTYbAMHLKVa1rVZDgrtOk8aKNVSlb8cEToWBqbLhT10E6n2yB24i51O3T4p18LzOe8KUmLpU3D2ZHAnnHfJy9wjyqlLrt3Tp/uKxdeuC+0Jtnt4KSfUdn25GtdPc97uxivZOqcD/6jG1OhUuIXclYJABcbVYnz70NZkR3ktJnxg2B6y5bkfvtx0j3DlYZPTYdpWeaZbFKbOt5pfA2GtGbSplMJ8yK1J1wwlybx/TTlmzzTP7698MMoiIOxrybfJL6iIUVyNI6kDEZxpGgUxyKaDMMwPNZHroSk52a5riK2lbf/BQAA//8DAI8e3weGAwAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:59 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:39 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "6422201b505511a95cf698411a2f9c95"
+              "value": "cfec842ce406c0743cb44263da49b577"
             },
             {
               "name": "x-trace-id",
-              "value": "68b32ae1b720f757d203341b976a21e4"
+              "value": "d9feab53e5c785cc0765de766a593111"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=k08Niz3Sxxb57UxAXIO71ZjJ6pZWGaALEK5ZfvdT%2FuabHOPY1w78FBe0hkbg6xXKQtKVhBbyzaxFi93L1TLwFnj1qUhtG0ReSvGj0hZgeHbV46I2fhhrhUW1L8k9MEs3qnZI%2FaCeP3HaOAP3DZCoTASyVzwhVtZ0VRkTfg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=WJqlgE1xHXj8q8aV2eu2h6%2BQbyPzWScwHDgLpob1v6KSTsvZWyIWQYDcMjxbts8GuKpp4f43sU5Ks4ZRtkTPu7BGNlkV3cNaGnY59YvmCQB3phxpY87L5DzCvmthoiSe%2F5ER3rq2J45ygDvnKP1bYYe0ndEkkqsoXPow4Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,7 +312,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e960cde617bd-EWR"
+              "value": "8479e500bbda4307-EWR"
             },
             {
               "name": "content-encoding",
@@ -325,8 +325,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:59.102Z",
-        "time": 294,
+        "startedDateTime": "2024-01-18T21:22:38.776Z",
+        "time": 301,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 294
+          "wait": 301
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasOne-relationship_3220970997/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasOne-relationship_3220970997/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "9d46ddfef89035ead8fc1689e3e2ec22",
+        "_id": "cd5658dbd3b1070f04a54bc0c6b0bc31",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 384,
-            "text": "[\"H4sIAAAAAAAAA4SRMW+DMBCFd37F6eaqkJSEwIZUqerQTt2jq30mVohB+KomivLfKwOl0CXj3b33/D35GgGgJiEs4BoBACA5/83dNAOg1VgArnYZPvyuhM8SlsJeYHB4+Go1Ces/lWvEGqtIbONmgVPkNpm0AMiOPmsOB0O159llv5dLy45OHFzv89RRdJveXGrLoUw002BFumJ541lpADxcdNdH+iWp6jiUKvu6zyT8YU88xx5b/xPc4XrpGcq2rcciPc6AGY025LOw8wskrJsqTHgQaX0Rx1Ulj7V1xzgc4tUm2Sa7WJmn1KgsS9PcbHJmMkbROt1lJleJXucjPkpHil/7r7hrCVTR7QcAAP//AwBhTWdfMAIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRzW6DQAyE7zyF5XNVQn5Ywg2pUtVDe+o9MuAlKGRBrKsmivLu1QKlSy852p6Z/UZ7CwCwJCFM4RYAACAZ+839PANgXWIKGCUKn35XwhdxS2ErMDosfHUlCZd/KtNKreuCpG6NFzhHxqtZC4BsKG/YHTQ1lr3L4SDXjg2d2bk+/NRJdJ/fXGqzsUzgabCismJ5Z680AB6vZT9E2iVp0bMrlQ11X0j4sz6zjz21/id4wPU6MGRd10xFBpwRM5hsyBdhYxdI2LSVm/Ao0tk0DKtKnpvanEJ3CKPdKl4lod4qRaTWKld6t8+VjqMkLvR6E/FmG6n9hI/SU8Fvw1c8tDiq4P4DAAD//wMAVFm0vjACAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:02 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:12 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "bad908f9b3145f52f39bb220a7ee18d0"
+              "value": "39fdd267c08b76deff939b96d045705e"
             },
             {
               "name": "x-trace-id",
-              "value": "cf34fc77449f59eeaffca2487f9c0d29"
+              "value": "f477aa727b7f59b7f6186cf231e34179"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=kCI99ixEh%2FiWgvDBnrbibh68B%2B4%2FB7OfNtHjbLRnDFFrIzFmctWR4UrTBnx4ITtYrAk%2FaPoDHultytmJfugyeMImDIqAE151cbGYSBSmcBZU%2FTDD6uILksR6z3unOcZC0QxlA7W0RynnKs3I2WhJfgajAmSoUDpXW0wTDQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=QUb0BBFIupXowRPtQhU4SCyzyZjpAXVZYMl2wlwVs8z4idbenARr8GD0MyEZ0aqPcNJlq%2FpIRQt3o3jyr51UJ6LLnn1vbQGtulfkYEJZvBNAj5WVv9Yy1bl%2BTJHfke9bLWL5WLxWsaaSPT16jIFkKOFIR%2FOkAVpVGZiVFQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e973cdbbc47c-EWR"
+              "value": "8479e45e0e3d43cb-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 945,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:02.145Z",
-        "time": 205,
+        "startedDateTime": "2024-01-18T21:22:12.750Z",
+        "time": 203,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 205
+          "wait": 203
         }
       },
       {
-        "_id": "6e3f264fc5f334d3e5356734eed272fe",
+        "_id": "b6a03b8d75325d12fcb708dbb47034c4",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -242,13 +242,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 436,
-            "text": "[\"H4sIAAAAAAAAA4SSMW+DMBCFd37F6eaoJEoIiC1SpapDO1TtHBn7IKiOQfahJory3ysDpYYlI+/eOz4/+xYBoBIsMIdbBACAXasE08G4H7KTCoCuk5KcwxzYdrT6k8naxnrVdFpPqljGAbBWmANushRX/yLThb3M5BiGlIMBQYU+03Bd1lJw3ZjZ2mnxfh34PZgRhSY/KoV2NJsdj3xtyYgz+eR7uHuy3YO/z/1jN9HCt3B9BT1+kOs0D4nRj5VQFfEbBd0D4OmqbA/i5uVJS76SQ1/Ws2D6rM8UFjR2tjA8YHzpGQ5tq8fj9zgDZjTGkC5Mxs2QUDeV/8ITc+vyOK4qftK1+Y79IN4k6/06i4nSrCzTVOwSlRa7bbJPZCG32XZTFLKY3gGyFZJe+0t8GPFU0f0XAAD//wMAKGwLsbcCAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRMW+DMBCFd37F6eaoGDUJhC1SpapDO1TtHDnmQlAcg+xDTRTlv1cGSg1LRr977/z5+RYBYCFZYg63CAAA26aQTFvjfsiOKgC6VilyDnNg29LiTyZra+tV02o9qnIeB8CqwBwwyVJc/ItMF/Yyk2PoUw56hCL0mZqrQ6UkV7WZrB0Xr0Xg92BG7jX50UFqR5PZbsfXhow8k09+hLtH2z24feofuolmvpnrO+jxk1yruU8MfixlURK/U9A9AB6vhe1A3LQ8ZclXsu3KepFMX9WZwoKGzmaGB4yvHcO2afTw/A6nx4yGGNKFybgJEuq69Cc8Mjcuj+Oy5CddmVPsB3GyEmuRxelGUqJEmu0pE4eNSGi5el6KTIllkgolB3xkKxW9dZ/4MOKpovsvAAAA//8DAKdq1sC3AgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:02 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:40 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "bf1095c3d28f30d3bb39f7477e4e53dd"
+              "value": "be5b95e40c0d59d9180009940b739bdd"
             },
             {
               "name": "x-trace-id",
-              "value": "ee78ff77a45d7b43565cbc3831bbcb87"
+              "value": "79ae1c078be80f901e453408c04170ca"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=X1ooxEM98aPY9LV%2FeWcb%2F9YQA%2BVnHAWhvKfmsoLV0UsTaKb%2BYPFRYlIeWSD4vGYbdFxz3KLJtEVJBXeFG4oaW9qz2BL5SyoCOt766OCFuxtUAs565cmL%2B5SjHzliWwJWZq5g%2Bv8AW2Yh8OWnF6TSEtxrhw4qyUD%2Buu%2F5ew%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=UAlYrXHSck%2Bke3aBrEi%2BdUJqz6YKcemxJcpKhf3wS1iRpewv2B1XoyfRhozSsPx0ZT79i6ykP%2Bz%2F6TxxEp5sJ6xb3vivS9oW%2B10UL9%2BzDAOxeSGxcH2XDj2K2Dp%2B3dWuDGwdtn%2F1DC4GHdaMVXvBq4xBJp%2FIc5KJaY6LwA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e9757ca643a3-EWR"
+              "value": "8479e50a5f7d4286-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 955,
+          "headersSize": 957,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:02.410Z",
-        "time": 417,
+        "startedDateTime": "2024-01-18T21:22:40.316Z",
+        "time": 221,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 417
+          "wait": 221
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "7dff9ab5ab10511ee8deb9137d277700",
+        "_id": "dfbb61790b5e9cc8f8f688f49d7db187",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -72,18 +72,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 456,
+          "bodySize": 460,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 456,
-            "text": "[\"H4sIAAAAAAAAA7yST0/CQBDF7/0Ukzmr7TbStNyIGuPBg4k3Y8janS4bYVvokPAnfHezS6ktSAgXb92Z9+t7M5ltAIBKssQhbAMAAJwvzaZ9AaBROAQUSYo3hxLTil2RqWZwelhWSjKpX8l8STWb0tadXwEgKU2u9NGWoNP2Elsq6kG9HLGIWpO2dZRn73zIBLcgTpHxmNcVWTlzXvjWMNiT7frUGeZJaepyPerK2cT1s8X/Olv7/fnLn2EfSmsp7zq3nieE2ew1jQK1VJr4lTp3CYCTtVrIP44qX5Bbxsjv6VEyvZsZddaCzbaOBBdSPfsMo6qamty7+jjBYQ0eQ1ox2boXCaeldi+cMFf1MAy15rupsd+ha4RiECVRGt4rUaRFnGbZV0SiSIo0Vmk+yEhSEWciaeIjL2ROL/48LiIuVbD7AQAA//8DAOnKHB7TAwAA\"]"
+            "size": 460,
+            "text": "[\"H4sIAAAAAAAAA7ySSW/CQAyF7/kVls9tswBhuaG2qnrooVJvVYUmGTOMCpNAjMQi/ns1AwkJixCX3jL2+/KeLW89AJSCBQ5g6wEA4HypN9ULALXEAWAY9/ChLDGt2BaZCgarh2UuBZM8SuZLKlhnpqj9CgBJKrKl76oEtbaTmExSA2rkiMKgMqlaJ3n2zmUmeITwHBmNeJ2TETPrhZ8HBhuyXZO6wrxKRXWuQd05W3j/bNG/zlZ9/xz5K+xzZgyldefK84zQm73moEAlpCL+oNpdAuBkLRfiwlGlC7LLGLo9vQimLz2j2lrwsK0TwY1Uby7DMM+nOnWuLo5XrsFhSCsmUzQi4TRT9oUT5rwY+L5S/DTV5te3DT/sBHHQ89si6rXCsej228m42w6TeBzJVpDEXZJJv1MeOfJCpPTuzuMmYlN5uz8AAAD//wMAR/gSPNMDAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:00 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:39 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "e229cf9ed4418dcd8d7eb75345aac42a"
+              "value": "31940ca7343cf3a248833467eb2a3d76"
             },
             {
               "name": "x-trace-id",
-              "value": "4d1f8f2899b0e1f6f82d8c59eaef2916"
+              "value": "4a2831fa794bf741b6f2d30b67edb950"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=OUcaaWSSmDF%2BuGM2Xsgv5o%2FFdS1Lo8agtyybcZuwQ6wjPLBruO9amBCX8PyvPmTSeK4LIdu8jOSIqIX2trAb07dhUu6myywKWklUfYCvFNE0gqhbTOUfeQtmN57jdkE9Ry0PsZV0FzjBCAGalREovaGKEOr4EPmA3h3ydg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=nJsFFgDV3aOeILWxY3xbuTJ7a7n81mKcj1Zbs7lhtSwocHSHEL2eTAX4HUdr%2FCXt%2B8ZuNnjve1Bo0D%2B1AlOlHfg953o9A1jRAZThQ57KKwP%2FNeu%2BaAVp76jZwK47%2B2gdeLaxoqcPeYEFGTPgpXhQY70EB4MxTRHsiulkHA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e9672a9d428f-EWR"
+              "value": "8479e5046aba41bd-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 943,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:00.126Z",
-        "time": 196,
+        "startedDateTime": "2024-01-18T21:22:39.370Z",
+        "time": 132,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 196
+          "wait": 132
         }
       },
       {
-        "_id": "3923eb5ee6ede8b5b4f0a52978e998a7",
+        "_id": "c9813c31c52363c898c358aa63a4f2d7",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -237,18 +237,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 512,
+          "bodySize": 523,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 512,
-            "text": "[\"H4sIAAAAAAAAA8STTU+DQBCG7/yKyZyrsNgP5NaoMR481OjJmGbLTiiRAmWHpB/pfzdLAYHaNOnF4777PjvvTGb3FgAqyRJ92FsAAFhkSjLNimjXaACoiyAgrdEHzgsa1DLleZobNSniuFHXXRgAI4U+oBh7OPgVmTZsZCbNYBg41lZt07ogzVGa6M6DprQKyYifLRE6ltKWpIp6aCeTK5xWuXPZjhnqfHAD4i9oPudtRolcmYo4qyjsGQ998gz3pELqsj3yil7FNb26/9Jr6/TVfuXMCw9pklDQzdCqfkJFu9rXuHqej+YjvJEuYj76KzeGUoXEr9T6OgC43Kpcnq4rBjmZYU7LOT9KpvdoRe01r6bdM1xI+FxmmGZZHAVl1TKOVY+vxJA2TInuRMI4Dc0Jl8yZ9m07DPk2jpJv21zYYuSMHc927keOJ4ZjUq63GApHLYScOBMK7rzAndCiio+cy4BeygW7iJhU1uEHAAD//wMASsFCUXYEAAA=\"]"
+            "size": 523,
+            "text": "[\"H4sIAAAAAAAAAwAAAP//\",\"xJNNT4NAEIbv/IrJnKt82FLk1qgxHjzU6MmYZstOKZECZYekH+l/N0sBgdo06cXjvvs+O+9MZvcGAErBAn3YGwAAWGRSME2LaNdoAKiKICCl0AfOCxrUMuV5mms1KeK4UdddGAAjiT6g7Xo4+BWZNqxlJsWgGTjWlm3TuiDFUZqozoO6tAxJi58tETqW0pakknpoJ5NjW61y57IdM9T54Absv6DZjLcZJWKlK+K0orBnPPTJM9yTDKnL9sgrerWv6dX5l15bp6/2K2deeEiThIJuhlb1Eyra1b7G1fN8NB/hjVQR89FfuTEUMiR+pdbXAcDlVubidF0xyEkPc1LO+VEwvUcraq95Ne2e4ULC5zLDJMviKCirlnGMenwlhrRhSlQnEsZpqE+4ZM6Ub5phyLdxlHyb+sK0R5ZreeZc0lg4IhjLhTO/X1iLoeM4wvW8+Z3nDq1RFR85FwG9lAt2EdGpjMMPAAAA//8DAK4PlLV2BAAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:00 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:39 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "2282de8eee98249f69ac5f7737138ae8"
+              "value": "3f179d5f60ffa31ca01ee33d6e58f747"
             },
             {
               "name": "x-trace-id",
-              "value": "09508146ed28b410db1a707ec38c27eb"
+              "value": "bde7a2ac7df2b9f0f4222a688b386405"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=WCj6xp9y%2B2EQ2ZnqnD25NwgUECkoK3%2BrFeVOb8hbVNmq%2BBkpPmO9S7D%2BV7pXAPbr5WMr4%2FL8%2Bw%2FS5QR7qYzx9wEchkp6vVVUyKCxEiN%2Bf%2F%2BI5X%2FSRAVA0sn0OCPPgxnqjHqV9VvmpKSZUbjkNtb382Row12tGvJas6SpRg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=uiU19gf4fIFQZiB9O1KsTIxLGU%2FInAHHlSwaDDJCZMnPU1riVeLek818Epp3ULq6p3PbOtn5m%2Frqp7eGTnicWPETCr7Cnaj7p3TRHu2xHuqWzIgcNCFlfWe7Mmtq8JTIv%2Bs4NanU728oMcsV3qQiu9OR8g6bbLawXPZVFA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e9688bc60fa8-EWR"
+              "value": "8479e5056d614344-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 961,
+          "headersSize": 945,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:34:00.343Z",
-        "time": 244,
+        "startedDateTime": "2024-01-18T21:22:39.528Z",
+        "time": 236,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 244
+          "wait": 236
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "7dff9ab5ab10511ee8deb9137d277700",
+        "_id": "dfbb61790b5e9cc8f8f688f49d7db187",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -72,18 +72,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 460,
+          "bodySize": 467,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 460,
-            "text": "[\"H4sIAAAAAAAAA7ySTW/CMAyG7/0Vls/b2pSvwg1t07TDDpN2myYUGi9Eg7RQI/Eh/vuUUEoLQ4jLbo39Pn1fW94GAKgkSxzANgAAwPnSbKoXABqFA0DRTfDuUGJasSsyFQxOD8tcSSZ1lMyXVLDJbFH7FQCS0uRKn1UJam0vsZmiBtTIEYuoMqlaJ3n2zodMcA/iHBmNeJ2TlTPnhe8lgw3ZrkldYJ6VpjrXoG6cTdw+W/yvs1XfX0f+AvuYWUtp3bnyPCPMZq8pFail0sRvVLtLAJys1UL+cVTpgtwyhn5PT5Lpw8yothYst3UiuJLqxWcY5vnUpN7VxwkOa/AY0orJFo1IOM20e+GEOS8GYag1P0yN/QldIxSdqBsloWrJOIrbot9J+mo8FoJ6cZvGUSsRrd53t1fGR17IlF79eVxFXKpg9wsAAP//AwAJLRWr0wMAAA==\"]"
+            "size": 467,
+            "text": "[\"H4sIAAAAAAAAAwAAAP//\",\"vJNPT8MwDMXv/RSWz0CbsFWltwkQ4sABiRtCU2isLGJLu9WV9kf77ihd17Ub07QLt8Z+v75nK9kEAKgVK0xhEwAA4Lyy6/YEgFZjCijiBG/2JaYl+yJTyeD1UBVaMemDZF5RyTZ3ZedXAEjakC99tiXotGuJyzX1oF4OKaLWpG0d5dk57zPBLYhTZDzmVUFOzbwXvjcM9mTbPnWGedaGulyPunI2cf1s8l9na7+/DvwZ9jF3jrKuc+t5Qtj1TtMo0ChtiN+ocy8BcLLSC/XHpcoW5Jcxqvf0pJg+7Iw6a8FmW0eCC6le6gyjopjarHat4wT7NdQY0pLJlb1IOM2NP+GEuSjTMDSG76bW/YS+EYphFEdJKAY6UbEgrb6lpMG91rEYZjIW8kEkUqomPvJCZfS6e4KXEJ8q2P4CAAD//wMA9CfgstMDAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:59 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:12 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "89cc0c4aa8861ce5afc5b57ae88c0889"
+              "value": "b0c86118e9eb051f041acf6c773620bb"
             },
             {
               "name": "x-trace-id",
-              "value": "d3a202419589dbb11e724eb038137f67"
+              "value": "14d8a61edab22e43dd615c261291822a"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=UhS8y2sCeM6EuHUrZyoD%2B5JzFAt%2BrlSaOyP0xFdlGpLdHq2d4c5DryDT6T6aeYtkYk4MNiaih%2FvHhwB0XyFk4CVvC8oVbmhj3CKQ5GQivRKaqGmCAQkbWaWV%2Bq3tPr%2F53Zg4NFPOguF2H5g%2BbwpQiU8gwqujB73TafPUfw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=2%2BIxmuv%2BLhP%2Fkrnkf2UQvEbgVbNEW6gJSi87VNOuHGOg%2Fe9wdk8xcTywsoI%2F9%2B%2BqX788RdCyXtPtN9XmL8HRir39hfB0SZ4TK8GQkOxxku3srEh0ynIS6s7uyXqnTFvssm%2BwUYRD4q1qQ%2FLVApPYAHC1jZJpv8GImiPFdA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e962cd854243-EWR"
+              "value": "8479e45b5c328cc5-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 957,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:59.424Z",
-        "time": 204,
+        "startedDateTime": "2024-01-18T21:22:12.319Z",
+        "time": 138,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 204
+          "wait": 138
         }
       },
       {
-        "_id": "3923eb5ee6ede8b5b4f0a52978e998a7",
+        "_id": "c9813c31c52363c898c358aa63a4f2d7",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -242,13 +242,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 512,
-            "text": "[\"H4sIAAAAAAAAA8STT0+DQBDF73yKyZyrQFFEbo0a48FDjZ6MaRZ2pEQKlB2S/onf3SyluFCbJr143Lfvt/NmMru1AFAKFhjC1gIAwLqUgmlap5tOA0BVxzEphSFwVdNoL1NVFZVW8zrLOnXZhwEwlRgCun6Ao1+RacVaZlIMmoFdbWmaljUpTotc9R7UpWVCWnw3ROhZGlteSBqgvUxj1zHKHcu2y7DPBxfg/gXNZrwuKRcLXRGnLYUD4/eQPMI9yIT67IA8o1f3nF7H/9KrcfowXznywl2R5xT3MxjVD6h0s/d1roHnrfsIL6TqjHf+1o2JkAnxMxlfBwDna1mJw3XFuCI9zEkz53vB9JouyFzzdtoDw4mEj02GSVlmadxUbeJY+/E1GNKKKVe9SJgViT7hnLlUoW0nCV9maf5l6wvbvXZ8J7Ajb+wEsSduAxE5jh/dRI4XB8L9JF9e+V7UxkeuRExPzYKdRHQq6/sHAAD//wMArArjEnYEAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA8STT0/CQBDF73yKyZzRdoGSyo2oMR48YPRkjFl2J6WxbEt3mvAnfHezpdS2SEi4eNy377fzZjK76wGglixxArseAAAWmZZMsyLe1hoA2kIpshYnwHlB/aNMeZ7mTjVFktTqqg0DYKxxAijGIfZ/RaY1O5nJMjgGDrV107QqyHKcGtt60JXWETnxoyFCy1LaTKqpg7YyDYTfKHcu2yHDMR/cgPgL+vriTUZGLl1FnFUUdoz7LnmGe9QRtdkOeUWv4ppeB//Sa+P02XzlzAv3qTGk2hka1U+oeHv01a6O573+CK9ki4QP/sqNkdQR8Qs1vg4ALjY6l6friionN8xpOecHyfQWL6m55tW0O4YLCZ/KDNMsS2JVVi3j9I7jKzGkNZOxrUiYpJE74YI5sxPPiyK+TWLz7bkLTwT+2A+9odaB8IVUQxWMR3oUjMM5BYG4C1Uw98W8io+cS0XP5YJdRFyq3v4HAAD//wMAwjHvo3YEAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:34:00 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:39 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "f9b0423d6e2d0f8b91a8ac8efdc95d61"
+              "value": "6dd724617d96c264d7aab843c18e60b6"
             },
             {
               "name": "x-trace-id",
-              "value": "b3208c3a98ab006b7b03c8a1fe6d463b"
+              "value": "3dd5101ac3c564d4568be55198c5b01b"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=sTwSEbm6JBc08z16pHU2bI%2F%2FTKc6WiirKmYINLRxFiol0mVt7xlLn1TYGKy%2F30Wo1U0xoPq4yPRAY%2B%2BfI2Wnm2fM0vs4a%2Fo5iLH0zztYJrQ6WO2kdqaGwsduaLKniLST%2BUF%2ByyekcUTtGZNTmU1TiRJRwJ8FYBrX8PAb%2Fw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=%2BhJ1RVGC2FVCRcgyyVjZAZpP3rqsSuyiTlgW5C9%2FQwTk4X8jIxliCoAh2xkPQ%2BZueA79VFh2GjxG0ad3X%2FDiRKXERioR6NpOd%2BA8Uy%2BhvB02MEi6V%2F6H7sYpyIv9cVWZbcX8Zh6YZIQbpUGrutnWzTOzxrUoPGN%2BLbj9Vg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e9647eaf727b-EWR"
+              "value": "8479e502fd390f59-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 957,
+          "headersSize": 955,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:59.691Z",
-        "time": 411,
+        "startedDateTime": "2024-01-18T21:22:39.138Z",
+        "time": 221,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 411
+          "wait": 221
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-even-if-nested_698860812/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-even-if-nested_698860812/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "72f3b4c5cbe8ff55b3c3b96a6a3c5e60",
+        "_id": "8145dcc60694b69d508463c641805f40",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 348,
-            "text": "[\"H4sIAAAAAAAAA4SQQW/CMAyF7/0Vls9oaUcaoDekSdMOO0zaHYXEDRGlhNZIMNT/PiV0jE2advR7z36ffMkA0GrWWMElAwDAw9F/3CYA9BYrwEJNcfIlMZ04ikw9Q8zDMVjNZL8jqxWfA7V6RzH4Fm8ma7gm0GnriF/prhkAN2fbafb7tr9TAdB0FM8vU+uTZnr3O7qVAeDY/ysw+sMfVM+JYRlC401qTThXzGxcQzoxtf0PJGz2Lk64YQ59JYRz/ND4diuiIYoyV/lc2AXRfL1WRS0NSaNMKWup8tljsZDTsp6N+MidNvSSnvzvSqTKhk8AAAD//wMAJ5UzzbUBAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQQUvDQBCF7/kVw5zFzWZjUnMrCOLBg+C9jNlxu5imazKF1pL/LruNtQricd57M+9jjhkAWhLCBo4ZAAC+7/zHeQJAb7EB1JXBqy9JeC9RFB4FYh52wZKw/Y6sVnII3NOGY/Ap3kzWdEqgI+tYHvmiGQDXBzuQ+G0/XqgA2A4czy9T6x0JP/sNn8sAcO7/FZj96Q+q+8SwDKHzbWpNOCfMbF5D3gv34w8k7LYuTrgWCWOjlHNy3fn+TUVD6Zu8yhfKmLo2L8VrSbpoK70oa3Nb67w0bIuiJJrxUQZq+SE9+d+VSJVNnwAAAP//AwBcIG5rtQEAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:58 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:38 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "1aac87134dd07108335879d59740fd17"
+              "value": "f33d76f00f0c1f3a9ff05b18c7031b75"
             },
             {
               "name": "x-trace-id",
-              "value": "d9ee8bb61f4ce4c6c54f4607219435f7"
+              "value": "33773b2f4a12c618473971043ed224aa"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=4LwYoIl5u2e9HjIlN9sqFxNTVWAC0hQP3PT6TGNUv6lFQ2qJ0zmOQCv1nxsi7ROSeuXk1nunQbASnUTWMaObGW%2FwPlMHWLF8Yn2xIzJ6J%2BD2K7TkxfIx3wzyVVCD606LavknP1FKxB4dttH7%2FG3CM%2Bl4jQMAN862zTOE1Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=EiHwaA8QLgC7GNU9056BGreJ0g69kQb%2F%2BaNvni21DVNYZa2bafuSxtoAuAgbG7qrnSobv4U1A30jqo91mD%2F9vawpUVCW%2BBBJirjWLEHMVddcuKjFwO9QCmXqi2XTu0UvwCvQCmoOrKObQw2dQkCP%2Bg0cDiYM%2FDRSxynwJA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e95c898443a7-EWR"
+              "value": "8479e4fdad580f6b-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:58.426Z",
-        "time": 187,
+        "startedDateTime": "2024-01-18T21:22:38.291Z",
+        "time": 138,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 187
+          "wait": 138
         }
       },
       {
-        "_id": "cc2fca976335b6034f9946efffb8de10",
+        "_id": "9d3ca9cf341e3ba1612ebe619dfc4ac9",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -237,18 +237,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 388,
+          "bodySize": 392,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 388,
-            "text": "[\"H4sIAAAAAAAAA4SRwU6DQBCG7zzFZM6NgLKI3JqYGA8eNHpupuyEEreAu7NJa9N3NwuIxUuP+8/3Z77JniIA1CSEJZwiAAD0vSbhV998zxkAOl9V7ByWINbz6jdmazsb0tYbM6dfyzIANhpLwDS/w9VfKHyQEAs7gdCBcbe+hDYbOfbc0p4DOmhNw/O8b8l8zAe8sfNGRn6isSZds7zwxckAuDtqS9J0rVt6V5aD0HrwfCTh92bPl3qT8T/giuHT4LDue9NUw9ZBZ9SMphryQbh1CyU0XR1euBPpXRnHdS03pmk/4zCIU5XkSRFryuk+eeAio2q7zXKV3RZ5kiqlCs5VQpM+iqWKn4ePuVoJVtH5BwAA//8DAFDF9HQuAgAA\"]"
+            "size": 392,
+            "text": "[\"H4sIAAAAAAAAA4SRsW6DMBCGd57idHNUDC2hYYtUqerQoVU7R8Y+ERQHqH1ISaO8e2VDKXTJ6P++X/edfIkAUEuWWMAlAgDAvtOS6a2vv6cMAF2vFDmHBbDtafUbk7Wt9WnTGzOlX8syANYaC8BkfY+rv5DpxD5mcgy+A8NuPYd2Oz531MgjeTRojcPrtG/JfE4HvJPrDQ/8SGMldUX8SrOTAXB/1lZy3TZu6a0seaFt8HySTB/1keZ6o/E/4Ibhc3DYdp2pVdgadAbNaKwhnZgat1BC01b+hXvmzhVxXFV8Z+rmEPtBnGRiLR7jPJNpqUWZlLkoU5k+iFxsZKYznYkNCTXqI1up6CV8zM2Kt4quPwAAAP//AwBqX6W0LgIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:58 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:38 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "45318204ffcd6a46b38a0f2b7058d64d"
+              "value": "6b87cb98a211e730a7782493d561c520"
             },
             {
               "name": "x-trace-id",
-              "value": "da6a709e84acbb4654286015558e650a"
+              "value": "75a2bd0b1b70b2a240709a5d5d509e0c"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=8sgDF%2Bn45JEgBwUc1I1VjV%2B138ECL0Of%2B39qKXaRcQbyH5J%2FpwmXJF1Mqn8sa9VJqx2NcwTbsx5jS4raHXxND7eovBoz%2BZ%2Buav4cbOsQvm3zBNtKh%2BTjZmCjI4lS%2FghL8wItxMTKn58jVnf8FeWuUN7BlNUbdAvuxTzjGA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=8aswfpFptteDeB58x6NO02A1zrY04pAUQ1vp8O3OPsAGDwE%2ByWk4nOKDEs9wTIP0hsqGTd0RozzVfml%2B56c4ayKjS2H9nsagxvM20MGEVPdpyNqYT%2B2Hi6rsX7oVzTempIz%2BQl%2BZLQXCQXuoZAA7HaP7y2qEUp6PRiRmPA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e95def37c445-EWR"
+              "value": "8479e4fea98078dc-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 955,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:58.637Z",
-        "time": 277,
+        "startedDateTime": "2024-01-18T21:22:38.444Z",
+        "time": 269,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 277
+          "wait": 269
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-object_3536142481/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-object_3536142481/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "72f3b4c5cbe8ff55b3c3b96a6a3c5e60",
+        "_id": "8145dcc60694b69d508463c641805f40",
         "_order": 0,
         "cache": {},
         "request": {
@@ -18,7 +18,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -77,13 +77,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 348,
-            "text": "[\"H4sIAAAAAAAAA4SQQU/DMAyF7/0Vls8TTRYaut4mISEOHJC4T1lisoiuC60nbUz97yhZGQMJcfR7z36ffCoA0Bk22MCpAADA9334uEwAGBw2gFIrnH1JTAdOItPAkPKwj84wue/IasXHSJ3ZUgo+p5vZGs8J9MZ54ie6agbAzdH1hsOuG65UALQ9pfPL3HpvmF7Cli5lADj1/wpM/vgH1UNmWMbYBptbM84Zs5jWkA5M3fADCdudTxNumOPQlKX3fNOG7q1MRikroUVdvjp5q5USd0IqVa8XlubVWtdaCmV1VdkJH7k3lh7zk/9dSVTF+AkAAP//AwBB2isWtQEAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQT2vCQBDF7/kUw5xLd6M2JrkJBfHgoeBdNrvjuhjjmozgH/Ldy66ptYXS47z3Zt6PuSUAaBQrLOGWAADg8eSujwkAncESMM3G+PIlMZ05iEwdQ8jDyRvFZL4j6zVfPDVqTyH4EW5Gq78n0CpjiZf01AyA24tpFbtD0z2pAKhbCudnsfVdMa3cnh5lADj0/woMfv8H1TwyzLyvnY6tEeeOmQxrSGempvuBhPXBhgm3zL4rhbCWX2vX7EQwRPomM5kLParktCo2myqX00zrtBhPdD6R1YhkkSs54CO3StMiPvnflUCV9J8AAAD//wMA97KMf7UBAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 14 Dec 2023 22:33:58 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:11 GMT"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "7e484a28a47fb1ba1c92ad8d64d96c7a"
+              "value": "5db26665cbe66286345e6bfc1ebd9dd9"
             },
             {
               "name": "x-trace-id",
-              "value": "fd146330701338b9ce25b686103c655c"
+              "value": "c2b07b9ffb8076cc1934c840b2e098a0"
             },
             {
               "name": "strict-transport-security",
@@ -135,7 +135,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=2KhqCxSHma4LvudKB1eq0ShfYzeqheu19mu5mZBGL8ONNqP7PSV6J8QgToDL%2BxKm08NQjHDNRbhPOaJmOESorZ8ouOq61cM90g%2FRqBo53RrRY%2F73PizegELI9jNUugcUaSTUoNUZQHzSVCdN2meEHEvbujF3DB%2FKtSfxFQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=wbyGatPBdBk9HA0XJcDcAhd19P87A8d%2Bu0SWCHNfMv7%2B%2FLjtFjfa5EPYIFt5WT3WGQmqIr18rO76MvGi2eCbEYcnrdu1AISMBgL6m7UsnxBdaEYnZiLz%2B5HlR7%2BjGQ9p1cDnbAWRY2DC4MI54RrX9LroZojobEnznMxouw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -147,21 +147,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "8359e959acd4c452-EWR"
+              "value": "8479e4577e991825-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-14T22:33:57.953Z",
-        "time": 150,
+        "startedDateTime": "2024-01-18T21:22:11.694Z",
+        "time": 217,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 150
+          "wait": 217
         }
       },
       {
-        "_id": "cc2fca976335b6034f9946efffb8de10",
+        "_id": "9d3ca9cf341e3ba1612ebe619dfc4ac9",
         "_order": 0,
         "cache": {},
         "request": {
@@ -183,7 +183,7 @@
             {
               "_fromType": "array",
               "name": "x-gadget-environment",
-              "value": "Development"
+              "value": "development"
             },
             {
               "_fromType": "array",
@@ -242,13 +242,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 392,
-            "text": "[\"H4sIAAAAAAAAA4SRPW+DMBCGd37F6eaofAQTwhapUtWhQ6t2jhx8EFQC1D5LSaP898pAKXTJ6PeeV/ecfPUAUEmWmMHVAwBA2ynJ9Gqr7ykDQGPznIzBDFhbWv3GpHWrXdrYup7Sr2UZACuFGWCYrHH1FzKd2cVMhsF1YNit5tB+z5eOGnkih/Za4/A27VsyH9MBb2RszQM/0lhKVRK/0OxkADxelJZctY1ZeueanNCu93yUTO/VieZ6o/E/4I7hU++w67q6yvutvc6g6Y01pDNTYxZKWLele+GRuTOZ75clP9RV8+m7gR+KIAlS/0AiKgohQnmIE5GnFESCongbF+tNnIabUR9Zy5ye+4+5W3FW3u0HAAD//wMAo0AtQy4CAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRsW6DMBCGd57idHNUYkwRYYtUqerQoVU7Ry6+EFQC1D5LSaO8e2VDKXTJ6P++X/edfIkAUCtWWMAlAgBA12vF9OLq7ykDQOvKkqzFAtg4Wv3GZExnfNq6ppnSr2UZAGuNBaDIJK7+QqYT+5jJMvgODLv1HNrt+NxTq47k0aA1Dq/TviXzPh3wStY1PPAjjZXSFfEzzU4GwMNZG8V119qld2nIC22D54NiequPNNcbjf8BNwwfg8O275u6DFuDzqAZjTWkE1NrF0rYdJV/4YG5t0UcVxXfNXX7GftBLO7X2TqPUylTRbQXOs9S+SFFJnOdbkSaqL1INsmoj2xUSU/hY25WvFV0/QEAAP//AwAiLlxWLgIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 22 Dec 2023 17:24:02 GMT"
+              "value": "Thu, 18 Jan 2024 21:22:38 GMT"
             },
             {
               "name": "content-type",
@@ -280,11 +280,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "c1fe6f273749cf5a9a9fa97bfa78ba1f"
+              "value": "f4131b88aed816ef9e1cc4a0060d9359"
             },
             {
               "name": "x-trace-id",
-              "value": "be52ff551ab465c8e025e2494f374817"
+              "value": "4334aeef1d8643b31638d49142af1292"
             },
             {
               "name": "strict-transport-security",
@@ -300,7 +300,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=02sq1a1DiSxCi8p7kJfHuIdF09afoK8c6Q926UOUora4V6bhYms1vA5xDqqVmXau8L0u4qUYRJ5F97GSI5ob%2FH9pq1aiBS%2F14e4T0Ylt1XLaOCRd9V%2BwP4a5xfZFHKyCSc0vMXgCRd7dCXO15X0BgwYQVS%2B%2BJevG0ICB7A%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=0Lec6Qlx0eaprkR%2F1BkfhcuEgv4%2BO12W6dNQ0ptOO1Z00AOMuQO0FrMsUfB53xfbkZx0XxI7VI4mH4ZscAJtD%2BhZWFL9ozAm1SX8VWZeqlvX9K95lK93usKi5EDwwcOHnOwVs1NZwNHBh1RrpEV5fUCnC4FLCTC6NAcQKg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -312,21 +312,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "839a0e57ea2c0c7e-EWR"
+              "value": "8479e4fc2bc2c47c-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 945,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-22T17:24:01.748Z",
-        "time": 378,
+        "startedDateTime": "2024-01-18T21:22:38.048Z",
+        "time": 230,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -334,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 378
+          "wait": 230
         }
       }
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,23 +13,23 @@ importers:
   .:
     devDependencies:
       '@gadget-client/app-with-no-user-model':
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: 1.6.0-development.5
+        version: 1.6.0-development.5
       '@gadget-client/bulk-actions-test':
-        specifier: ^1.104.0
-        version: 1.104.0
+        specifier: 1.108.0-development.111
+        version: 1.108.0-development.111
       '@gadget-client/full-auth':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.5.0-development.4
+        version: 1.5.0-development.4
       '@gadget-client/related-products-example':
-        specifier: ^1.859.0
-        version: 1.859.0
+        specifier: 1.860.0-development.859
+        version: 1.860.0-development.859
       '@gadget-client/zxcv-deeply-nested':
-        specifier: ^1.207.0
-        version: 1.207.0
+        specifier: 1.208.0-development.207
+        version: 1.208.0-development.207
       '@gadget-client/zxcv-simple-relationship':
-        specifier: ^1.17.0
-        version: 1.17.0
+        specifier: 1.18.0-development.17
+        version: 1.18.0-development.17
       '@gadgetinc/api-client-core':
         specifier: workspace:*
         version: link:packages/api-client-core
@@ -1204,8 +1204,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@gadget-client/app-with-no-user-model@1.5.0:
-    resolution: {integrity: sha1-d5IrGFX84chk/GT66IJTpSji5ts=, tarball: https://registry.gadget.dev/npm/_/tarball/45852/90385/5457}
+  /@gadget-client/app-with-no-user-model@1.6.0-development.5:
+    resolution: {integrity: sha1-/OxvUVxpTmdvtDgNMe8AzyPnOes=, tarball: https://registry.gadget.dev/npm/_/tarball/45852/90385/6423}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
@@ -1216,32 +1216,32 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: false
 
-  /@gadget-client/bulk-actions-test@1.104.0:
-    resolution: {integrity: sha1-93pd5nm57sBs7Y2gRA0/YAHM8TM=, tarball: https://registry.gadget.dev/npm/_/tarball/6681/12076/5459}
+  /@gadget-client/bulk-actions-test@1.108.0-development.111:
+    resolution: {integrity: sha1-mHCySRuSHRkbqHLLvm7G4w2CEek=, tarball: https://registry.gadget.dev/npm/_/tarball/6681/12077/6421}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/full-auth@1.4.0:
-    resolution: {integrity: sha1-npUnTWStWGH5v2nmd5hPrLQBZwA=, tarball: https://registry.gadget.dev/npm/_/tarball/66538/131724/5610}
+  /@gadget-client/full-auth@1.5.0-development.4:
+    resolution: {integrity: sha1-8DlLcM9IjdFvsyi34/v06Iu2u9o=, tarball: https://registry.gadget.dev/npm/_/tarball/66538/131724/6422}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/related-products-example@1.859.0:
-    resolution: {integrity: sha1-nb14pOPLAMiw0Yz7IiLFBLedUu0=, tarball: https://registry.gadget.dev/npm/_/tarball/1268/1362/6228}
+  /@gadget-client/related-products-example@1.860.0-development.859:
+    resolution: {integrity: sha1-AmNJ4SOUtpCatG/+uQxrx+xTkKg=, tarball: https://registry.gadget.dev/npm/_/tarball/1268/1362/6391}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/zxcv-deeply-nested@1.207.0:
-    resolution: {integrity: sha1-bXcspYSq+sVyQiQ3AoqiWT5CSnc=, tarball: https://registry.gadget.dev/npm/_/tarball/76013/150608/6227}
+  /@gadget-client/zxcv-deeply-nested@1.208.0-development.207:
+    resolution: {integrity: sha1-tKrVYctNyiMfb7tsjG8huy1PgTc=, tarball: https://registry.gadget.dev/npm/_/tarball/76013/150608/6424}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/zxcv-simple-relationship@1.17.0:
-    resolution: {integrity: sha1-FRYfc5QiRRNZtlbEI8YO9VVxIo4=, tarball: https://registry.gadget.dev/npm/_/tarball/79412/157406/6169}
+  /@gadget-client/zxcv-simple-relationship@1.18.0-development.17:
+    resolution: {integrity: sha1-FRYfc5QiRRNZtlbEI8YO9VVxIo4=, tarball: https://registry.gadget.dev/npm/_/tarball/79412/157406/6420}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
This updates the tests to use the version of the npm client with the new development format since the old ones broke. I updated the test recordings as well

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
