### PR TITLE
Allow pagination parameters to be passed through select option

### DIFF
--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -550,6 +550,91 @@ describe("operation builders", () => {
         }
       `);
     });
+
+    test("findManyOperation can select field called edges", () => {
+      const select = {
+        id: true,
+        edges: true,
+      };
+
+      expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+                edges
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+    test("findManyOperation can select field called edges on nested connection", () => {
+      const select = {
+        id: true,
+        state: true,
+        posts: {
+          edges: {
+            node: {
+              id: true,
+              edges: true,
+            },
+          },
+        },
+      };
+
+      expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+                state
+                posts {
+                  edges {
+                    node {
+                      id
+                      edges
+                    }
+                  }
+                }
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
   });
 
   describe("findOneByFieldOperation", () => {

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -71,6 +71,114 @@ describe("operation builders", () => {
         }
       `);
     });
+
+    test("findOneOperation can select connection with pagination arguments", () => {
+      const select = {
+        id: true,
+        state: true,
+        posts: {
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: true,
+            startCursor: true,
+            endCursor: true,
+          },
+          before: "before_cursor",
+          after: "after_cursor",
+          first: 10,
+          last: 5,
+          edges: {
+            node: {
+              id: true,
+            },
+          },
+        },
+      };
+
+      expect(findOneOperation("widget", "123", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widget($id: GadgetID!) {
+          widget(id: $id) {
+            id
+            state
+            posts(before: "before_cursor", after: "after_cursor", first: 10, last: 5) {
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+            __typename
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {
+            "id": "123",
+          },
+        }
+      `);
+    });
+
+    test("findOneOperation can select connection with no pagination arguments", () => {
+      const select = {
+        id: true,
+        state: true,
+        posts: {
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: true,
+            startCursor: true,
+            endCursor: true,
+          },
+          edges: {
+            node: {
+              id: true,
+            },
+          },
+        },
+      };
+
+      expect(findOneOperation("widget", "123", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widget($id: GadgetID!) {
+          widget(id: $id) {
+            id
+            state
+            posts {
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+            __typename
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {
+            "id": "123",
+          },
+        }
+      `);
+    });
   });
 
   describe("findManyOperation", () => {
@@ -256,6 +364,181 @@ describe("operation builders", () => {
                 __typename
                 id
                 state
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("findManyOperation can select connection with pagination arguments", () => {
+      const select = {
+        id: true,
+        state: true,
+        posts: {
+          before: "before_cursor",
+          after: "after_cursor",
+          first: 10,
+          last: 5,
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: true,
+            startCursor: true,
+            endCursor: true,
+          },
+          edges: {
+            node: {
+              id: true,
+            },
+          },
+        },
+      };
+
+      expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+                state
+                posts(before: "before_cursor", after: "after_cursor", first: 10, last: 5) {
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("findManyOperation can select connection with no pagination arguments", () => {
+      const select = {
+        id: true,
+        state: true,
+        posts: {
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: true,
+            startCursor: true,
+            endCursor: true,
+          },
+          edges: {
+            node: {
+              id: true,
+            },
+          },
+        },
+      };
+
+      expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+                state
+                posts {
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("findManyOperation can select connection without pageInfo", () => {
+      const select = {
+        id: true,
+        state: true,
+        posts: {
+          edges: {
+            node: {
+              id: true,
+            },
+          },
+        },
+      };
+
+      expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+                state
+                posts {
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+                __typename
               }
             }
           }

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -693,8 +693,8 @@ describe("operation builders", () => {
         id: true,
         state: true,
         child: {
-          edges: true
-        }
+          edges: true,
+        },
       };
 
       expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { select: select }))

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -687,6 +687,47 @@ describe("operation builders", () => {
         }
       `);
     });
+
+    test("findManyOperation can select belongs to with field called edges", () => {
+      const select = {
+        id: true,
+        state: true,
+        child: {
+          edges: true
+        }
+      };
+
+      expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+                state
+                child {
+                  edges
+                }
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
   });
 
   describe("findOneByFieldOperation", () => {

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -585,6 +585,7 @@ describe("operation builders", () => {
         }
       `);
     });
+
     test("findManyOperation can select field called edges on nested connection", () => {
       const select = {
         id: true,
@@ -616,6 +617,57 @@ describe("operation builders", () => {
                 id
                 state
                 posts {
+                  edges {
+                    node {
+                      id
+                      edges
+                    }
+                  }
+                }
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("findManyOperation can select connection called edges", () => {
+      const select = {
+        id: true,
+        state: true,
+        edges: {
+          edges: {
+            node: {
+              id: true,
+              edges: true,
+            },
+          },
+        },
+      };
+
+      expect(findManyOperation("widgets", { __typename: true, id: true, state: true }, "widget", { select: select }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                id
+                state
+                edges {
                   edges {
                     node {
                       id

--- a/packages/api-client-core/src/FieldSelection.ts
+++ b/packages/api-client-core/src/FieldSelection.ts
@@ -22,7 +22,7 @@ export interface EdgeFieldSelection {
 }
 
 function isEdgeConnection(selection: FieldSelection | ConnectionFieldSelection): boolean {
-  return ("edges" in selection && typeof selection["edges"] == "object");
+  return "edges" in selection && typeof selection["edges"] == "object";
 }
 
 export function isFieldSelection(selection: FieldSelectionType): selection is FieldSelection {

--- a/packages/api-client-core/src/FieldSelection.ts
+++ b/packages/api-client-core/src/FieldSelection.ts
@@ -3,5 +3,28 @@
  * Example: `{ id: true, name: false, richText: { markdown: true, html: false } }`
  **/
 export interface FieldSelection {
-  [key: string]: boolean | null | undefined | FieldSelection;
+  [key: string]: FieldSelectionType;
+}
+
+export type FieldSelectionType = boolean | null | undefined | FieldSelection | ConnectionFieldSelection;
+
+export interface ConnectionFieldSelection {
+  before?: string;
+  after?: string;
+  first?: number;
+  last?: number;
+  pageInfo?: FieldSelection;
+  edges: EdgeFieldSelection;
+}
+
+export interface EdgeFieldSelection {
+  node: FieldSelection;
+}
+
+export function isFieldSelection(selection: FieldSelectionType): selection is FieldSelection {
+  return !!(selection && typeof selection == "object" && !("edges" in selection));
+}
+
+export function isConnectionFieldSelection(selection: FieldSelectionType): selection is ConnectionFieldSelection {
+  return !!(selection && typeof selection == "object" && "edges" in selection);
 }

--- a/packages/api-client-core/src/FieldSelection.ts
+++ b/packages/api-client-core/src/FieldSelection.ts
@@ -21,10 +21,14 @@ export interface EdgeFieldSelection {
   node: FieldSelection;
 }
 
+function isEdgeConnection(selection: FieldSelection | ConnectionFieldSelection): boolean {
+  return ("edges" in selection && typeof selection["edges"] == "object");
+}
+
 export function isFieldSelection(selection: FieldSelectionType): selection is FieldSelection {
-  return !!(selection && typeof selection == "object" && !("edges" in selection));
+  return !!(selection && typeof selection == "object" && !isEdgeConnection(selection));
 }
 
 export function isConnectionFieldSelection(selection: FieldSelectionType): selection is ConnectionFieldSelection {
-  return !!(selection && typeof selection == "object" && "edges" in selection);
+  return !!(selection && typeof selection == "object" && isEdgeConnection(selection));
 }

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -16,7 +16,7 @@ const hydrationOptions = (modelApiIdentifier: string): BuilderFieldSelection => 
 /**
  * Converts Selection nested object format to the tiny-graphql-query-compiler shape
  **/
-export const fieldSelectionToQueryCompilerFields = (selection: FieldSelection, includeTypename = false): BuilderFieldSelection => {
+const fieldSelectionToQueryCompilerFields = (selection: FieldSelection, includeTypename = false): BuilderFieldSelection => {
   const output: BuilderFieldSelection = compileSelection(selection);
   if (includeTypename) output.__typename = true;
   return output;


### PR DESCRIPTION
A problem faced is with pagination of `has many` relationships. The root nodes are paginated using a cursor based paginator where as the nested `has many` relationships are paginated with an offset paginator. This means passing the cursor from a has many connection back to a root query will raise an error. 

## Example

We want to paginate through all the comments for a given post. 

```graphql
query PostWithComments($id: GadgetID!) {
  post(id: $id) {
    id
    comments {
      pageInfo {
        endCursor
        hasNextPage
      }
      edges {
        node {
          id
        }
      }
    }
  }
}
```

Passing the `endCursor` to a `findMany` will fail. Instead we need to get the next page of comments for this given post. 

```graphql
query PostWithComments($id: GadgetID!) {
  post(id: $id) {
    id
    comments(after: "cursor") {
      pageInfo {
        endCursor
        hasNextPage
      }
      edges {
        node {
          id
        }
      }
    }
  }
}
```

## Solution

Technically this is already possible to do today with the API however you need to use the `tiny-query-graph-compiler` directly with the `Call`. This change introduces some specific keys that if present are automatically extracted into the `Call`.  

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
