### PR TITLE
use document.referrer instead of window.top

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
+++ b/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
@@ -214,12 +214,9 @@ describe("GadgetProvider", () => {
     test("should throw if embedded app type is in embedded context and shopify global is not defined", () => {
       // @ts-expect-error mock
       const windowSelf = jest.spyOn(window, "self", "get").mockImplementation(() => ({}));
-      // @ts-expect-error mock
-      const windowTop = jest.spyOn(window, "top", "get").mockImplementation(() => ({
-        location: {
-          href: "https://admin.shopify.com/store/some-test-shop/apps/fake-app",
-        },
-      }));
+      const documentMock = jest
+        .spyOn(document, "referrer", "get")
+        .mockImplementation(() => "https://admin.shopify.com/store/some-test-shop/apps/fake-app");
       // @ts-expect-error reset mock
       window.shopify = undefined;
 
@@ -235,7 +232,7 @@ describe("GadgetProvider", () => {
 
       // resetting the mocked values
       windowSelf.mockRestore();
-      windowTop.mockRestore();
+      documentMock.mockRestore();
       window.shopify = {
         // @ts-expect-error mock
         environment: {

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -235,10 +235,21 @@ export const Provider = ({ type, children, api }: { type?: AppType; children: Re
   });
 
   if (coalescedType == AppType.Embedded && !shopifyGlobalDefined && globalThis.top && globalThis.top !== globalThis.self) {
-    const topHref = globalThis.top.location.href;
-    const url = new URL(topHref);
+    let url: URL | undefined = undefined;
 
-    if (url.hostname === "admin.shopify.com") {
+    try {
+      const topHref = document.referrer;
+      url = new URL(topHref);
+    } catch (e) {
+      const event = new CustomEvent("gadget:devharness:rsab.invalidReferrer", {
+        detail: {
+          url: document.referrer,
+        },
+      });
+      globalThis.dispatchEvent(event);
+    }
+
+    if (url && url.hostname === "admin.shopify.com") {
       throw new Error(
         "Expected app bridge to be defined in embedded context, but it was not. This is likely due to a missing script tag, see https://shopify.dev/docs/api/app-bridge-library"
       );


### PR DESCRIPTION
`window.top.href` throws an error if you try to access it cross origin so I think the best we can do is to check `document.referrer`. ran through ci in gadget

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
