### PR TITLE
Throw only if app bridge undefined and embedded in admin

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
+++ b/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
@@ -214,6 +214,12 @@ describe("GadgetProvider", () => {
     test("should throw if embedded app type is in embedded context and shopify global is not defined", () => {
       // @ts-expect-error mock
       const windowSelf = jest.spyOn(window, "self", "get").mockImplementation(() => ({}));
+      // @ts-expect-error mock
+      const windowTop = jest.spyOn(window, "top", "get").mockImplementation(() => ({
+        location: {
+          href: "https://admin.shopify.com/store/some-test-shop/apps/fake-app",
+        },
+      }));
       // @ts-expect-error reset mock
       window.shopify = undefined;
 
@@ -229,6 +235,7 @@ describe("GadgetProvider", () => {
 
       // resetting the mocked values
       windowSelf.mockRestore();
+      windowTop.mockRestore();
       window.shopify = {
         // @ts-expect-error mock
         environment: {

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -234,10 +234,15 @@ export const Provider = ({ type, children, api }: { type?: AppType; children: Re
     isReady,
   });
 
-  if (coalescedType == AppType.Embedded && !shopifyGlobalDefined && globalThis.top !== globalThis.self) {
-    throw new Error(
-      "Expected app bridge to be defined in embedded context, but it was not. This is likely due to a missing script tag, see https://shopify.dev/docs/api/app-bridge-library"
-    );
+  if (coalescedType == AppType.Embedded && !shopifyGlobalDefined && globalThis.top && globalThis.top !== globalThis.self) {
+    const topHref = globalThis.top.location.href;
+    const url = new URL(topHref);
+
+    if (url.hostname === "admin.shopify.com") {
+      throw new Error(
+        "Expected app bridge to be defined in embedded context, but it was not. This is likely due to a missing script tag, see https://shopify.dev/docs/api/app-bridge-library"
+      );
+    }
   }
 
   if (coalescedType === AppType.Embedded && globalThis.top === globalThis.self) {


### PR DESCRIPTION
We should only throw this error if the app is embedded, missing app bridge, and we're embedded in shopify admin. Ran into some issues with cypress tests in gadget since cypress is also an iframe

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
