### PR TITLE
handle shopify managed installation

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -48,6 +48,7 @@
     "globby": "^11.0.4",
     "gql-tag": "^1.0.1",
     "nock": "^13.5.4",
+    "p-retry": "^4.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tiny-graphql-query-compiler": "workspace:*",

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship-with-support-for-Id-pre_1709343723/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship-with-support-for-Id-pre_1709343723/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 743,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twQmFpboitVlTqCi3spatVNbUnIbvBtuwJIqr491XSQAlNKLco896bmednv/YY4woIeMRee4wxxv3a2DQuFs6oXJI/FhjjFhKc69ic/GOMr8H/wB0tIEEesRgyj18a1YXDbWpy34HwBI5mufPG8YhxLB7s02w+nv+9Lx6Lhzt+AkWtrgM+P1NhUcOmbMgXh7lrwP6A5KgSLFf8faS+L8YYl9c0Y4xro7BhSssQy4avDT5j/MWoouqzg43NkG0hy5HFxrGqcoaWZmPB4ZQWLpX4E3RlrM6z7BzoEAjVlErtUITDmyC8CcJVMI7CMApHfSGCp3P1NWiVdQimqlQKwuE5yb7tNQPCxLiinV2DVoXtkLf5S5b6dT3xJcBSmi6ROsGztt1FsBKjSIhIiL4Q4sPuNfeXVUduWwcCyn17jSDpquDGZkC4zOM43XVgUuqyPj+Z6eqz3KJWVYJLwZPSvpHfS0m9VwnyI3hff/05XqFL3JnRGiWl\",\"Rr8p1F15AipBesSTd6fMXaEclGDffGDazvMbEK7SDZ5e+mZ4WiHyM42GyW2AloC84z68L01zvldrT63NUlktWjnQO/ha0TjuCLVvuMAzU2WKr4msjwaDJKF+lup/g7IwCEZiLCaDobjDr7fhSwi3MhAyVGoIQk3iyVAGE8TDk8XJgcR5dY8/pZRT9fb/AQAA//8DAIggRbwmBgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twkoJoboitVlTqCi3spdWqmsaTkN1gW/YEEVX8+yppoAlNKLco896bec9jvw0Y4xIIeMjeBowxxt1GmzQullbLPCJ3KjDGDSS4ULFu/GOMb8D9xD0tIUEeshgyh99a1aXFXapz14NwBJbmuXXa8pBxLB7M03wxWfy9Lx6LhzvegKKS1wFfXqgwqGBbNuTL49w14HBEcpQJlhafT9QPY4zx6JpmjHGlJbZC6Rhi1cq1xWeMv2pZVH32sDUZsh1kObJYW1ZVztCR3hqwOKOlTSP8BaoKVuVZdg60CIRyRqW2L/zgxvNvPH/tTULfD/3xUAjv6Vx9A0pmPYKpLJU8PzgnmXdfcyBMtC262TVoXZgeeZO/Zqnb1BNfAqwi3SdSb/C8y7vw1mIcChEKMRRCfPJec38beeJ2dSCg3HXXCJK+Cm5NBoSrPI7TfQ8mpb7o88ZMV5/lDpWsNrgUbJQOrf29tKn3MkF+Ah/qrz+nK3SJO9dKYUSpVu8KdVee\",\"gEyQHrHx7pR7V0gLJdi1H5iu8/wOhOt0i81L316eTkj0lUYr5C5Ax4J84D69L+1wflS2Z8ZkaVQZrRIYHHOtaBz3hMq1UuCZrnaKb4iMC0ejJKFhlqp/o7Iw8sZiIqYjfzoNoti7w1vwAz8IxpNJJILgFj2cxgCT2gUnCxEuqnv8JaWcanD4DwAA//8DAE0jH3smBgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:36 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:53 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "4e09527b8be7bbadcf804b18250060cb"
+              "value": "dca7f89e24948b99b9422721ed2d76cc"
             },
             {
               "name": "x-trace-id",
-              "value": "309e742b2a4c10c2dd3a0d8f83c18ee9"
+              "value": "2883cf19e4a23233566c0334e1e8faa6"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=7vgXBCxrJWoijH1yBHiblIgoENha5vqNBDD8rxsughCiPUvAQ%2BBOrhCaCQysjQ%2FoSezH3Zmy7SpWlcmRghqUgQhVdoxvb9VaHiD5cRJ5aiwty7epNjnHTGf1%2B%2F%2Bn3vv6o0VdbPZOzoZ63QbZIDQjWw0RpN%2BeGOFKb7kfiw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=AijeBDrGdw3cHOGNcI3fX%2FA6u8fHFIKMu2OcyqwxRKAyFqbecNPCzFonUbZ6Cjpknxtp%2BH92igIJJ4X4Qezz2Bhc4a12gSSVOHWe3EOxPO8TTlbCmEmYCjo3eYIXha3AMb18Iw0pIeVvqtU8PfEO0%2FlM8yNxHKjZpDpwww%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0838f39ae5e60-EWR"
+              "value": "87a0d029e98b8c21-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 945,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:35.708Z",
-        "time": 273,
+        "startedDateTime": "2024-04-25T19:41:53.486Z",
+        "time": 229,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 273
+          "wait": 229
         }
       },
       {
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 435,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sgj8l7h1qp6qKLVqy6QdOMCVFDCDOOBEX8e5VHU4JU0eVc32sfe84WACrJElM4WwAAmGmSTK9N8TVqAGiaLCNjMAXWDc1+ZNJ6r1u1aspyVA/TMACu13yqqZI7whSwaz77rfYj1ZLboud4/tzx516wcuPUT1IRLkQQvV8HCtU6XeH51yrTsevAZBgONzOaWv1jxuC/jKtMwR/G27yRaUru/YMbc6ly4he6uiYAbk9KSy72lZmeZLL0o2RaFTv6k3g03CF86hiWdV0WWTe1w+kxrSGGdGSqzAQJy33evnDLXJvUtvOcF2VRfdptwXYDJ3RiWypJQSjcaOMmmf9BrohksonFxgnjUIl4wEfWMqPn7pPuRloq6/INAAD//wMAcL3ar4kCAAA=\"]"
+            "size": 435,
+            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sg75Bkh1qp6qKLVqy6QcOMG6KGJMw4EhTx71UepKRSRZdzfa997DlbAKgEC0zhbAEAoNQkmF6b/GvUANA0UpIxmALrhmZXmbSudKuWTVGM6mEaBsDNhk81lWJPmAJ2zWc/1X6kWnFb9BwvmDvB3AvXbpIGbhoGC8dN3m8DuWqdrh8GtyrTsevAZBgOv2Y0tfrHjMF/GVeZgj+Mt3kj0xTc+wc3ZkJlxC90c00A3J2UFpxXpZmeZLL0o2Ba53v6k3g03CF86hhWdV3kspva4fSY1hBDOjKVZoKERZW1L9wx1ya17SzjRZGXn3ZbsN3QiZzY9mPpx8nSS5YUKeHJIJaStvIjdtxIxtsrPrIWkp67T7obaamsyzcAAAD//w==\",\"AwCp2tFsiQIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:36 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:54 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "e8b8e366734d031f5a083b41356150fb"
+              "value": "5f78ddcbcbb230b102397cf162ddf2e0"
             },
             {
               "name": "x-trace-id",
-              "value": "adae56317f19c4be137a9f83f0686d38"
+              "value": "38c3897297e6da2c48ccebcf8016c8be"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=sC6q%2FGe4wcaXvfnbAwbYSHOX35bBaAolr8uI27z5amSasOyPSliEdRj7yMYGdVZW5ZH76f0HOPv%2FfshPuQZGJIq2KA%2BCGhu%2BRGpAC7qyZ5kgVZabMsd%2Buq43GWQXfbeGZT0hA9%2B5NJ7%2B5aBRnPkxmg2EX1QUi2kLUitpyQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=hJHyFZoQOraIuZONHsnuFILpzln9eaEbz8Qnbqzb7qshZzpmbdw%2FGN8Itr9gq9ihWQIqaIzNH%2Fzu43UT%2BlMIiQr29aFkTg6ivU0tN0AZTKPNFMNQQoNVJeLxG%2B8EdwogXjZvtkqug5IS7EGYTUTfEQGsyuH3ibnzHpbCjw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083910d214394-EWR"
+              "value": "87a0d02b9a20c454-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 953,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:36.023Z",
-        "time": 403,
+        "startedDateTime": "2024-04-25T19:41:53.751Z",
+        "time": 306,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 403
+          "wait": 306
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship_3235963512/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship_3235963512/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 747,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twwsKW3BBbrajUFdrSS1erarAnIbvBtuwJIqr491XSQAlNKLco896bec9jv/YY4woIeMRee4wxxv3a2DQuFs6oXJI/FhjjFhKc69ic/GOMr8H/xB0tIEEesRgyj18a1YXDbWpy34HwBI5mufPG8YhxLO7t82w+nv+9Kx6K+wk/gaJW1wFfXqiwqGFTNuSLw9w1YH9AclQJlhZ/H6nvxhjj8ppmjHFtFDZCaRnisZFrg88YXxlVVH12sLEZsi1kObLYOFZVztDSbCw4nNLCpRJ/ga6C1XmWnQMdAqGaUqkdinB4E4Q3QbgMxlEYRuGoL0TwfK6+Bq2yDsFUlUpBODwn2TdfMyBMjCva2TVoWdgOeZuvstSv64kvAR6l6RKpN3jW5l0ESzGKhIiE6AshPnivuU9WHbltHQgo9+01gqSrghubAeFjHsfprgOTUlf0+clMV5/lFrWqNrgUPCntG/t7aVPvVIL8CN7XX3+OV+gSd2Y=\",\"tEZJqdFvCnVXnoBKkB7w5N0p965QDkqwbz4wbef5HQiX6QZPL31zeVoh8jONRshtgJYFecd9eF+a4fyobE+tzVJZGa0S6B1yrWgcd4TaN1Lgmal2iq+JrI8GgyShfpbqf4OyMAhGYixuB+PhJA6+TpSMV1KMZPwtDm7DGMYgVnICoahdcHIgcV7d408p5VS9/X8AAAD//wMAvR+XbCYGAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twQoGSG2KrFZW6Qlt66WpVDfEkZDfYlj1BRBX/vkoaaEITyi3KvPdm3vPYbz3GuAQCHrC3HmOMcbfRJonypdUyC8mdCoxxAzEuVKRr/xjjG3A/cU9LiJEHLILU4bdGdWlxl+jMdSAcgaV5Zp22PGAc8wfzMl+MF3/v88f8YcprUFTyOuDrK+UGFWyLhnx5nLsCHI5IjjLGwuLvE/XDGGM8vKYZY1xpiY1QWoZ4auTa4DPG11rmZZ89bE2KbAdphizSlpWVM3SotwYszmhpkxB/gSqDVVmangMtAqGcUaHtC3944/k3nr/yxoHvB/6oL4T3cq6+ASXTDsFEFkqePzwnmXdfcyCMtc3b2RVolZsOeZOt08RtqokvAZ5C3SVSbfC8zbvwVmIUCBEI0RdCfPJecZ+NPHHbOhBQ5tprBHFXBbcmBcKnLIqSfQcmoa7os9pMV5/lDpUsN7gQrJUOjf29tKn3MkZ+Ah+qrz+nK3SJO9dKYUiJVu8KVQ==\",\"Vx6DjJEesfbuFHuXSwsF2DUfmLbz/A6Eq2SL9UvfXJ5WSPiVRiPkNkDLgnzgPr0vzXB+lLZnxqRJWBotE+gdcy1pHPeEyjVS4Kkud4pviIwLBoM4pn6aqH+DojDwRmIs7gZCRNF6KCa34XA9uZ2MhZwC4p0/nfjhaA2ycsHJQoiL8h5/SSmm6h3+AwAA//8DAIM2BAQmBgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:34 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:52 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "f866222a98903ec4fff51fd076ba2610"
+              "value": "83872f36920ebf2f1ab82e56d4272238"
             },
             {
               "name": "x-trace-id",
-              "value": "639f149dcfbc05cf7f182fa6a0bc9a20"
+              "value": "00ffb3074c3b74760d9aee82972c5bad"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=AoQgoYDgoUwXaps%2FoWwV8mW5WrHdxjSCu80vHcTefuLDkfQ90sP2ZYELsg9xgsHbB6OSA0Ccfcr77K81%2BLKYyJ64p40JyScizab%2BroezQg86lQyPK%2FI%2BL8Nb2VWPNpL%2BXNZWeZrTFmVswLcQHjqUfi881L85zUM%2B6Yp3%2BQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=IowrhcYyfYwkaDrdxKeElTA073zfMK2Xx5hmVME8xGIGJcWrC38iA6zQ5wUoQ2en8EiElNII7KY3FRCtoo3Y%2FyOuBxKjRFc4LNVHDTnUXCr4eJAncBgLy7Tb4A1dSij%2FR6D6GJYGbJzrn5HEuZ2wB3%2BGsr5zKYHxpFv0%2Bg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083837a938cc0-EWR"
+              "value": "87a0d0218a8c7c7c-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 955,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:33.801Z",
-        "time": 249,
+        "startedDateTime": "2024-04-25T19:41:52.123Z",
+        "time": 280,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 249
+          "wait": 280
         }
       },
       {
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 435,
+          "bodySize": 428,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 435,
-            "text": "[\"H4sIAAAAAAAAA4yRQU+DQBCF7/yKyZzbAsuClFujifHgQdOTl2ZZRkqkQHeHpLXpfzdQxGJi6nHfvDfzzezJAcBMscIETg4AAGpDiumlLT5HDQBtqzVZiwmwaWn2LZMxtenUqi3LUd1PwwC42fCxoUrtCBPAvvnsp3oZma24KwpPyLkn5yJc+3Eil0kgFzKWb9eBIuucfiDEtcp06DswWYb9rxltk/1jxuA/j6tMwe/H27ySbUu++Ac35irLiZ/p6poAuD1mRnFRV3Z6ksnSD4ppXezoT+LRcIPwsWdYNU1Z6H5qj3PBdIYY0oGpshMkLOu8e+GWubGJ6+Y5L8qi+nC7guuHXuTFrheQlyqRhkLLZZTGQZSST/pdR1LfBVIO+MhGaXrqP+lmpKNyzl8AAAD//w==\",\"AwCRnSlwiQIAAA==\"]"
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9Am6yhf25ok6YddtjEaRcUGlOqlVISV4IhvvvUAh2dNLFjnt+Lf7aPHgAazRpTOHoAAJhZ0kxvTfHVawDomiwj5zAFtg2NrjJZu7WtWjVl2au7YRgAFws+1FTpDWEK2H0++qmeW5oZt0UZyHAchGOp5iJJQ5EqOYlE8nEbKEzrFA9K3qpM++4HJsew+9Wjqc0/elz8p36UIfhjv5t3ck3JZ//Fjbk2OfEr3WwTANcHYzUX28oNVzIY+kkzzYsN/UncG+4QPncMs7oui6zr2uGcMb1LDGnPVLkBEpbbvH3hmrl2qe/nOU/Kovr024IvVDANYn8ZxJmIopVQcSSkkWqZxBStzHQlpQrC6zWQrc7opTvS3UhL5Z2+AQAA//8DAN1DDr6JAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:34 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:52 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "c3587c9d62ed994a37d1d45e0a00967c"
+              "value": "59ffe9f1efb69f9c52886fc2fdab5067"
             },
             {
               "name": "x-trace-id",
-              "value": "03e0ba2b52c496b836be1ecfc64c7344"
+              "value": "b08c177f158712d25b98e7fd6f225042"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=%2FNNAU9QaQXcrUEgCWS%2FAgTCAaYJvYLW3Jpz4Rf25y1BpENdAFGoEOyMLWGKzjtQetuWABLWCP9bM%2FyJq1qRafXaup24A3rqxPxxFRaWK4xghYN6%2BQKMtHZAi8qdJDFdBRga8qpH8xS3a3dHLzRfAR0%2BHnAJC9NtaOgGLXA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=a8R52nhb3w4824f7czCIH0u2t%2Bab4%2F8wwQJOgM%2FcnzeY8TtbTZSdUSUI067w8g97WHz8Up5GmcjkqAyRjwSwoOh9zxYpJlZmok6NAyg9DOWgfYZSN1mSBcwGN5Cdn3jsXF6wGlyljijzB7Oz1jtpYjYUMpag1ER1%2Fq%2FHTA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,7 +302,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083858e3a7d08-EWR"
+              "value": "87a0d023ae4a7c96-EWR"
             },
             {
               "name": "content-encoding",
@@ -315,8 +315,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:34.113Z",
-        "time": 413,
+        "startedDateTime": "2024-04-25T19:41:52.476Z",
+        "time": 402,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 413
+          "wait": 402
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship-with-support-f_3501493881/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship-with-support-f_3501493881/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
         },
         "response": {
-          "bodySize": 751,
+          "bodySize": 754,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 751,
-            "text": "[\"H4sIAAAAAAAAA4xUXW/iMBB851dYfr6CEz6a5g1x1YlKPaErfenpVC3xJuQu2Ja9QUQV//2UNFBCE8pblJ2Z3Rmv/dZjjEsg4CF76zHGGHdrbdK4WFgt84jcscAYN5DgXMX65B9jfA3uJ+5oAQnykMWQOfzWqC4sblOduw6EI7A0y63TloeMY/FgXmbzyfzvffFYPNzxEygqeR3w9ZUKgwo2ZUO+OMxdA/YHJEeZYGnx95H6YYwxHl3TjDGutMRGKC1DPDVybfAZ4ysti6rPDjYmQ7aFLEcWa8uqyhk60hsDFqe0sGmEv0BVwao8y86BFoFQTqnU9oU/vPH8G89fepPQ90N/3BfCezlXX4OSWYdgKkslzx+ek8y7rxkQJtoW7ewatCxMh7zJV1nq1vXElwBPke4SqTd41uZdeEsxDoUIhegLIT55r7nPRh65bR0IKHftNYKkq4IbkwHhUx7H6a4Dk1JX9PnJTFef5RaVrDa4FDwp7Rv7e2lT72WC/Aje119/jlfoEnemlQ==\",\"wohSrd4V6q48AZkgPeLJu1PuXSEtlGDXfGDazvM7EC7TDZ5e+ubytEKirzQaIbcBWhbkA/fpfWmG86OyPTUmS6PKaJVA75BrReO4I1SukQLPdLVTfE1kXDgYJAn1s1T9G5SFgTcWExEMJqu7OAiGfnAbCRyLEUTxaDgKvDj28VZCULvgZCHCeXWPv6SUU/X2/wEAAP//AwChM2QYJgYAAA==\"]"
+            "size": 754,
+            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1tw3ELb3BBbrajUFdrSS1erampPQnaNbdkOIqr491XSQBOaUG5R5r03857HfhsQQiUEoDF5GxBCCPUrY7OkWDgjcxH8oUAItZDiXCem8Y8QugL/E7dhASnSmCSgPH5rVRcON5nJfQ/CB3BhljtvHI0JxeLePs/mk/nfu+KhuL+lDShqeR7w5SUUFjWsy4Z0sZ+7Buz2SIoyxdLi7wP1wxghVJzTjBCqjcRWKB1DPLZybfEJoa9GFlWfLaytQrIBlSNJjCNV5QgtzNqCw2lYuEzgL9BVsDpX6hjoEALKaSi1OeOXFxG/iPgymsScx3w8ZCx6PlZfgZaqRzCTpVLEL49J9t3XDAKmxhXd7Bq0LGyPvM1fVeZX9cSnAI/C9InUGzzr8s6iJRvHjMWMDRljn7zX3CcrD9yuDgFC7rtrAdK+Cq6tgoCPeZJk2x5MFvqizxsznX2WG9Sy2uBSsFHatfb31KbeyRTpAbyrv/4crtAp7sxojQ==\",\"ImRGvyvUXWkKMsXwgI13p9y7Qjoowb79wHSd53cIuMzW2Lz07eXphIivNFohdwE6FuQD9+l9aYfzo7I9tVZlojJaJTDY51rRKG4Dat9KgSpT7RRdhWB9PBqlaRiqTP8blYVRNGYTdjMSgnN+I8fJFRNX1+JaTBCi20RyziESPKpd0OBA4Ly6x19SyqkGu/8AAAD//w==\",\"AwCDwaWeJgYAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:36 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:54 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "5ce996954fd5fc87b9795ef26dfde42d"
+              "value": "9aa79b89d27603e949c7a60f3f47451a"
             },
             {
               "name": "x-trace-id",
-              "value": "6b9f883287c0e504acf43481ff2e7da8"
+              "value": "cc2228d5f40c47c7c6ea19fd222a1c21"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=bEnDc3VHVz2j2cO%2BCOtI0Lz2DUOwSAvBo00MAftpPw7a9xcJFl8LLeDoSSznKE62lxLenx3xgPsPmGYEzDT5L%2B%2B24frhr0wLqPwfXm9xSr5G17tlNAQzjjwXC%2FAztbkEtNDRN%2Fsge%2FF%2Bhjs59n5vVeGTQpuWtSva5YuNdw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=lTmyvfTZ7%2BXRj3dvN6X5cq9kd8gj3iTFRNPeojjK7vwHR7WR3xOHc3GAngXbaOmjKT%2BjxRjevlOsCazMgWeq7XqBemZEi7zTigYGRNpet7glm%2F17GPTtJ3Ij1NBTlJjcfdrZ%2F%2FvaRt0EpDbS75Pg0CbbI7CYxDkzvr%2FO%2Fw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,7 +142,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a08393ff6e8c48-EWR"
+              "value": "87a0d02d9fed5e72-EWR"
             },
             {
               "name": "content-encoding",
@@ -155,8 +155,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:36.436Z",
-        "time": 240,
+        "startedDateTime": "2024-04-25T19:41:54.076Z",
+        "time": 206,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 240
+          "wait": 206
         }
       },
       {
@@ -232,13 +232,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sgDxLy2KFWqrroohWrbpAzMSFqCGHGkaCIf68S0pRUquhyru+1jz1nCwAzEsIEzhYAACrNJPzaFJ+DBoCmUYqNwQRENzz5llnrvW7VqinLQT2MwwC4Xsup5op2jAlg13zyU72OzJbSFj3H86eOP/WClRslfpzMw5kTh++3gSJrne7cC25V4WPXQdgIHH7NaOrsHzN6/2VYZQz+MNzmjU1TytXfuzGnLGd54ZtrAuD2lGmSYl+Z8UlGSz+S8KrY8Z/Eg+EO4VPHsKzrslDd1A7nimn1MeSjcGVGSFju8/aFW5HaJLad5zIri+rDbgu2GzgLJ7LjgALXD313k8ZEzkJt0pRUlMYhhQuKNj0+iibFz90n3Y20VNblCwAA//8DAKxpj2KJAgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVlgWscjNt0vTQQxtPvZhld0RSRNwdEq3xvzcgpWLS2OO+eW/mm9mTB4BGscIETh4AAGpLiumtzr96DQBdrTU5hwmwrWn0I5O1O9uoZV0UvbofhgFwteJjRaXaEiaAbfPRb/Uy0iy4KUoho7GIxjJeBvMkCpI4mjyE4uM6kJvGGYRxfK0yHdoOTI5hfzOjrsw/ZnT+c7/KEPyxv807ubrgi79zY6ZMRvxKV9cEwM3RWMX5rnTDkwyWflJMy3xLfxL3hjuEzy3DoqqKXLdTW5wLptfFkA5MpRsgYbHLmhdumCuX+H6W8aTIy0+/KfhBLKZi5ptwLs1cCqPl2kgtUiN1mE7jdBataZ3KDh/ZKk0v7SfdjTRU3vkbAAD//wMAbc1c+4kCAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:37 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:54 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "0bf8f156dc652e725757e1174b0e71a7"
+              "value": "b368d63f9be9754238bf8da4c3386720"
             },
             {
               "name": "x-trace-id",
-              "value": "95a514741fb9aa06cfbbac8b97a76a8f"
+              "value": "d392d920dc2fd2c0bd2c3b65b84fefb2"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=E7pJnWLp3j3QnAPhNEXBxEgyqIZN5CxOqSLsWg5mugJwHt68LzmGQnZHjgzDtlZ0V7nLdoG8T9mn7OLKOZsDdF1V1i%2BOqlaHtVGl%2F8fjJYxr07uaxLJnZNTn%2B5jGJNbcp5lb70G%2F7VflLD3PjRsobgX1hiLEVZQxpIjlrw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=XSEXHBjaOW6sMsliFaMwOR1R6R8UOGlukWAc62%2BtVU8B%2FCQ6Qqcqy2GS%2Bimouo0mxuIyG5WrHandukYJ%2FvDil1NMt9zX4si7%2FAHj4vdBZi7qwIa2DqhU%2FYTujjjs8vISuWMTb9wLHo%2FPTBjlbIPAINRSR2Ke6OGB56%2Bj2Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083959e0a43df-EWR"
+              "value": "87a0d02f4d8443d7-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 955,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:36.697Z",
-        "time": 477,
+        "startedDateTime": "2024-04-25T19:41:54.342Z",
+        "time": 461,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 477
+          "wait": 461
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship_1667904710/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship_1667904710/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
         },
         "response": {
-          "bodySize": 743,
+          "bodySize": 751,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 743,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7aQBC98xWrPTewNjUlviEaVURKhQq5pKqiiXds3Jrd1e4YYUX8e2XHEJvYhJvlee/NvLez+zpgjEsg4CF7HTDGGHcbbdK4WFot84jcqcAYN5DgQsW68Y8xvgH3E/e0hAR5yGLIHH5pVZcWd6nOXQ/CEVia59Zpy0PGsbg3T/PFZPH3rngo7m95A4pKXgd8fqbCoIJt2ZAvj3PXgMMRyVEmWFr8faK+G2OMR9c0Y4wrLbEVSscQq1auLT5j/EXLouqzh63JkO0gy5HF2rKqcoaO9NaAxRktbRrhL1BVsCrPsnOgRSCUMyq1feGPbzz/xvPX3iT0/dAPhkJ4T+fqG1Ay6xFMZank+eNzknnzNQfCRNuim12D1oXpkTf5S5a6TT3xJcAq0n0i9QbPu7wLby2CUIhQiKEQ4oP3mvto5Inb1YGActddI0j6Krg1GRCu8jhO9z2YlPqizxszXX2WO1Sy2uBSsFE6tPb30qbeyQT5CXyov/6crtAl7lwrhRGl\",\"Wr0p1F15AjJBesDGu1PuXSEtlGDXfmC6zvM7EK7TLTYvfXt5OiHRZxqtkLsAHQvyjvvwvrTD+VHZnhmTpVFltEpgcMy1onHcEyrXSoFnutopviEyLhyNkoSGWar+jcrCyAvERExHGOD4duz5EX6dChH7AcZBAAjfpv40iKVXu+BkIcJFdY8/pZRTDQ7/AQAA//8DANvMZp8mBgAA\"]"
+            "size": 751,
+            "text": "[\"H4sIAAAAAAAAA4xU0W7aMBR95yssP6/gJAuUvCFWTVTqhAZ76TRVF/smZAu2ZTuIqOLfp6SBJjShvEW555x77/GxXweEUAEOaEReB4QQQu1W6TQulkaJnDt7LhBCNSS4kLFq/COEbsH+wINbQoI0IjFkFr+0qkuD+1TltgdhHRg3z41VhkaEYvGon+eL8eLvQ/FUPE5pA4pS3AZ8eXGFRgm7siFdnuauAccTkqJIsFzx95n6vhghlN/SjBAqlcCWKR1DrFq+tviE0I0SRdXnADudIdlDliOJlSFV5QLN1U6DwZlbmpTjT5CVsTLPskugQXAoZq7U9pkf3Hn+neevvXHk+5EfDhnzni/VtyBF1iOYilLJ84NLkn7baw4OE2WKbnYNWhe6R17nmyy123ria4AVV30idYLnXbszb83CiLGIsSFj7MPuNfeXFmduVwcHLrfdNQdJXwV3OgOHqzyO00MPJnV91ueNmW4+yz1KUSW4FGyUjq38Xkvqg0iQnsHH+uvP+Qpd486VlMhdquSbQg==\",\"3ZUmIBJ0T9h4d8rcFcJACbbtB6brPL+Bw3W6w+alb4enE8I/02iZ3AXoCMg77sP70jbne7X2TOss5dWilQODk68VjeLBobQtF2imqkzRrXPaRqNRkrhhlsp/o7Iw8kI2Zvcj4IEIg7G/mXjTgHsMp/chn2A4icdhMP56urHUGeC4qO7xp5RyqsHxPwAAAP//AwATPeHWJgYAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:34 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:53 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "430723971b51ba5c54e60b73e6ac91a9"
+              "value": "dcf83bf90913bb51919cfbb417f601a1"
             },
             {
               "name": "x-trace-id",
-              "value": "e5e39312ce4800f25ef55aea78285fd1"
+              "value": "ac3d5362b7193c10e985c7e57f653643"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=UqRcvWHX9pGqmp%2Bqqd4d0fQrgiMHqmFvQzfNcL4tPlfnQ%2FslKDdDP3ff3euiBS5VUa%2Fy6RJeg5wlzB50porD%2FDqd51q4ttlEUpJpiUQO9lqB2%2F6VgEHC7mBnLUH61M09wjEzMVABWZHJlP%2BIHJUsUOPfGA1ZVv0agUDLkQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=nXAkysTkiGSzOm%2ByUW%2FXUlgmasFmmh%2BJLAQsiVARhv9xYP1Utuw2BwuLj77BnOB9mGGC21K9jacTV1Fa2EgCp4YYzdCqzVM13CEqFfb162IU8aTLGJSFaim0mT8E4j5AmpiuWh8LpU1fJT9r3SSfVr7PkM6aCQh%2FgHb08g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083888ea94319-EWR"
+              "value": "87a0d0264d4441a3-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:34.547Z",
-        "time": 368,
+        "startedDateTime": "2024-04-25T19:41:52.900Z",
+        "time": 176,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 368
+          "wait": 176
         }
       },
       {
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 435,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sgkyc0O9RKVRddtGLVDZrMmBA1hDDjSFDEv1d5kJJKFV3O9b32sefsAKCWLDGBswMAgMqQZHqr869BA0BbK0XWYgJsappcZTJmbxq1rItiUA/jMACu13yqqJQ7wgSwbT75qXYj9ZKboi/8cCrCqR+tvEUSPiRBNItF/HEbyHXj9AI/uFWZjm0HJstw+DWjrvQ/ZvT+y7DKGPxxuM072brgzt+7MZM6I36lm2sC4PakjeR8X9rxSUZLP0mmVb6jP4kHwx3C55ZhWVVFrtqpLU6H6fQxpCNTaUdIWOyz5oVb5somrptlPCvy8tNtCq4XiVgsXOVHQkWppzcbj1JBFKQ0n2+UCAKd0vyKj2ykopf2k+5GGirn8g0AAP//AwB+KYIXiQIAAA==\"]"
+            "size": 435,
+            "text": "[\"H4sIAAAAAAAAA4yRTW/CMAyG7/0Vls9Av5Ky9YY2adphh02cdkEhMaVaKSVxJRjiv0/9WEcnTeyY1+9rP3bOHgAaxQpTOHsAAKgtKabXOv8cNAB0tdbkHKbAtqbJt0zW7m2jlnVRDOphHAbA1YpPFZVqR5gCts0nP9VupFlwU4yCSEwDMY3kMrxPRZjKeCai+ft1IDeNM4xlfK0yHdsOTI7h8GtGXZl/zOj9l2GVMfjDcJs3cnXBnb93Y6ZMRvxCV9cEwO3JWMX5vnTjk4yWflRMy3xHfxIPhhuETy3DoqqKXLdTW5wO0+tjSEem0o2QsNhnzQu3zJVLfT/LeFbk5YffFPxQBklw50sdzM06mSsTm02kNmZt1huSMhQ6EYEWPT6yVZqe20+6GWmovMsXAAAA//8=\",\"AwADjk33iQIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:35 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:53 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "dacc24a12560b0f24027e7281c976d81"
+              "value": "aac7684ad5dda5f0a5469c38f4c8a08a"
             },
             {
               "name": "x-trace-id",
-              "value": "c250c5b1dff1eb0ee3be77fc033dbe7e"
+              "value": "5c07db67ad3df2afdbdbfe5514c640c4"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=R2Bf4PBkRSGH7I7ISGJfvwxHrgn%2FLIENh61LvAfki2jAD0PDE0vgl5ymHsxfLPu4ZkLdDtLctaHCKdO7hwRtAWy%2FwOwUwhfPeCg02ITtbJAJPh%2FE7rVhTYRVwKAOUKLyfIeXr0l14EU1Pk3%2BTJO%2BCCZ%2B2lLrVAWEM0DzGQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=EsIH9NNBAMp4MZQgWLLxuTvIgAS3qg4b3ozFP4DtJa1rwkviD7pxgm79ds899QUDoLcTVUQB9sGThZAwMxdXAGHhzyfMv4yBsdycZMwiT55mKOsM3eGf5sUnekRbqntSEORguWusJbXEG1jFsy4B4ylSo5Siep%2BFcQ25KQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0838bcf260f77-EWR"
+              "value": "87a0d0278a4e42a1-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 941,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:34.962Z",
-        "time": 736,
+        "startedDateTime": "2024-04-25T19:41:53.105Z",
+        "time": 358,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 736
+          "wait": 358
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-relationship_933332662/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-relationship_933332662/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 435,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sgkxdNskOtVHXRRStW3aBhxoSoIYQZR4Ii/r3KoylBquhyru+1jz1nBwC1ZIkpnB0AAFSGJNNbnX8NGgDaWimyFlNgU9PkRyZj9qZRy7ooBvUwDgPgasWnikq5I0wB2+aT32o3Ui+4KfrCD6cinPrR0ovTMEmDYBYI/+M6kOvG6QW+uFaZjm0HJstwuJlRV/ofM3r/ZVhlDP443OadbF1w5+/dmEmdEb/S1TUBcHvSRnK+L+34JKOlnyTTMt/Rn8SD4Q7hc8uwqKoiV+3UFqfDdPoY0pGptCMkLPZZ88Itc2VT180ynhV5+ek2BdeLxFzEbhwH2hPrjZpvlL9WXpKoSG4kJSElnk4eenxkIxW9tJ90N9JQOZdvAAAA//8DAByXoJ6JAgAA\"]"
+            "size": 435,
+            "text": "[\"H4sIAAAAAAAAA4yRMW/CMBCF9/yKk2cgtrEjyIZaqerQoRVTF+Ta1xA1JMG+SFDEf68S0pRUqujod+/dfXc+RQDMGTIshVMEAMCsR0P43OSfgwbAQmMthsBSIN/g5FtG7yvfqmVTFIO6H4cB2GZDxxpLs0OWAuuaT36ql5FuRW1RcqmmXE2lXotlqkSqxUwt5Ot1IHetU8w1v1YJD10HwkCw/zWjqd0/ZvT+87DKGPxuuM0Lhqagi793s8y4DOkJr64JwLZH5w3lVRnGJxktfW8I1/kO/yQeDDcIHzqGVV0Xue2mdjgXzKiPMTwQlmGExIoqa19sS1SHNI6zjGZFXn7EbSEWmid8ESu5xDmfS/WuhUjQoDW4fLOSa5ckWtken5E3Fh+7T7oZaami8xcAAAD//w==\",\"AwDBUt1wiQIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:33 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:51 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "c62370fcdf53b0079c52149a279479bd"
+              "value": "e5af431503c806f274b2a1f3612f728a"
             },
             {
               "name": "x-trace-id",
-              "value": "883d10bfc6fc2bc199c5afae94e91d97"
+              "value": "429e30324f5116eaecae9bc205d6654c"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=xjxFYvSM%2Fey5uzeZRqAVmrU4I2q%2BS2HRGo4kQ5anauhqG3aoKAUOPHIL9nliBoYooBmVWYW5vEVMc7feO5V4kx2SsSGf7nls2quqa8KaRljZo2UzM5Xp4ul%2BL08N7xAG2Xbgpsl4%2BpjbRK91KX9VgnN7cQKbYkYrd2Mb9w%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=kQtSsmBgW22z5sgnHZc8N%2FpFrWCxhgOo7viMiiauQrBHnuarqXOxXALxDHNObhP%2Bfp79GwmNu96mzKOOZiKv0hJMe2duIHt1Nx%2BDFdXgi%2BczDgs8AESZHPO2FRik14C25CkmKvmDTx%2F3p5AHDpVmop19EGXyivi9Q3XT4w%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0837e39ab41b4-EWR"
+              "value": "87a0d01b39e78c8f-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:32.974Z",
-        "time": 364,
+        "startedDateTime": "2024-04-25T19:41:50.869Z",
+        "time": 704,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 364
+          "wait": 704
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-relationship_2952094097/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-relationship_2952094097/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxV2AUqcjNt0vTQQxtPvZh1d4qkCLg7JFrjf29ASqVJY4/75r2Zb2ZPHgAaxQpTOHkAAKgtKaaXJv8cNAB0jdbkHKbAtqHJt0zWVrZVy6YoBnU/DgPges3Hmkq1I0wBu+aTn+plpFlyW5SBjKZBNJXxSiRptEhDOYvn0dt1IDetU4QiuVaZDl0HJsew/zWjqc0/ZvT+87DKGPx+uM0ruabgi793Y6ZMRvxMV9cEwO3RWMV5VbrxSUZLPyimVb6jP4kHww3Cx45hWddFrrupHc4F0+tjSAem0o2QsKiy9oVb5tqlvp9lPCvy8sNvC76Ig7sg8RNp3hcyiAIlEhlvQpPMN5KUCKWKdKxFj49slaan7pNuRloq7/wFAAD//wMAncsBbYkCAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRT2+CQBDF73yKyZxVWFyocDNt0vTQQxtPvZiVHZEUEXeHRGv87g1/SsGkscd9897Mb2YvDgBqxQpjuDgAAJgYUkxvVfbVawBoqyQhazEGNhVNfmQy5mBqtajyvFeP4zAArtd8LqlQe8IYsGk++a22I/WS66Lv+XLqyakfrEQUSxHLaBYF/scwkOnaKeZyMVSZTk0HJstwvJlRlfofMzr/tV9lDP7Y3+adbJVz6+/cmCqdEr/S4JoAuDtrozg7FHZ8ktHST4pple3pT+LecIfwuWFYlmWeJc3UBqfFdLoY0ompsCMkzA9p/cIdc2lj101TnuVZ8enWBVcEXugt3MjbBIFUWofhVsiHKNgoGSZzJdRcC+1vO3xkoxJ6aT7pbqSmcq7fAAAA//8DAF41TPyJAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:32 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:50 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "791df5783973390e32671a9bb09a997e"
+              "value": "bb6087834aebea10bcb7963959215a60"
             },
             {
               "name": "x-trace-id",
-              "value": "82df92040a1825b3d87b2ea132a4c5c1"
+              "value": "90b554add66f14795ba46c3a1a3d1d2f"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=cVcM2NXpOp9uLZr%2FZ%2FSQaxG5tt%2B5BYQQeKmeOIV%2FzVOcsOKjQ2S1ZanPQzTVCJIHziz4K3DbqdU2bAbgOZeyT0p%2F5V7EcEX8afbPGXJTTu2mQDb1q8zeCXeWidJ%2FR0%2BxbihXOWIraspt6b%2BRNsBYaVFKTfZ4yMn4EHfhxw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ghA9WbWF8qvIfpLYKOL%2FTfjptkJfgtckAtoyIMWBBiSMT8P8jYV%2BYSxVo%2B9E9WTNGdQ3WzEsWCMV419n0AKuDFwiyKgt6VyHKBfLj9b2AylC4RUp0bjLY7GIWAfjm0s5Pk6RfS%2FcdAqccHrYlm%2FtIp1g3SUGnGQNYT9FeQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a08379bd1141ef-EWR"
+              "value": "87a0d0117f758c65-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 955,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:32.265Z",
-        "time": 323,
+        "startedDateTime": "2024-04-25T19:41:49.575Z",
+        "time": 755,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 323
+          "wait": 755
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-relationship_3875503635/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-relationship_3875503635/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+DMAyF7/wKy+e2kFAQcKs2adphh0097VKFxKJolNLESO2q/vcJyliZNHXHPL9nf3bOHgAaxQozOHsAAKgtKabXtvwcNQB0rdbkHGbAtqXZt0zW7m2n1m1VjephGgbAzYZPDdVqR5gB9s1nP9XrSLPirigDuZwHy7mM1iLJlmkWikUayPfbQGk6pwhFfKsyHfsOTI7h8GtG25h/zBj8l3GVKfjDeJs3cm3FV//gxkKZgviFbq4JgNuTsYrLfe2mJ5ks/aiY1uWO/iQeDXcIn3qGVdNUpe6n9jhXTG+IIR2ZajdBwmpfdC/cMjcu8/2i4EVV1h9+V/BFFMRB4sexFIICIY2Mc8pzEwupo1DlqdJhkkQDPrJVmp77T7ob6ai8yxcAAAD//wMAW+GHVokCAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVWFyU5WbapOmhhzaeejHLMkVSRNwdEq3xvzegUmnS2OO+eW/nm5mjB4CZZo0JHD0AADSWNNNrU3z1GgC6xhhyDhNg29DoKpO1W9uqVVOWvbobhgFwteJDTZXeECaA3eejn+q5ZbbgthgGoRwHchxGS6ESKRIZT4JQvd8Giqx1iqmc3apM++4HJsew+9WjqbN/9Lj4T/0oQ/CHfjdv5JqSz/6LG3Od5cQvdLNNAFwfMqu52FZuuJLB0I+aaVls6E/i3nCH8KljWNR1WZiua4dzxvQuMaQ9U+UGSFhu8/aFa+baJb6f5zwpi+rTbwu+iIJZEPsqmutYGRlE4iONjYrSlMRUzYWM9Vyo6zWQrTb03B3pbqSl8k7fAAAA//8DAAfPRqOJAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:31 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:48 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "e1258587b29842565a394a33387336af"
+              "value": "5a87e7be89d7a718e4b231656689c423"
             },
             {
               "name": "x-trace-id",
-              "value": "66211e012d26bebbd612c53ab9ac3885"
+              "value": "957a89c4051fb8c95bbe1397148a7196"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=kkigDZjgZwiY4zYbJb0GajvWuEnspBa2ExH8QjIXDesjy%2FgnG6uN4LH10j15HzQvlwKFuNn6fbUbUJak3%2FgNFA4DusRBn4HiR6gYFpWE5Z4C5%2BdB8y%2Bg6iaYrmXWyblAUxtfgHgkgcv8Y%2Bijc8fhnbeuLFatOChY38U3fg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=N39EfyFbQLNOJdcWsmsMuQ3rYUPJjccR1mr1DBbhANfj0KxN1dwA9pr9N5dGDSJP5V6wRF%2F5M7n4QQWCdnlgmmUMoZt%2FEKwjyofUYwtnhFfxzjwMFo9j4L3VWujm74xH%2Flhj9OztMZac4m5bdV0D6g%2BjqPrqeqShSQU8Ig%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083752ed81809-EWR"
+              "value": "87a0cff45a23c427-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:31.500Z",
-        "time": 421,
+        "startedDateTime": "2024-04-25T19:41:44.848Z",
+        "time": 3454,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 421
+          "wait": 3454
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-HasOne-relationships_2856696492/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-HasOne-relationships_2856696492/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVlmWxwM20SdNDD2089dKsy4ikiLg7JFrjf29ASqVJY4/75r2Zb2ZPHgBmmjWmcPIAANBY0kwvTfE5aADoGmPIOUyBbUOTb5ms3dlWrZqyHNT9OAyA7+98rKnSW8IUsGs++aleRmYLbotSSDUVaiqjZRCnKknDcHYn5dt1oMhaZxDK4FplOnQdmBzD/teMps7+MaP3n4dVxuD3w21eyTUlX/y9G3Od5cTPdHVNANwcM6u52FVufJLR0g+aaVls6U/iwXCD8LFjWNR1WZhuaodzwfT6GNKBqXIjJCx3efvCDXPtUt/Pc56VRfXhtwU/iMRcxL4S85WMExLJSkplKBHrMMpWMjJKqHWse3xkqw09dZ90M9JSeecvAAAA//8DAD+i/hOJAgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRy07DQAxF9/kKy+u2mckDkuwqkBALFqCu2FTTjEkj0iSdcaSWqv+O8iA0lVBZzvW99rHn5ACgVqwwgZMDAICpIcX02uRfowaAtklTshYTYNPQ7EcmYyrTqmVTFKO6n4YBcL3mY02l2hEmgF3z2W+1H6mX3BY94QVzEcy9cCXjJJBJ6C2EjN8vA7lundIP5aXKdOg6MFmG/dWMptb/mDH4z+MqU/CH8TZvZJuCe//gxkzpjPiFLq4JgNujNorzqrTTk0yWflRMq3xHfxKPhhuETx3Dsq6LPO2mdjg9pjPEkA5MpZ0gYVFl7Qu3zLVNXDfLeFHk5afbFlwZijsRuYHWSkUqFl6sA+lvfC+OhPjY+GoT3pMMB3xko1J67j7pZqSlcs7fAAAA//8DAHsqpS+JAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:33 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:52 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "d302b756974f88413ee34ddb61d119b3"
+              "value": "6bcc161e610f22641294d295e58f5e43"
             },
             {
               "name": "x-trace-id",
-              "value": "406b289e09b224ce90f35db25c404f8a"
+              "value": "4ddaa8a9029d413b329800fb3ab57e15"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=fjqI9DP2BaboOeNsGxF0OScyl%2BRjr29IPo0s34bxLEjeS5jZibjI0OruiujUYPUBRn35I3F7dDpHu6VQxqnf5UZif13psL6b4TIN7kkBThElInZR2M9KxiBfGYNpED7lZtzIwX701efzeCuP1DxfxvNmNWwTAMGvwEQ%2FIw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=uPwfVPbLSo6HZ1O07U5fa26iY3OR6HdNBz6XlmlO7wZSkPoaOWR%2BHpHivoH6Or0O02Vgss4nf4hGlv7TqGjsm3syHf5BiLXqmiJpTWKWtJVgE3t4IKRyCmndrf7jUEZ8ZodvvYX3aVSY2RpzSBiLMXw5YRJzLZRMvQfm5w%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a08380ade60f6b-EWR"
+              "value": "87a0d01e096941a1-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 943,
+          "headersSize": 941,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:33.354Z",
-        "time": 428,
+        "startedDateTime": "2024-04-25T19:41:51.589Z",
+        "time": 520,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 428
+          "wait": 520
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-relationships_3250074585/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-relationships_3250074585/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVYFkUuJk2aXrooY2nXprt7oikiLg7JFrjf29ASqVJY4/75r2Zb2ZPHgAaxQozOHkAAKgtKabnpvgcNAB0jdbkHGbAtqHJt0zW7myrVk1ZDup+HAbAtzc+1lSpLWEG2DWf/FQvI82S26IIhJwGciriVZhkMs0iMUujxet1oDCtM4zC9FplOnQdmBzD/teMpjb/mNH7z8MqY/C74TYv5JqSL/7ejbkyOfETXV0TADdHYxUXu8qNTzJa+l4xrYot/Uk8GG4QPnQMy7ouC91N7XAumF4fQzowVW6EhOUub1+4Ya5d5vt5zrOyqD78tuCHcTAPEn8RS5I6llEizbsOIjHXci3MQqRBLJP5usdHtkrTY/dJNyMtlXf+AgAA//8DAOb1OMuJAgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sgD5IJyQ61UtVFF61YdYOGGStEDSHMOBIU8e9VHk2TShVdzvW99rHn6gCgliwxhasDAIDKkGR6rfPPQQNAWytF1mIKbGqafctkzNE0alkXxaCepmEA3G75UlEpD4QpYNt89lPtRuo1N8XAC8K5F86DaOMnaeinkbeIV/H7OJDrxukvw2SsMp3bDkyW4fRrRl3pf8zo/bdhlSn4w3CbN7J1wZ2/d2MmdUb8QqNrAuD+oo3k/Fja6UkmSz9Kpk1+oD+JB8MdwqeWYV1VRa7aqS1Oh+n0MaQzU2knSFgcs+aFe+bKpq6bZbwo8vLDbQquH3nCW7nCW6pgF/hRIBItRCKVinfxUgtJQsXa7/GRjVT03H7S3UhD5dy+AAAA//8DAAFK98eJAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:32 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:50 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "83ed2fb33d82b7eec51de7f2bd535d95"
+              "value": "d26f463e5ff96a21e650178df4a52ad9"
             },
             {
               "name": "x-trace-id",
-              "value": "754e4c54384dbc0326c4f2d72905486f"
+              "value": "603c2b215269d669acc7b73d6ae6c7d1"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=W5sFQFdpA2bI2PEbXrIH7m5jFEriNUPtTW2jvzXKKN3yr0lWBoEva0ignC7su2swHqnqTkdwNv8ijPaDsHUehm%2F8NwJaH%2Fuf6q96w5qJF10f1TBoRXYn0%2FsFZVQbeKiDfyKAlzyh3kDPDsGsabE43BzVKTYI5tl%2BLV4GIw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=OVSZnv6Pnp0ht44%2FQigIR2OkP7znQ7ijrL70uuT58lpByEvhKj%2Bjdq2q7gO7JZp1m3sLPHdpDmDOAmSY8RncphHqOLEWnTmxpOj%2By0lPrxl7uGIIUyX8HZTxFX3PXTS3aEzk1%2Bk7ZICXMNsKrRtCI%2F3ckjDZbhtgXY4UJA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0837c0f9342d7-EWR"
+              "value": "87a0d0167c7e42ab-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:32.600Z",
-        "time": 353,
+        "startedDateTime": "2024-04-25T19:41:50.345Z",
+        "time": 512,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 353
+          "wait": 512
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-relationships_2510062961/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-relationships_2510062961/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVWBaUcjNt0vTQQxtPvZiFHZAUEXeHRGv87w1IqZg09rhv3pv5ZvbkAKBWrDCGkwMAgKkhxfTWFF+DBoC2SVOyFmNg09DkRyZjdqZVq6YsB3U/DgPges3Hmiq1JYwBu+aT3+plpF5yW/Q9P5h6wdQPVyKKg4dY+jNfyo/rQKFbp5Bica0yHboOTJZhfzOjqfU/ZvT+87DKGPxxuM072abki793Y650TvxKV9cEwM1RG8XFrrLjk4yWflJMq2JLfxIPhjuEzx3Dsq7LIu2mdjgXTKePIR2YKjtCwnKXty/cMNc2dt0851lZVJ9uW3BF6M29yF2EQvpJqkNPZ4nMPJmIeRRJPZciSwIhenxko1J66T7pbqSlcs7fAAAA//8DADD2e7+JAgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVFlwqcjNt0vTQQxtPvZgpOyIpIu4Oidb43xuQUmnS2OO+eW/mm9mTB4CGhDCBkwcAgKllEn6p889eA0BXpyk7hwmIrXn0LbO1O9uoZV0UvbofhgFwtZJjxSVtGRPAtvnop3oZaRbSFEMV6rHS4zBaBvNEB4meT3Q0fbsO5KZxBlM9u1aFD20HYSew/zWjrsw/ZnT+c7/KEPy+v80ru7qQi79zY0YmY3nmq2sC4OZoLEm+K93wJIOlH0h4mW/5T+LecIPwsWVYVFWRp+3UFueC6XUx5INw6QZIWOyy5oUbkcolvp9lMiny8sNvCn4QqTsV+2GojIlms/X6nXSc6jhYE6n3OCZF0ZTjDh/FUspP7SfdjDRU3vkLAAD//wMATMxb3okCAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:32 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:49 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "8e8a505e6a41a33d18938be40efe5986"
+              "value": "f9a53558bb7842af5aeca0b6100a5e52"
             },
             {
               "name": "x-trace-id",
-              "value": "75132bcd50dfb3f03b16883d631fb411"
+              "value": "220dd577ffba48c481faa0b88a0a53e8"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=sDLea0vMOZUZQXcwYSo8rPwY8180TmQ87ZWwxA%2FP7QvFa6roEjxKC0%2BTJMgMy0gmMKZPSr7wA67il7tHJ9%2FW2yecg1mLjh4GJT4LP%2Bm2XDxcd1jApHJzFpSSXT3P2i3UE1pDnkeSR%2B2MhcQuEUSnBisuHOCTfWUAcb13ag%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=Jz7pbd6Ez03sk%2Bz6s9%2FORuRX5JWbrSywK%2BaZCQYDzDaezAzVvLT%2FCeYUNnxpNBJtvQj%2B5%2FWmIyjJfL1I1utRe%2F%2BsWULLRxx2tqJW%2ByKKXw784wFUwHJi9aN4bIblwvnaJAI1m5HhtVsjO72cikkQ5jA5nW3YgtsGSgBofg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083778abb7d11-EWR"
+              "value": "87a0d009be051861-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 957,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:31.941Z",
-        "time": 312,
+        "startedDateTime": "2024-04-25T19:41:48.328Z",
+        "time": 1224,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 312
+          "wait": 1224
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship-with-support-for-Id-prefix-test_2503398001/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship-with-support-for-Id-prefix-test_2503398001/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 360,
-            "text": "[\"H4sIAAAAAAAAA4SQQW/CMAyF7/0Vls/TQgorpbdKk6YddtsdmcQtFaVkjdFAqP99StMBmzTt6Pf8/D75kgCgJSEs4JIAACB1/pP76wyAjcUCUOdLfPiWhE8SRGEvEBMejs6SsL1tfRzZS3PoXuOBdH6z1ms5O+5oz8EqY+doDnEHa7I1yxvfsQHg9mx7Cjf9nQqApufQXY5UzyT83uz5WgeAE9yvhckf/uB6GRlK59rGjK0jTsRMphjySbjzP5CwPdRhwq2I84VSdS2PbdPtVDCUfppls1wt83S+MoZ0uskyMlZnerFZVCuuuEq1zSZ8lJ4Mxx/+GwlUyfAFAAD//wMAnWrYctcBAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQzU7DQAyE73kKy2dEtpDm7xYJCXHgxr1yd91tRJouWVe0qvLuaLOhLUiIo2c8nk8+JwBoSAhrOCcAAEi9/+ThMgNga7AGXJQF3n1LwkcJorAXiAkPB2dI2Fy3Pg7spd33L/HAw+PVWq3k5LinHQeriZ2TOcYdtGQsyyvfsAHg9mQGCjf9jQqAeuDQ3UxUTyT81u74UgeAM9yvhdkf/+B6nhga57pWT60TTsRM5hjyUbj3P5Cw29sw4VbE+TpNrZX7ru3f02Cki6XKVZmqrFhrbTKz4WVWUsVlZZjzfF2oqtgoNeOjDKQ5/vDfSKBKxi8AAAD//wMAb09DFtcBAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:44 GMT"
+              "value": "Thu, 25 Apr 2024 19:42:03 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "8ca85ff7c5d0aa7c83968241f1694736"
+              "value": "2a5d9ab3ed643135db3aa0912864287b"
             },
             {
               "name": "x-trace-id",
-              "value": "78239cca12b66acd1614b4f9efef21d6"
+              "value": "047bccd4dfe548a9e89dee66b7097f00"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=kQBPW%2BKkKfcBBt3pCBokJb19isSo%2F5FF8aNPGQOmT4xLKgDZz31LXdj2zCzSxj5iz4pJ4e7QcCSvLpUoK%2BQBJBRQsBaEYytgboHuG%2BpPPqMZewfqMfjwuLpZDa4eTeV89k6epdMwqPZd4HfRgWCI94zSq6t05feIRtyjrA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=1Eh0Z01ukZLxfk%2FE8fQpRNwabD1%2BYgN4wh7RpnrvUN%2F%2BqxbovJrRr7SxPe5LDdcW%2Fv6KCOVjuC%2B9gk5tmheVjofwFRtepBUE0ZZf0fM%2FglAzzNb3514o9wkzczqH2l6m2ajStmkMtNRwtqxYG%2FHPGw5uCNcRAsGbRi3YcQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083c468454233-EWR"
+              "value": "87a0d065184c436a-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 955,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:44.194Z",
-        "time": 230,
+        "startedDateTime": "2024-04-25T19:42:02.948Z",
+        "time": 232,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 230
+          "wait": 232
         }
       },
       {
@@ -232,13 +232,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 404,
-            "text": "[\"H4sIAAAAAAAAA4SRPW+DMBCGd37F6eaoQJoUyoZUqerQpWrnyDUHQXUMtc9qoij/vTKmFLJk9PthP3c+RwBYCRZYwDkCAEDXV4Kp1PaHzKQCoHVSkrVYABtHqz+ZjOmMV7VTalLFdR0A2woLwDTPcPUvMh3Zy0yWIbQsBIRqnvt2ZLnt9Eu4ZH0/N3c7PvWkxYG8OaKP9mViWqY+ZmO+kXWKQ2PMYyOqhviVZqsBwP2pMsJz2OVs0pAnLodZngTTe3ugOeI40lXgBuPzwFD2vWrl8OqAEzCjsYZ0ZNJ2gYSqa/wJ98y9LeK4afhOtfor9kacbpOHJI+TvKb6cZNRuklI1mkmc/GZrcWW0kTW0zchGyEp7P1mxVNFl18AAAD//wMAdABnklYCAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQTU+DQBCG7/yKyZwbAbVAuZGYGA9ejJ6bYZlQ4nbB3SG2afrfzQJF2kuPvB/L884pAMCKhDCHUwAAgH1XkXBh3C/bWQVA1yvFzmEOYnteXWS2trVeNb3Ws0q3dQBsKswB4yzF1b8ofBAvCzuBseVgRKiWuZ+enTSteRsfeXxamtutHDs2tGdvTuiTfZ6ZrlNfi5kf7HotY2PKY01VzfLOi9MA4O5YWfIc7nqbsuyJi2HLCwl/NnteIk6TbgJ3GF8HhqLrdKOGvw44I2Yw1ZAPwsZdIaFua/+FO5HO5WFY1/KgG/MdeiOM11ESZaEqn1WaxVmpVMq8KdMoiymJOF0TJWV6uTCKJcXj3e9WPFVw/gMAAP//AwBQyt28VgIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:44 GMT"
+              "value": "Thu, 25 Apr 2024 19:42:03 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "bc9b0f37ddac6423abbba142da2579f1"
+              "value": "4977450a3ea69bcb839cee0ea7b0145e"
             },
             {
               "name": "x-trace-id",
-              "value": "08fef947e140ecf17c8ab72a5e10cf87"
+              "value": "cb4c7818bcc7ee9b7081a60e75aa6b73"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=kFXJRbgSodozVVvGk%2FLppbhUQUG%2BXo7jeaWgEfd4aqbCiQcaNh53XF6QMFjW4Lhw%2FplBLA378pyKEJD5pg9pkPdSFyOMk5wS%2FGYgTmRNl4fJccAuK5udnGhtE56pG77OFeYHF4pijxLymr4dKoZyQLMfG7ytVxvBJkAiwQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ThY1GXcz%2BhIX%2BDb45cSvCtfmDiNxBCEkRzc9P%2BgkdsKXmfCEaGenqJa%2BpXftFvpfEc8N0X2DxhPxAxuiQ4JE8LRP2bga%2FRxtbMak9KDAYMaGyJNftRjf4QQ6wIc%2Bvxv0ttz8BkagBouMJeIoLgMDiertau%2Bpsf1uHuuayg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083c648b4c32b-EWR"
+              "value": "87a0d066af9172b9-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 953,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:44.456Z",
-        "time": 367,
+        "startedDateTime": "2024-04-25T19:42:03.205Z",
+        "time": 214,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 367
+          "wait": 214
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=answer"
         },
         "response": {
-          "bodySize": 372,
+          "bodySize": 368,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 372,
-            "text": "[\"H4sIAAAAAAAAA4SQMW+DMBCFd37F6eaqBiKwYUOqVHXoUKl75OALsUIIxRc1UZT/XhkIgS4Z7+695+/5GgCg0awxh2sAAIC6cb/UTTMAWoM5YKQkvtxXTGf2SybHMDgcnFqjmcxD9XMix/bYzMIecfFqEgLges2Xlhp9IH/8uhtHwW2KXOqKgTWYabDSpiL+pFknANxdTKd9pFvClB155qJv86aZvu2B5mBjqX+CJ1zvPUPRtrUt+1d7nAEzGG1IZ6bGLZCwPlZ+wh1z63Ihqopfa9vshT+IKAnTUIk0M0pl8WZbRrKMN0myStJtpEwmJalUhiM+cqdL+uh/+6nFUwW3PwAAAP//AwCPndYhDwIAAA==\"]"
+            "size": 368,
+            "text": "[\"H4sIAAAAAAAAA4SRy26DQAxF93yF5XVVICG8dkiVoiy6qNR9ZBiXoBIyZRw1UZR/r4ZXoJssbd9759hzcwBQkRCmcHMAAJAa88vtVANgpTAF9OMIX8aW8EVsU9gI9A4DZ61IWD1UP2c2Up2aWdgjbrWehAC438tVc0NHtsOP0TgI7lPkUpf1rM5MgyWpkuWdZzsB4OGqWrKRZglTtGyZs26bNxL+rI48BxuW+id4wrXtGDKt66roXu1wekxnsCFfhBuzQML6VNoKDyLapK5blvJaV823aweuv/FCL3ajPPjaRBytKVSelxMlSZDkyqd4FcZBNH4TSksF77prP7VYKuf+BwAA//8DAGeMXGAPAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:43 GMT"
+              "value": "Thu, 25 Apr 2024 19:42:02 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "130baa86068112e88138799442570a6d"
+              "value": "90fcb42f5ba8b6985b641746804fc755"
             },
             {
               "name": "x-trace-id",
-              "value": "69d8892bfc17c2b55356f18d977e8670"
+              "value": "7b4f57e73a6d00baa9949bd1a8268477"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=lGJAHgV787Z8du8MhJFZxf4g7vsTFqYA1npvwY5%2BWvFWzj4vm30KPwVD0ntIcbQviC4%2Flzv1sYzetb9ZiTwQJXqAehj4OPmLj26mRohvHJFmwT7G24XGmvn5rhKtB54aYSUWxOi2%2BiIlwtj5CeZBZ8%2FgSNGbSoX5k1v2Kg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=eWKKg%2FKCBnFKmUSXPymUgxcZxoiVI%2FHvG7X%2B5Gce%2BTP3FFkbPDiOeCBDnGOW7JnHdiHb4pF%2FZvVum6DxJRaMziRkRXy3LERmO3IAbyA%2FIoWld5uwYMgy6kvF7e4NmJ8zOwkRMQY%2FcLKJ6CwWYvqNaJc2VSmVIWt%2Fdh8fmw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083c01ba34384-EWR"
+              "value": "87a0d05a8e32433a-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 955,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:43.448Z",
-        "time": 368,
+        "startedDateTime": "2024-04-25T19:42:01.269Z",
+        "time": 1185,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 368
+          "wait": 1185
         }
       },
       {
@@ -232,13 +232,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 424,
-            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9RMRAo4oZUqeqhh1btOXLxhqAQoPaiJory7pX5C3DJ0eOZ9bfjqwOASrLEBK4OAAC2jZJMaWX+SE8qAJo2y8gYTIB1S5tRJq1rbdWqLctJles4ABYKE0AvfsbNXWQ6s5WZDEOfMtAjqLnvtyXDRV0tRt6H+sHMDIC7HV8aquSJ7PXHGJ4st9nopXdY3Fn5Vq7vWUmfZNqS+8Tgx1yqnPidZsUC4OGitLQgZtlMpsnum3ZNvEimr+JE8+2HQlaGB4yvHUPaNGWRda92OD2mM8SQzkyVWSBhWef2hAfmxiSum+f8VBbV0bUXrheKSMTufhsEfuxnIQklfmLy5DbywkgIfx8GIh4/D1nLjN66X3oYsVTO7R8AAP//AwC4W8vWlAIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9R+QkQwg2pUtVDD63ac2SZNUEhQO1FTRTl3SsDSYBLjh7PrL8dXxwAzAULTOHiAABg1+aCKavNH+m7CoCmk5KMwRRYd7S6yaR1o61ad1V1V8UyDoBljimgn2xw9RCZTmxlJsMwpAwMCPnU99uR4bKpZyMfQ4P1xAyAux2fW6rFkez15y18t1wno+fecXFn4Vu4fiYlfZHpKh4Sox8LkRfEHzQpFgD351wLC2LmzUhNdt+sb+JVMH2XR5puPxayMDxhfOsZsratStm/2uMMmM4YQzox1WaGhFVT2BPumVuTum5R8EtV1gfXXrh+5MVe4oZekAQ+SbWVSRgp6SVxuNnGa0+pQEVKjvjIWkh673/pacRSOdd/AAAA//8DACp03RCUAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:44 GMT"
+              "value": "Thu, 25 Apr 2024 19:42:02 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "4b5ee26b331ba44ce97102e6a0c691f0"
+              "value": "1a9852de2e92a4ff9fd71adcbd584ebd"
             },
             {
               "name": "x-trace-id",
-              "value": "f433282c5e0d0b8e1a46156002f5308d"
+              "value": "402821ecf9c845fc086479630ff2f5fc"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=uR2YcaJTjnig0Evqz4pVgJikoxNWj9hEH8bGFVkxi50iASNH9D67NszEYgWsBZ4FI%2BwwhEd9Nez%2FSpsJ1ApXNZRKYn1z63ogrdaseQdg08V5miPfUDWQ8VKPdEaIpmpf0ejkp5Hv9cwXmh6y9N58z0Q7G6ZMrF5VoY0FIA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=vUKyeQkjMFFWTWLT7DYjO2gpPwCvvHNJeakIty2BzhA2ufXtO3mxj2P%2B6e3Ri%2FbspExLmFDV5p1s3LX3C2wIAKZFRSn%2FAzQf2kW0CGBn28RysYVvWaQrKc%2B1J2woA3Ce5VFjot9jscyMAZMWJgm3TpzCiDMjltqC4Kxa1Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083c23cbd4301-EWR"
+              "value": "87a0d0622fef4217-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 943,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:43.862Z",
-        "time": 307,
+        "startedDateTime": "2024-04-25T19:42:02.483Z",
+        "time": 439,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 307
+          "wait": 439
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 563,
-            "text": "[\"H4sIAAAAAAAAA9SUTU/DMAyG7/0Vls9A13Zj3W4TIMSBAxI3hKasMV3FlnZtJvah/XeUbC1tkzExLnCM4/f1EzvJ1gFAziTDIWwdAABcLJNNtQLAhOMQ0Bv4eFGGJK2kCkoqJKh8WGacSeJfKYslFTJJRVGzAkDiManQSxWC2rZOESmnhqjB4XeDqki11eLZVy6Z4BI8U8JE8UF5YSl0hNJOe4q6Re+FJor9FHu+b89QCcdjuc5IsLkiwJFWojV5Z/ewOtzxmGwuVo9fdsU/tyv+n+mKEXs1Xa2ON6kQFKkb2/Y1uFr6p8NNb+paqiOa9jkaqh++yO7PX6R/7ov8Z111LLfhiNYkrmoaimSzzzlkYMx4TPKRav84AE7XPGeWTzjKSY1hpCd0yyQ9J3OqDQQPc2olnKC61wyjLJslka6qcZyyDVqGtJIkigYSztJYrXAqZVYMXTeO5dUsEe+u2nC9Xue6E7r9oO/3wsALo4kXTMLwrT/oEXmdIGBBSIPyd0SZs4ge9MU8KVFUzu4TAA==\",\"AP//AwCipvR9AwcAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA9SUy07DMBBF9/mK0ayBPEjTtLsKEGLBAokdQpUVT9OI1kkTV/Sh/juy24Q8XKqWDSw9nnvneDz21gJAziTDIWwtAABcLJNNtQLAhOMQ0B14eFWGJK2kCkoqJKh8WGacSeLfKYslFTJJRVGzAkDiManQWxWC2rZOESmnhqjB4fm3VZFqq8Wzr1wywTW4XQkTxSflhaHQEUoz7SnqFr0bdlHMp9jz/XiGSjgey3VGgs0VAY60Eo3JO7OH0eGBx2RyMXr8sivepV3x/kxXOrH3rqvR8S4VgiI1sW3fDldL/3KY9KaupTqiaZ+joTrzRfrnv0jv0hf5z7pqGabhiLZLXNXsKJLNPueQgTHjMclnqv3jADhd85wZPuEoJ3UNI31D90zSazKn2oXg4Z5aCSeoHjXDKMtmSaSrahyrbIOWIa0kiaKBhLM0ViucSpkVQ9uOY3kzS8SHrTZst+cETmizwB/4HvOC0InI6feD0PEd7kf9QW8SOJNynlDmLKInPZgnJYrK2n0BAA==\",\"AP//AwCVxtz6AwcAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:41 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:59 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "df2a7220d04bceb82a60a4f87ee85599"
+              "value": "ab1398b4dd2d25dc37fa1510651f624f"
             },
             {
               "name": "x-trace-id",
-              "value": "737258318cb13b88f795ee1033a38e91"
+              "value": "a64942a2680ce07768040d4c795f60f2"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=%2B%2FtyeaimyDc0kkWjDqFnr5nb4NJXTfNhl5SKcaf%2FfdtLch1d90jrTKBWOXh0g360PDUttPhMo6nji7nZowyuMZ4DyirRksyOuZCNF%2FIvOGLuWyWh12Uy2Z57zQeeaiIdAJa6McNTyBoIY6Cn7fhzPcj4L8rUoMLF5cQ3fA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ULJpTOBrxdh9q%2B9q2IrDYwMw64RrR5TLuY1TnJAVNS3dsQQQO5p4sjgQTQ30nUgzlUfFYwUMSkd83GHD1JYBJVFsA%2BKUrevsGt54glLM%2B%2BW2zTbYTMFgRBrC7U2cjTxw2qXqETTuWDyGO8oRwZYQsHc9Ws0x8zS1qK4qxw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,7 +142,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083b2d8578c4b-EWR"
+              "value": "87a0d04f0bbf42b7-EWR"
             },
             {
               "name": "content-encoding",
@@ -155,8 +155,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:41.338Z",
-        "time": 358,
+        "startedDateTime": "2024-04-25T19:41:59.400Z",
+        "time": 186,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 358
+          "wait": 186
         }
       },
       {
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 615,
+          "bodySize": 619,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 615,
-            "text": "[\"H4sIAAAAAAAAA9RVy07DMBC85ytWewaSphSlvVWAEAcOIDghhKx4EyKCE+KNeIl/R07bkIetSoUDHDOZmZ1de+UPDwClYIEL+PAAALAupWC6rLP3FgNAXccxaY0L4KqmvQ1MVVVUBlV1nrfoc18MgJnEBeBkHuLeN8j0ygZm0gxGA6vaskt6rklzVijdMzSlZUoGvO2A0KM0NFVIGkh7mcLDaaecK9sqwyYf7MPEJhJKv1ClreWciV3Jt3cwnG5kC2XvaJV0Sz+t9P6e30pS4snkwGWjRQf90+VjdTmVKdmdHD6/MKVw9ymFf25KFvTO5m31PS6Uotjc7LG7JeHA43K9FUPtSOnQjbsaKHfY5cNddjn8yS7/42l7jjvjcLDl71QfqbL3Da9lDTg37VNzRbrOecVfszEVMiW+oM7jBIAPb7IS4wcB44rMcS6bkz4RTNfZE3UfkvV5DwhbEp41GZZlmWdxU7WJ423G18iQXpmU7kXCvEjNFz4wl3rh+2nKB3mmHn3zw5/MgqMg8uU0CQ==\",\"kyQO5GwuplEyD6OZCINZHE0CKSmZr+MjVyKm8+aKb5WYVN7nFwAAAP//AwAz4aoa2AcAAA==\"]"
+            "size": 619,
+            "text": "[\"H4sIAAAAAAAAA9RVTW+bQBC98ytGc06KjcEyvlltFeWQQ6r2VFXRhh0IKlkIO6j5UP57tdgQPnZlye0hOfJ4782b2V3NiweAUrDALbx4AADYVFIwXTf5c48BoG6ShLTGLXDd0FkHU12XtUFVUxQ9+jAWA2AucQu4jAM8ewOZHtnATJrBaGBfWw5JDw1pzkulR4amtMzIgD8HIIwoLU2VkibSUaYgXA3KubLtM3T54ByWNpFQ+g/V2lrOmdiV/HgH0+lubKHsHe2THumnl97c8FNFStybHLhrteigv7p8rC5fZUZ2J4fPf5hScPqUgnc3JQv6y+Zt9f1cKkWJudlzd0vCicf14VVMtTOlQzfvaqI84S2Hp7zl4F/e8geetue4Mw4HW/5B9Zkqf+54PWvC+dGvmm+km4L3/AMbMyEz4isaLCcAvHuStZgvBExqMse5a0/6i2D6nt/TcJEczntCOJLwos2wq6oiT9qqbRyvG18rQ3pkUnoUCYsyM194x1zpre9nGX8qcvXbNz/8ZbQ=\",\"WC82fkrxKohXURyl6Sa8TYNlGAmKw7WIFuv0ttuDyLVI6LK94kclJpX3+hcAAP//AwCUrfQF2AcAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:42 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:59 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "c6bb8197e782c0c4675d24c24b7baac9"
+              "value": "8a45e1ad921881842795e26da8a4b0a1"
             },
             {
               "name": "x-trace-id",
-              "value": "d3f2ffc0d59a38f9285a205c810ddef9"
+              "value": "fe93293595ff84bf2145ae946a506fbd"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=okhdB4c5lqDvB8oNggHavcF8eDcgJ5lR0SBefg6%2F6pa7FB5dJnKPaBXnQ2xllqdmDUkMHy72Ccb%2Bwy7KBfQCMaHfPfvxpNZiD93jw%2FNuZymTRPZiTD5zVXGxvLRwpHzRxGZZOKBszy7PzP1c0PXe4j%2B5I8yBRt4oMga97w%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=zIZMepAznpYm6Do2VqD92AdbP0i%2Bv6IFwaFFRvN%2FuhlDB1v2t64kVCNJlWtB3u7jjm8ZfVef%2FcqWYd6MwXCMcjwBanuxDd05%2BrLF3gXMbmbtpOfDhJpRNGyIJCSeDdbDbFTjVPqLeIDoJEH0dglzhCZeBFOwu3t%2BPlxKoQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083b4fad9c45e-EWR"
+              "value": "87a0d0504b1c4233-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:41.754Z",
-        "time": 371,
+        "startedDateTime": "2024-04-25T19:41:59.620Z",
+        "time": 290,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 371
+          "wait": 290
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 436,
-            "text": "[\"H4sIAAAAAAAAA4SSzW7CMBCE73mK1Z6rJoEmCtxQW1U99FCpt6pCTrwYq+AEskj8KO9e2RCTQBG3ePebzGjsQwCAUrDAMRwCAABcbfTenwBQSxwDxukTPrQjpi3bIVPNYHnYVFIwyTOy2lDNujR151cASFKRHX37EXTWDjGlpJ6ol2MQpd7Ery7yHJ2vMnl8OuVdRUYsrQ9+nnjsYU1fdUPzKhV1dY3//jnrb2ifS2Oo6Dp7zyuF3h+ZE4FKSEX8QZ17A8D5Tq7FP6UXa7JFTFxHL4LpSy+pUwuemroA7qR6cxkmVbXQhXN1cYK2BidD2jKZuhcJF6WyJ5wzV/U4DJXix4U2v6FdhHESpVEWDtPZYJDkRZKPKJF5Mhql8TChLI5IZjPRPkbktSjo3T2NuxKbKmj+AAAA//8DAL+FQCvzAgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4SSzW6DMBCE7zzFas9VgZaQwi1qq6qHHir1VlWRY68cq4khYSPlR7x7ZSAOJI1yw7vfMKOxDwEAKsECczgEAAC42pi9PwGgUZgDxmmCd8cR05bdkKlicDxsSiWY1AlZbahiU9iq9ysAJKXJjb79CHrrBrGFooFokOMhSr2JX53laZ0vMnl8OuVdSVYsnQ9+djwOsHqouqJ5VZr6utp//5z0V7TPhbUk+87e80Jh9i3TEaiF0sQf1Ls3AJzv1Fr8U7pckyti0nT0Ipi+zJJ6tWDX1BlwI9Vbk2FSlgsjG9cmTnCsoZEhbZlsNYiEi0K7E86ZyyoPQ635fmHsb+gWYTyK0ugpjGOZUirjZJallIzGySiZZfRIFMlMjZXs4iOvhaT39onekrhUQf0HAAD//wMAckry5vMCAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:39 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:57 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "40cb56412548cea924b61317ca606573"
+              "value": "131d3857ae8a7fc792914b11ee140b20"
             },
             {
               "name": "x-trace-id",
-              "value": "36f225bc5b9e5db5996135e810ed8fa4"
+              "value": "11c6e6c14b96e457454b9e3ee0c9d7dc"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=LE4lNcy34O6FClGEUPXomK2LQk6LtJKqfkq8kIwi4RdcgC7mSEgZLAzuhSfDwdITz1Vl2c0Ef1ja00dsNx%2Bt5EsEITJDn49%2Bl%2BKCENyUHyVffw6NStwwF7QuY75n426mCzUOW43kFOyiPwgfSFxRsYqVzb9bIHxbWD3eig%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=1HLS29hE9rFRxUXNqm5F%2BjOc5YH8%2BA0eugG0UX2AbYaBdngvQh%2By4D3S5ftgKLKIpVbJJbZqIMoqSpWwTOzxZcTRoYUBE14vJAeH1H357pa7wyzG4EYn6MK1FVfxd6dT4LqUXjUUD%2FrJ1RlpkD4UKKesFcEPifDYbLbsNQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083a27e7c4349-EWR"
+              "value": "87a0d03e2e31435e-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:38.691Z",
-        "time": 378,
+        "startedDateTime": "2024-04-25T19:41:56.722Z",
+        "time": 793,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 378
+          "wait": 793
         }
       },
       {
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 488,
+          "bodySize": 492,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 488,
-            "text": "[\"H4sIAAAAAAAAA4SST2+CQBDF73yKyZxNURBsuJm2aXrowaY9NY1Z2RFJcUF2SPwTv3uzKHRBjcd9+377Xmbn4ACgFCwwgoMDAIBVIQXTrEr3rQaAuopj0hoj4LKiQSNTWealUVWVZa266cIAmEqMAEfhGAf/ItOWjcykGQwDp2xpmzYVaU5zpTsPmmiZkBG/LRE6ltqmckk9tNPJG4ZW3K1upw5X+rXAfM67gpRYmzScnQnsGY998gb3IhPqskfr9GO/cuOFp1wpirsdrPQLKt03vtbV83y1i/FBusr45D+7MREyIX4na5UAcLWTpbj8PoxLMoOc1jN+Fkyf6Zrsbz9Pume40/C17jAtiiyN69S6jtOMr8aQtkxKdyphlifmhCvmQkeumyT8kKXq1zUX7igYhsNHd+wHHok4XE6E9P2xCBYLzwskLReTkU+iqY9cipje6uW6i5hWzvEPAAD//wMATjc0BoYDAAA=\"]"
+            "size": 492,
+            "text": "[\"H4sIAAAAAAAAA4SST2+CQBDF73yKyZxNARVquZm2aXrowaY9NY1Zd0ckRUB2SPwTv3uziHTBGo/79v32vczOwQFAJVhgBAcHAACrQgmmWZXsWw0AdSUlaY0RcFnR4CxTWealUbMqTVt104UBMFEYAfrhGAd/ItOWjcykGQwDp2xlmzYVaU7yTHceNNEqJiN+WSJ0LLUtyxX10E6noRdacde6nTr8068F5nPeFZSJtUnDWUNgz3jsk1e4ZxVTlz1ap2/7lSsvPOZZRrLbwUq/oJL92de6ep7PdjHeSVcpn/yNG2OhYuI3slYJAFc7VYrL70NZkhnktJ7xk2D6SNZkf3sz6Z7hRsOXusO0KNJE1ql1Hec8vhpD2jJlulMJ0zw2J1wxFzpy3TjmuzTJflxz4fqBF3oTNxiNJsMJhQ+BEgsKx74IpL+UchF4tPTug6Y+cikkvdbLdRMxrZzjLwAAAP//AwBhnnuQhgMAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:39 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:58 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "d8de91c01b1dad6109f5f5366b49529d"
+              "value": "f0a458ef48ef52c70d6de0c06ecaca89"
             },
             {
               "name": "x-trace-id",
-              "value": "4352eac6f7ad334a5bb225defb713eae"
+              "value": "533828e695dabe641a5c1fccb50ef075"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=Xp3K%2Fm8yQHzIyE9FamxMaBWjMzCschOZJB6QyL6AJto7%2FIcJb9SovClzYOwssMV1US0apHAyJcHgMGG%2Bjwf19scYeDv7jr%2BdI5VViUkrQ3D6tEvRpYHbGpPzRSaS5MXfHKQLkZLEbWrPweDKctQqabNamWD2UYKZpVpAVg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=4xq0HL8yQrzU4BxdbLOPCLyPhneIEa6iuWZYvckabNin2TRUxF6RmxlxiNDqxFdyDb4zzbedEFBK21SDcIyO5fPK9INmb5xSnO970IwXtwU6%2BENbJ1BMciUZI9uRtgEZ0aOu3ASsP9nlrGCKRqD9UJrv5HQADoJy1hcL1g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083a4ec15429b-EWR"
+              "value": "87a0d0435cee43a0-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 941,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:39.117Z",
-        "time": 587,
+        "startedDateTime": "2024-04-25T19:41:57.556Z",
+        "time": 410,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 587
+          "wait": 410
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasOne-relationship_3220970997/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasOne-relationship_3220970997/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 384,
-            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9VMeWnwA2pUtVDe+o9cvBCrBCD8FZNFOXdKwOlppccd3dm/I18DQBQSZZYwjUAAEBp7DeN6wyAWmEJGOXP+PC7YjqzWzJZhtlh4WtQkkn9qUzPutG1ZN0bL3CNzMSqBUAyct+ROzSys+Rddju+DGTkiZzrw09dRLf1za22mssEngZbqVrid/JKA+DhosYp0m5J65FcqWqq+yKZPvWJfOyl9T/BHa7XiaEahm4pMuHMmMFiQzozGbtBwq5v3YQH5sGWYdi2/NhpcwzdIYxSkYk8TJo4ecoLIiGKPKV0H8u0TuKiEBRFUZ4t+MijrOlt+oq7FkcV3H4AAAD//wMAbWWtazACAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRzW6DQAyE7zyF5XNVoKjLzw2pUtVDe+o9Mqwhq5AFsa6aKMq7VwuUkl5ytD0z+432EgCgJiEs4BIAACBZ983jOgOg0VgAxlmKD78r4ZP4pbATmB0OvgZNwvpPZXsxjalJTG83gWukilYtALKlqmN/aKhzvLnsdnIe2NKRvetjm7qIruubt9pyLhNsNNiSblneeVMaAPdnPU6R7pa0HtmXKqe6LyT8aY68xV5a/xPc4XqdGMph6JYiE86MGSw25JOwdTdI2PWtn3AvMrgiDNtWHjtjD6E/hPFzpKIszPJEk8qanHTFTyrJM63SNFZVlTdKp8mCjzJSzW/TV9y1eKrg+gMAAP//AwCvSN2wMAIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:42 GMT"
+              "value": "Thu, 25 Apr 2024 19:42:00 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "ed75b7f06355057909b7ec71e50f05a5"
+              "value": "7d69e2e92a1ec813f512fcd462198a34"
             },
             {
               "name": "x-trace-id",
-              "value": "4f34289ee00985e5b3a5c43990e11186"
+              "value": "893da68f9adbe26398d67716bb9f6d73"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=%2FgpuSA%2FAZ1hX7nghVmCakVLO2IBov1GfGf4Pj2u12Jl608c1GLFcI1BEhSpSAfasY7052bDyLxSO%2Bzi0fRHdHa8S7d1n9WJsaq8lK2ul70caTTTKFwcOs9fi%2BGs1bjWX3zfT26sbC3C%2Bkg5IOGF0xDOviFqbzyRNO60WQw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=IkZX1Uij4UFJSsizdty3taGJNzh8b1bd2RpC21IPi074xDRDMpqeZzg9rEYHzw%2FKFrVhNKuB5%2Bi%2F9S4W1UCgJV8owalqaMA8padJTb1v8Fo%2BJJZwT0gcaOCVH7XJhzkpC7dkc%2Bcaa9uu0Mho4QhykFEfkN2I3Viof4Ao%2BA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083b7895842c9-EWR"
+              "value": "87a0d0523e9e43b9-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:42.146Z",
-        "time": 652,
+        "startedDateTime": "2024-04-25T19:41:59.941Z",
+        "time": 212,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 652
+          "wait": 212
         }
       },
       {
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateAnswer"
         },
         "response": {
-          "bodySize": 436,
+          "bodySize": 440,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 436,
-            "text": "[\"H4sIAAAAAAAAA4SRMW+DMBCFd37FyXNUoGlIwhapUtWhHap2ji72QVAdg+xDTRTlv1cGQg1LR7977/z5+RoBCIWMIodrBAAg2kYh0864H7KjCiBcKyU5J3Jg29LiLpO1tfWqabUeVZzHAUSlRA4i3azF4k9kOrOXmRxDn3LQI6jQZ2quikoiV7WZrB0XZ0ng92AGD5r8qEDtaDLb7/nSkMET+eR7uHu03YLbp/6hm2jmm7m+gh4/yLWa+8TgFyWqkviNgu4BxPGibAfipuVJS76SXVfWMzJ9VicKCxo6mxn+YXzpGHZNo4fndzg9ZjTEBJ2ZjJsgCV2X/iSOzI3L47gs+UFX5jv2gzhdJVmyidcpHZZFhnK7zZ6wUEuZIq6TzSPK7Uod7viCLUp67T7x34inim6/AAAA//8DAIXdw+C3AgAA\"]"
+            "size": 440,
+            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9RyS9xuCFVqnpoD1V7jgwsBNUxyF7URFHevTJQarjk6NmZ9efxLQDAXLLEGG4BAAC2TS6ZEm1/yIwqANo2y8hajIFNS4s/mYypjVN1q9SoynkcAKscY8CV2OPiX2S6sJOZLEOfstAj5L5P11wVVSa5qvVk7bg4Wnp+B6ZlqsiNCqksTWbHI18b0vJMLvnu7x5td+/2qX/oJpj5Zq4vr8cPsq3iPjH4sZR5SfxGXvcAeLrmpgOx0/IyQ66SpCvrWTJ9VmfyCxo6mxkeML50DEnTqOH5HU6PGQwxpAuTthMkVHXpTnhibmwchmXJT6rS36EbhKvdMlqKcLfPKF2n24PYbvIo3Yh1kRXiIEUaie1uvRnwkY3M6LX7xIcRRxXcfwEAAP//AwBrF/6AtwIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:43 GMT"
+              "value": "Thu, 25 Apr 2024 19:42:01 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "fe6ab3b6aa0603ccc18ba136439127bb"
+              "value": "100a53053a5b4e4bcdfc72f74608106f"
             },
             {
               "name": "x-trace-id",
-              "value": "71eb3f6ac9964afd3c1aa7082ac95dbe"
+              "value": "57ceb2b49843d6b382fcf89a8b684523"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=CyaZMGcmkEv6g1YY7YDn3FtfoI4iHd3ABoHRU%2FsP%2FsDNn2bFJ1CoASSVdm0eZK%2FHLH5x%2Bm%2FJnnl8qBYy5lWZtZBujJrbyBQzZEmhUbFt6I64d0PJKXV9vc2dBZfKg78ZmHQaL6axjZ9aS6lXGuXjKpS%2F4wb14n4MOpxPiQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=3pJ7Hvaes6aLBNFqXsS40J0oRwwjZ2GG%2Fl%2FeAAKxhqqRrgyRHcUv2%2FQB14l4XolqEH2Qn%2FfAoQuazM%2FMBi7GAoaFXzRV1%2BoQJnFjUXOEntNd0RvONdTOfu0usdRppypf3sAvHpNfZkTMFaYLxnah1IAznEMoyDvx8%2BM7BQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083bba95b80dc-EWR"
+              "value": "87a0d053fc38c342-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 953,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:42.822Z",
-        "time": 596,
+        "startedDateTime": "2024-04-25T19:42:00.210Z",
+        "time": 1033,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 596
+          "wait": 1033
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 467,
+          "bodySize": 460,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 467,
-            "text": "[\"H4sIAAAAAAAAA7yTT2/CMAzF7/0Uls/b2gCFwg1t07TDDpN2myYUGi9Eg7S0rsQf8d2nlFJaGEJcdmvs9+t7tpKtB4BKssQRbD0AAFwWZlOfANAoHAGKfoR3hxLTil2RKWdweihSJZnUUbIsKGeT2LzxKwAkpcmVPusSNNqlxCaKWlArR0cEtUndOsmzdz5kgnsQ58hkwuuUrFw4L3yvGGzJdm3qAvOsNDW5FnXjbOL22Tr/Olv9/XXkL7CPibUUN51rzzPCbPaaSoFaKk38Ro17CYCztcrkH5cqzsgtY1zu6UkyfZgFNdaC1bZOBFdSvZQZxmk6N3HpWsbxDmsoMaQVk81bkXCeaHfCGXOaj3xfa36YG/vju4YvwqAfRL6YDuMwpGF38K2UCHoUCSkHURR2+9QLxbCKj5zJmF73T/Aa4lJ5u18AAAD//w==\",\"AwDTKnCx0wMAAA==\"]"
+            "size": 460,
+            "text": "[\"H4sIAAAAAAAAA7ySTW/CMAyG7/0Vls/b2sCgFTe0TdMOO0zabZpQaLwQraSFGokP8d+nhFJaPoS47NbY79P3teVNAIBKssQBbAIAAJwtzLp+AaBROAAU/QTv9iWmJbsiU8ng9LAolGRSB8lsQSWb3JaNXwEgKU2u9FWXoNH2EpsrakGtHB0R1SZ16yjPznmfCe5BnCKjEa8KsnLqvPCjYrAl27apC8yL0tTkWtSNs4nbZ+v862z19/eBv8A+5dZS2nSuPU8Is95pKgVqqTTxOzXuEgAnKzWXZ44qnZNbxtDv6VkyfZopNdaC1baOBFdSvfoMw6LITOpdfZxgvwaPIS2ZbNmKhFmu3QsnzEU5CEOt+SEz9jd0jVD0on6UhLHsPcqok6gkGfdj2Y2lUqo7jsRP0o1FPK7iI89lSm/+PK4iLlWw/QMAAP//AwCRPdCr0wMAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:40 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:58 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "c03321369274fcf108f245c62d967e06"
+              "value": "2e4efc885b81730acd27d53753897930"
             },
             {
               "name": "x-trace-id",
-              "value": "1b9c55e937fdd104e81aa788536e4519"
+              "value": "7a54a028d88b67a37addd3b01f83717b"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=yAdLZnBesmMQHrjIdoosz9dBriB8rjYmEAvQEl0RuDL3NI69OfWcj1C2%2BOTycRns35yyR1kOAJW%2BPM2X5NDhckd9sXGX7%2Fy67GcuEcxSOLxVR8T7%2F%2FLx6T2oGWnuGXjZN%2FWYB%2FDXNWDaX%2FrtTAVTUMv5qE%2FAzlk6jAPjVw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=YTTwZIRLmlJEGY7OVBwbWniFEoQ4efQeiBzQnhHka1vda0R0cFNVkTlNTXSTRkeY3LZnCjejLcVxS7i%2B%2BUXle5BPnQ%2BA0WOdxW6RgOIimAGRfb%2FfP03hnh%2FgbeovcXt9LWYJkHIiLt2zEno2jNgqKqiMmy%2BANMXr4XMNWg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083ad9a898c8a-EWR"
+              "value": "87a0d04af83a1a0b-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 957,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:40.487Z",
-        "time": 308,
+        "startedDateTime": "2024-04-25T19:41:58.776Z",
+        "time": 162,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 308
+          "wait": 162
         }
       },
       {
@@ -232,13 +232,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 512,
-            "text": "[\"H4sIAAAAAAAAA8RTTU+DQBC98ysmc64C/cDKrVFjPHio0ZMxzcJOKJEulB2SfqT/3SwtdaE2TXrxuG/fm/dmMrN1AFAKFhjC1gEAwKqQgmlapZsjBoC6imPSGkPgsqJeA1NZ5qVBVZVlR3TZFgNgKjEE9IMx9n5BphUbmEkzGA3svaVNWlakOc2VbhU01jIhA35aILQoNU3lkjrSVqa+71l257LtMzT54Ab8v0SzGa8LUmJhHHF6UGGHuOsqz+ieZEJtbUd5Ra/+Nb32/6VX6/VlVzlT4SFXiuJ2Bsv9RJVuGt6R1eF8HA/hjXSV8Z5/YGMiZEL8StbpAOB8LUtxuq4Yl2SGOann/CiY3tMF2Wt+mHaHcCHhc51hUhRZGteudRynGV8tQ1oxKd2KhFmemBfOmQsdum6S8G2Wqm/XfLj+yAu8sRtEYnR3NxhGfnTvBdL3ItGngRhQMIxH46g5ZeRSxPRSL9hFiUnl7H4AAAD//wMAdA5h2HYEAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA8STT0/CQBDF7/0UkzmjbWlA2htRYzx4wOjJGLLuDqWxtKU7TfgTvrvZQnFbJCRcPO7b99t5M5ndOgCoBAuMYOsAAGBVKME0qZLNUQNAXUlJWmMEXFbUa2Qqy7w0alal6VFdtmEATBRGgP5whL1fkWnFRmbSDIaBfW1lm5YVaU7yTLceNKVVTEb8sERoWWpblivqoK1Mfd+zyp3Lts/Q5IMb8P+CplNeF5SJhamIkwOFHeOuS57hHlVMbbZDXtGrf02v/X/p1Tp92q+ceeE+zzKS7QxW9RMq2TS+o6vjeT9+hFfSVcp7/8GNsVAx8QtZXwcA52tVitN1RVmSGea4nvODYHpLFmSv+WHaHcOFhE91hnFRpImsq9ZxnGZ8NYa0Ysp0KxKmeWxOOGcudOS6ccy3aZJ9u+bC9Qfe0Bu5YdCfBXLmBb73NRuSFGEYDqR/5/kyUEHQbAVyKSQ91wt2ETGpnN0PAAAA//8DANdvnON2BAAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:41 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:59 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "d351529a09e26fcbeed9df0fd9cf1b9c"
+              "value": "d0d3a563e50d8745065f0fc16589eef1"
             },
             {
               "name": "x-trace-id",
-              "value": "6ba57734b1b906d10ba2e3a3e64c58b8"
+              "value": "932f3cf0310bf6eca9995c1701c3d332"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=gShAQ4594byJIbe9a2DIGF4vacBo0%2FaukWAs9UhdzWIaodq886JSOkBTAAQBUBvUTSSHTrFo7Dk5fXItXv8%2F8aJsmKEdHBsx%2BzVlMVMtGp8Bi7d5ymMqUV3qK2D5iAqY4mSZd7VMvveuiN3Jy7pggLLEj9OJ%2F%2B2anm0gPg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ktkNcJKKX6SIWHIaH4j3qCeALNJzfHtsEe04LIQkSMzJ4cXKNgiQVXHDP3sTH0r8LTZdEz84SEEqIll5WFatesJk3kp%2BPkKir2NeRiVFmuY2IB4%2Fy6PsIpxPZh%2FrvVnfYXonsMIk52%2BKeurO8UhEuemfbSryNJL5dgQC7A%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083af995d5e80-EWR"
+              "value": "87a0d04c6cd14222-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:40.845Z",
-        "time": 475,
+        "startedDateTime": "2024-04-25T19:41:59.002Z",
+        "time": 371,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 475
+          "wait": 371
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
@@ -72,13 +72,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 456,
-            "text": "[\"H4sIAAAAAAAAA7yST0/CQBDF7/0Ukzmr7VapwI2oMR48mHgzhqy7w7IRtoUOCX/Cdze7lNqChHDx1p15v743k9lEAKglS+zDJgIAwNnCrusXAFqNfUCRdfFqX2Jasi8ylQxeD4tCSyb9K5ktqGSbu7LxKwAkbciXPuoSNNpB4nJNLaiVIxVJbVK3DvLsnPeZ4BrEMTIc8qogJ6feC98qBluybZs6wTxpQ02uRV04m7h8tvRfZ6u/P3/5E+xD7hyppnPteUTY9U5TKdBIbYhfqXGXADhe6bn846jUnPwyBmFPj5Lp3U6psRastnUgOJPqOWQYFMXEquAa4kT7NQQMacnkylYknOTGv3DMXJT9ODaGbybWfce+EYtOkiXdWGWalKD0Xt72lP7qCN2jbHSXykSMZKc7quIjz6Wil3AeZxGfKtr+AAAA//8DAFd5K4bTAwAA\"]"
+            "text": "[\"H4sIAAAAAAAAA7yST2vCQBDF7/kUw5zbJmtNNLlJW0oPPRR6K0WW3WFdqkk0I/gHv3vZNcZEK+Klt+zM++W9GWYbAKCWLDGDbQAAgPOl3TQvALQaM0CRDPHuUGJasSsyVQxOD8tSSyZ9lMyXVLEt8qr1KwAkbciVvpoStNpekheaOlAnR09EjUnTOsmzdz5kgnsQ58h4zOuScjlzXvhRM9iR7brUBeZFG2pzHerG2cTts/X+dbbm+/vIX2Cfijwn1XZuPM8Iu9lragUaqQ3xO7XuEgAna72QfxyVWpBbxsjv6VkyfdoZtdaC9bZOBFdSvfoMo7KcWuVdfZzgsAaPIa2Y8qoTCaeFcS+cMJdVFobG8MPU5j+ha4QijpJoGCaxUoKS3nCQiL5SIol1mjxGJNN+nPbTQR0feSEVvfnzuIq4VMHuFwAA//8DAPLuT6fTAwAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:40 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:58 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "0677c1adc7cb297a15db434683c2f6ac"
+              "value": "6e40af077e7838c465c85f91ff94c55c"
             },
             {
               "name": "x-trace-id",
-              "value": "c6dec1e27a39cdb51d9e6f42a01fa58f"
+              "value": "65cc1e6287614cc165d9630ea9459497"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=bPD9K06Af1ohXPI5FrMPFqhnDQEEOmRUQWtneP0VrA92aV8wMVzf3lww0dg8P3pp6zHKizeKl57zjMI3Ze31fuhvdAKS4a81gTmNOvrZ56xqYSMbEmHdcXVmGEJo7B05pUDm6AFDAPkRWEeonMhGqr85CoZJZ0olBf43Zw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=8mrPgOF2YLz5oohF3gZ0ABWYmBBhuR0WoEfi0aEm70rzF2UMZHsNQU%2B81jVuRw%2Fgkp%2FeqOYIVlN2gg1o4I%2B2d9rFLB0ZVa3PqhJh%2BJeG1hXxviBS9U3XZllYiTxgcmLFbloXU81YwuwU5TESaQqeqRYXbcV%2B3%2BWyN8lF%2FQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083a88dc9238e-EWR"
+              "value": "87a0d0461decc32c-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 939,
+          "headersSize": 955,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:39.715Z",
-        "time": 259,
+        "startedDateTime": "2024-04-25T19:41:57.996Z",
+        "time": 245,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 259
+          "wait": 245
         }
       },
       {
@@ -232,13 +232,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 512,
-            "text": "[\"H4sIAAAAAAAAA8STT0+DQBDF73yKyZyrsNRW5NaoMR481OjJmGbDTimRLpQdkv6J390sLQjUpkkvHvft++28mczuHABUkiWGsHMAALDMlWSalsm20QDQlFFExmAIXJQ0qGUqiqywqi7TtFFXXRgAE4UhoBgHOPgVmdZsZSbDYBnY11Zt06okw0mmTedBW1rFZMWPlggdS2XTmaIe2snkC69V7lS2fYY6H1yB+AuazXiTk5ZLWxGnBwp7xu8+eYJ7VDF12R55Qa/ikl79f+m1dfpsv3LihftMa4q6GVrVj6hkW/saV8/z3nyEVzJlynv/wY2xVDHxC7W+DgAuNqqQx+uKUUF2mJNqzg+S6S1ZUnvND9PuGc4kfKoyTPI8TaKqahXHqcdXYUhrJm06kTDNYnvCBXNuQteNY75OE/3l2gtXjLyxF7iemIvIvx0JGgW+DIbDIBjfeTekhPTnc6rjIxcyoudqwc4iNpXz/QMAAP//AwCndf7hdgQAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA8STTU+DQBCG7/yKyZyrfJSSyq1RYzx4qNGTMc1md6RECpQdkn6k/90sBQRq06QXj/vu++y8M5ndWwCoBAsMYW8BAGCZK8E0L+NdqwGgLqUkrTEELkoaNTIVRVYYNS2TpFXXfRgAY4UhoBtMcfQrMm3YyEyawTBwrK26pnVJmuMs1b0HTWkVkRE/OiL0LJUtzRQN0F4mz3U65c5lO2Zo8sENuH9BiwVvc0rFylTEeU3hwHgYkme4RxVRnx2QV/TqXtOr9y+9dk6f3VfOvHCfpSnJfoZO9RMq3jW+1jXwvLcf4ZV0mfDRX7sxEioifqHO1wHA5VYV4nRdURZkhjmr5vwgmN7iFXXXvJ72wHAh4VOVYZbnSSyrqlUcqxlfhSFtmFLdi4RJFpkTLplzHdp2FPFtEqfftrmw3YkTOFNbyTupXOl4Uz+QE1eqie+4nj+ejn3HC75kHR+5EJKeqwW7iJhU1uEHAAD//wMAKFDOu3YEAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:40 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:58 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "b4bd551aa95e05d835718ae320602e8b"
+              "value": "2abe5512328ea3a4d189dc177e18f9d9"
             },
             {
               "name": "x-trace-id",
-              "value": "01f1c2751e582a833886904ed1a2ffee"
+              "value": "dc9cd1c02846c51cd5401243834026fc"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ofIomGKnRPovw9OgSs5Q%2FLstVyohvSC2mUBd5W4AWY%2F6H2qrutQByKKGg7v2hF1Bae3qk0ZQvDLzC6Lq%2BLagxY6GTRTPDic9UinuBzYuYuc8zUebxXdT4IdqOFzGDiQmYY6VsPJXvztFqJe3RMoP8M1a6k9HcdUUtlLC6A%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ufnEMwcU1aaPT47YD7bI%2FFxjyYkVfxYvzFdn2gVJ918Dx6U9uSAQq5qnlfP2Sk8o9JJJ0YJgxsQb96yFVpH%2BFfW6VPiVdRa2iAlsJsdO573WrI0S1%2FEaLmXM59d04V%2BD%2FUQclLS1cIJq8KRpZNuNdeeLmVuLB7w0RbmVZg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a083aa6dc943fb-EWR"
+              "value": "87a0d047cac443c3-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:40.022Z",
-        "time": 450,
+        "startedDateTime": "2024-04-25T19:41:58.256Z",
+        "time": 483,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 450
+          "wait": 483
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-even-if-nested_698860812/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-even-if-nested_698860812/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 348,
+          "bodySize": 344,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 348,
-            "text": "[\"H4sIAAAAAAAAA4SQQWvDMAyF7/kVQucxN3XijNwKg7HDDoPdixqrrmmaeokK7Ur++7Cbdd1g7Kj3nvQ+dM4A0JIQ1nDOAADw/eA/rhMAeos1YG403n1JwkeJovAgEPNwCJaE7XdkuZRT4I52HIOv8WayxksCHVnH8sI3zQC4OdmexO+74UYFwKbneH6RWh9J+M3v+FoGgFP/r8Dkj39QPSWGRQitb1JrwrlgZtMa8lG4G34gYbt3ccKNSBhqpZyT+9Z3WxUNlZczM3tQ69W8qthQUeaabKXzZrW2uiiNZmPnVTHho/TU8HN68r8rkSobPwEAAP//AwDKxNS2tQEAAA==\"]"
+            "size": 344,
+            "text": "[\"H4sIAAAAAAAAA4SQQWvDMAyF7/kVQucxJ7TxstwKg9HDDoPdi2orrlmauokK7Ur++7Cbdd1g7Kj3nvQ+dM4A0JIQ1nDOAABwf/Af1wkAvcUasNAzvPuShI8SReFBIObhECwJ2+/IaiWnwB1tOQZf481kjZcEOrKO5YVvmgFwc7I9id91w40KgKbneH6RWp9I+M1v+VoGgFP/r8Dkj39QPSeGRQitN6k14Vwws2kN+SjcDT+QsN25OOFGJAy1Us7Jfeu7dxUNVZS5zivVPJqGH3Kb22rONCuqQttSM63X5dyQbiZ8lJ4ML9OT/12JVNn4CQAA//8DALtSioW1AQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:38 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:56 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "e25db6aabda0eb32cd06cac6aa8fd44f"
+              "value": "197d7e2b0981ed77f1f2e9ac63468966"
             },
             {
               "name": "x-trace-id",
-              "value": "fb277e6a4513ad731cbfd34563e6d274"
+              "value": "f9cfe70d0d84ea31816d56eabb54ca6f"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=VQFsNjIw0kfUsoK91l3ilS92LeKNzbGHpuo0dWVZCr%2Fkm7NBJKbwGT8uKXzcOfyGPxmxUfmVTMhNsrSXkwzVd%2B27fU9hIj3SV8HystgDjVEnRZbAYX%2F8NGDIL2qr11Bu3OeiBmULfNMKcGxMS6TFoutRJ4mt03TVnz0EHw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=decx%2BjKW4ucCYMoFipdOLdMn%2F0g2R4Ry2f0mVweoaF6tGp0WKXw0UK4ghvyZ6ih9rlVX3ON62bLsLTxCJJhavTeoZ8zCE5eqM6l89AGwUfYG7m%2BpJo1cq%2FU42aWYHxvbUmqk%2BP3MOXG4gHYrGoYd4IUWutOOwUUPwQGaNA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0839d891c8c95-EWR"
+              "value": "87a0d039ceea6a4e-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:37.907Z",
-        "time": 311,
+        "startedDateTime": "2024-04-25T19:41:56.021Z",
+        "time": 235,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 311
+          "wait": 235
         }
       },
       {
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 392,
+          "bodySize": 388,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 392,
-            "text": "[\"H4sIAAAAAAAAA4SRPU/DMBCG9/yK080VSVPlg2yVkBADAwjmyrGP1MJNgn2RWqr+d2QnhIalo997Xt1z8jkCQCVYYAXnCAAAh14JppdBf88ZALpBSnIOK2A70Oo3Jms769N2MGZOv5ZlANQKK8B1vsHVX8h0ZB8zOQbfgXG3uoZ2Oz711IoDeTRoTcPLvG/JvM8HvJIbDI/8RGMjVEP8TFcnA+D+pKxg3bVu6S0teaFt8HwQTG/6QNd6k/E/4IbhY3DY9r3RMmwNOqNmNNWQjkytWyih6Rr/wj1z76o4bhq+M7r9jP0gXmdJnpRxkW9IqjItalmrohQfJLP0nvIyS7O6TJJJH9kKSU/hY25WvFV0+QEAAP//AwDVC6ZYLgIAAA==\"]"
+            "size": 388,
+            "text": "[\"H4sIAAAAAAAAA4SRPWvDMBCGd/+K4+ZQW/gD4y1QKB06tLRzUKSLI+rYrnSCpCH/vch2XbtLRr33vNxz6BoBoJYssYJrBACAvteS6dWb7zkDQOeVIuewAraeNr8xWdvZkLa+aeb0a10GQKOxAhRFipu/kOnMIWZyDKED4269hHY7vvTUyhMFdNCahrd535r5mA94I+cbHvmJxlrqmviFFicD4PGirWTTtW7trSwFoe3g+SiZ3s2JlnqT8T/gjuHT4LDt+8aoYeugM2pGUw3pzNS6lRI2XR1eeGTuXRXHdc0PjWk/4zCIRZ4USRlLEiJTiUgp1Qedi32WF0WSlWWusj2Jw6SPbKWi5+Fj7laCVXT7AQAA//8DAPKH9uAuAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:38 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:56 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "f5af21bda7969e28820bf9be667992dd"
+              "value": "78edd6d9108885e17bdb84b35622f37c"
             },
             {
               "name": "x-trace-id",
-              "value": "763ecd827bcbd78afec529e68525b800"
+              "value": "ae114c013e3dfd51b456604885c4be1f"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=3u9y6%2FLtZAgc%2BJUjR3I3JxDNuYU7a3siUR%2BUQmgNDtsnNWo9XD6e9cUmyCuErqqaBpg4UZQqy4fjQ3aUnP%2FtMkK%2F48zS%2FPC96KabKeXV95xCAMdwX94aqf8Ttp5E3MrYNfFjtwEpDiRkt0A%2FOyByJTgdd1VRyR6dHSg3Pw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=usbReQikaJptPbD1Rar77rl56tHpbUiOZncsiKHX4r9gRUWbN3bz6zNgndUTsAc2HOgx8Gw39EJXwQRGBAEW60bzmqS2vDu1TIw6HiQ%2FDyQ4GLZSLaEhnN358JarLjCx69rhHJbRq8p8rccV5BEgcOdb0LEsT8bpYsICSw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0839f5c914346-EWR"
+              "value": "87a0d03b7d964213-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 953,
+          "headersSize": 941,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:38.270Z",
-        "time": 399,
+        "startedDateTime": "2024-04-25T19:41:56.293Z",
+        "time": 397,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 399
+          "wait": 397
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-object_3536142481/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-object_3536142481/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 351,
+          "bodySize": 344,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 351,
-            "text": "[\"H4sIAAAAAAAAA4SQT2vCQBDF7/kUw5yla9D8vQmC9NCD0LuM2cm6GOOajKCVfPeya2ptofQ4772Z92NuEQBqEsISbhEAAJ7O9uMxAaDVWALG6QwnX5LwRbwo3Av4PJydJmH9Hdls5Oq4pQP74NrfDNZwT6AhbVje+KkZAHdX3ZHYY9s/qQBYdezPL0LrkoTf7YEfZQA49v8KjP7wB9UqMCyca2wVWgPOHTMa15Avwm3/Awmbo/ET7kRcXypljLw0tt0rb6g4mabTXCV1lumkTnKKdbGtNBVZPk/rnHiWFtuYRnyUjip+DU/+d8VTRcMnAAAA//8=\",\"AwC/7xZNtQEAAA==\"]"
+            "size": 344,
+            "text": "[\"H4sIAAAAAAAAA4SQzWrDMBCE736KZc+hkmzqpL4FCqGHHAK9B9VaKaKOo9obSBr87kWK81coPe7M7M7HnjIANJo1VnDKAADwa++/rxMAeoMVoCoLnFwkpgNHkalniHnYB6OZzC2yXvMxUKu3FIOreDNZwzmBThtHvKS7ZgDcHE2n2e/a/k4FwLqjeH6eWl8107vf0rUMAMf+X4HRH/6gWiSGeQiNr1NrwjljZuMa0oGp7R+QsNm5OOGGOfSVEM7xU+PbTxENoZ5lKWeieLFFLqfS1lIVytDHzOaWrJ7m0qqyvPwKudM1vaUn/7sSqbLhBwAA//8DAJ+nW621AQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:37 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:55 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "5e9ebe281ce7dffa46e156c880beab50"
+              "value": "10a435ab917fa097f6aaa75b58bd4793"
             },
             {
               "name": "x-trace-id",
-              "value": "5f77d5f58a1d9bcda97846f8ae369b1a"
+              "value": "39f32070fc0131deb8f2fefa720f166d"
             },
             {
               "name": "strict-transport-security",
@@ -130,7 +130,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=sXVnFRrRTiti%2BahTUA4rSmBSrg68rzsR3oQXTeubl0c5V3xperLVXSA7EzxhMCWNzFfSPQJNqMmqeWYMnLjZBpyMLXsWTVTLR0xntivx3zR6BWCAynuwcFyFh96jXi6KpYg3rj1dWKTiXox3MbF4fJmakq28MBFRuCqh5Q%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=IPJ0Fa8xsikE0mSGEVbGkGCDcHovbLsm5LYto%2B6CoTGm7lNYeyM1F23ka5MUaLwESYJrA3RB8AZlc%2Fb9Qb3etJXTZHRM1yphmKtgaQ86Mh2D132v9HQFyFRVHgnG9OmjfRxM5pKVD0RX0A7OoQ%2F8lkzKAVTa1O7O2LXn5g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -142,21 +142,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a08398ea2542c8-EWR"
+              "value": "87a0d0323e977293-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 941,
+          "headersSize": 945,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:37.197Z",
-        "time": 277,
+        "startedDateTime": "2024-04-25T19:41:54.817Z",
+        "time": 539,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +164,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 277
+          "wait": 539
         }
       },
       {
@@ -232,13 +232,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 392,
-            "text": "[\"H4sIAAAAAAAAA4SRsU7DMBCG9zzF6eaKJASSJlslJMTAAIK5MvY1tXCTYJ+llqrvjpyEkLB09H/fr/tOPkcAqAQLrOAcAQCg75RgevH6e8oA0HkpyTmsgK2n1W9M1rY2pI03Zkq/lmUA1AorwDTPcPUXMh05xEyOIXRg2K3m0HbLp44acaCA9lrj8DLtWzLv0wGv5LzhgR9prIWqiZ9pdjIA7k/KCtZt45be0lIQ2vSeD4LpTR9orjca/wOuGD72DpuuM1r2W3udQTMaa0hHpsYtlNC0dXjhnrlzVRzXNd8Y3XzGYRCn90merOOszAohUrEm2q0zSR9ZonKRlDK9K26LXTnqI1sh6an/mKuVYBVdfgAAAP//AwC3U9f3LgIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRPWvDMBCGd/+K4+ZQW7Hjry1QKB06tLRzENbhiDq2K50hach/L5Jd1+6SUe89L/ccugYAqCRLLOEaAADg0CvJ9Dro7zkDQDtUFVmLJbAZaPMbkzGdcWk7NM2cfq3LAKgVloAijXHzFzKd2cVMlsF1YNytltDhwJeeWnkih3qtaXib962Zj/mAN7JDwyM/0VhLVRO/0OJkADxelJGsu9auvStDTmjvPR8l07s+0VJvMv4H3DF88g77vm905bd6nVEzmGpIZ6bWrpSw6Wr3wiNzb8swrGt+aHT7GbpBKHZRGuXhVsSp2Iok35GMkryQRZXFiZBFJLOkyIpJH9nIip79x9ytOKvg9gMAAP//AwA+rDU7LgIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 18:49:37 GMT"
+              "value": "Thu, 25 Apr 2024 19:41:56 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "1936012b3d33222fad9fbaa0f2f0b6a3"
+              "value": "cff0012ff01112510dfdc1d92706981c"
             },
             {
               "name": "x-trace-id",
-              "value": "3937aa1a8eef83ceb30d6a09c14727f9"
+              "value": "2136121485ea0489a9c7341a90a74979"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=6xJQsQQX3H34LJOmR8grnv1zQ6OQAXYNeNgsrFPzP7e2Ic14%2BZfjPsdyzwCJcHYlQz3vxv5iZalv3G%2BS82uf0HGrpwELPSabh3yriYv2BQo6BVfWblNKwEs67%2FVIfZTzfSADlBqtYVpvf3fKwHxnzf9hoHPqWClZDRRdMA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=yAgwyUOSLmffJVVUzULzToVkXgqA%2Fg3wK%2BVSOzSQ5VXzn2A3lxOWWgNTb6mhNftY1Q6m1HORlLGhCK%2FVM3IBGLk0hEC8pKoJoHO62CwToDKQd4HBZVtmzAuz1bpZxZhfkmwBXGsSvzFHR7vMAiwtQYf%2BVSqRjhFG%2BRODnw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0839a8e174388-EWR"
+              "value": "87a0d035b8fe4263-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T18:49:37.507Z",
-        "time": 373,
+        "startedDateTime": "2024-04-25T19:41:55.382Z",
+        "time": 590,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 373
+          "wait": 590
         }
       }
     ],

--- a/packages/react/spec/useActionFormNested.spec.tsx
+++ b/packages/react/spec/useActionFormNested.spec.tsx
@@ -315,27 +315,27 @@ describe("useActionFormNested", () => {
       await waitFor(() => expect(useFindFirstHook.current[0].fetching).toBe(false), { timeout: 3000 });
 
       expect(useFindFirstHook.current[0].data).toMatchInlineSnapshot(`
-              {
-                "__typename": "ShopifyProduct",
-                "body": "example value for body",
-                "compareAtPriceRange": null,
-                "createdAt": "2023-12-12T16:22:25.001Z",
-                "handle": null,
-                "id": "123",
-                "productCategory": null,
-                "productType": null,
-                "publishedAt": null,
-                "publishedScope": null,
-                "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
-                "shopifyUpdatedAt": null,
-                "status": null,
-                "tags": null,
-                "templateSuffix": null,
-                "title": null,
-                "updatedAt": "2023-12-12T16:22:25.001Z",
-                "vendor": null,
-              }
-          `);
+        {
+          "__typename": "ShopifyProduct",
+          "body": "example value for body",
+          "compareAtPriceRange": null,
+          "createdAt": "2023-12-12T16:22:25.001Z",
+          "handle": null,
+          "id": "123",
+          "productCategory": null,
+          "productType": null,
+          "publishedAt": null,
+          "publishedScope": null,
+          "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
+          "shopifyUpdatedAt": null,
+          "status": null,
+          "tags": null,
+          "templateSuffix": null,
+          "title": null,
+          "updatedAt": "2023-12-12T16:22:25.001Z",
+          "vendor": null,
+        }
+      `);
 
       const productSuggestionId = useFindFirstHook?.current[0]?.data?.id;
 
@@ -398,27 +398,27 @@ describe("useActionFormNested", () => {
       await waitFor(() => expect(useFindFirstHook.current[0].fetching).toBe(false), { timeout: 3000 });
 
       expect(useFindFirstHook.current[0].data).toMatchInlineSnapshot(`
-              {
-                "__typename": "ShopifyProduct",
-                "body": "example value for body",
-                "compareAtPriceRange": null,
-                "createdAt": "2023-12-12T16:22:25.001Z",
-                "handle": null,
-                "id": "123",
-                "productCategory": null,
-                "productType": null,
-                "publishedAt": null,
-                "publishedScope": null,
-                "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
-                "shopifyUpdatedAt": null,
-                "status": null,
-                "tags": null,
-                "templateSuffix": null,
-                "title": null,
-                "updatedAt": "2023-12-12T16:22:25.001Z",
-                "vendor": null,
-              }
-          `);
+        {
+          "__typename": "ShopifyProduct",
+          "body": "example value for body",
+          "compareAtPriceRange": null,
+          "createdAt": "2023-12-12T16:22:25.001Z",
+          "handle": null,
+          "id": "123",
+          "productCategory": null,
+          "productType": null,
+          "publishedAt": null,
+          "publishedScope": null,
+          "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
+          "shopifyUpdatedAt": null,
+          "status": null,
+          "tags": null,
+          "templateSuffix": null,
+          "title": null,
+          "updatedAt": "2023-12-12T16:22:25.001Z",
+          "vendor": null,
+        }
+      `);
 
       const productSuggestionId = useFindFirstHook?.current[0]?.data?.id;
 
@@ -485,27 +485,27 @@ describe("useActionFormNested", () => {
       await waitFor(() => expect(useFindFirstHook.current[0].fetching).toBe(false), { timeout: 3000 });
 
       expect(useFindFirstHook.current[0].data).toMatchInlineSnapshot(`
-              {
-                "__typename": "ShopifyProduct",
-                "body": "example value for body",
-                "compareAtPriceRange": null,
-                "createdAt": "2023-12-12T16:22:25.001Z",
-                "handle": null,
-                "id": "123",
-                "productCategory": null,
-                "productType": null,
-                "publishedAt": null,
-                "publishedScope": null,
-                "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
-                "shopifyUpdatedAt": null,
-                "status": null,
-                "tags": null,
-                "templateSuffix": null,
-                "title": null,
-                "updatedAt": "2023-12-12T16:22:25.001Z",
-                "vendor": null,
-              }
-          `);
+        {
+          "__typename": "ShopifyProduct",
+          "body": "example value for body",
+          "compareAtPriceRange": null,
+          "createdAt": "2023-12-12T16:22:25.001Z",
+          "handle": null,
+          "id": "123",
+          "productCategory": null,
+          "productType": null,
+          "publishedAt": null,
+          "publishedScope": null,
+          "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
+          "shopifyUpdatedAt": null,
+          "status": null,
+          "tags": null,
+          "templateSuffix": null,
+          "title": null,
+          "updatedAt": "2023-12-12T16:22:25.001Z",
+          "vendor": null,
+        }
+      `);
 
       const productSuggestionId = useFindFirstHook?.current[0]?.data?.id;
 
@@ -568,27 +568,27 @@ describe("useActionFormNested", () => {
       await waitFor(() => expect(useFindFirstHook.current[0].fetching).toBe(false), { timeout: 3000 });
 
       expect(useFindFirstHook.current[0].data).toMatchInlineSnapshot(`
-              {
-                "__typename": "ShopifyProduct",
-                "body": "example value for body",
-                "compareAtPriceRange": null,
-                "createdAt": "2023-12-12T16:22:25.001Z",
-                "handle": null,
-                "id": "123",
-                "productCategory": null,
-                "productType": null,
-                "publishedAt": null,
-                "publishedScope": null,
-                "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
-                "shopifyUpdatedAt": null,
-                "status": null,
-                "tags": null,
-                "templateSuffix": null,
-                "title": null,
-                "updatedAt": "2023-12-12T16:22:25.001Z",
-                "vendor": null,
-              }
-          `);
+        {
+          "__typename": "ShopifyProduct",
+          "body": "example value for body",
+          "compareAtPriceRange": null,
+          "createdAt": "2023-12-12T16:22:25.001Z",
+          "handle": null,
+          "id": "123",
+          "productCategory": null,
+          "productType": null,
+          "publishedAt": null,
+          "publishedScope": null,
+          "shopifyCreatedAt": "2023-12-01T05:00:00.000Z",
+          "shopifyUpdatedAt": null,
+          "status": null,
+          "tags": null,
+          "templateSuffix": null,
+          "title": null,
+          "updatedAt": "2023-12-12T16:22:25.001Z",
+          "vendor": null,
+        }
+      `);
 
       const productSuggestionId = useFindFirstHook?.current[0]?.data?.id;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       nock:
         specifier: ^13.5.4
         version: 13.5.4
+      p-retry:
+        specifier: ^4.5.0
+        version: 4.6.2
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -2219,6 +2222,10 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.5
       csstype: 3.1.0
+    dev: true
+
+  /@types/retry@0.12.0:
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
     dev: true
 
   /@types/semver@7.5.8:
@@ -6007,6 +6014,14 @@ packages:
       aggregate-error: 3.1.0
     dev: true
 
+  /p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+    dev: true
+
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
@@ -6451,6 +6466,11 @@ packages:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+    dev: true
+
+  /retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
     dev: true
 
   /reusify@1.0.4:


### PR DESCRIPTION
To support shopify managed installs I am changing our Shopify app bridge provider to do initial setup with an app by calling a mutation that may have as a side effect that a shop is installed as part of loading the app for the first time. We need to do this because with Shopify managed installation there is no prior communication with a Gadget app during the installation process and the first request to the Gadget backend will come the first time the app is loaded in an embedded context. This mutation will detect this scenario and will install the app Gadget side using a session token exchange

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
