### PR TITLE
Remove options parameter from BackgroundActionHandle

### DIFF
--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -1,7 +1,7 @@
 import type { GadgetConnection } from "./GadgetConnection.js";
 import type { AnyActionFunction } from "./GadgetFunctions.js";
 import { actionResultRunner } from "./operationRunners.js";
-import type { ActionFunctionOptions, EnqueueBackgroundActionOptions } from "./types.js";
+import type { ActionFunctionOptions } from "./types.js";
 
 export type BackgroundActionResult<R = any> = {
   id: string;
@@ -11,12 +11,7 @@ export type BackgroundActionResult<R = any> = {
 
 /** Represents a handle to a background action which has been enqueued */
 export class BackgroundActionHandle<Action extends AnyActionFunction> {
-  constructor(
-    readonly connection: GadgetConnection,
-    readonly action: Action,
-    readonly id: string,
-    readonly options: EnqueueBackgroundActionOptions<Action>
-  ) {}
+  constructor(readonly connection: GadgetConnection, readonly action: Action, readonly id: string) {}
 
   /** Wait for this background action to complete and return the result. */
   async result<Options extends ActionFunctionOptions<Action>>(options?: Options) {

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -271,10 +271,10 @@ export const enqueueActionRunner = async <Action extends AnyActionFunction>(
 
   try {
     const result = assertMutationSuccess(response, dataPath);
-    return new BackgroundActionHandle(connection, action, result.backgroundAction.id, options);
+    return new BackgroundActionHandle(connection, action, result.backgroundAction.id);
   } catch (error: any) {
     if ("code" in error && error.code == "GGT_DUPLICATE_BACKGROUND_ACTION_ID" && options?.id && options.onDuplicateID == "ignore") {
-      return new BackgroundActionHandle(connection, action, options.id, options);
+      return new BackgroundActionHandle(connection, action, options.id);
     }
     throw error;
   }

--- a/packages/react/src/useEnqueue.ts
+++ b/packages/react/src/useEnqueue.ts
@@ -97,7 +97,7 @@ const processResult = <Action extends AnyActionFunction>(
       if (errors && errors[0]) {
         error = ErrorWrapper.forErrorsResponse(errors, error?.response);
       } else {
-        handle = new BackgroundActionHandle<Action>(connection, action, mutationData.backgroundAction.id, {});
+        handle = new BackgroundActionHandle<Action>(connection, action, mutationData.backgroundAction.id);
       }
     }
   }


### PR DESCRIPTION
This removes the `options` parameter from `BackgroundActionHandle` which was previously accepting the options that the job was enqueued with. The parameter is not being used anywhere right now and is the same object that is called with `enqueue`. Having this parameter as required makes it harder to implement the construction of a handle from just an ID as the options are not necessarily known. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
