### PR TITLE
Add an runner to get action results

### DIFF
--- a/packages/api-client-core/spec/mockActions.ts
+++ b/packages/api-client-core/spec/mockActions.ts
@@ -5,6 +5,7 @@ export const MockWidgetCreateAction = {
   isBulk: false,
   operationName: "createWidget",
   modelApiIdentifier: "widget",
+  modelSelectionField: "widget",
   variables: {
     widget: {
       type: "CreateWidgetInput",

--- a/packages/api-client-core/spec/mockActions.ts
+++ b/packages/api-client-core/spec/mockActions.ts
@@ -3,6 +3,10 @@ import type { ActionFunction, BulkActionFunction, GlobalActionFunction } from ".
 export const MockWidgetCreateAction = {
   type: "action",
   isBulk: false,
+  defaultSelection: {
+    id: true,
+    name: true,
+  },
   operationName: "createWidget",
   modelApiIdentifier: "widget",
   modelSelectionField: "widget",

--- a/packages/api-client-core/spec/mockUrqlClient.ts
+++ b/packages/api-client-core/spec/mockUrqlClient.ts
@@ -107,8 +107,11 @@ const newMockOperationFn = (assertions?: (request: GraphQLRequest) => void) => {
         operation: null as any,
         ...response,
       });
-      subjects[key].complete();
-      delete subjects[key];
+
+      if (!response.hasNext) {
+        subjects[key].complete();
+        delete subjects[key];
+      }
     });
   };
 

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -621,21 +621,23 @@ describe("operation builders", () => {
           backgroundAction(id: $id) {
             id
             outcome
-            ... on CreateWidgetResult {
-              success
-              errors {
-                message
-                code
-                ... on InvalidRecordError {
-                  validationErrors {
-                    message
-                    apiIdentifier
+            result {
+              ... on CreateWidgetResult {
+                success
+                errors {
+                  message
+                  code
+                  ... on InvalidRecordError {
+                    validationErrors {
+                      message
+                      apiIdentifier
+                    }
                   }
                 }
-              }
-              widget {
-                id
-                __typename
+                widget {
+                  id
+                  __typename
+                }
               }
             }
           }

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -617,7 +617,7 @@ describe("operation builders", () => {
     test("builds query for action", async () => {
       expect(actionResultOperation("app-job-1234567", MockWidgetCreateAction, { select: { id: true } })).toMatchInlineSnapshot(`
         {
-          "query": "query createWidget($id: String!) {
+          "query": "subscription createWidget($id: String!) {
           backgroundAction(id: $id) {
             id
             outcome
@@ -652,7 +652,7 @@ describe("operation builders", () => {
     test("builds query for globalAction", async () => {
       expect(actionResultOperation("app-job-1234567", MockGlobalAction)).toMatchInlineSnapshot(`
         {
-          "query": "query flipAllWidgets($id: String!) {
+          "query": "subscription flipAllWidgets($id: String!) {
           backgroundAction(id: $id) {
             id
             outcome

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -6,7 +6,7 @@ import {
   findOneByFieldOperation,
   findOneOperation,
 } from "../src/index.js";
-import { MockWidgetCreateAction } from "./mockActions.js";
+import { MockGlobalAction, MockWidgetCreateAction } from "./mockActions.js";
 
 describe("operation builders", () => {
   describe("findOneOperation", () => {
@@ -614,7 +614,7 @@ describe("operation builders", () => {
   });
 
   describe("actionResultOperation", () => {
-    test("actionResultOperation builds query", async () => {
+    test("builds query for action", async () => {
       expect(actionResultOperation("app-job-1234567", MockWidgetCreateAction, { select: { id: true } })).toMatchInlineSnapshot(`
         {
           "query": "query createWidget($id: String!) {
@@ -638,6 +638,38 @@ describe("operation builders", () => {
                   id
                   __typename
                 }
+              }
+            }
+          }
+        }",
+          "variables": {
+            "id": "app-job-1234567",
+          },
+        }
+      `);
+    });
+
+    test("builds query for globalAction", async () => {
+      expect(actionResultOperation("app-job-1234567", MockGlobalAction)).toMatchInlineSnapshot(`
+        {
+          "query": "query flipAllWidgets($id: String!) {
+          backgroundAction(id: $id) {
+            id
+            outcome
+            result {
+              ... on FlipAllWidgetsResult {
+                success
+                errors {
+                  message
+                  code
+                  ... on InvalidRecordError {
+                    validationErrors {
+                      message
+                      apiIdentifier
+                    }
+                  }
+                }
+                result
               }
             }
           }

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -1,4 +1,12 @@
-import { actionOperation, enqueueActionOperation, findManyOperation, findOneByFieldOperation, findOneOperation } from "../src/index.js";
+import {
+  actionOperation,
+  actionResultOperation,
+  enqueueActionOperation,
+  findManyOperation,
+  findOneByFieldOperation,
+  findOneOperation,
+} from "../src/index.js";
+import { MockWidgetCreateAction } from "./mockActions.js";
 
 describe("operation builders", () => {
   describe("findOneOperation", () => {
@@ -599,6 +607,41 @@ describe("operation builders", () => {
         }",
           "variables": {
             "backgroundOptions": null,
+          },
+        }
+      `);
+    });
+  });
+
+  describe("actionResultOperation", () => {
+    test("actionResultOperation builds query", async () => {
+      expect(actionResultOperation("app-job-1234567", MockWidgetCreateAction, { select: { id: true } })).toMatchInlineSnapshot(`
+        {
+          "query": "query createWidget($id: String!) {
+          backgroundAction(id: $id) {
+            id
+            outcome
+            ... on CreateWidgetResult {
+              success
+              errors {
+                message
+                code
+                ... on InvalidRecordError {
+                  validationErrors {
+                    message
+                    apiIdentifier
+                  }
+                }
+              }
+              widget {
+                id
+                __typename
+              }
+            }
+          }
+        }",
+          "variables": {
+            "id": "app-job-1234567",
           },
         }
       `);

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -1,7 +1,7 @@
 import nock from "nock";
 import { BackgroundActionHandle } from "../src/BackgroundActionHandle.js";
 import type { GadgetErrorGroup } from "../src/index.js";
-import { GadgetConnection, actionRunner, enqueueActionRunner } from "../src/index.js";
+import { GadgetConnection, actionResultRunner, actionRunner, enqueueActionRunner } from "../src/index.js";
 import { MockBulkFlipDownWidgetsAction, MockBulkUpdateWidgetAction, MockGlobalAction, MockWidgetCreateAction } from "./mockActions.js";
 import { mockUrqlClient } from "./mockUrqlClient.js";
 
@@ -771,6 +771,102 @@ describe("operationRunners", () => {
       const handle = await promise;
       expect(handle).toBeInstanceOf(BackgroundActionHandle);
       expect(handle.id).toEqual("fixed-id");
+    });
+  });
+
+  describe("actionResultRunner", () => {
+    describe("action", () => {
+      test("handles background action without an outcome", async () => {
+        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, { widget: { name: "new widget" } });
+
+        expect(mockUrqlClient.executeQuery.mock.calls.length).toEqual(1);
+        expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toEqual({
+          id: "app-job-123456",
+        });
+
+        mockUrqlClient.executeQuery.pushResponse("createWidget", {
+          data: {
+            backgroundAction: {
+              id: "app-job-123456",
+              outcome: null,
+              result: null,
+            },
+          },
+          stale: false,
+          hasNext: false,
+        });
+
+        const result = await promise;
+
+        expect(result.outcome).toBeNull();
+        expect(result.result).toBeNull();
+      });
+
+      test("handles background action with a completed result", async () => {
+        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, { widget: { name: "new widget" } });
+
+        expect(mockUrqlClient.executeQuery.mock.calls.length).toEqual(1);
+        expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toEqual({
+          id: "app-job-123456",
+        });
+
+        mockUrqlClient.executeQuery.pushResponse("createWidget", {
+          data: {
+            backgroundAction: {
+              id: "app-job-123456",
+              outcome: "completed",
+              result: {
+                success: true,
+                errors: null,
+                widget: {
+                  id: "123",
+                  name: "foo",
+                },
+              },
+            },
+          },
+          stale: false,
+          hasNext: false,
+        });
+
+        const result = await promise;
+
+        expect(result.outcome).toEqual("completed");
+        expect(result.result.id).toBeTruthy();
+        expect(result.result.name).toBeTruthy();
+      });
+
+      test("handles background action with a failed result", async () => {
+        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, { widget: { name: "new widget" } });
+
+        expect(mockUrqlClient.executeQuery.mock.calls.length).toEqual(1);
+        expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toEqual({
+          id: "app-job-123456",
+        });
+
+        mockUrqlClient.executeQuery.pushResponse("createWidget", {
+          data: {
+            backgroundAction: {
+              id: "app-job-123456",
+              outcome: "failed",
+              result: {
+                success: false,
+                errors: [
+                  {
+                    code: "GGT_SOMETHING_OR_OTHER",
+                    message: "An internal error occurred",
+                  },
+                ],
+                widget: null,
+              },
+            },
+          },
+          stale: false,
+          hasNext: false,
+        });
+
+        await expect(promise).rejects.toThrowErrorMatchingInlineSnapshot(`"GGT_SOMETHING_OR_OTHER: An internal error occurred"`);
+      });
     });
   });
 });

--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -1,13 +1,22 @@
 import type { GadgetConnection } from "./GadgetConnection.js";
 import type { AnyActionFunction } from "./GadgetFunctions.js";
+import { actionResultRunner } from "./operationRunners.js";
 import type { ActionFunctionOptions, EnqueueBackgroundActionOptions } from "./types.js";
 
 /** Represents a handle to a background action which has been enqueued */
 export class BackgroundActionHandle<Action extends AnyActionFunction> {
-  constructor(readonly connection: GadgetConnection, readonly id: string, readonly options: EnqueueBackgroundActionOptions<Action>) {}
+  constructor(
+    readonly connection: GadgetConnection,
+    readonly action: Action,
+    readonly id: string,
+    readonly options: EnqueueBackgroundActionOptions<Action>
+  ) {}
 
   /** Wait for this background action to complete and return the result. */
   async result<Options extends ActionFunctionOptions<Action>>(options?: Options) {
-    // TODO: implement
+    // Get the background action with result
+    // Check to see if there is an outcome
+    // If there is we process the result
+    return await actionResultRunner(this.connection, this.id, this.action, options);
   }
 }

--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -3,6 +3,12 @@ import type { AnyActionFunction } from "./GadgetFunctions.js";
 import { actionResultRunner } from "./operationRunners.js";
 import type { ActionFunctionOptions, EnqueueBackgroundActionOptions } from "./types.js";
 
+export type BackgroundActionResult<R = any> = {
+  id: string;
+  outcome: string | null;
+  result: R | null;
+}
+
 /** Represents a handle to a background action which has been enqueued */
 export class BackgroundActionHandle<Action extends AnyActionFunction> {
   constructor(
@@ -14,9 +20,24 @@ export class BackgroundActionHandle<Action extends AnyActionFunction> {
 
   /** Wait for this background action to complete and return the result. */
   async result<Options extends ActionFunctionOptions<Action>>(options?: Options) {
-    // Get the background action with result
-    // Check to see if there is an outcome
-    // If there is we process the result
+    let result = await this.fetchResult(options);
+
+    while(result.outcome === null || result.outcome === undefined) {
+      await this.sleep(250);
+      result = await this.fetchResult(options);
+    }
+
+    // Do some processing on the result
+    return result.result;
+  }
+
+  fetchResult = async <Options extends ActionFunctionOptions<Action>>(options?: Options) => {
     return await actionResultRunner(this.connection, this.id, this.action, options);
+  }
+
+  sleep = (delay: number) => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, delay);
+    });
   }
 }

--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -7,7 +7,7 @@ export type BackgroundActionResult<R = any> = {
   id: string;
   outcome: string | null;
   result: R | null;
-}
+};
 
 /** Represents a handle to a background action which has been enqueued */
 export class BackgroundActionHandle<Action extends AnyActionFunction> {
@@ -22,22 +22,21 @@ export class BackgroundActionHandle<Action extends AnyActionFunction> {
   async result<Options extends ActionFunctionOptions<Action>>(options?: Options) {
     let result = await this.fetchResult(options);
 
-    while(result.outcome === null || result.outcome === undefined) {
+    while (result.outcome === null || result.outcome === undefined) {
       await this.sleep(250);
       result = await this.fetchResult(options);
     }
 
-    // Do some processing on the result
     return result.result;
   }
 
   fetchResult = async <Options extends ActionFunctionOptions<Action>>(options?: Options) => {
     return await actionResultRunner(this.connection, this.id, this.action, options);
-  }
+  };
 
   sleep = (delay: number) => {
     return new Promise((resolve) => {
       setTimeout(resolve, delay);
     });
-  }
+  };
 }

--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -20,23 +20,6 @@ export class BackgroundActionHandle<Action extends AnyActionFunction> {
 
   /** Wait for this background action to complete and return the result. */
   async result<Options extends ActionFunctionOptions<Action>>(options?: Options) {
-    let result = await this.fetchResult(options);
-
-    while (result.outcome === null || result.outcome === undefined) {
-      await this.sleep(250);
-      result = await this.fetchResult(options);
-    }
-
-    return result.result;
+    return (await actionResultRunner(this.connection, this.id, this.action, options)).result;
   }
-
-  fetchResult = async <Options extends ActionFunctionOptions<Action>>(options?: Options) => {
-    return await actionResultRunner(this.connection, this.id, this.action, options);
-  };
-
-  sleep = (delay: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, delay);
-    });
-  };
 }

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -188,6 +188,12 @@ export const actionResultOperation = <Action extends AnyActionFunction, Options 
           action.hasReturnType
         ),
       };
+      break;
+    }
+    case "globalAction": {
+      fields = {
+        [`... on ${camelize(action.operationName)}Result`]: globalActionFieldSelection(),
+      };
     }
   }
 
@@ -201,14 +207,22 @@ export const actionResultOperation = <Action extends AnyActionFunction, Options 
           id: true,
           outcome: true,
           result: {
-            ...fields
-          }
+            ...fields,
+          },
         }
       ),
     },
   };
 
   return compileWithVariableValues(actionResultOperation);
+};
+
+const globalActionFieldSelection = () => {
+  return {
+    success: true,
+    errors: ErrorsSelection,
+    result: true,
+  } as FieldSelection;
 };
 
 export const globalActionOperation = (
@@ -218,11 +232,7 @@ export const globalActionOperation = (
   options?: { live?: boolean }
 ) => {
   let fields: BuilderFieldSelection = {
-    [operation]: Call(variableOptionsToVariables(variables), {
-      success: true,
-      errors: ErrorsSelection,
-      result: true,
-    }),
+    [operation]: Call(variableOptionsToVariables(variables), globalActionFieldSelection()),
   };
 
   const dataPath = [operation];

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -198,7 +198,7 @@ export const actionResultOperation = <Action extends AnyActionFunction, Options 
   }
 
   const actionResultOperation: BuilderOperation = {
-    type: "query",
+    type: "subscription",
     name: action.operationName,
     fields: {
       backgroundAction: Call(

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -200,7 +200,9 @@ export const actionResultOperation = <Action extends AnyActionFunction, Options 
         {
           id: true,
           outcome: true,
-          ...fields,
+          result: {
+            ...fields
+          }
         }
       ),
     },

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -293,7 +293,7 @@ export const actionResultRunner = async <Action extends AnyActionFunction, Optio
   // If we have an outcome we should process the result accordingly
   if (backgroundAction.outcome) {
     // Check for errors in the action result and throw
-    assertResponseSuccess(backgroundAction);
+    assertResponseSuccess(backgroundAction.result);
 
     switch (action.type) {
       case "action": {

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -20,6 +20,7 @@ import {
   assertMutationSuccess,
   assertNullableOperationSuccess,
   assertOperationSuccess,
+  assertResponseSuccess,
   disambiguateActionVariables,
   disambiguateBulkActionVariables,
   gadgetErrorFor,
@@ -278,9 +279,7 @@ export const enqueueActionRunner = async <Action extends AnyActionFunction>(
   }
 };
 
-export const actionResultRunner = async <
-  Action extends AnyActionFunction,
-  Options extends ActionFunctionOptions<Action>>(
+export const actionResultRunner = async <Action extends AnyActionFunction, Options extends ActionFunctionOptions<Action>>(
   connection: GadgetConnection,
   id: string,
   action: Action,
@@ -293,6 +292,9 @@ export const actionResultRunner = async <
 
   // If we have an outcome we should process the result accordingly
   if (backgroundAction.outcome) {
+    // Check for errors in the action result and throw
+    assertResponseSuccess(backgroundAction);
+
     switch (action.type) {
       case "action": {
         backgroundAction.result = processActionResponse(

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -296,7 +296,7 @@ export const actionResultRunner = async <Action extends AnyActionFunction, Optio
         backgroundAction.result = processActionResponse(
           action.defaultSelection,
           response,
-          get(response, [action.modelSelectionField]),
+          get(backgroundAction.result, [action.modelSelectionField]),
           action.hasReturnType
         )
       }

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -1,5 +1,5 @@
-import { OperationResult } from "@urql/core";
-import { BackgroundActionHandle, BackgroundActionResult } from "./BackgroundActionHandle.js";
+import type { BackgroundActionResult } from "./BackgroundActionHandle.js";
+import { BackgroundActionHandle } from "./BackgroundActionHandle.js";
 import type { FieldSelection } from "./FieldSelection.js";
 import type { GadgetConnection } from "./GadgetConnection.js";
 import type { AnyActionFunction } from "./GadgetFunctions.js";
@@ -234,7 +234,7 @@ const processActionResponse = <Shape extends RecordShape = any>(
   } else {
     return record.result;
   }
-}
+};
 
 export const globalActionRunner = async (
   connection: GadgetConnection,
@@ -278,7 +278,9 @@ export const enqueueActionRunner = async <Action extends AnyActionFunction>(
   }
 };
 
-export const actionResultRunner = async <Action extends AnyActionFunction, Options extends ActionFunctionOptions<Action>, Shape extends RecordShape = any>(
+export const actionResultRunner = async <
+  Action extends AnyActionFunction,
+  Options extends ActionFunctionOptions<Action>>(
   connection: GadgetConnection,
   id: string,
   action: Action,
@@ -291,14 +293,18 @@ export const actionResultRunner = async <Action extends AnyActionFunction, Optio
 
   // If we have an outcome we should process the result accordingly
   if (backgroundAction.outcome) {
-    switch(action.type) {
+    switch (action.type) {
       case "action": {
         backgroundAction.result = processActionResponse(
           action.defaultSelection,
           response,
           get(backgroundAction.result, [action.modelSelectionField]),
           action.hasReturnType
-        )
+        );
+        break;
+      }
+      case "globalAction": {
+        backgroundAction.result = backgroundAction.result.result;
       }
     }
   }

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -1,4 +1,4 @@
-import { BackgroundActionHandle } from "./BackgroundActionHandle.js";
+import { BackgroundActionHandle, BackgroundActionResult } from "./BackgroundActionHandle.js";
 import type { FieldSelection } from "./FieldSelection.js";
 import type { GadgetConnection } from "./GadgetConnection.js";
 import type { AnyActionFunction } from "./GadgetFunctions.js";
@@ -272,7 +272,7 @@ export const actionResultRunner = async <Action extends AnyActionFunction, Optio
   id: string,
   action: Action,
   options?: Options
-) => {
+): Promise<BackgroundActionResult> => {
   const plan = actionResultOperation(id, action, options);
   const response = await connection.currentClient.query(plan.query, plan.variables).toPromise();
 

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -288,12 +288,14 @@ export const actionResultRunner = async <Action extends AnyActionFunction, Optio
 ): Promise<BackgroundActionResult> => {
   const plan = actionResultOperation(id, action, options);
   const subscription = connection.currentClient.subscription(plan.query, plan.variables);
+
   const response = await pipe(
     subscription,
-    filter((operation) => operation.data?.backgroundAction?.outcome),
+    filter((operation) => operation.error || operation.data?.backgroundAction?.outcome),
     take(1),
     toPromise
   );
+
   const backgroundAction = assertOperationSuccess(response, ["backgroundAction"]);
 
   assertResponseSuccess(backgroundAction.result);

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -1,10 +1,10 @@
 import type { OperationResult } from "@urql/core";
 import { CombinedError } from "@urql/core";
 import { DataHydrator } from "./DataHydrator.js";
-import { ActionFunctionMetadata, AnyActionFunction } from "./GadgetFunctions.js";
+import type { ActionFunctionMetadata, AnyActionFunction } from "./GadgetFunctions.js";
 import type { RecordShape } from "./GadgetRecord.js";
 import { GadgetRecord } from "./GadgetRecord.js";
-import { VariablesOptions } from "./types.js";
+import type { VariablesOptions } from "./types.js";
 
 /**
  * Generic type of the state of any record of a Gadget model
@@ -351,6 +351,10 @@ export const gadgetErrorFor = (error: Record<string, any>) => {
 export const assertMutationSuccess = (response: OperationResult<any>, dataPath: string[]) => {
   const operationResponse = assertOperationSuccess(response, dataPath);
 
+  return assertResponseSuccess(operationResponse);
+};
+
+export const assertResponseSuccess = (operationResponse: any) => {
   if (!operationResponse.success) {
     const firstErrorBlob = operationResponse.errors && operationResponse.errors[0];
     if (firstErrorBlob) {

--- a/packages/react/src/useEnqueue.ts
+++ b/packages/react/src/useEnqueue.ts
@@ -97,7 +97,7 @@ const processResult = <Action extends AnyActionFunction>(
       if (errors && errors[0]) {
         error = ErrorWrapper.forErrorsResponse(errors, error?.response);
       } else {
-        handle = new BackgroundActionHandle<Action>(connection, mutationData.backgroundAction.id, {});
+        handle = new BackgroundActionHandle<Action>(connection, action, mutationData.backgroundAction.id, {});
       }
     }
   }


### PR DESCRIPTION
Uses a subscription endpoint on gadget (https://github.com/gadget-inc/gadget/pull/10364) to get the background action result. 

We are waiting on the subscription for the first pushed result that either has an outcome set or contains an error (for example permission error) and processes the responses in the same way as the "api" version of the actions. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
