### PR TITLE
Shopify app bridge v4 support

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "files": [
     "README.md",
     "dist/**/*"
@@ -28,15 +28,13 @@
   },
   "dependencies": {
     "@gadgetinc/api-client-core": "^0.15.13",
-    "@shopify/app-bridge-utils": "^3.1.1",
     "crypto-js": "^4.1.1",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",
     "@gadgetinc/react": "workspace:*",
-    "@shopify/app-bridge": "^3.1.0",
-    "@shopify/app-bridge-react": "^3.0.0",
+    "@shopify/app-bridge-react": "^4.0.0",
     "@types/crypto-js": "^4.1.1",
     "@types/node": "^16.11.7",
     "@types/react": "^18.2.9",
@@ -49,8 +47,7 @@
   },
   "peerDependencies": {
     "@gadgetinc/react": "^0.15.0",
-    "@shopify/app-bridge": "^2.0.0 || ^3.0.0",
-    "@shopify/app-bridge-react": "^2.0.0 || ^3.0.0",
+    "@shopify/app-bridge-react": "^4.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   }

--- a/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
+++ b/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
@@ -1,7 +1,6 @@
 import type { AnyClient } from "@gadgetinc/api-client-core";
 import { GadgetConnection } from "@gadgetinc/api-client-core";
-import { AppBridgeContext } from "@shopify/app-bridge-react/context.js";
-import { Redirect } from "@shopify/app-bridge/actions/index.js";
+import * as AppBridgeReact from "@shopify/app-bridge-react";
 import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
@@ -12,7 +11,9 @@ describe("GadgetProvider", () => {
   let mockApiClient: AnyClient;
   const { location } = window;
   const mockNavigate = jest.fn();
+  const mockOpen = jest.fn();
   const mockApiKey = "some-api-key";
+  let useAppBridgeMock: jest.SpyInstance;
 
   describe.each([true, false])("as install request: %s", (isInstallRequest) => {
     beforeAll(() => {
@@ -27,15 +28,17 @@ describe("GadgetProvider", () => {
         search: isInstallRequest ? "?shop=example.myshopify.com&hmac=abcdefg&host=abcdfg" : "",
       };
 
-      const originalUseContext = React.useContext;
+      window.open = mockOpen;
 
-      jest.spyOn(React, "useContext").mockImplementation((context) => {
-        if (context === AppBridgeContext) {
-          return {};
-        } else {
-          return originalUseContext(context);
-        }
-      });
+      window.shopify = {
+        // @ts-expect-error mock
+        environment: {
+          embedded: false,
+          mobile: false,
+        },
+      };
+
+      useAppBridgeMock = jest.spyOn(AppBridgeReact, "useAppBridge").mockImplementation(() => window.shopify);
     });
 
     beforeEach(() => {
@@ -50,6 +53,7 @@ describe("GadgetProvider", () => {
 
     afterEach(() => {
       mockNavigate.mockClear();
+      useAppBridgeMock.mockClear();
     });
 
     afterAll(() => {
@@ -93,19 +97,19 @@ describe("GadgetProvider", () => {
       });
 
       if (isInstallRequest) {
-        expect(mockNavigate).toHaveBeenCalledWith(
-          "https://test-app.gadget.app/api/connections/auth/shopify?shop=example.myshopify.com&hmac=abcdefg&host=abcdfg"
+        expect(mockOpen).toHaveBeenCalledWith(
+          "https://test-app.gadget.app/api/connections/auth/shopify?shop=example.myshopify.com&hmac=abcdefg&host=abcdfg",
+          "_top"
         );
+        expect(mockNavigate).not.toHaveBeenCalled();
       } else {
         expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockOpen).not.toHaveBeenCalled();
         expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
       }
     });
 
     test("can render a standalone app type in embedded context", () => {
-      // @ts-expect-error mock
-      jest.spyOn(window, "self", "get").mockImplementation(() => ({}));
-
       const { container } = render(
         <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Standalone}>
           <span>hello world</span>
@@ -125,9 +129,7 @@ describe("GadgetProvider", () => {
     });
 
     test("can render a standalone app type in mobile context", () => {
-      window.MobileWebView = {
-        postMessage: jest.fn(),
-      };
+      window.shopify.environment.mobile = true;
 
       const { container } = render(
         <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Standalone}>
@@ -146,17 +148,10 @@ describe("GadgetProvider", () => {
         expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
       }
 
-      delete window.MobileWebView;
+      window.shopify.environment.mobile = false;
     });
 
     test("can render an embedded app type in embedded context", () => {
-      const mockDispatch = jest.fn();
-      // @ts-expect-error mock
-      jest.spyOn(Redirect, "create").mockImplementation((_appBridge) => {
-        return {
-          dispatch: mockDispatch,
-        };
-      });
       // @ts-expect-error mock
       jest.spyOn(window, "self", "get").mockImplementation(() => ({}));
 
@@ -177,28 +172,20 @@ describe("GadgetProvider", () => {
       });
 
       if (isInstallRequest) {
-        expect(mockDispatch).toHaveBeenCalledWith(
-          "APP::NAVIGATION::REDIRECT::REMOTE",
-          "https://test-app.gadget.app/api/connections/auth/shopify?shop=example.myshopify.com&hmac=abcdefg&host=abcdfg"
+        expect(mockOpen).toHaveBeenCalledWith(
+          "https://test-app.gadget.app/api/connections/auth/shopify?shop=example.myshopify.com&hmac=abcdefg&host=abcdfg",
+          "_top"
         );
+        expect(mockNavigate).not.toHaveBeenCalled();
       } else {
-        expect(mockDispatch).not.toHaveBeenCalled();
         expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockOpen).not.toHaveBeenCalled();
       }
-
-      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     test("can render an embedded app type that's already authenticated", () => {
-      const mockDispatch = jest.fn();
-      // @ts-expect-error mock
-      jest.spyOn(Redirect, "create").mockImplementation((_appBridge) => {
-        return {
-          dispatch: mockDispatch,
-        };
-      });
-      // @ts-expect-error mock
-      jest.spyOn(window, "self", "get").mockImplementation(() => ({}));
+      window.shopify.environment.embedded = true;
 
       const { container } = render(
         <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
@@ -218,9 +205,37 @@ describe("GadgetProvider", () => {
         hasNext: false,
       });
 
-      expect(mockDispatch).not.toHaveBeenCalled();
       expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
       expect(mockNavigate).not.toHaveBeenCalled();
+
+      window.shopify.environment.embedded = false;
+    });
+
+    test("should throw if embedded app type is in embedded context and shopify global is not defined", () => {
+      // @ts-expect-error mock
+      const windowSelf = jest.spyOn(window, "self", "get").mockImplementation(() => ({}));
+      // @ts-expect-error reset mock
+      window.shopify = undefined;
+
+      expect(() =>
+        render(
+          <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
+            <span>hello world</span>
+          </Provider>
+        )
+      ).toThrow(
+        "Expected app bridge to be defined in embedded context, but it was not. This is likely due to a missing script tag, see https://shopify.dev/docs/api/app-bridge-library"
+      );
+
+      // resetting the mocked values
+      windowSelf.mockRestore();
+      window.shopify = {
+        // @ts-expect-error mock
+        environment: {
+          embedded: false,
+          mobile: false,
+        },
+      };
     });
   });
 });

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -1,12 +1,8 @@
 import type { AnyClient } from "@gadgetinc/api-client-core";
 import { Provider as GadgetUrqlProvider, useQuery } from "@gadgetinc/react";
-import type { History, LocationOrHref } from "@shopify/app-bridge-react";
-import * as AppBridgeReact from "@shopify/app-bridge-react";
-import { AppBridgeContext } from "@shopify/app-bridge-react/context.js";
-import { getSessionToken } from "@shopify/app-bridge-utils";
-import { Redirect } from "@shopify/app-bridge/actions/index.js";
+import { useAppBridge } from "@shopify/app-bridge-react";
 import type { ReactNode } from "react";
-import React, { memo, useContext, useEffect, useMemo, useState } from "react";
+import React, { memo, useEffect, useMemo, useState } from "react";
 import type { GadgetAuthContextValue } from "./index.js";
 import { GadgetAuthContext } from "./index.js";
 
@@ -18,14 +14,13 @@ export enum AppType {
 /** Internal props used to create the right structure of providers */
 type GadgetProviderProps = {
   children: ReactNode;
-  forceRedirect: boolean;
-  isEmbedded: boolean;
   gadgetAppUrl: string;
   originalQueryParams?: URLSearchParams;
   api: AnyClient;
-  isRootFrameRequest: boolean;
-  isInstallRequest: boolean;
   type: AppType;
+  host: string | undefined;
+  isReady: boolean;
+  isRootFrameRequest: boolean;
 };
 
 const GetCurrentSessionQuery = `
@@ -44,19 +39,17 @@ const GetCurrentSessionQuery = `
 
 // inner component that exists in order to ask for the app bridge
 const InnerGadgetProvider = memo(
-  ({
-    children,
-    forceRedirect,
-    isEmbedded,
-    gadgetAppUrl,
-    originalQueryParams,
-    api,
-    isRootFrameRequest,
-    type,
-    isInstallRequest,
-  }: GadgetProviderProps) => {
-    const appBridge = useContext(AppBridgeContext);
-
+  ({ children, gadgetAppUrl, originalQueryParams, api, type, host, isReady, isRootFrameRequest }: GadgetProviderProps) => {
+    const appBridge = useAppBridge();
+    // We need to be sure we're in the destination context when running any of the auth steps.
+    // Some browsers have strict policies that prevent sharing local/session storage between embedded & non-embedded contexts.
+    //
+    // We make an exception for install requests since in that scenario there's no embedded app that we can redirect to.
+    // On a browser that this policy enabled, we'll just re-run the auth process after redirecting to the embedded app.
+    const isInstallRequest = originalQueryParams?.has("hmac") && originalQueryParams?.has("shop");
+    const isEmbedded = appBridge.environment.embedded || appBridge.environment.mobile;
+    const inDestinationContext = isEmbedded && type === AppType.Embedded;
+    const forceRedirect = isReady && typeof host !== "undefined" && !inDestinationContext;
     const [context, setContext] = useState<GadgetAuthContextValue>({
       isAuthenticated: false,
       isEmbedded: false,
@@ -76,14 +69,14 @@ const InnerGadgetProvider = memo(
         custom: {
           async processFetch(_input, init) {
             const headers = new Headers(init.headers);
-            headers.append("Authorization", `ShopifySessionToken ${await getSessionToken(appBridge)}`);
+            headers.append("Authorization", `ShopifySessionToken ${await appBridge.idToken()}`);
             init.headers ??= {};
             headers.forEach(function (value, key) {
               (init.headers as Record<string, string>)[key] = value;
             });
           },
           async processTransactionConnectionParams(params) {
-            params.auth.shopifySessionToken = await getSessionToken(appBridge);
+            params.auth.shopifySessionToken = await appBridge.idToken();
           },
         },
       });
@@ -97,8 +90,6 @@ const InnerGadgetProvider = memo(
     // always run one session fetch to the gadget backend on boot to discover if this app is installed
     const [{ data: currentSessionData, fetching: sessionFetching, error }] = useQuery({
       query: GetCurrentSessionQuery,
-      // for now don't fetch a session's shop in standalone mode since it leverages session tokens which aren't available if standalone
-      pause: type == AppType.Standalone,
     });
 
     if (currentSessionData) {
@@ -112,8 +103,6 @@ const InnerGadgetProvider = memo(
           isAuthenticated = !currentSessionData.shopifyConnection?.requiresReauthentication;
         }
       }
-    } else if (type == AppType.Standalone && isInstallRequest) {
-      runningShopifyAuth = true;
     }
 
     // redirect to Gadget to initiate the oauth process if we need to.
@@ -132,12 +121,9 @@ const InnerGadgetProvider = memo(
         gadgetAppUrl,
       });
 
-      if (isEmbedded && appBridge) {
-        Redirect.create(appBridge).dispatch(Redirect.Action.REMOTE, redirectURLWithOAuthParams);
-      } else {
-        window.location.assign(redirectURLWithOAuthParams);
-      }
-    }, [appBridge, gadgetAppUrl, isEmbedded, isRootFrameRequest, originalQueryParams, runningShopifyAuth]);
+      open(redirectURLWithOAuthParams, "_top");
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [gadgetAppUrl, isRootFrameRequest, originalQueryParams, runningShopifyAuth]);
 
     const loading = (forceRedirect || runningShopifyAuth || sessionFetching) && !isRootFrameRequest;
 
@@ -161,27 +147,66 @@ const InnerGadgetProvider = memo(
   }
 );
 
+const StandaloneInnerProvider = ({
+  isRootFrameRequest,
+  children,
+  query,
+  gadgetAppUrl,
+  type,
+}: {
+  isRootFrameRequest: boolean;
+  children: ReactNode;
+  query?: URLSearchParams;
+  gadgetAppUrl: string;
+  type: AppType;
+}) => {
+  // we still need to run the oauth process if we're in an install context so we should redirect to gadget
+  const isInstallRequest = query?.has("hmac") && query?.has("shop");
+  const runningShopifyAuth = isInstallRequest;
+
+  // redirect to Gadget to initiate the oauth process if we need to.
+  useEffect(() => {
+    if (!runningShopifyAuth || isRootFrameRequest) return;
+    // redirect to gadget app root pages url with oauth params
+    const redirectURL = new URL("/api/connections/auth/shopify", gadgetAppUrl);
+    redirectURL.search = query?.toString() ?? "";
+    const redirectURLWithOAuthParams = redirectURL.toString();
+
+    console.debug("[gadget-rsab] redirecting to gadget to initiate oauth process in standalone mode or missing app bridge global", {
+      appType: type,
+      isInstallRequest,
+      redirectURL: redirectURLWithOAuthParams,
+      gadgetAppUrl,
+    });
+
+    window.location.assign(redirectURLWithOAuthParams);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gadgetAppUrl, isRootFrameRequest, query, runningShopifyAuth]);
+
+  return (
+    <GadgetAuthContext.Provider
+      value={{
+        isAuthenticated: false,
+        isEmbedded: false,
+        canAuth: false,
+        loading: false,
+        appBridge: null,
+        isRootFrameRequest: isRootFrameRequest,
+      }}
+    >
+      {children}
+    </GadgetAuthContext.Provider>
+  );
+};
+
 type ProviderLocation = {
   query?: URLSearchParams;
   asPath?: string;
 };
 
-export const Provider = ({
-  type,
-  children,
-  shopifyApiKey,
-  api,
-  router,
-}: {
-  type?: AppType;
-  children: ReactNode;
-  shopifyApiKey: string;
-  api: AnyClient;
-  router?: {
-    location: LocationOrHref;
-    history: History;
-  };
-}) => {
+export const Provider = ({ type, children, api }: { type?: AppType; children: ReactNode; shopifyApiKey: string; api: AnyClient }) => {
+  // if we haven't properly set up the shopify global then skip anything that requires app bridge
+  const shopifyGlobalDefined = !!(globalThis && globalThis.shopify);
   const [location, setLocation] = useState<ProviderLocation | null>(null);
   const isReady = !!location;
   const { query } = location ?? {};
@@ -191,25 +216,8 @@ export const Provider = ({
   // We store the original query params as that is what shopify uses to generate the HMAC in embedded apps
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const originalQueryParams = useMemo(() => query, [isReady]);
-
-  // We need to be sure we're in the destination context when running any of the auth steps.
-  // Some browsers have strict policies that prevent sharing local/session storage between embedded & non-embedded contexts.
-  //
-  // We make an exception for install requests since in that scenario there's no embedded app that we can redirect to.
-  // On a browser that this policy enabled, we'll just re-run the auth process after redirecting to the embedded app.
-  const isInstallRequest = query?.has("hmac") && query?.has("shop");
-  // detect if we're in an iframe by looking if this window object has a reference to a different top window
-  const inIframe = typeof window !== "undefined" ? window.top !== window.self : false;
-  // detect if we're in the shopify mobile app by looking for the injected global context the app bridge uses
-  const inShopifyMobileApp = typeof window !== "undefined" && !!window.MobileWebView;
-  const isEmbedded = inIframe || inShopifyMobileApp;
-  const inDestinationContext =
-    isEmbedded == (coalescedType == AppType.Embedded) && (coalescedType == AppType.Standalone ? !isInstallRequest : true);
-
   // We need to inform developers if the component is being rendered in a non embedded context when it should be AND we're not in an interstitial installation state. This is determined for now by the absence of both hmac and shop. This will generally occur when someone visits the app url while not in the Shopify admin.
-  const isRootFrameRequest = !query?.has("hmac") && !query?.has("shop") && coalescedType == AppType.Embedded;
-
-  const forceRedirect = isReady && typeof host !== "undefined" && !inDestinationContext;
+  const isRootFrameRequest = !query?.has("hmac") && !query?.has("shop") && type == AppType.Embedded;
 
   const gadgetAppUrl = new URL(api.connection.options.endpoint).origin;
 
@@ -220,51 +228,42 @@ export const Provider = ({
     });
   }, []);
 
-  let app = (
-    <GadgetUrqlProvider api={api}>
-      <InnerGadgetProvider
-        forceRedirect={forceRedirect}
-        isEmbedded={isEmbedded}
-        gadgetAppUrl={gadgetAppUrl}
-        api={api}
-        originalQueryParams={originalQueryParams}
-        isRootFrameRequest={isRootFrameRequest}
-        type={coalescedType}
-        isInstallRequest={!!isInstallRequest}
-      >
-        {children}
-      </InnerGadgetProvider>
-    </GadgetUrqlProvider>
-  );
-
-  const shouldMountAppBridge = host && coalescedType != AppType.Standalone && (!isInstallRequest || inDestinationContext);
-
   console.debug("[gadget-rsab] provider rendering", {
     host,
     coalescedType,
-    isInstallRequest,
     isReady,
-    isEmbedded,
-    isRootFrameRequest,
-    inDestinationContext,
-    shouldMountAppBridge,
   });
 
-  // app bridge provider seems to prevent urql from sending graphql requests when it cannot communicate using postMessage when not embedded so we must skip using the app bridge provider on the very first redirect from shopify
-  if (shouldMountAppBridge) {
-    app = (
-      <AppBridgeReact.Provider
-        config={{
-          apiKey: shopifyApiKey,
-          host,
-          forceRedirect,
-        }}
-        router={router}
-      >
-        {app}
-      </AppBridgeReact.Provider>
+  if (coalescedType == AppType.Embedded && !shopifyGlobalDefined && globalThis.top !== globalThis.self) {
+    throw new Error(
+      "Expected app bridge to be defined in embedded context, but it was not. This is likely due to a missing script tag, see https://shopify.dev/docs/api/app-bridge-library"
     );
   }
 
-  return app;
+  if (coalescedType === AppType.Embedded && globalThis.top === globalThis.self) {
+    const event = new CustomEvent("gadget:devharness:rsab.embeddedInRootContext");
+    globalThis.dispatchEvent(event);
+  }
+
+  return (
+    <GadgetUrqlProvider api={api}>
+      {coalescedType === AppType.Embedded && shopifyGlobalDefined ? (
+        <InnerGadgetProvider
+          gadgetAppUrl={gadgetAppUrl}
+          api={api}
+          originalQueryParams={originalQueryParams}
+          type={coalescedType}
+          host={host}
+          isReady={isReady}
+          isRootFrameRequest={isRootFrameRequest}
+        >
+          {children}
+        </InnerGadgetProvider>
+      ) : (
+        <StandaloneInnerProvider isRootFrameRequest={isRootFrameRequest} query={query} type={coalescedType} gadgetAppUrl={gadgetAppUrl}>
+          {children}
+        </StandaloneInnerProvider>
+      )}
+    </GadgetUrqlProvider>
+  );
 };

--- a/packages/react-shopify-app-bridge/src/context.ts
+++ b/packages/react-shopify-app-bridge/src/context.ts
@@ -1,4 +1,4 @@
-import type { AppBridgeState, ClientApplication } from "@shopify/app-bridge";
+import type { ShopifyGlobal } from "@shopify/app-bridge-react";
 import { createContext, useContext } from "react";
 import type { AppType } from "./Provider.js";
 
@@ -12,7 +12,7 @@ export type GadgetAuthContextValue = {
   /** The current embedding state of this JS context. Will return true if running inside the iframe in the Shopify Admin, false otherwise */
   isEmbedded: boolean;
   /** An instance of the AppBridge object. Only available in embedded contexts. */
-  appBridge: ClientApplication<AppBridgeState> | null;
+  appBridge: ShopifyGlobal | null;
   /** Is this browser window ready to authenticate in the current state */
   canAuth: boolean;
   /** Is this browser window authenticated and ready to make requests to the Gadget backend */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,9 +288,6 @@ importers:
       '@gadgetinc/api-client-core':
         specifier: workspace:*
         version: link:../api-client-core
-      '@shopify/app-bridge-utils':
-        specifier: ^3.1.1
-        version: 3.1.1
       crypto-js:
         specifier: ^4.1.1
         version: 4.1.1
@@ -301,12 +298,9 @@ importers:
       '@gadgetinc/react':
         specifier: workspace:*
         version: link:../react
-      '@shopify/app-bridge':
-        specifier: ^3.1.0
-        version: 3.7.7
       '@shopify/app-bridge-react':
-        specifier: ^3.0.0
-        version: 3.0.0(react@18.2.0)
+        specifier: ^4.0.0
+        version: 4.0.0(react-dom@18.2.0)(react@18.2.0)
       '@types/crypto-js':
         specifier: ^4.1.1
         version: 4.1.1
@@ -1962,31 +1956,20 @@ packages:
     resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
     dev: false
 
-  /@shopify/app-bridge-core@1.0.2:
-    resolution: {integrity: sha512-lI+nZHMDqBJSqTBQiI1GY3Xs7YjPuZ83/sW7TIvWtTsxQZyoanAVXloo63sGEd58t1KvKFnDtVFN1NJYe/zouQ==}
-
-  /@shopify/app-bridge-react@3.0.0(react@18.2.0):
-    resolution: {integrity: sha512-tePRKtH/7GV9hZ7Ln2FE5AO5IPehO74Hsffq/4Dtkc65nfbUMekotnNJYu3Bmgcz41dHoM2909mD7yP86F8vlQ==}
+  /@shopify/app-bridge-react@4.0.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-a300DQIyYmNl5jNFHXsAICMfafY6LizXnaG5ElaAumfoIt28owgM8daDm9BwBkHSroHArvJuZS96kpDzTVg1+Q==}
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
-      '@shopify/app-bridge': 3.7.7
+      '@shopify/app-bridge-types': 0.0.7
       react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@shopify/app-bridge-utils@3.1.1:
-    resolution: {integrity: sha512-le1/A62naIj5yq2o/G8htECvYTiAbVzOo9Ue3/gGqlJJC6w7+Uu4ppDHdkg6yfZCmkPUXCIr7+yU3kZHYV5z0g==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    dependencies:
-      '@shopify/app-bridge': 3.7.7
-    dev: false
-
-  /@shopify/app-bridge@3.7.7:
-    resolution: {integrity: sha512-8Y3gCur852ATEiLUjen3SEuKV9GGceC7yalLaA99MIuBpefaOUDafCHrdX6Fv+MlaP8vL49cfCeCJZUB7yq0Ig==}
-    dependencies:
-      '@shopify/app-bridge-core': 1.0.2
-      base64url: 3.0.1
-      web-vitals: 3.3.2
+  /@shopify/app-bridge-types@0.0.7:
+    resolution: {integrity: sha512-x2A86xSjBPaB4rDufkY+pGH2UK8gR/rvjeXGwttIjir1l70ELHnZj+eGzHShmBitCbVoN3fkBrDnFLZdjWqyLg==}
+    dev: true
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -2943,10 +2926,6 @@ packages:
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
-
-  /base64url@3.0.1:
-    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
-    engines: {node: '>=6.0.0'}
 
   /basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
@@ -7332,9 +7311,6 @@ packages:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
     dev: true
-
-  /web-vitals@3.3.2:
-    resolution: {integrity: sha512-qRkpmSeKfEWAzNhtX541xA8gCJ+pqCqBmUlDVkVDSCSYUvfvNqF+k9g8I+uyreRcDBdfiJrd0/aLbTy5ydo49Q==}
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}


### PR DESCRIPTION
This updates `react-shopify-app-bridge` to support `@shopify/app-bridge-react` v4. Will run this through CI over in gadget before merging

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
