### PR TITLE
Support startAt parameter to BackgroundActionOptions

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.18",
+  "version": "0.15.19",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -613,7 +613,7 @@ describe("operation builders", () => {
     });
 
     test("enqueueActionOperation with startsAt as string", () => {
-      expect(enqueueActionOperation("createWidget", {}, undefined, { startsAt: "2024-03-18T18:14:08.257Z" })).toMatchInlineSnapshot(`
+      expect(enqueueActionOperation("createWidget", {}, undefined, { startAt: "2024-03-18T18:14:08.257Z" })).toMatchInlineSnapshot(`
         {
           "query": "mutation enqueueCreateWidget($backgroundOptions: EnqueueBackgroundActionOptions) {
           background {
@@ -631,7 +631,7 @@ describe("operation builders", () => {
         }",
           "variables": {
             "backgroundOptions": {
-              "startsAt": "2024-03-18T18:14:08.257Z",
+              "startAt": "2024-03-18T18:14:08.257Z",
             },
           },
         }
@@ -639,7 +639,7 @@ describe("operation builders", () => {
     });
 
     test("enqueueActionOperation with startsAt as Date", () => {
-      expect(enqueueActionOperation("createWidget", {}, undefined, { startsAt: new Date("2024-03-18T18:14:08.257Z") }))
+      expect(enqueueActionOperation("createWidget", {}, undefined, { startAt: new Date("2024-03-18T18:14:08.257Z") }))
         .toMatchInlineSnapshot(`
         {
           "query": "mutation enqueueCreateWidget($backgroundOptions: EnqueueBackgroundActionOptions) {
@@ -658,7 +658,7 @@ describe("operation builders", () => {
         }",
           "variables": {
             "backgroundOptions": {
-              "startsAt": "2024-03-18T18:14:08.257Z",
+              "startAt": "2024-03-18T18:14:08.257Z",
             },
           },
         }

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -611,6 +611,59 @@ describe("operation builders", () => {
         }
       `);
     });
+
+    test("enqueueActionOperation with startsAt as string", () => {
+      expect(enqueueActionOperation("createWidget", {}, undefined, { startsAt: "2024-03-18T18:14:08.257Z" })).toMatchInlineSnapshot(`
+        {
+          "query": "mutation enqueueCreateWidget($backgroundOptions: EnqueueBackgroundActionOptions) {
+          background {
+            createWidget(backgroundOptions: $backgroundOptions) {
+              success
+              errors {
+                message
+                code
+              }
+              backgroundAction {
+                id
+              }
+            }
+          }
+        }",
+          "variables": {
+            "backgroundOptions": {
+              "startsAt": "2024-03-18T18:14:08.257Z",
+            },
+          },
+        }
+      `);
+    });
+
+    test("enqueueActionOperation with startsAt as Date", () => {
+      expect(enqueueActionOperation("createWidget", {}, undefined, { startsAt: new Date("2024-03-18T18:14:08.257Z") }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "mutation enqueueCreateWidget($backgroundOptions: EnqueueBackgroundActionOptions) {
+          background {
+            createWidget(backgroundOptions: $backgroundOptions) {
+              success
+              errors {
+                message
+                code
+              }
+              backgroundAction {
+                id
+              }
+            }
+          }
+        }",
+          "variables": {
+            "backgroundOptions": {
+              "startsAt": "2024-03-18T18:14:08.257Z",
+            },
+          },
+        }
+      `);
+    });
   });
 
   describe("actionResultOperation", () => {

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -265,8 +265,13 @@ export const graphqlizeBackgroundOptions = (options?: EnqueueBackgroundActionOpt
       name: obj.queue,
     };
   }
+
+  if (obj.startsAt instanceof Date) {
+    obj.startsAt = obj.startsAt.toISOString();
+  }
+
   for (const key of Object.keys(obj)) {
-    if (["id", "retries", "queue", "priority"].includes(key)) continue;
+    if (["id", "retries", "queue", "priority", "startsAt"].includes(key)) continue;
     delete obj[key];
   }
 

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -266,12 +266,12 @@ export const graphqlizeBackgroundOptions = (options?: EnqueueBackgroundActionOpt
     };
   }
 
-  if (obj.startsAt instanceof Date) {
-    obj.startsAt = obj.startsAt.toISOString();
+  if (obj.startAt instanceof Date) {
+    obj.startAt = obj.startAt.toISOString();
   }
 
   for (const key of Object.keys(obj)) {
-    if (["id", "retries", "queue", "priority", "startsAt"].includes(key)) continue;
+    if (["id", "retries", "queue", "priority", "startAt"].includes(key)) continue;
     delete obj[key];
   }
 

--- a/packages/api-client-core/src/types.ts
+++ b/packages/api-client-core/src/types.ts
@@ -1,4 +1,4 @@
-import { OperationContext } from "@urql/core";
+import type { OperationContext } from "@urql/core";
 import type { VariableOptions } from "tiny-graphql-query-compiler";
 import type { FieldSelection } from "./FieldSelection.js";
 import type { ActionFunction, AnyActionFunction, BulkActionFunction, GlobalActionFunction } from "./GadgetFunctions.js";
@@ -858,6 +858,18 @@ export type EnqueueBackgroundActionOptions<Action extends AnyActionFunction> = {
    * - `error` will throw the GGT_DUPLICATE_BACKGROUND_ACTION_ID error for the caller to handle
    */
   onDuplicateID?: "ignore" | "error";
+
+  /**
+   * Schedules the background action to run in the future after this datetime.
+   *
+   * @example
+   * startAt: "2024-03-18T18:14:08.257Z"
+   *
+   * @example
+   * // Start in 60 seconds from now
+   * startAt: new Date(new Date().getTime() + 60 * 1000)
+   */
+  startsAt?: Date | string;
 } & Partial<OperationContext>;
 
 export type ActionFunctionOptions<Action extends AnyActionFunction> = Action extends ActionFunction<infer Options, any, any, any, any>

--- a/packages/api-client-core/src/types.ts
+++ b/packages/api-client-core/src/types.ts
@@ -869,7 +869,7 @@ export type EnqueueBackgroundActionOptions<Action extends AnyActionFunction> = {
    * // Start in 60 seconds from now
    * startAt: new Date(new Date().getTime() + 60 * 1000)
    */
-  startsAt?: Date | string;
+  startAt?: Date | string;
 } & Partial<OperationContext>;
 
 export type ActionFunctionOptions<Action extends AnyActionFunction> = Action extends ActionFunction<infer Options, any, any, any, any>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.16",
+    "@gadgetinc/api-client-core": "^0.15.19",
     "react-fast-compare": "^3.2.2",
     "react-hook-form": "~7.48.2",
     "tslib": "^2.6.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/spec/useEnqueue.spec.tsx
+++ b/packages/react/spec/useEnqueue.spec.tsx
@@ -1,4 +1,4 @@
-import { BackgroundActionHandle } from "@gadgetinc/api-client-core";
+import type { BackgroundActionHandle } from "@gadgetinc/api-client-core";
 import { act, renderHook } from "@testing-library/react";
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
@@ -205,10 +205,13 @@ describe("useEnqueue", () => {
 
   test("can pass background options as a second argument to the enqueue function", async () => {
     const { result } = renderHook(() => useEnqueue(relatedProductsApi.user.update), { wrapper: MockClientWrapper(relatedProductsApi) });
-
+    const startAt = new Date(new Date().getTime() + 1000);
     let mutationPromise: any;
     act(() => {
-      mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } }, { priority: "high", retries: 5 });
+      mutationPromise = result.current[1](
+        { id: "123", user: { email: "test@test.com" } },
+        { priority: "high", retries: 5, startAt: startAt }
+      );
     });
 
     expect(result.current[0].handle).toBeFalsy();
@@ -218,7 +221,7 @@ describe("useEnqueue", () => {
     expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
     expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
-      backgroundOptions: { priority: "high", retries: { retryCount: 5 } },
+      backgroundOptions: { priority: "high", retries: { retryCount: 5 }, startAt: startAt.toISOString() },
       id: "123",
       user: { email: "test@test.com" },
     });


### PR DESCRIPTION
Adds support for `startAt` option to enqueuing background actions to allow them to be scheduled into the future. This is already supported by the graphql api inside gadget. For convenience I am allowing both ISO strings and `Date` objects that will automatically be converted. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
