### PR TITLE
Add support for enqueuing actions in the background in bulk

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.19",
+  "version": "0.15.20",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -1,6 +1,6 @@
 import {
   actionOperation,
-  actionResultOperation,
+  backgroundActionResultOperation,
   enqueueActionOperation,
   findManyOperation,
   findOneByFieldOperation,
@@ -690,9 +690,9 @@ describe("operation builders", () => {
     });
   });
 
-  describe("actionResultOperation", () => {
+  describe("backgroundActionResultOperation", () => {
     test("builds query for action", async () => {
-      expect(actionResultOperation("app-job-1234567", MockWidgetCreateAction, { select: { id: true } })).toMatchInlineSnapshot(`
+      expect(backgroundActionResultOperation("app-job-1234567", MockWidgetCreateAction, { select: { id: true } })).toMatchInlineSnapshot(`
         {
           "query": "subscription CreateWidgetBackgroundResult($id: String!) {
           backgroundAction(id: $id) {
@@ -727,7 +727,7 @@ describe("operation builders", () => {
     });
 
     test("builds query for globalAction", async () => {
-      expect(actionResultOperation("app-job-1234567", MockGlobalAction)).toMatchInlineSnapshot(`
+      expect(backgroundActionResultOperation("app-job-1234567", MockGlobalAction)).toMatchInlineSnapshot(`
         {
           "query": "subscription FlipAllWidgetsBackgroundResult($id: String!) {
           backgroundAction(id: $id) {
@@ -759,7 +759,8 @@ describe("operation builders", () => {
     });
 
     test("builds query for one result of a bulk action", async () => {
-      expect(actionResultOperation("app-job-1234567", MockBulkUpdateWidgetAction, { select: { id: true } })).toMatchInlineSnapshot(`
+      expect(backgroundActionResultOperation("app-job-1234567", MockBulkUpdateWidgetAction, { select: { id: true } }))
+        .toMatchInlineSnapshot(`
         {
           "query": "subscription UpdateWidgetBackgroundResult($id: String!) {
           backgroundAction(id: $id) {

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -6,7 +6,7 @@ import {
   findOneByFieldOperation,
   findOneOperation,
 } from "../src/index.js";
-import { MockGlobalAction, MockWidgetCreateAction } from "./mockActions.js";
+import { MockBulkUpdateWidgetAction, MockGlobalAction, MockWidgetCreateAction } from "./mockActions.js";
 
 describe("operation builders", () => {
   describe("findOneOperation", () => {
@@ -575,7 +575,7 @@ describe("operation builders", () => {
                 }
               }
             }
-            results
+            result
           }
           gadgetMeta {
             hydrations(modelName: "widget")
@@ -694,7 +694,7 @@ describe("operation builders", () => {
     test("builds query for action", async () => {
       expect(actionResultOperation("app-job-1234567", MockWidgetCreateAction, { select: { id: true } })).toMatchInlineSnapshot(`
         {
-          "query": "subscription createWidget($id: String!) {
+          "query": "subscription CreateWidgetBackgroundResult($id: String!) {
           backgroundAction(id: $id) {
             id
             outcome
@@ -729,7 +729,7 @@ describe("operation builders", () => {
     test("builds query for globalAction", async () => {
       expect(actionResultOperation("app-job-1234567", MockGlobalAction)).toMatchInlineSnapshot(`
         {
-          "query": "subscription flipAllWidgets($id: String!) {
+          "query": "subscription FlipAllWidgetsBackgroundResult($id: String!) {
           backgroundAction(id: $id) {
             id
             outcome
@@ -747,6 +747,41 @@ describe("operation builders", () => {
                   }
                 }
                 result
+              }
+            }
+          }
+        }",
+          "variables": {
+            "id": "app-job-1234567",
+          },
+        }
+      `);
+    });
+
+    test("builds query for one result of a bulk action", async () => {
+      expect(actionResultOperation("app-job-1234567", MockBulkUpdateWidgetAction, { select: { id: true } })).toMatchInlineSnapshot(`
+        {
+          "query": "subscription UpdateWidgetBackgroundResult($id: String!) {
+          backgroundAction(id: $id) {
+            id
+            outcome
+            result {
+              ... on UpdateWidgetResult {
+                success
+                errors {
+                  message
+                  code
+                  ... on InvalidRecordError {
+                    validationErrors {
+                      message
+                      apiIdentifier
+                    }
+                  }
+                }
+                widget {
+                  id
+                  __typename
+                }
               }
             }
           }

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -612,6 +612,30 @@ describe("operation builders", () => {
       `);
     });
 
+    test("enqueueActionOperation should build a mutation query for enqueuing a bulk action action", () => {
+      expect(enqueueActionOperation("bulkCreateWidgets", {}, undefined, null, true)).toMatchInlineSnapshot(`
+        {
+          "query": "mutation enqueueBulkCreateWidgets($backgroundOptions: EnqueueBackgroundActionOptions) {
+          background {
+            bulkCreateWidgets(backgroundOptions: $backgroundOptions) {
+              success
+              errors {
+                message
+                code
+              }
+              backgroundActions {
+                id
+              }
+            }
+          }
+        }",
+          "variables": {
+            "backgroundOptions": null,
+          },
+        }
+      `);
+    });
+
     test("enqueueActionOperation with startsAt as string", () => {
       expect(enqueueActionOperation("createWidget", {}, undefined, { startAt: "2024-03-18T18:14:08.257Z" })).toMatchInlineSnapshot(`
         {

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -691,7 +691,7 @@ describe("operationRunners", () => {
       expect(handle.id).toEqual("widget-flipAllWidgets-123");
     });
 
-    test("can enqueue a bulk action with ids only and return a handle", async () => {
+    test("can enqueue a bulk action with ids only and return handles", async () => {
       const promise = enqueueActionRunner(connection, MockBulkFlipDownWidgetsAction, ["123", "456"]);
 
       expect(mockUrqlClient.executeMutation.mock.calls.length).toEqual(1);
@@ -706,9 +706,14 @@ describe("operationRunners", () => {
             bulkFlipDownWidgets: {
               success: true,
               errors: null,
-              backgroundAction: {
-                id: "widget-bulkFlipWidgets-123",
-              },
+              backgroundActions: [
+                {
+                  id: "widget-bulkFlipWidgets-123",
+                },
+                {
+                  id: "widget-bulkFlipWidgets-456",
+                },
+              ],
             },
           },
         },
@@ -716,12 +721,13 @@ describe("operationRunners", () => {
         hasNext: false,
       });
 
-      const handle = await promise;
-      expect(handle).toBeInstanceOf(BackgroundActionHandle);
-      expect(handle.id).toEqual("widget-bulkFlipWidgets-123");
+      const handles = await promise;
+      expect(handles[0]).toBeInstanceOf(BackgroundActionHandle);
+      expect(handles[0].id).toEqual("widget-bulkFlipWidgets-123");
+      expect(handles[1].id).toEqual("widget-bulkFlipWidgets-456");
     });
 
-    test("can enqueue a bulk action with a list of inputs and return a handle", async () => {
+    test("can enqueue a bulk action with a list of inputs and return handles", async () => {
       const promise = enqueueActionRunner(connection, MockBulkUpdateWidgetAction, [
         { id: "123", name: "foo" },
         { id: "124", name: "bar" },
@@ -742,9 +748,14 @@ describe("operationRunners", () => {
             bulkUpdateWidgets: {
               success: true,
               errors: null,
-              backgroundAction: {
-                id: "background-123",
-              },
+              backgroundActions: [
+                {
+                  id: "background-123",
+                },
+                {
+                  id: "background-456",
+                },
+              ],
             },
           },
         },
@@ -752,9 +763,10 @@ describe("operationRunners", () => {
         hasNext: false,
       });
 
-      const handle = await promise;
-      expect(handle).toBeInstanceOf(BackgroundActionHandle);
-      expect(handle.id).toEqual("background-123");
+      const handles = await promise;
+      expect(handles[0]).toBeInstanceOf(BackgroundActionHandle);
+      expect(handles[0].id).toEqual("background-123");
+      expect(handles[1].id).toEqual("background-456");
     });
 
     test("throws a duplicate ID error by default from the server", async () => {

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -830,14 +830,14 @@ describe("operationRunners", () => {
   describe("actionResultRunner", () => {
     describe("action", () => {
       test("waits for background action with a completed result", async () => {
-        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, { widget: { name: "new widget" } });
+        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
           id: "app-job-123456",
         });
 
-        mockUrqlClient.executeSubscription.pushResponse("createWidget", {
+        mockUrqlClient.executeSubscription.pushResponse("CreateWidgetBackgroundResult", {
           data: {
             backgroundAction: {
               id: "app-job-123456",
@@ -849,7 +849,7 @@ describe("operationRunners", () => {
           hasNext: true,
         });
 
-        mockUrqlClient.executeSubscription.pushResponse("createWidget", {
+        mockUrqlClient.executeSubscription.pushResponse("CreateWidgetBackgroundResult", {
           data: {
             backgroundAction: {
               id: "app-job-123456",
@@ -876,14 +876,14 @@ describe("operationRunners", () => {
       });
 
       test("waits for background action with failed result", async () => {
-        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, { widget: { name: "new widget" } });
+        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
           id: "app-job-123456",
         });
 
-        mockUrqlClient.executeSubscription.pushResponse("createWidget", {
+        mockUrqlClient.executeSubscription.pushResponse("CreateWidgetBackgroundResult", {
           data: {
             backgroundAction: {
               id: "app-job-123456",
@@ -895,7 +895,7 @@ describe("operationRunners", () => {
           hasNext: true,
         });
 
-        mockUrqlClient.executeSubscription.pushResponse("createWidget", {
+        mockUrqlClient.executeSubscription.pushResponse("CreateWidgetBackgroundResult", {
           data: {
             backgroundAction: {
               id: "app-job-123456",
@@ -929,7 +929,7 @@ describe("operationRunners", () => {
           id: "app-job-123456",
         });
 
-        mockUrqlClient.executeSubscription.pushResponse("flipAllWidgets", {
+        mockUrqlClient.executeSubscription.pushResponse("FlipAllWidgetsBackgroundResult", {
           data: {
             backgroundAction: {
               id: "app-job-123456",
@@ -941,7 +941,7 @@ describe("operationRunners", () => {
           hasNext: true,
         });
 
-        mockUrqlClient.executeSubscription.pushResponse("flipAllWidgets", {
+        mockUrqlClient.executeSubscription.pushResponse("FlipAllWidgetsBackgroundResult", {
           data: {
             backgroundAction: {
               id: "app-job-123456",
@@ -970,7 +970,7 @@ describe("operationRunners", () => {
           id: "app-job-123456",
         });
 
-        mockUrqlClient.executeSubscription.pushResponse("flipAllWidgets", {
+        mockUrqlClient.executeSubscription.pushResponse("FlipAllWidgetsBackgroundResult", {
           data: {
             backgroundAction: {
               id: "app-job-123456",
@@ -982,7 +982,7 @@ describe("operationRunners", () => {
           hasNext: true,
         });
 
-        mockUrqlClient.executeSubscription.pushResponse("flipAllWidgets", {
+        mockUrqlClient.executeSubscription.pushResponse("FlipAllWidgetsBackgroundResult", {
           data: {
             backgroundAction: {
               id: "app-job-123456",
@@ -1007,15 +1007,63 @@ describe("operationRunners", () => {
       });
     });
 
+    describe("bulk action", () => {
+      test("waits for a background bulk action element with a completed result", async () => {
+        const promise = actionResultRunner(connection, "app-job-123456", MockBulkUpdateWidgetAction);
+
+        expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
+        expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
+          id: "app-job-123456",
+        });
+
+        mockUrqlClient.executeSubscription.pushResponse("UpdateWidgetBackgroundResult", {
+          data: {
+            backgroundAction: {
+              id: "app-job-123456",
+              outcome: null,
+              result: null,
+            },
+          },
+          stale: false,
+          hasNext: true,
+        });
+
+        mockUrqlClient.executeSubscription.pushResponse("UpdateWidgetBackgroundResult", {
+          data: {
+            backgroundAction: {
+              id: "app-job-123456",
+              outcome: "completed",
+              result: {
+                success: true,
+                errors: null,
+                widget: {
+                  id: "123",
+                  name: "foo",
+                },
+              },
+            },
+          },
+          stale: false,
+          hasNext: false,
+        });
+
+        const result = await promise;
+
+        expect(result.outcome).toEqual("completed");
+        expect(result.result.id).toBeTruthy();
+        expect(result.result.name).toBeTruthy();
+      });
+    });
+
     test("permission error", async () => {
-      const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, { widget: { name: "new widget" } });
+      const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
 
       expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
       expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
         id: "app-job-123456",
       });
 
-      mockUrqlClient.executeSubscription.pushResponse("createWidget", {
+      mockUrqlClient.executeSubscription.pushResponse("CreateWidgetBackgroundResult", {
         error: new CombinedError({
           graphQLErrors: [
             {

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -2,7 +2,7 @@ import { CombinedError } from "@urql/core";
 import nock from "nock";
 import { BackgroundActionHandle } from "../src/BackgroundActionHandle.js";
 import type { GadgetErrorGroup } from "../src/index.js";
-import { GadgetConnection, actionResultRunner, actionRunner, enqueueActionRunner } from "../src/index.js";
+import { GadgetConnection, actionRunner, backgroundActionResultRunner, enqueueActionRunner } from "../src/index.js";
 import { MockBulkFlipDownWidgetsAction, MockBulkUpdateWidgetAction, MockGlobalAction, MockWidgetCreateAction } from "./mockActions.js";
 import { mockUrqlClient } from "./mockUrqlClient.js";
 
@@ -830,7 +830,7 @@ describe("operationRunners", () => {
   describe("actionResultRunner", () => {
     describe("action", () => {
       test("waits for background action with a completed result", async () => {
-        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -876,7 +876,7 @@ describe("operationRunners", () => {
       });
 
       test("waits for background action with failed result", async () => {
-        const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -922,7 +922,7 @@ describe("operationRunners", () => {
 
     describe("globalAction", () => {
       test("waits for completed background action response", async () => {
-        const promise = actionResultRunner(connection, "app-job-123456", MockGlobalAction, {});
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockGlobalAction, {});
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -963,7 +963,7 @@ describe("operationRunners", () => {
       });
 
       test("waits for failed background action response", async () => {
-        const promise = actionResultRunner(connection, "app-job-123456", MockGlobalAction, {});
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockGlobalAction, {});
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -1009,7 +1009,7 @@ describe("operationRunners", () => {
 
     describe("bulk action", () => {
       test("waits for a background bulk action element with a completed result", async () => {
-        const promise = actionResultRunner(connection, "app-job-123456", MockBulkUpdateWidgetAction);
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockBulkUpdateWidgetAction);
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -1056,7 +1056,7 @@ describe("operationRunners", () => {
     });
 
     test("permission error", async () => {
-      const promise = actionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
+      const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
 
       expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
       expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({

--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -1,6 +1,6 @@
 import type { GadgetConnection } from "./GadgetConnection.js";
 import type { AnyActionFunction } from "./GadgetFunctions.js";
-import { actionResultRunner } from "./operationRunners.js";
+import { backgroundActionResultRunner } from "./operationRunners.js";
 import type { ActionFunctionOptions } from "./types.js";
 
 export type BackgroundActionResult<R = any> = {
@@ -15,6 +15,6 @@ export class BackgroundActionHandle<Action extends AnyActionFunction> {
 
   /** Wait for this background action to complete and return the result. */
   async result<Options extends ActionFunctionOptions<Action>>(options?: Options) {
-    return (await actionResultRunner(this.connection, this.id, this.action, options)).result;
+    return (await backgroundActionResultRunner(this.connection, this.id, this.action, options)).result;
   }
 }

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -108,11 +108,12 @@ export interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, Schema
   variablesType: VariablesT;
   isBulk: IsBulk;
   hasAmbiguousIdentifier?: boolean;
-  /** @deprecated */
-  hasCreateOrUpdateEffect?: boolean;
   acceptsModelInput?: boolean;
   paramOnlyVariables?: readonly string[];
   hasReturnType?: boolean;
+  singleActionFunctionName?: string;
+  /** @deprecated */
+  hasCreateOrUpdateEffect?: boolean;
 }
 
 export type ActionFunction<OptionsT, VariablesT, SelectionT, SchemaT, DefaultsT> = ActionFunctionMetadata<

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -160,6 +160,8 @@ export interface GlobalActionFunction<VariablesT> {
   namespace: string | null;
   variables: VariablesOptions;
   variablesType: VariablesT;
+  isBulk?: undefined;
 }
 
 export type AnyActionFunction = ActionFunctionMetadata<any, any, any, any, any, any> | GlobalActionFunction<any>;
+export type AnyBulkActionFunction = ActionFunctionMetadata<any, any, any, any, any, true>;

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -161,7 +161,7 @@ export const actionOperation = (
   return compileWithVariableValues(actionOperation);
 };
 
-export const actionResultOperation = <Action extends AnyActionFunction, Options extends ActionFunctionOptions<Action>>(
+export const backgroundActionResultOperation = <Action extends AnyActionFunction, Options extends ActionFunctionOptions<Action>>(
   id: string,
   action: Action,
   options?: Options
@@ -209,6 +209,9 @@ export const actionResultOperation = <Action extends AnyActionFunction, Options 
 
   return compileWithVariableValues(actionResultOperation);
 };
+
+/** @deprecated previous export name, @see backgroundActionResultOperation */
+export const actionResultOperation = backgroundActionResultOperation;
 
 const globalActionFieldSelection = () => {
   return {

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -277,11 +277,13 @@ export const graphqlizeBackgroundOptions = (options?: EnqueueBackgroundActionOpt
 
   return obj;
 };
+
 export const enqueueActionOperation = (
   operation: string,
   variables: VariablesOptions,
   namespace?: string | null,
-  options?: EnqueueBackgroundActionOptions<any> | null
+  options?: EnqueueBackgroundActionOptions<any> | null,
+  isBulk?: boolean
 ) => {
   let fields: BuilderFieldSelection = {
     background: {
@@ -299,7 +301,7 @@ export const enqueueActionOperation = (
             message: true,
             code: true,
           },
-          backgroundAction: {
+          [isBulk ? "backgroundActions" : "backgroundAction"]: {
             id: true,
           },
         }

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -2,7 +2,7 @@ import type { FieldSelection as BuilderFieldSelection, BuilderOperation, Variabl
 import { Call, Var, compileWithVariableValues } from "tiny-graphql-query-compiler";
 import type { FieldSelection } from "./FieldSelection.js";
 import type { AnyActionFunction } from "./index.js";
-import { camelize, filterTypeName, sortTypeName } from "./support.js";
+import { camelize, capitalizeIdentifier, filterTypeName, sortTypeName } from "./support.js";
 import type { ActionFunctionOptions, BaseFindOptions, EnqueueBackgroundActionOptions, FindManyOptions, VariablesOptions } from "./types.js";
 
 const hydrationOptions = (modelApiIdentifier: string): BuilderFieldSelection => {
@@ -117,17 +117,12 @@ const variableOptionsToVariables = (variables: VariablesOptions) => {
   return Object.fromEntries(Object.entries(variables).map(([name, options]) => [name, Var(options)]));
 };
 
-const actionResultFieldSelection = (
-  modelSelectionField: string,
-  selection: FieldSelection,
-  isBulkAction?: boolean | null,
-  hasReturnType?: boolean | null
-) => {
+const actionResultFieldSelection = (modelSelectionField: string, selection: FieldSelection, hasReturnType?: boolean | null) => {
   return {
     success: true,
     errors: ErrorsSelection,
     [modelSelectionField]: selection && !hasReturnType ? fieldSelectionToQueryCompilerFields(selection, true) : false,
-    [isBulkAction ? "results" : "result"]: !!hasReturnType,
+    result: !!hasReturnType,
   } as FieldSelection;
 };
 
@@ -145,10 +140,7 @@ export const actionOperation = (
   const selection = options?.select || defaultSelection;
 
   let fields: BuilderFieldSelection = {
-    [operation]: Call(
-      variableOptionsToVariables(variables),
-      actionResultFieldSelection(modelSelectionField, selection, isBulkAction, hasReturnType)
-    ),
+    [operation]: Call(variableOptionsToVariables(variables), actionResultFieldSelection(modelSelectionField, selection, hasReturnType)),
   };
 
   if (namespace) {
@@ -175,31 +167,32 @@ export const actionResultOperation = <Action extends AnyActionFunction, Options 
   options?: Options
 ) => {
   let fields: FieldSelection = {};
+  let operationName = action.operationName;
 
   switch (action.type) {
     case "action": {
       const selection = options?.select || action.defaultSelection;
+      // background bulk actions enqueue many of the same action, each returning the result of one element of the bulk. so, the GraphQL result type is the singular result type, not the bulk result type.
+      if (action.isBulk) {
+        operationName = action.operationName.replace(/^bulk/, "").replace(/s$/, "");
+      }
+      const resultType = `${camelize(operationName)}Result`;
 
       fields = {
-        [`... on ${camelize(action.operationName)}Result`]: actionResultFieldSelection(
-          action.modelApiIdentifier,
-          selection,
-          action.isBulk,
-          action.hasReturnType
-        ),
+        [`... on ${resultType}`]: actionResultFieldSelection(action.modelApiIdentifier, selection, action.hasReturnType),
       };
       break;
     }
     case "globalAction": {
       fields = {
-        [`... on ${camelize(action.operationName)}Result`]: globalActionFieldSelection(),
+        [`... on ${camelize(operationName)}Result`]: globalActionFieldSelection(),
       };
     }
   }
 
   const actionResultOperation: BuilderOperation = {
     type: "subscription",
-    name: action.operationName,
+    name: capitalizeIdentifier(operationName) + "BackgroundResult",
     fields: {
       backgroundAction: Call(
         { id: Var({ value: id, type: "String!" }) },

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -322,7 +322,7 @@ export const actionResultRunner = async <Action extends AnyActionFunction, Optio
         action.defaultSelection,
         response.data,
         backgroundAction.result,
-        action.modelSelectionField,
+        action.isBulk ? action.modelApiIdentifier : action.modelSelectionField,
         action.hasReturnType
       );
       break;

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -9,7 +9,7 @@ import { GadgetRecordList } from "./GadgetRecordList.js";
 import type { AnyModelManager } from "./ModelManager.js";
 import {
   actionOperation,
-  actionResultOperation,
+  backgroundActionResultOperation,
   enqueueActionOperation,
   findManyOperation,
   findOneByFieldOperation,
@@ -296,13 +296,13 @@ export async function enqueueActionRunner<Action extends AnyActionFunction>(
   }
 }
 
-export const actionResultRunner = async <Action extends AnyActionFunction, Options extends ActionFunctionOptions<Action>>(
+export const backgroundActionResultRunner = async <Action extends AnyActionFunction, Options extends ActionFunctionOptions<Action>>(
   connection: GadgetConnection,
   id: string,
   action: Action,
   options?: Options
 ): Promise<BackgroundActionResult> => {
-  const plan = actionResultOperation(id, action, options);
+  const plan = backgroundActionResultOperation(id, action, options);
   const subscription = connection.currentClient.subscription(plan.query, plan.variables);
 
   const response = await pipe(
@@ -335,3 +335,6 @@ export const actionResultRunner = async <Action extends AnyActionFunction, Optio
 
   return backgroundAction;
 };
+
+/** @deprecated previous export name, @see backgroundActionResultRunner */
+export const actionResultRunner = backgroundActionResultRunner;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "files": [
     "README.md",
     "dist/**/*"
@@ -28,7 +28,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.19",
+    "@gadgetinc/api-client-core": "^0.15.20",
     "react-fast-compare": "^3.2.2",
     "react-hook-form": "~7.48.2",
     "tslib": "^2.6.2",

--- a/packages/react/spec/useEnqueue.spec.tsx
+++ b/packages/react/spec/useEnqueue.spec.tsx
@@ -82,7 +82,7 @@ describe("useEnqueue", () => {
   };
 
   const _TestUseEnqueueCanRunBulkActionsWithIds = () => {
-    const [_, enqueue] = useEnqueue(bulkExampleApi.widget.bulkFlipDown);
+    const [{ handles }, enqueue] = useEnqueue(bulkExampleApi.widget.bulkFlipDown);
 
     // can call with variables
     void enqueue({ ids: ["1", "2", "3"] });
@@ -151,6 +151,19 @@ describe("useEnqueue", () => {
     // data is accessible via dot access
     if (handle) {
       handle.id;
+    }
+  };
+
+  const _TestUseEnqueueBulkReturnsTypedHandle = () => {
+    const [{ handles, fetching, error }, _enqueue] = useEnqueue(relatedProductsApi.user.bulkUpdate);
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+    assert<IsExact<typeof handles, BackgroundActionHandle<typeof relatedProductsApi.user.bulkUpdate>[] | null>>(true);
+    assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+
+    // data is accessible via dot access
+    if (handles) {
+      handles[0].id;
     }
   };
 

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from "@gadgetinc/api-client-core";
 import { gadgetErrorFor, getNonNullableError } from "@gadgetinc/api-client-core";
 import type { BackgroundActionHandle } from "@gadgetinc/api-client-core/dist/cjs/BackgroundActionHandle.js";
+import { AnyBulkActionFunction } from "@gadgetinc/api-client-core/src/GadgetFunctions.js";
 import type { CombinedError, RequestPolicy } from "@urql/core";
 import { GraphQLError } from "graphql";
 import { useMemo } from "react";
@@ -135,14 +136,23 @@ export type ActionHookResult<Data = any, Variables extends AnyVariables = AnyVar
 /**
  * The inner result object returned from a mutation result
  */
-export interface EnqueueHookState<Action extends AnyActionFunction> {
-  fetching: boolean;
-  stale: boolean;
-  handle: BackgroundActionHandle<Action> | null;
-  error?: ErrorWrapper;
-  extensions?: Record<string, any>;
-  operation?: Operation<{ backgroundAction: { id: string } }, Action["variablesType"]>;
-}
+export type EnqueueHookState<Action extends AnyActionFunction> = Action extends AnyBulkActionFunction
+  ? {
+      fetching: boolean;
+      stale: boolean;
+      handles: BackgroundActionHandle<Action>[] | null;
+      error?: ErrorWrapper;
+      extensions?: Record<string, any>;
+      operation?: Operation<{ backgroundAction: { id: string } }, Action["variablesType"]>;
+    }
+  : {
+      fetching: boolean;
+      stale: boolean;
+      handle: BackgroundActionHandle<Action> | null;
+      error?: ErrorWrapper;
+      extensions?: Record<string, any>;
+      operation?: Operation<{ backgroundAction: { id: string } }, Action["variablesType"]>;
+    };
 
 /**
  * The return value of a `useEnqueue` hook.


### PR DESCRIPTION
This updates our operation planners and runners to work with background enqueued bulk actions, which return an array of handles instead of just one. 