### PR TITLE
Fix result processing

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.17",
+  "version": "0.15.18",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -106,6 +106,46 @@ describe("operationRunners", () => {
       expect(result.name).toBeTruthy();
     });
 
+    test("can run an action with hasReturnType", async () => {
+      const promise = actionRunner(
+        {
+          connection,
+        },
+        "createWidget",
+        { id: true, name: true },
+        "widget",
+        "widget",
+        false,
+        {
+          widget: {
+            value: { name: "hello" },
+            required: false,
+            type: "CreateWidgetInput",
+          },
+        },
+        {},
+        null,
+        true
+      );
+
+      mockUrqlClient.executeMutation.pushResponse("createWidget", {
+        data: {
+          createWidget: {
+            success: true,
+            errors: null,
+            result: {
+              result: "ok"
+            }
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.result).toEqual("ok");
+    });
+
     test("can throw the error returned by the server for a single action", async () => {
       const promise = actionRunner<{ id: string; name: string }>(
         {

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -134,8 +134,8 @@ describe("operationRunners", () => {
             success: true,
             errors: null,
             result: {
-              result: "ok"
-            }
+              result: "ok",
+            },
           },
         },
         stale: false,

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -206,7 +206,7 @@ export const actionRunner: ActionRunner = async <Shape extends RecordShape = any
   if (!isBulkAction) {
     const mutationTriple = assertMutationSuccess(response, dataPath);
 
-    return processActionResponse(defaultSelection, response, mutationTriple[modelSelectionField], hasReturnType);
+    return processActionResponse(defaultSelection, response, mutationTriple, modelSelectionField, hasReturnType);
   } else {
     const mutationTriple = get(response.data, dataPath);
     const results =
@@ -226,13 +226,14 @@ const processActionResponse = <Shape extends RecordShape = any>(
   defaultSelection: FieldSelection | null,
   response: any,
   record: any,
+  modelSelectionField: string,
   hasReturnType?: boolean | null
 ) => {
   // Delete actions have a null selection. We do an early return for this because `hydrateRecordArray` will fail
   // if there's nothing at `mutationResult[modelSelectionField]`, but the caller isn't expecting a return (void).
   if (defaultSelection == null) return;
   if (!hasReturnType) {
-    return hydrateRecord<Shape>(response, record);
+    return hydrateRecord<Shape>(response, record[modelSelectionField]);
   } else {
     return record.result;
   }
@@ -305,7 +306,8 @@ export const actionResultRunner = async <Action extends AnyActionFunction, Optio
       backgroundAction.result = processActionResponse(
         action.defaultSelection,
         response.data,
-        get(backgroundAction.result, [action.modelSelectionField]),
+        backgroundAction.result,
+        action.modelSelectionField,
         action.hasReturnType
       );
       break;


### PR DESCRIPTION
Caught a case that I had broken with https://github.com/gadget-inc/js-clients/pull/322 where the result was not properly being accessed. Unfortunately this case where `hasReturnType` being true had no tests so was not caught during refactoring. 

I don't know if its possible to re-release the version; whether this happens automatically or I need to bump the version again.


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
