### PR TITLE
Add live query support to the imperative operation runners

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -40,6 +40,7 @@
     "tiny-graphql-query-compiler": "^0.2.2",
     "tslib": "^2.6.2",
     "type-fest": "^3.3.0",
+    "wonka": "^6.3.2",
     "ws": "^8.17.0"
   },
   "devDependencies": {
@@ -51,7 +52,6 @@
     "p-retry": "^4.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tiny-graphql-query-compiler": "workspace:*",
     "typescript": "5.4.5"
   }
 }

--- a/packages/api-client-core/spec/helpers.ts
+++ b/packages/api-client-core/spec/helpers.ts
@@ -1,4 +1,6 @@
 import { parse } from "graphql";
+import { defaults } from "lodash";
+import pRetry from "p-retry";
 
 export const withWindowMissingSupport = (key: keyof typeof window, run: () => void) => {
   const old = window[key];
@@ -27,3 +29,21 @@ export function delayPromise<T>(wait: number, value?: T, error?: Error): Promise
     }, wait);
   });
 }
+
+export const asyncIterableToIterator = <T>(iterator: AsyncIterable<T>) => {
+  return iterator[Symbol.asyncIterator]();
+};
+
+/**
+ * Wait for a given expectation to pass
+ * Useful as a more robust alternative to `sleep` in tests, where we want to wait for something to happen, but we don't know how long it will take
+ */
+export const waitForExpectationToPass = async (run: () => void | Promise<void>, options?: pRetry.Options) => {
+  await pRetry(
+    run,
+    defaults(options, {
+      attempts: 10,
+      maxTimeout: 1000,
+    })
+  );
+};

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -2,9 +2,10 @@ import type { GadgetRecord, RecordShape } from "./GadgetRecord.js";
 import type { GadgetRecordList } from "./GadgetRecordList.js";
 import type { LimitToKnownKeys, VariablesOptions } from "./types.js";
 
-export type AsyncRecord<T extends RecordShape> = Promise<GadgetRecord<T>>;
-export type AsyncNullableRecord<T extends RecordShape> = Promise<GadgetRecord<T> | null>;
-export type AsyncRecordList<T extends RecordShape> = Promise<GadgetRecordList<T>>;
+export type PromiseOrLiveIterator<T> = Promise<T> | AsyncIterable<T>;
+export type AsyncRecord<T extends RecordShape> = PromiseOrLiveIterator<GadgetRecord<T>>;
+export type AsyncNullableRecord<T extends RecordShape> = PromiseOrLiveIterator<GadgetRecord<T> | null>;
+export type AsyncRecordList<T extends RecordShape> = PromiseOrLiveIterator<GadgetRecordList<T>>;
 
 export interface FindOneFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   <Options extends OptionsT>(fieldValue: string, options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       type-fest:
         specifier: ^3.3.0
         version: 3.3.0
+      wonka:
+        specifier: ^6.3.2
+        version: 6.3.2
       ws:
         specifier: ^8.17.0
         version: 8.17.0


### PR DESCRIPTION
We shipped all the backend support for live queries and the frontend support to the react client only. This adds support to the helper functions we use within the imperative, non-react JS client for live queries also!

I chose to use async iterators for this api. Calls will look like this:

```typescript
for await (const widget of api.widget.findOne("123")) {
  console.log(widget);
}
```

`widget` there is a fully formed `GadgetRecord` instance, and each time it changed on the backend, we push a whole new instance out the async iterator.

This async iterator approach is the smallest amount of code, and doesn't couple our external interface to any one library's interface for observables or event emitters or whatever. It just uses JS builtins (async iterators), and those can be adapted outside of the client to anything you want. This means a minimal bundle size increase, and we already depend on async iterator support within the client for live queries, so no change in required browser features.

## PR Checklist

- [X] Important or complicated code is tested
- [X] Any user facing changes are documented in the Gadget-side changelog
- [X] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [X] Versions within this monorepo are matching and there's a valid upgrade path
