### PR TITLE
Unify on the same version of json-patch-plus

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@manufac/repeater": "^4.0.6",
     "@n1ru4l/graphql-live-query": "^0.10.0",
-    "@n1ru4l/json-patch-plus": "^0.1.2",
+    "@n1ru4l/json-patch-plus": "^0.2.0",
     "@n1ru4l/push-pull-async-iterable-iterator": "^3.2.0",
     "@urql/core": "^4.0.10",
     "cross-fetch": "^3.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.10.0
         version: 0.10.0(graphql@16.8.1)
       '@n1ru4l/json-patch-plus':
-        specifier: ^0.1.2
-        version: 0.1.4
+        specifier: ^0.2.0
+        version: 0.2.0
       '@n1ru4l/push-pull-async-iterable-iterator':
         specifier: ^3.2.0
         version: 3.2.0
@@ -1839,13 +1839,8 @@ packages:
       graphql: 16.8.1
     dev: false
 
-  /@n1ru4l/json-patch-plus@0.1.4:
-    resolution: {integrity: sha512-VJSHZGg0cDud4t0mvfigFtd0fg/PMrTfmXWaJrBK7y6hdCEFT3rFq6Sw7SEb58tP0lveNCDqL14joc+MuZ+bsw==}
-    dev: false
-
   /@n1ru4l/json-patch-plus@0.2.0:
     resolution: {integrity: sha512-pLkJy83/rVfDTyQgDSC8GeXAHEdXNHGNJrB1b7wAyGQu0iv7tpMXntKVSqj0+XKNVQbco40SZffNfVALzIt0SQ==}
-    dev: true
 
   /@n1ru4l/push-pull-async-iterable-iterator@3.2.0:
     resolution: {integrity: sha512-3fkKj25kEjsfObL6IlKPAlHYPq/oYwUkkQ03zsTTiDjD7vg/RxjdiLeCydqtxHZP0JgsXL3D/X5oAkMGzuUp/Q==}


### PR DESCRIPTION
Don't want to depend on multiple different ones and inflate the bundle size

## PR Checklist

- [X] Important or complicated code is tested
- [X] Any user facing changes are documented in the Gadget-side changelog
- [X] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [X] Versions within this monorepo are matching and there's a valid upgrade path
