### PR TITLE
don't throw if useActionForm doesn't have a fieldType but interpret t…

### DIFF
--- a/packages/react/src/useActionForm.ts
+++ b/packages/react/src/useActionForm.ts
@@ -269,22 +269,8 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
         return depth <= 1 ? { ...rest, ...belongsTo } : { ...rest, create: { ...belongsTo } }; // when we're in the root, we need to return the belongsTo object as part of the result otherwise wrap it in a create
       }
 
-      if (depth <= 1) {
+      if (depth <= 1 || fieldType == null) {
         return { ...rest };
-      }
-
-      if (fieldType == null) {
-        throw new Error(
-          `Can't transform input, no field type found. ${JSON.stringify(
-            {
-              input,
-              path,
-              referencedTypes,
-            },
-            null,
-            2
-          )}`
-        );
       }
 
       const inputHasId = "id" in input;


### PR DESCRIPTION
useActionForm throws if it gets to a field like `user.roles` that is an array of objects because it assumes that this should represent a field of relationships; if it can't find a field type it throws. I don't think we should throw here (it's breaking our change password form on the web template)

@pistachiobaby is there a reason we must throw here?

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
