### PR TITLE
Remove Repeater dep

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -28,7 +28,6 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@manufac/repeater": "^4.0.6",
     "@n1ru4l/graphql-live-query": "^0.10.0",
     "@n1ru4l/json-patch-plus": "^0.2.0",
     "@n1ru4l/push-pull-async-iterable-iterator": "^3.2.0",

--- a/packages/api-client-core/spec/repeater.spec.ts
+++ b/packages/api-client-core/spec/repeater.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests adopted from https://github.com/repeaterjs/repeater/blob/master/packages/repeater/src/__tests__/repeater.ts.
+ */
+
 import {
     Repeater,
     RepeaterOverflowError,

--- a/packages/api-client-core/spec/repeater.spec.ts
+++ b/packages/api-client-core/spec/repeater.spec.ts
@@ -1,0 +1,1626 @@
+import {
+    Repeater,
+    RepeaterOverflowError,
+    DroppingBuffer,
+    FixedBuffer,
+    MAX_QUEUE_LENGTH,
+    SlidingBuffer,
+} from "../src/repeater/index.js";
+import { delayPromise } from "./helpers.js";
+
+
+describe("RepeaterBuffer", () => {
+    test("FixedBuffer", () => {
+        const buffer = new FixedBuffer(2);
+        expect([buffer.empty, buffer.full]).toEqual([true, false]);
+        buffer.add(1);
+        expect([buffer.empty, buffer.full]).toEqual([false, false]);
+        buffer.add(2);
+        expect([buffer.empty, buffer.full]).toEqual([false, true]);
+        expect(() => buffer.add(3)).toThrow();
+        expect(buffer.remove()).toEqual(1);
+        expect([buffer.empty, buffer.full]).toEqual([false, false]);
+        expect(buffer.remove()).toEqual(2);
+        expect([buffer.empty, buffer.full]).toEqual([true, false]);
+        expect(() => buffer.remove()).toThrow();
+    });
+
+    test("SlidingBuffer", () => {
+        const buffer = new SlidingBuffer(2);
+        expect([buffer.empty, buffer.full]).toEqual([true, false]);
+        buffer.add(1);
+        buffer.add(2);
+        buffer.add(3);
+        buffer.add(4);
+        buffer.add(5);
+        expect([buffer.empty, buffer.full]).toEqual([false, false]);
+        expect(buffer.remove()).toEqual(4);
+        expect(buffer.remove()).toEqual(5);
+        expect([buffer.empty, buffer.full]).toEqual([true, false]);
+        expect(() => buffer.remove()).toThrow();
+    });
+
+    test("DroppingBuffer", () => {
+        const buffer = new DroppingBuffer(2);
+        expect([buffer.empty, buffer.full]).toEqual([true, false]);
+        buffer.add(1);
+        buffer.add(2);
+        buffer.add(3);
+        buffer.add(4);
+        buffer.add(5);
+        expect([buffer.empty, buffer.full]).toEqual([false, false]);
+        expect(buffer.remove()).toEqual(1);
+        expect(buffer.remove()).toEqual(2);
+        expect([buffer.empty, buffer.full]).toEqual([true, false]);
+        expect(() => buffer.remove()).toThrow();
+    });
+});
+
+
+describe("Repeater", () => {
+    test("push", async () => {
+        const r = new Repeater((push) => {
+            push(1);
+            push(2);
+            push(3);
+            push(4);
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+    });
+
+    test("async push", async () => {
+        const r = new Repeater(async (push) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+    });
+
+    test("push promises", async () => {
+        const r = new Repeater((push) => {
+            push(Promise.resolve(1));
+            push(Promise.resolve(2));
+            push(Promise.resolve(3));
+            push(Promise.resolve(4));
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+    });
+
+    test("async push promises", async () => {
+        const r = new Repeater(async (push) => {
+            await push(Promise.resolve(1));
+            await push(Promise.resolve(2));
+            await push(Promise.resolve(3));
+            await push(Promise.resolve(4));
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+    });
+
+    test("push delayed promises", async () => {
+        const r = new Repeater((push) => {
+            push(delayPromise(5, 1));
+            push(Promise.resolve(2));
+            push(3);
+            push(delayPromise(10, 4));
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+    });
+
+    test("async push delayed promises", async () => {
+        const r = new Repeater(async (push) => {
+            await push(delayPromise(5, 1));
+            await push(Promise.resolve(2));
+            await push(3);
+            await push(delayPromise(10, 4));
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+    });
+
+    test("push rejection", async () => {
+        const error = new Error("push rejection");
+        const r = new Repeater((push) => {
+            push(Promise.resolve(1));
+            push(Promise.resolve(2));
+            push(Promise.reject(error));
+            push(Promise.resolve(4));
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("async push rejection", async () => {
+        const error = new Error("async push rejection");
+        const r = new Repeater(async (push) => {
+            await push(Promise.resolve(1));
+            await push(Promise.resolve(2));
+            await push(Promise.reject(error));
+            await push(Promise.resolve(4));
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push rejection immediately", async () => {
+        const error = new Error("push rejection immediately");
+        const r = new Repeater((push) => push(Promise.reject(error)));
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push delayed rejection", async () => {
+        const error = new Error("push delayed rejection");
+        const r = new Repeater(async (push) => {
+            push(delayPromise(5, 1));
+            push(Promise.resolve(2));
+            push(delayPromise(1, null, error));
+            push(4);
+            return -1;
+        });
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("async push delayed rejection", async () => {
+        const error = new Error("async push delayed rejection");
+        const r = new Repeater(async (push) => {
+            await push(delayPromise(5, 1));
+            await push(Promise.resolve(2));
+            await push(delayPromise(1, null, error));
+            await push(4);
+            return -1;
+        });
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push delayed rejection with buffer", async () => {
+        const error = new Error("push delayed rejection with buffer");
+        const r = new Repeater((push) => {
+            push(delayPromise(5, 1));
+            push(Promise.resolve(2));
+            push(delayPromise(1, null, error));
+            push(4);
+            return -1;
+        }, new FixedBuffer(100));
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("async push delayed rejection with buffer", async () => {
+        const error = new Error("async push delayed rejection with buffer");
+        const r = new Repeater((push) => {
+            push(delayPromise(5, 1));
+            push(Promise.resolve(2));
+            push(delayPromise(1, null, error));
+            push(4);
+            return -1;
+        }, new FixedBuffer(100));
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push multiple rejections", async () => {
+        const error1 = new Error("push multiple rejections 1");
+        const error2 = new Error("push multiple rejections 2");
+        const error3 = new Error("push multiple rejections 3");
+        const r = new Repeater((push) => {
+            push(Promise.resolve(1));
+            push(Promise.resolve(2));
+            push(Promise.reject(error1));
+            push(Promise.reject(error2));
+            push(Promise.reject(error3));
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error1);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("stop", async () => {
+        const r = new Repeater((_, stop) => {
+            stop();
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("stop with error", async () => {
+        const error = new Error("stop with error");
+        const r = new Repeater(async (push, stop) => {
+            stop(error);
+            return -1;
+        });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push then stop", async () => {
+        const r = new Repeater((push, stop) => {
+            push(1);
+            push(2);
+            push(3);
+            push(4);
+            stop();
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("async push and stop", async () => {
+        const r = new Repeater(async (push, stop) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+            stop();
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push and stop with error", async () => {
+        const error = new Error("push and stop with error");
+        const r = new Repeater((push, stop) => {
+            push(1);
+            push(2);
+            push(3);
+            push(4);
+            stop(error);
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("async push and stop with error", async () => {
+        const error = new Error("async push and stop with error");
+        const r = new Repeater(async (push, stop) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+            stop(error);
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push promise and stop", async () => {
+        const r = new Repeater((push, stop) => {
+            push(1);
+            push(2);
+            push(Promise.resolve(3));
+            push(4);
+            stop();
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push delayed promise and stop", async () => {
+        const r = new Repeater((push, stop) => {
+            push(1);
+            push(2);
+            push(delayPromise(10, 3));
+            push(4);
+            stop();
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push rejection and stop", async () => {
+        const error = new Error("push rejection and stop");
+        const r = new Repeater((push, stop) => {
+            push(1);
+            push(2);
+            push(Promise.reject(error));
+            push(4);
+            stop();
+            return -1;
+        });
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("push delayed rejection and stop", async () => {
+        const error = new Error("push delayed rejection and stop");
+        const r = new Repeater((push, stop) => {
+            push(1);
+            push(2);
+            push(delayPromise(50, null, error));
+            push(4);
+            stop();
+            return -1;
+        });
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("async push rejection and stop with error", async () => {
+        const error1 = new Error("async push rejection and stop with error 1");
+        const error2 = new Error("async push rejection and stop with error 2");
+        const r = new Repeater(async (push, stop) => {
+            await push(1);
+            await push(2);
+            await push(Promise.reject(error1));
+            await push(4);
+            stop(error2);
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error1);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("async push delayed promises and stop with pending next", async () => {
+        const r = new Repeater(async (push, stop) => {
+            await push(delayPromise(50, 1));
+            await push(delayPromise(50, 2));
+            stop();
+            return -1;
+        });
+        const result1 = r.next();
+        const result2 = r.next();
+        const result3 = r.next();
+        await expect(result1).resolves.toEqual({ value: 1, done: false });
+        await expect(result2).resolves.toEqual({ value: 2, done: false });
+        await expect(result3).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("awaiting stop promise", async () => {
+        const mock = jest.fn();
+        const r = new Repeater(async (push, stop) => {
+            push(1);
+            push(2);
+            setTimeout(() => stop());
+            await stop;
+            push(3);
+            mock();
+        });
+        await expect(r.next()).resolves.toEqual({ done: false, value: 1 });
+        await expect(r.next()).resolves.toEqual({ done: false, value: 2 });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
+
+    test("throw error in executor", async () => {
+        const error = new Error("throw error in executor");
+        const r = new Repeater(() => {
+            throw error;
+        });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error in executor after push", async () => {
+        const error = new Error("throw error in executor after push");
+        const r = new Repeater((push) => {
+            push(1);
+            push(2);
+            push(3);
+            push(4);
+            throw error;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error in executor after async push", async () => {
+        const error = new Error("throw error in executor after async push");
+        const r = new Repeater(async (push) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+            throw error;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error in executor after push and stop", async () => {
+        const error = new Error("throw error in executor after push and stop");
+        const r = new Repeater((push, stop) => {
+            push(1);
+            stop();
+            throw error;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error in executor after async push and stop", async () => {
+        const error = new Error(
+            "throw error in executor after async push and stop",
+        );
+        const r = new Repeater(async (push, stop) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+            stop();
+            throw error;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error after stop with error", async () => {
+        const error1 = new Error("throw error after stop with error 1");
+        const error2 = new Error("throw error after stop with error 2");
+        const r = new Repeater((push, stop) => {
+            stop(error1);
+            throw error2;
+        });
+        await expect(r.next()).rejects.toBe(error2);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error after stop with error and delay", async () => {
+        const error1 = new Error("throw error after stop with error and delay 1");
+        const error2 = new Error("throw error after stop with error and delay 2");
+        const r = new Repeater(async (_, stop) => {
+            stop(error1);
+            await delayPromise(10);
+            throw error2;
+        });
+        await expect(r.next()).rejects.toBe(error2);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error after pushing rejection", async () => {
+        const error1 = new Error("throw error after pushing rejection 1");
+        const error2 = new Error("throw error after pushing rejection 2");
+        const r = new Repeater((push) => {
+            push(1);
+            push(2);
+            push(Promise.reject(error1));
+            push(4);
+            throw error2;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error2);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error after async pushing rejection", async () => {
+        const error1 = new Error("throw error after async pushing rejection 1");
+        const error2 = new Error("throw error after async pushing rejection 2");
+        const r = new Repeater(async (push) => {
+            await push(1);
+            await push(2);
+            await push(Promise.reject(error1));
+            await push(4);
+            throw error2;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error2);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw error after stopping with error and pushing rejection", async () => {
+        const error1 = new Error(
+            "throw error after stopping with error and pushing rejection 1",
+        );
+        const error2 = new Error(
+            "throw error after stopping with error and pushing rejection 2",
+        );
+        const error3 = new Error(
+            "throw error after stopping with error and pushing rejection 3",
+        );
+        const r = new Repeater((push, stop) => {
+            push(1);
+            push(2);
+            push(Promise.reject(error1));
+            push(4);
+            stop(error2);
+            throw error3;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error3);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return rejection from executor", async () => {
+        const error = new Error("return rejection from executor");
+        const r = new Repeater(() => Promise.reject(error));
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return rejection from executor after async pushes", async () => {
+        const error = new Error(
+            "return rejection from executor after async pushes",
+        );
+        const r = new Repeater(async (push) => {
+            await push(1);
+            await push(2);
+            return Promise.reject(error);
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("ignored repeater", async () => {
+        const mock = jest.fn();
+        new Repeater(() => mock());
+        expect(mock).toHaveBeenCalledTimes(0);
+    });
+
+    test("pushes await next", async () => {
+        const mock = jest.fn();
+        const r = new Repeater(async (push) => {
+            for (let i = 0; i < 100; i++) {
+                mock(await push(i));
+            }
+
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 0, done: false });
+        expect(mock).toHaveBeenCalledTimes(0);
+        for (let i = 1; i < 50; i++) {
+            expect(mock).toHaveBeenCalledTimes(i - 1);
+            await expect(r.next(i)).resolves.toEqual({
+                value: i,
+                done: false,
+            });
+            expect(mock).toHaveBeenCalledWith(i);
+            expect(mock).toHaveBeenCalledTimes(i);
+        }
+
+        await expect(r.next()).resolves.toEqual({ value: 50, done: false });
+        expect(mock).toHaveBeenCalledTimes(50);
+        await delayPromise(1);
+        expect(mock).toHaveBeenCalledTimes(50);
+    });
+
+    test("next then push avoids buffer", async () => {
+        const buffer: FixedBuffer = new FixedBuffer(100);
+        const add = jest.spyOn(buffer, "add");
+        let push!: (value: unknown) => Promise<unknown>;
+        const r = new Repeater(async (push1) => {
+            push = push1;
+        }, buffer);
+        const next1 = r.next();
+        const next2 = r.next();
+        push(1);
+        push(2);
+        await expect(next1).resolves.toEqual({ value: 1, done: false });
+        await expect(next2).resolves.toEqual({ value: 2, done: false });
+        expect(buffer.empty).toBe(true);
+        expect(add).toHaveBeenCalledTimes(0);
+        push(3);
+        expect(buffer.empty).toBe(false);
+        expect(add).toHaveBeenCalledTimes(1);
+    });
+
+    test("pushes resolve to value passed to next", async () => {
+        let push!: (value: unknown) => Promise<unknown>;
+        const r = new Repeater((push1) => (push = push1));
+        r.next(-1);
+        r.next(-2);
+        r.next(-3);
+        r.next(-4);
+        const push1 = push(1);
+        const push2 = push(2);
+        const push3 = push(3);
+        const push4 = push(4);
+        await expect(push1).resolves.toEqual(-2);
+        await expect(push2).resolves.toEqual(-3);
+        await expect(push3).resolves.toEqual(-4);
+        await expect(
+            Promise.race([push4, delayPromise(100, -1000)]),
+        ).resolves.toEqual(-1000);
+    });
+
+    test("pushes resolve to value passed to next alternating", async () => {
+        let push!: (value: unknown) => Promise<unknown>;
+        const r = new Repeater((push1) => (push = push1));
+        r.next(-1);
+        const push1 = push(1);
+        r.next(-2);
+        const push2 = push(2);
+        r.next(-3);
+        const push3 = push(3);
+        r.next(-4);
+        const push4 = push(4);
+        await expect(push1).resolves.toEqual(-2);
+        await expect(push2).resolves.toEqual(-3);
+        await expect(push3).resolves.toEqual(-4);
+        await expect(
+            Promise.race([push4, delayPromise(100, -1000)]),
+        ).resolves.toEqual(-1000);
+    });
+
+    test("pushes resolve to value passed to next irregular", async () => {
+        let push!: (value: unknown) => Promise<unknown>;
+        const r = new Repeater((push1) => (push = push1));
+        r.next(-1);
+        const push1 = push(1);
+        const push2 = push(2);
+        r.next(-2);
+        r.next(-3);
+        const push3 = push(3);
+        r.next(-4);
+        const push4 = push(4);
+        await expect(push1).resolves.toEqual(-2);
+        await expect(push2).resolves.toEqual(-3);
+        await expect(push3).resolves.toEqual(-4);
+        await expect(
+            Promise.race([push4, delayPromise(1, -1000)]),
+        ).resolves.toEqual(-1000);
+    });
+
+    test("pushes resolve to value passed to next pushes first", async () => {
+        let push!: (value: unknown) => Promise<unknown>;
+        const r = new Repeater((push1) => (push = push1));
+        r.next(-1);
+        const push1 = push(1);
+        const push2 = push(2);
+        const push3 = push(3);
+        const push4 = push(4);
+        r.next(-2);
+        r.next(-3);
+        r.next(-4);
+        await expect(push1).resolves.toEqual(-2);
+        await expect(push2).resolves.toEqual(-3);
+        await expect(push3).resolves.toEqual(-4);
+        await expect(
+            Promise.race([push4, delayPromise(1, -1000)]),
+        ).resolves.toEqual(-1000);
+    });
+
+    test("pushes resolve to undefined with buffer", async () => {
+        let push!: (value: unknown) => Promise<unknown>;
+        const r = new Repeater(async (push1) => {
+            push = push1;
+        }, new FixedBuffer(3));
+        const next1 = r.next(-1);
+        const push1 = push(1);
+        const push2 = push(2);
+        const push3 = push(3);
+        const push4 = push(4);
+        const push5 = push(5);
+        await expect(next1).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next(-2)).resolves.toEqual({ value: 2, done: false });
+        await expect(push1).resolves.toEqual(-2);
+        await expect(r.next(-3)).resolves.toEqual({ value: 3, done: false });
+        await expect(r.next(-4)).resolves.toEqual({ value: 4, done: false });
+        await expect(r.next(-5)).resolves.toEqual({ value: 5, done: false });
+        await expect(push2).resolves.toBeUndefined();
+        await expect(push3).resolves.toBeUndefined();
+        await expect(push4).resolves.toBeUndefined();
+        await expect(push5).resolves.toBe(-3);
+        const push6 = push(6);
+        const push7 = push(7);
+        const push8 = push(8);
+        const push9 = push(9);
+        await expect(r.next(-6)).resolves.toEqual({ value: 6, done: false });
+        await expect(r.next(-7)).resolves.toEqual({ value: 7, done: false });
+        await expect(r.next(-8)).resolves.toEqual({ value: 8, done: false });
+        await expect(r.next(-9)).resolves.toEqual({ value: 9, done: false });
+        await expect(push6).resolves.toBeUndefined();
+        await expect(push7).resolves.toBeUndefined();
+        await expect(push8).resolves.toBeUndefined();
+        await expect(push9).resolves.toBe(-7);
+    });
+
+    test("push throws when push queue is full", async () => {
+        let push!: (value: unknown) => Promise<unknown>;
+        const r = new Repeater(async (push1) => {
+            push = push1;
+            push(null);
+        });
+        await expect(r.next()).resolves.toEqual({
+            value: null,
+            done: false,
+        });
+
+        for (let i = 0; i < MAX_QUEUE_LENGTH; i++) {
+            push(i);
+        }
+
+        expect(() => push(-1)).toThrow(RepeaterOverflowError);
+        expect(() => push(-2)).toThrow(RepeaterOverflowError);
+    });
+
+    test("push throws when buffer and push queue are full", async () => {
+        const bufferLength = 1000;
+        let push!: (value: unknown) => Promise<unknown>;
+        const r = new Repeater(async (push1) => {
+            push = push1;
+            push(null);
+        }, new FixedBuffer(bufferLength));
+        await expect(r.next()).resolves.toEqual({
+            value: null,
+            done: false,
+        });
+
+        for (let i = 0; i < bufferLength; i++) {
+            push(i);
+        }
+
+        for (let i = 0; i < MAX_QUEUE_LENGTH; i++) {
+            push(i);
+        }
+
+        expect(() => push(-1)).toThrow(RepeaterOverflowError);
+        expect(() => push(-2)).toThrow(RepeaterOverflowError);
+    });
+
+    test("next throws when pull queue is full", async () => {
+        const r = new Repeater(() => { }, new FixedBuffer(3));
+        for (let i = 0; i < MAX_QUEUE_LENGTH; i++) {
+            r.next();
+        }
+
+        expect(() => r.next()).toThrow(RepeaterOverflowError);
+        expect(() => r.next()).toThrow(RepeaterOverflowError);
+    });
+
+    test("dropping buffer", async () => {
+        const r = new Repeater((push, stop) => {
+            for (let i = 0; i < 100; i++) {
+                push(i);
+            }
+            stop();
+        }, new DroppingBuffer(3));
+        await expect(r.next()).resolves.toEqual({ value: 0, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("sliding buffer", async () => {
+        const r = new Repeater((push, stop) => {
+            for (let i = 0; i < 100; i++) {
+                push(i);
+            }
+            stop();
+        }, new SlidingBuffer(3));
+        await expect(r.next()).resolves.toEqual({ value: 97, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 98, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 99, done: false });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("break in for await", async () => {
+        const r = new Repeater<number>(async (push) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+        });
+        const spy = jest.spyOn(r, "return");
+        const result: number[] = [];
+        for await (const num of r) {
+            result.push(num);
+            if (num === 3) {
+                break;
+            }
+        }
+        expect(result).toEqual([1, 2, 3]);
+        expect(spy).toHaveBeenCalledTimes(1);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw in for await", async () => {
+        const error = new Error("throw in for await");
+        const r = new Repeater<number>(async (push) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+        });
+        const spy = jest.spyOn(r, "return");
+        const result: number[] = [];
+        await expect(
+            (async () => {
+                for await (const num of r) {
+                    result.push(num);
+                    if (num === 3) {
+                        throw error;
+                    }
+                }
+            })(),
+        ).rejects.toBe(error);
+        expect(result).toEqual([1, 2, 3]);
+        expect(spy).toHaveBeenCalledTimes(1);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method", async () => {
+        const r = new Repeater<number>(async (push) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+            return -1;
+        });
+        const result: number[] = [];
+        for await (const num of r) {
+            result.push(num);
+            if (num === 3) {
+                await expect(r.return()).resolves.toEqual({ done: true });
+            }
+        }
+        expect(result).toEqual([1, 2, 3]);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method before execution", async () => {
+        const mock = jest.fn();
+        const r = new Repeater(() => mock());
+        await expect(r.return(-1)).resolves.toEqual({
+            value: -1,
+            done: true,
+        });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        expect(mock).toHaveBeenCalledTimes(0);
+    });
+
+    test("return method with buffer", async () => {
+        const r = new Repeater(async (push) => {
+            for (let i = 1; i < 100; i++) {
+                push(i);
+            }
+            return -1;
+        }, new FixedBuffer(100));
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.return()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method with buffer after stop", async () => {
+        const r = new Repeater(async (push, stop) => {
+            for (let i = 1; i < 100; i++) {
+                push(i);
+            }
+            stop();
+            return -1;
+        }, new FixedBuffer(100));
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.return()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method with buffer after stop with error", async () => {
+        const error = new Error("return method with buffer after stop with error");
+        const r = new Repeater(async (push, stop) => {
+            for (let i = 1; i < 100; i++) {
+                push(i);
+            }
+            stop(error);
+            return -1;
+        }, new FixedBuffer(100));
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.return()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method with throw in executor", async () => {
+        const error = new Error("return method with throw in executor");
+        const r = new Repeater(async (push) => {
+            for (let i = 1; i < 100; i++) {
+                await push(i);
+            }
+
+            throw error;
+        }, new FixedBuffer(100));
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.return()).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method with argument", async () => {
+        const r = new Repeater(async (push, stop) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await stop;
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.return(-2)).resolves.toEqual({
+            value: -2,
+            done: true,
+        });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.return()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.return(-3)).resolves.toEqual({
+            value: -3,
+            done: true,
+        });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method with promise argument", async () => {
+        const r = new Repeater(async (push, stop) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await stop;
+            return -1;
+        });
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.return(Promise.resolve(-2))).resolves.toEqual({
+            value: -2,
+            done: true,
+        });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.return()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.return(Promise.resolve(-3))).resolves.toEqual({
+            value: -3,
+            done: true,
+        });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method with argument and pending next", async () => {
+        const r = new Repeater(() => {
+            return -1;
+        });
+        const next = r.next();
+        const returned = r.return(-2);
+        await expect(next).resolves.toEqual({ value: -1, done: true });
+        await expect(returned).resolves.toEqual({ value: -2, done: true });
+    });
+
+    test("return method with pushed rejection", async () => {
+        const error = new Error("return method with pushed rejection");
+        const r = new Repeater((push) => {
+            push(1);
+            push(Promise.reject(error));
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.return(-2)).resolves.toEqual({
+            value: -2,
+            done: true,
+        });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("return method with async pushed rejection", async () => {
+        const error = new Error("return method with async pushed rejection");
+        const r = new Repeater(async (push) => {
+            await push(1);
+            await push(Promise.reject(error));
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.return(-2)).resolves.toEqual({
+            value: -2,
+            done: true,
+        });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw method", async () => {
+        const error = new Error("throw method");
+        const mock = jest.fn();
+        const r = new Repeater(async (push, stop) => {
+            push(1);
+            push(2);
+            push(3);
+            push(4);
+            await stop;
+            mock();
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.throw(error)).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
+
+    test("throw method before execution", async () => {
+        const error = new Error("throw method before execution");
+        const mock = jest.fn();
+        const r = new Repeater(() => mock());
+        await expect(r.throw(error)).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        expect(mock).toHaveBeenCalledTimes(0);
+    });
+
+    test("throw method caught in async function", async () => {
+        const error = new Error("throw method caught in async function");
+        const errors: Error[] = [];
+        const r = new Repeater(async (push, stop) => {
+            for (let i = 0; i < 8; i++) {
+                try {
+                    await push(i);
+                } catch (err) {
+                    errors.push(err);
+                }
+            }
+
+            stop();
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 0, done: false });
+        await expect(r.throw(error)).resolves.toEqual({
+            value: 1,
+            done: false,
+        });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.throw(error)).resolves.toEqual({
+            value: 3,
+            done: false,
+        });
+        await expect(r.next()).resolves.toEqual({ value: 4, done: false });
+        await expect(r.throw(error)).resolves.toEqual({
+            value: 5,
+            done: false,
+        });
+        await expect(r.next()).resolves.toEqual({ value: 6, done: false });
+        await expect(r.throw(error)).resolves.toEqual({
+            value: 7,
+            done: false,
+        });
+        await expect(r.next()).resolves.toEqual({ value: -1, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        expect(errors).toEqual(Array(4).fill(error));
+    });
+
+    test("throw method with Promise.prototype.catch", async () => {
+        const error = new Error("throw method with Promise.prototype.catch");
+        const mock = jest.fn();
+        const r = new Repeater((push) => {
+            push(1).catch(mock);
+            push(2).catch(mock);
+            push(3).catch(mock);
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.throw(error)).resolves.toEqual({
+            value: 2,
+            done: false,
+        });
+        await expect(r.throw(error)).resolves.toEqual({
+            value: 3,
+            done: false,
+        });
+        expect(mock).toHaveBeenCalledTimes(2);
+    });
+
+    test("throw method with buffer after stop", async () => {
+        const error = new Error("throw method with buffer after stop");
+        const mock = jest.fn();
+        const r = new Repeater((push, stop) => {
+            for (let i = 1; i < 100; i++) {
+                push(i).catch(mock);
+            }
+            stop();
+            return -1;
+        }, new FixedBuffer(100));
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.throw(error)).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        expect(mock).toHaveBeenCalledTimes(0);
+    });
+
+    test("throw method after stop with error", async () => {
+        const error1 = new Error("throw method after stop with error 1");
+        const error2 = new Error("throw method after stop with error 2");
+        const r = new Repeater((push, stop) => {
+            for (let i = 1; i < 100; i++) {
+                push(i);
+            }
+            stop(error1);
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.throw(error2)).rejects.toBe(error1);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw method with throw in executor", async () => {
+        const error1 = new Error("throw method with throw in executor 1");
+        const error2 = new Error("throw method with throw in executor 2");
+        const r = new Repeater((push) => {
+            for (let i = 1; i < 100; i++) {
+                push(i);
+            }
+
+            throw error1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.throw(error2)).rejects.toBe(error1);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw method with pending next", async () => {
+        const error = new Error("throw method with pending next");
+        const mock = jest.fn();
+        const r = new Repeater(async (push, stop) => {
+            for (let i = 1; i < 100; i++) {
+                push(i);
+            }
+
+            await stop;
+            mock();
+            return -1;
+        });
+        const next1 = r.next(-1);
+        const next2 = r.next(-2);
+        const next3 = r.next(-3);
+        const next4 = r.next(-4);
+        const thrown = r.throw(error);
+        await expect(next1).resolves.toEqual({ value: 1, done: false });
+        await expect(next2).resolves.toEqual({ value: 2, done: false });
+        await expect(next3).resolves.toEqual({ value: 3, done: false });
+        await expect(next4).resolves.toEqual({ value: 4, done: false });
+        await expect(thrown).rejects.toBe(error);
+        expect(mock).toHaveBeenCalledTimes(1);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw method before stop", async () => {
+        const error = new Error("throw method before stop");
+        const r = new Repeater((push, stop) => {
+            push(1);
+            stop();
+            return -1;
+        });
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.throw(error)).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw method before async stop", async () => {
+        const error = new Error("throw method before async stop");
+        const r = new Repeater(async (push, stop) => {
+            await push(1);
+            stop();
+            return -1;
+        });
+
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.throw(error)).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw method before return method", async () => {
+        const error = new Error("throw method before return method");
+        const mock = jest.fn();
+        const r = new Repeater(async (push, stop) => {
+            push(1);
+            await stop;
+            mock();
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        const thrown = r.throw(error);
+        const returned = r.return(-2);
+        await expect(thrown).rejects.toBe(error);
+        await expect(returned).resolves.toEqual({ value: -2, done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
+
+    test("throw method after return method", async () => {
+        const error = new Error("throw method after return method");
+        const r = new Repeater(async (push) => {
+            await push(1);
+            await push(2);
+            await push(3);
+            await push(4);
+            return -1;
+        });
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        const returned = r.return(-2);
+        const thrown = r.throw(error);
+        await expect(returned).resolves.toEqual({ value: -2, done: true });
+        await expect(thrown).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("throw method with buffer", async () => {
+        const error = new Error("throw method with buffer");
+        const mock = jest.fn();
+        const r = new Repeater((push) => {
+            for (let i = 1; i < 100; i++) {
+                push(i).catch(mock);
+            }
+            return -1;
+        }, new FixedBuffer(100));
+        await expect(r.next()).resolves.toEqual({ value: 1, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 2, done: false });
+        await expect(r.next()).resolves.toEqual({ value: 3, done: false });
+        await expect(r.throw(error)).rejects.toBe(error);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        expect(mock).toHaveBeenCalledTimes(0);
+    });
+
+    test("results settle in order", async () => {
+        const r = new Repeater((push, stop) => {
+            push(delayPromise(10, 1));
+            push(Promise.resolve(2));
+            push(3);
+            stop();
+            return -1;
+        });
+        const r1 = r.next();
+        const r2 = r.next();
+        const r3 = r.next();
+        const r4 = r.next();
+        const r5 = r.next();
+        await Promise.all([
+            expect(Promise.race([r5, r4, r3, r2, r1])).resolves.toEqual({
+                value: 1,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3, r2, r1])).resolves.toEqual({
+                value: 1,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3, r2])).resolves.toEqual({
+                value: 2,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3])).resolves.toEqual({
+                value: 3,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4])).resolves.toEqual({
+                value: -1,
+                done: true,
+            }),
+            expect(r5).resolves.toEqual({ done: true }),
+        ]);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("results settle in order with buffer", async () => {
+        const r = new Repeater((push, stop) => {
+            push(delayPromise(10, 1));
+            push(Promise.resolve(2));
+            push(3);
+            stop();
+            return -1;
+        }, new FixedBuffer(100));
+        const r1 = r.next();
+        const r2 = r.next();
+        const r3 = r.next();
+        const r4 = r.next();
+        const r5 = r.next();
+        await Promise.all([
+            expect(Promise.race([r5, r4, r3, r2, r1])).resolves.toEqual({
+                value: 1,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3, r2])).resolves.toEqual({
+                value: 2,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3])).resolves.toEqual({
+                value: 3,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4])).resolves.toEqual({
+                value: -1,
+                done: true,
+            }),
+            expect(r5).resolves.toEqual({ done: true }),
+        ]);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("results settle in order with rejection", async () => {
+        const error = new Error("results settle in order with rejection");
+        const r = new Repeater((push) => {
+            push(delayPromise(100, 1));
+            push(delayPromise(10, 2));
+            push(Promise.reject(error));
+            push(4);
+            return 5;
+        });
+        const r1 = r.next();
+        const r2 = r.next();
+        const r3 = r.next();
+        const r4 = r.next();
+        const r5 = r.next();
+        await Promise.all([
+            expect(Promise.race([r5, r4, r3, r2, r1])).resolves.toEqual({
+                value: 1,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3, r2])).resolves.toEqual({
+                value: 2,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3])).rejects.toBe(error),
+            expect(Promise.race([r5, r4])).resolves.toEqual({ done: true }),
+            expect(r5).resolves.toEqual({ done: true }),
+        ]);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+
+    test("results settle in order with return method and rejection", async () => {
+        const error = new Error(
+            "results settle in order with return method and rejection",
+        );
+        const r = new Repeater((push) => {
+            push(delayPromise(100, 1));
+            push(delayPromise(10, 2));
+            push(Promise.reject(error));
+            push(4);
+            return 5;
+        });
+        const r1 = r.next();
+        const r2 = r.next();
+        const r3 = r.return(-1);
+        const r4 = r.next();
+        const r5 = r.return(-2);
+        await Promise.all([
+            expect(Promise.race([r5, r4, r3, r2, r1])).resolves.toEqual({
+                value: 1,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3, r2])).resolves.toEqual({
+                value: 2,
+                done: false,
+            }),
+            expect(Promise.race([r5, r4, r3])).resolves.toEqual({
+                value: -1,
+                done: true,
+            }),
+            expect(Promise.race([r5, r4])).resolves.toEqual({ done: true }),
+            expect(r5).resolves.toEqual({ value: -2, done: true }),
+        ]);
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+        await expect(r.next()).resolves.toEqual({ done: true });
+    });
+});

--- a/packages/api-client-core/src/graphql-live-query-utils/createApplyLiveQueryPatch.ts
+++ b/packages/api-client-core/src/graphql-live-query-utils/createApplyLiveQueryPatch.ts
@@ -1,4 +1,4 @@
-import { Repeater } from "@manufac/repeater";
+import { Repeater } from "../repeater/index.js";
 import type { ExecutionResult } from "graphql";
 
 export type ExecutionLivePatchResult<PatchPayload = unknown> = {
@@ -24,56 +24,56 @@ export const createApplyLiveQueryPatch =
     /* Function which is used for generating the patches */
     applyPatch: ApplyPatchFunction<PatchPayload>
   ) =>
-  <TExecutionResult = Record<string, unknown>>(source: AsyncIterable<TExecutionResult>) =>
-    new Repeater<TExecutionResult>(async (push, stop) => {
-      const iterator = source[Symbol.asyncIterator]();
-      stop.then(() => iterator.return?.()).catch(console.log);
-      let mutableData: ExecutionResult | null = null;
-      let lastRevision = 0;
-      let next: IteratorResult<ExecutionLivePatchResult<PatchPayload>>;
-      // @ts-expect-error bad types
-      while ((next = await iterator.next()).done === false) {
-        // no revision means this is no live query patch.
-        if ("revision" in next.value && next.value.revision) {
-          const valueToPublish: ExecutionLivePatchResult = {};
+    <TExecutionResult = Record<string, unknown>>(source: AsyncIterable<TExecutionResult>) =>
+      new Repeater<TExecutionResult>(async (push, stop) => {
+        const iterator = source[Symbol.asyncIterator]();
+        stop.then(() => iterator.return?.()).catch(console.log);
+        let mutableData: ExecutionResult | null = null;
+        let lastRevision = 0;
+        let next: IteratorResult<ExecutionLivePatchResult<PatchPayload>>;
+        // @ts-expect-error bad types
+        while ((next = await iterator.next()).done === false) {
+          // no revision means this is no live query patch.
+          if ("revision" in next.value && next.value.revision) {
+            const valueToPublish: ExecutionLivePatchResult = {};
 
-          if (next.value.revision === 1) {
-            if (!next.value.data) {
-              throw new Error("Missing data.");
-            }
-            valueToPublish.data = next.value.data;
-            mutableData = next.value.data;
-            lastRevision = 1;
-          } else {
-            if (!mutableData) {
-              throw new Error("No previousData available.");
-            }
-            if (!next.value.patch) {
-              throw new Error("Missing patch.");
-            }
-            if (lastRevision + 1 !== next.value.revision) {
-              throw new Error("Wrong revision received.");
+            if (next.value.revision === 1) {
+              if (!next.value.data) {
+                throw new Error("Missing data.");
+              }
+              valueToPublish.data = next.value.data;
+              mutableData = next.value.data;
+              lastRevision = 1;
+            } else {
+              if (!mutableData) {
+                throw new Error("No previousData available.");
+              }
+              if (!next.value.patch) {
+                throw new Error("Missing patch.");
+              }
+              if (lastRevision + 1 !== next.value.revision) {
+                throw new Error("Wrong revision received.");
+              }
+
+              mutableData = applyPatch(mutableData as Record<string, unknown>, next.value.patch);
+              valueToPublish.data = { ...mutableData } as Record<string, unknown>;
+
+              lastRevision++;
             }
 
-            mutableData = applyPatch(mutableData as Record<string, unknown>, next.value.patch);
-            valueToPublish.data = { ...mutableData } as Record<string, unknown>;
+            if (next.value.extensions) {
+              valueToPublish.extensions = next.value.extensions;
+            }
+            if (next.value.errors) {
+              valueToPublish.errors = next.value.errors;
+            }
 
-            lastRevision++;
+            await push(valueToPublish as TExecutionResult);
+            continue;
           }
 
-          if (next.value.extensions) {
-            valueToPublish.extensions = next.value.extensions;
-          }
-          if (next.value.errors) {
-            valueToPublish.errors = next.value.errors;
-          }
-
-          await push(valueToPublish as TExecutionResult);
-          continue;
+          await push(next.value as TExecutionResult);
         }
 
-        await push(next.value as TExecutionResult);
-      }
-
-      stop();
-    });
+        stop();
+      });

--- a/packages/api-client-core/src/repeater/index.ts
+++ b/packages/api-client-core/src/repeater/index.ts
@@ -1,0 +1,587 @@
+/** An error subclass which is thrown when there are too many pending push or next operations on a single repeater. */
+export class RepeaterOverflowError extends Error {
+    constructor(message: string) {
+        super(message);
+        Object.defineProperty(this, "name", {
+            value: "RepeaterOverflowError",
+            enumerable: false,
+        });
+        if (typeof Object.setPrototypeOf === "function") {
+            Object.setPrototypeOf(this, this.constructor.prototype);
+        } else {
+            (this as any).__proto__ = this.constructor.prototype;
+        }
+
+        if (typeof (Error as any).captureStackTrace === "function") {
+            (Error as any).captureStackTrace(this, this.constructor);
+        }
+    }
+}
+
+/*** BUFFERS ***/
+/** A special queue interface which allow multiple values to be pushed onto a repeater without having pushes wait or throw overflow errors, passed as the second argument to the repeater constructor. */
+export interface RepeaterBuffer<TValue = unknown> {
+    empty: boolean;
+    full: boolean;
+    add(value: TValue): unknown;
+    remove(): TValue;
+}
+
+/** A buffer which allows you to push a set amount of values to the repeater without pushes waiting or throwing errors. */
+export class FixedBuffer implements RepeaterBuffer {
+    // capacity
+    _c: number;
+    // queue
+    _q: Array<unknown>;
+
+    constructor(capacity: number) {
+        if (capacity < 0) {
+            throw new RangeError("Capacity may not be less than 0");
+        }
+
+        this._c = capacity;
+        this._q = [];
+    }
+
+    get empty(): boolean {
+        return this._q.length === 0;
+    }
+
+    get full(): boolean {
+        return this._q.length >= this._c;
+    }
+
+    add(value: unknown): void {
+        if (this.full) {
+            throw new Error("Buffer full");
+        } else {
+            this._q.push(value);
+        }
+    }
+
+    remove(): unknown {
+        if (this.empty) {
+            throw new Error("Buffer empty");
+        }
+
+        return this._q.shift()!;
+    }
+}
+
+// TODO: Use a circular buffer here.
+/** Sliding buffers allow you to push a set amount of values to the repeater without pushes waiting or throwing errors. If the number of values exceeds the capacity set in the constructor, the buffer will discard the earliest values added. */
+export class SlidingBuffer implements RepeaterBuffer {
+    // capacity
+    _c: number;
+    // queue
+    _q: Array<unknown>;
+
+    constructor(capacity: number) {
+        if (capacity < 1) {
+            throw new RangeError("Capacity may not be less than 1");
+        }
+
+        this._c = capacity;
+        this._q = [];
+    }
+
+    get empty(): boolean {
+        return this._q.length === 0;
+    }
+
+    get full(): boolean {
+        return false;
+    }
+
+    add(value: unknown): void {
+        while (this._q.length >= this._c) {
+            this._q.shift();
+        }
+
+        this._q.push(value);
+    }
+
+    remove(): unknown {
+        if (this.empty) {
+            throw new Error("Buffer empty");
+        }
+
+        return this._q.shift();
+    }
+}
+
+/** Dropping buffers allow you to push a set amount of values to the repeater without the push function waiting or throwing errors. If the number of values exceeds the capacity set in the constructor, the buffer will discard the latest values added. */
+export class DroppingBuffer implements RepeaterBuffer {
+    // capacity
+    _c: number;
+    // queue
+    _q: Array<unknown>;
+
+    constructor(capacity: number) {
+        if (capacity < 1) {
+            throw new RangeError("Capacity may not be less than 1");
+        }
+
+        this._c = capacity;
+        this._q = [];
+    }
+
+    get empty(): boolean {
+        return this._q.length === 0;
+    }
+
+    get full() {
+        return false;
+    }
+
+    add(value: unknown): void {
+        if (this._q.length < this._c) {
+            this._q.push(value);
+        }
+    }
+
+    remove(): unknown {
+        if (this.empty) {
+            throw new Error("Buffer empty");
+        }
+
+        return this._q.shift();
+    }
+}
+
+/** Makes sure promise-likes don’t cause unhandled rejections. */
+function swallow(value: any): void {
+    if (value != null && typeof value.then === "function") {
+        value.then(NOOP, NOOP);
+    }
+}
+
+/*** TYPES ***/
+/** The type of the first argument passed to the executor callback. */
+export type Push<T, TNext = unknown> = (
+    value: PromiseLike<T> | T,
+) => Promise<TNext | undefined>;
+
+/** The type of the second argument passed to the executor callback. A callable promise. */
+export type Stop = ((err?: unknown) => undefined) & Promise<undefined>;
+
+/** The type of the callback passed to the Repeater constructor. */
+export type RepeaterExecutor<T, TReturn = any, TNext = unknown> = (
+    push: Push<T, TNext>,
+    stop: Stop,
+) => PromiseLike<TReturn> | TReturn;
+
+/** The type of the object passed to the push queue. */
+interface PushOperation<T, TNext> {
+    // The value passed to the push function.
+    value: Promise<T | undefined>;
+    // The resolve function of the promise return from push.
+    resolve(next?: PromiseLike<TNext> | TNext): unknown;
+}
+
+/** The type of the object passed to the next queue. */
+interface NextOperation<T, TReturn, TNext> {
+    // The value passed to the next method.
+    value: PromiseLike<TNext> | TNext | undefined;
+    // The resolve function of the promise returned from next.
+    resolve(iteration: Promise<IteratorResult<T, TReturn>>): unknown;
+}
+
+/*** REPEATER STATES ***/
+/** The following is an enumeration of all possible repeater states. These states are ordered, and a repeater may only advance to higher states. */
+
+/** The initial state of the repeater. */
+const Initial = 0;
+
+/** Repeaters advance to this state the first time the next method is called on the repeater. */
+const Started = 1;
+
+/** Repeaters advance to this state when the stop function is called. */
+const Stopped = 2;
+
+/** Repeaters advance to this state when there are no values left to be pulled from the repeater. */
+const Done = 3;
+
+/** Repeaters advance to this state if an error is thrown into the repeater. */
+const Rejected = 4;
+
+/** The maximum number of push or next operations which may exist on a single repeater. */
+export const MAX_QUEUE_LENGTH = 1024;
+
+const NOOP = () => { };
+
+/** An interface containing the private data of repeaters, only accessible through a private WeakMap. */
+interface RepeaterRecord<T, TReturn, TNext> {
+    // A number enum. States are ordered and the repeater will move through these states over the course of its lifetime. See REPEATER STATES.
+    state: number;
+
+    // The function passed to the repeater constructor.
+    executor: RepeaterExecutor<T, TReturn, TNext>;
+
+    // The buffer passed to the repeater constructor.
+    buffer: RepeaterBuffer | undefined;
+
+    // A queue of values which were pushed.
+    pushes: Array<PushOperation<T, TNext>>;
+
+    // A queue of requests for values.
+    nexts: Array<NextOperation<T, TReturn, TNext>>;
+    // NOTE: both the push queue and the next queue will never contain values at the same time.
+
+    // A promise which is continuously reassigned and chained so that all repeater iterations settle in order.
+    pending: Promise<unknown> | undefined;
+
+    // The return value of the executor.
+    execution: Promise<TReturn | undefined> | undefined;
+
+    // An error passed to the stop function.
+    err: unknown;
+
+    // A callback set to the resolve function of the promise returned from push.
+    onnext: (value?: PromiseLike<TNext> | TNext) => unknown;
+
+    // A callback set to the resolve function of the stop promise.
+    onstop: () => unknown;
+}
+
+/** A helper function used to mimic the behavior of async generators where the final iteration is consumed. */
+function consumeExecution<T, TReturn, TNext>(
+    r: RepeaterRecord<T, TReturn, TNext>,
+): Promise<TReturn | undefined> {
+    const err = r.err;
+    const execution = Promise.resolve(r.execution).then((value) => {
+        if (err != null) {
+            throw err;
+        }
+
+        return value;
+    });
+
+    r.err = undefined;
+    r.execution = execution.then(
+        () => undefined,
+        () => undefined,
+    );
+
+    return r.pending === undefined ? execution : r.pending.then(() => execution);
+}
+
+/** A helper function for building iterations from values. Promises are unwrapped, so that iterations never have their value property set to a promise. */
+function createIteration<T, TReturn, TNext>(
+    r: RepeaterRecord<T, TReturn, TNext>,
+    value: Promise<T | TReturn | undefined> | T | TReturn | undefined,
+): Promise<IteratorResult<T, TReturn>> {
+    const done = r.state >= Done;
+    return Promise.resolve(value).then((value: any) => {
+        if (!done && r.state >= Rejected) {
+            return consumeExecution<T, TReturn, TNext>(r).then((value: any) => ({
+                value,
+                done: true,
+            }));
+        }
+
+        return { value, done };
+    });
+}
+
+/**
+ * This function is bound and passed to the executor as the stop argument.
+ *
+ * Advances state to Stopped.
+ */
+function stop<T, TReturn, TNext>(
+    r: RepeaterRecord<T, TReturn, TNext>,
+    err?: unknown,
+): void {
+    if (r.state >= Stopped) {
+        return;
+    }
+
+    r.state = Stopped;
+    r.onnext();
+    r.onstop();
+    if (r.err == null) {
+        r.err = err;
+    }
+
+    if (
+        r.pushes.length === 0 &&
+        (typeof r.buffer === "undefined" || r.buffer.empty)
+    ) {
+        finish(r);
+    } else {
+        for (const push of r.pushes) {
+            push.resolve();
+        }
+    }
+}
+
+/**
+ * The difference between stopping a repeater vs finishing a repeater is that stopping a repeater allows next to continue to drain values from the push queue and buffer, while finishing a repeater will clear all pending values and end iteration immediately. Once, a repeater is finished, all iterations will have the done property set to true.
+ *
+ * Advances state to Done.
+ */
+function finish<T, TReturn, TNext>(r: RepeaterRecord<T, TReturn, TNext>): void {
+    if (r.state >= Done) {
+        return;
+    }
+
+    if (r.state < Stopped) {
+        stop(r);
+    }
+
+    r.state = Done;
+    r.buffer = undefined;
+    for (const next of r.nexts) {
+        const execution: Promise<TReturn | undefined> =
+            r.pending === undefined
+                ? consumeExecution<T, TReturn, TNext>(r)
+                : r.pending.then(() => consumeExecution<T, TReturn, TNext>(r));
+        next.resolve(createIteration<T, TReturn, TNext>(r, execution));
+    }
+
+    r.pushes = [];
+    r.nexts = [];
+}
+
+/**
+ * Called when a promise passed to push rejects, or when a push call is unhandled.
+ *
+ * Advances state to Rejected.
+ */
+function reject(r: RepeaterRecord<any, any, any>): void {
+    if (r.state >= Rejected) {
+        return;
+    }
+
+    if (r.state < Done) {
+        finish(r);
+    }
+
+    r.state = Rejected;
+}
+
+/** This function is bound and passed to the executor as the push argument. */
+function push<T, TReturn, TNext>(
+    r: RepeaterRecord<T, TReturn, TNext>,
+    value: PromiseLike<T> | T,
+): Promise<TNext | undefined> {
+    swallow(value);
+    if (r.pushes.length >= MAX_QUEUE_LENGTH) {
+        throw new RepeaterOverflowError(
+            `No more than ${MAX_QUEUE_LENGTH} pending calls to push are allowed on a single repeater.`,
+        );
+    } else if (r.state >= Stopped) {
+        return Promise.resolve(undefined);
+    }
+
+    let valueP: Promise<T | undefined> =
+        r.pending === undefined
+            ? Promise.resolve(value)
+            : r.pending.then(() => value);
+
+    valueP = valueP.catch((err) => {
+        if (r.state < Stopped) {
+            r.err = err;
+        }
+
+        reject(r);
+        return undefined; // void :(
+    });
+
+    let nextP: Promise<TNext | undefined>;
+    if (r.nexts.length) {
+        const next = r.nexts.shift()!;
+        next.resolve(createIteration<T, TReturn, TNext>(r, valueP));
+        if (r.nexts.length) {
+            nextP = Promise.resolve(r.nexts[0].value);
+        } else {
+            nextP = new Promise((resolve) => (r.onnext = resolve));
+        }
+    } else if (typeof r.buffer !== "undefined" && !r.buffer.full) {
+        r.buffer.add(valueP);
+        nextP = Promise.resolve(undefined);
+    } else {
+        nextP = new Promise((resolve) => r.pushes.push({ resolve, value: valueP }));
+    }
+
+    // If an error is thrown into the repeater via the next or throw methods, we give the repeater a chance to handle this by rejecting the promise returned from push. If the push call is not immediately handled we throw the next iteration of the repeater.
+    // To check that the promise returned from push is floating, we modify the then and catch methods of the returned promise so that they flip the floating flag. The push function actually does not return a promise, because modern engines do not call the then and catch methods on native promises. By making next a plain old javascript object, we ensure that the then and catch methods will be called.
+    let floating = true;
+    let next = {} as Promise<TNext | undefined>;
+    const unhandled = nextP.catch((err) => {
+        if (floating) {
+            throw err;
+        }
+
+        return undefined; // void :(
+    });
+
+    next.then = (onfulfilled, onrejected): any => {
+        floating = false;
+        return Promise.prototype.then.call(nextP, onfulfilled, onrejected);
+    };
+
+    next.catch = (onrejected): any => {
+        floating = false;
+        return Promise.prototype.catch.call(nextP, onrejected);
+    };
+
+    next.finally = nextP.finally.bind(nextP);
+    r.pending = valueP
+        .then(() => unhandled)
+        .catch((err) => {
+            r.err = err;
+            reject(r);
+        });
+
+    return next;
+}
+
+/**
+ * Creates the stop callable promise which is passed to the executor
+ */
+function createStop<T, TReturn, TNext>(
+    r: RepeaterRecord<T, TReturn, TNext>,
+): Stop {
+    const stop1 = stop.bind(null, r) as Stop;
+    const stopP = new Promise<undefined>((resolve) => (r.onstop = resolve));
+    stop1.then = stopP.then.bind(stopP);
+    stop1.catch = stopP.catch.bind(stopP);
+    stop1.finally = stopP.finally.bind(stopP);
+    return stop1;
+}
+
+/**
+ * Calls the executor passed into the constructor. This function is called the first time the next method is called on the repeater.
+ *
+ * Advances state to Started.
+ */
+function execute<T, TReturn, TNext>(
+    r: RepeaterRecord<T, TReturn, TNext>,
+): void {
+    if (r.state >= Started) {
+        return;
+    }
+
+    r.state = Started;
+    const push1 = (push as any).bind(null, r) as Push<T, TNext>;
+    const stop1 = createStop(r);
+    r.execution = new Promise((resolve) => resolve(r.executor(push1, stop1)));
+    // TODO: We should consider stopping all repeaters when the executor settles.
+    r.execution.catch(() => stop(r));
+}
+
+type RecordMap<T, TResult, TNext> = WeakMap<
+    Repeater<T, TResult, TNext>,
+    RepeaterRecord<T, TResult, TNext>
+>;
+
+const records: RecordMap<any, any, any> = new WeakMap();
+
+// NOTE: While repeaters implement and are assignable to the AsyncGenerator interface, and you can use the types interchangeably, we don’t use typescript’s implements syntax here because this would make supporting earlier versions of typescript trickier. This is because TypeScript version 3.6 changed the iterator types by adding the TReturn and TNext type parameters.
+export class Repeater<T, TReturn = any, TNext = unknown> {
+    constructor(
+        executor: RepeaterExecutor<T, TReturn, TNext>,
+        buffer?: RepeaterBuffer | undefined,
+    ) {
+        records.set(this, {
+            executor,
+            buffer,
+            err: undefined,
+            state: Initial,
+            pushes: [],
+            nexts: [],
+            pending: undefined,
+            execution: undefined,
+            onnext: NOOP,
+            onstop: NOOP,
+        });
+    }
+
+    next(
+        value?: PromiseLike<TNext> | TNext,
+    ): Promise<IteratorResult<T, TReturn>> {
+        swallow(value);
+        const r = records.get(this);
+        if (r === undefined) {
+            throw new Error("WeakMap error");
+        }
+
+        if (r.nexts.length >= MAX_QUEUE_LENGTH) {
+            throw new RepeaterOverflowError(
+                `No more than ${MAX_QUEUE_LENGTH} pending calls to next are allowed on a single repeater.`,
+            );
+        }
+
+        if (r.state <= Initial) {
+            execute(r);
+        }
+
+        r.onnext(value);
+        if (typeof r.buffer !== "undefined" && !r.buffer.empty) {
+            const result = createIteration(
+                r,
+                r.buffer.remove() as Promise<T | undefined>,
+            );
+            if (r.pushes.length) {
+                const push = r.pushes.shift()!;
+                r.buffer.add(push.value);
+                r.onnext = push.resolve;
+            }
+
+            return result;
+        } else if (r.pushes.length) {
+            const push = r.pushes.shift()!;
+            r.onnext = push.resolve;
+            return createIteration(r, push.value);
+        } else if (r.state >= Stopped) {
+            finish(r);
+            return createIteration(r, consumeExecution(r));
+        }
+
+        return new Promise((resolve) => r.nexts.push({ resolve, value }));
+    }
+
+    return(
+        value?: PromiseLike<TReturn> | TReturn,
+    ): Promise<IteratorResult<T, TReturn>> {
+        swallow(value);
+        const r = records.get(this);
+        if (r === undefined) {
+            throw new Error("WeakMap error");
+        }
+
+        finish(r);
+        // We override the execution because return should always return the value passed in.
+        r.execution = Promise.resolve(r.execution).then(() => value);
+        return createIteration(r, consumeExecution(r));
+    }
+
+    throw(err: unknown): Promise<IteratorResult<T, TReturn>> {
+        const r = records.get(this);
+        if (r === undefined) {
+            throw new Error("WeakMap error");
+        }
+
+        if (
+            r.state <= Initial ||
+            r.state >= Stopped ||
+            (typeof r.buffer !== "undefined" && !r.buffer.empty)
+        ) {
+            finish(r);
+            // If r.err is already set, that mean the repeater has already produced an error, so we throw that error rather than the error passed in, because doing so might be more informative for the caller.
+            if (r.err == null) {
+                r.err = err;
+            }
+
+            return createIteration(r, consumeExecution(r));
+        }
+
+        return this.next(Promise.reject(err));
+    }
+
+    [Symbol.asyncIterator](): this {
+        return this;
+    }
+}

--- a/packages/api-client-core/src/repeater/index.ts
+++ b/packages/api-client-core/src/repeater/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Code adopted from https://github.com/repeaterjs/repeater/blob/master/packages/repeater/src/repeater.ts after removing static classes.
+ */
+
 /** An error subclass which is thrown when there are too many pending push or next operations on a single repeater. */
 export class RepeaterOverflowError extends Error {
     constructor(message: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
 
   packages/api-client-core:
     dependencies:
-      '@manufac/repeater':
-        specifier: ^4.0.6
-        version: 4.0.6
       '@n1ru4l/graphql-live-query':
         specifier: ^0.10.0
         version: 0.10.0(graphql@16.8.1)
@@ -1826,10 +1823,6 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
-
-  /@manufac/repeater@4.0.6:
-    resolution: {integrity: sha512-qvSJXgzSjkx13dIqg23pGivfdXY1+fHEZanFqKFzaH9klq1RTUUAi36ryEbCc0Nw099IQt6qZFERnloCWRP0dg==}
-    dev: false
 
   /@n1ru4l/graphql-live-query@0.10.0(graphql@16.8.1):
     resolution: {integrity: sha512-qZ7OHH/NB0NcG/Xa7irzgjE63UH0CkofZT0Bw4Ko6iRFagPRHBM8RgFXwTt/6JbFGIEUS4STRtaFoc/Eq/ZtzQ==}


### PR DESCRIPTION
The repeater-lite code is moved to js-clients monorepo (api-client-core package) itself for easier maintenance.

Test cases passing:

![image](https://github.com/gadget-inc/js-clients/assets/25290212/9f328946-7bef-44a5-8a35-d7f8f7b55881)

Test Video with a prerelease version:

https://github.com/gadget-inc/js-clients/assets/25290212/ea6cd6bb-d0a0-4010-8d73-e148dd0075a3

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
