### PR TITLE
Add support for using the `fetch` global from node, and for importing cross-fetch in ESM contexts

### DIFF
--- a/packages/api-client-core/jest.config.js
+++ b/packages/api-client-core/jest.config.js
@@ -126,7 +126,7 @@ export default {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: ["<rootDir>/spec/jest.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/spec/jest.setup.ts"],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],

--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -32,7 +32,7 @@
     "@n1ru4l/json-patch-plus": "^0.2.0",
     "@n1ru4l/push-pull-async-iterable-iterator": "^3.2.0",
     "@urql/core": "^4.0.10",
-    "cross-fetch": "^3.1.8",
+    "cross-fetch": "^4.0.0",
     "graphql": "^16.8.1",
     "graphql-ws": "^5.13.1",
     "isomorphic-ws": "^5.0.0",

--- a/packages/api-client-core/spec/imports/cjs-import.js
+++ b/packages/api-client-core/spec/imports/cjs-import.js
@@ -1,3 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { GadgetConnection } = require("../..");
-new GadgetConnection({ endpoint: "/test" });
+const connection = new GadgetConnection({ endpoint: "/test" });
+void connection.fetch("https://gadget.dev").then(() => {
+  console.log("ok");
+});

--- a/packages/api-client-core/spec/imports/named-esm-import.mjs
+++ b/packages/api-client-core/spec/imports/named-esm-import.mjs
@@ -1,2 +1,5 @@
 import { GadgetConnection } from "../../dist/esm/index.js";
-new GadgetConnection({ endpoint: "/test" });
+const connection = new GadgetConnection({ endpoint: "/test" });
+void connection.fetch("https://gadget.dev").then(() => {
+  console.log("ok");
+});

--- a/packages/api-client-core/spec/jest.setup.ts
+++ b/packages/api-client-core/spec/jest.setup.ts
@@ -1,7 +1,2 @@
-import "@testing-library/jest-dom/extend-expect";
-jest.setTimeout(process.env.CI == "vscode-jest-tests" ? 20 * 60 * 1000 : 5 * 1000);
-
 // nock's fetch support is forthcoming and still broken, so we mock the global fetch to use cross-fetch, which nock supports mocking just fine
 global.fetch = require("cross-fetch");
-
-export {};

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -40,7 +40,6 @@
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
     "conditional-type-checks": "^1.0.6",
-    "cross-fetch": "^3.1.8",
     "nock": "^13.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^4.0.10
         version: 4.0.10(graphql@16.8.1)
       cross-fetch:
-        specifier: ^3.1.8
-        version: 3.1.8
+        specifier: ^4.0.0
+        version: 4.0.0
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -316,9 +316,6 @@ importers:
       conditional-type-checks:
         specifier: ^1.0.6
         version: 1.0.6
-      cross-fetch:
-        specifier: ^3.1.8
-        version: 3.1.8
       nock:
         specifier: ^13.5.4
         version: 13.5.4
@@ -3067,12 +3064,13 @@ packages:
       - ts-node
     dev: true
 
-  /cross-fetch@3.1.8:
-    resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
+  /cross-fetch@4.0.0:
+    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
     dependencies:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+    dev: false
 
   /cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
@@ -5754,6 +5752,7 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: false
 
   /node-fetch@3.2.10:
     resolution: {integrity: sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==}
@@ -7006,6 +7005,7 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
 
   /tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
@@ -7264,6 +7264,7 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
 
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -7295,6 +7296,7 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+    dev: false
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}


### PR DESCRIPTION
A user on discord reported that the way we import cross-fetch doesn't work in a native ESM context:
![CleanShot 2024-04-22 at 18 06 49@2x](https://github.com/gadget-inc/js-clients/assets/158950/5017710f-a4d7-4153-bbcc-96e3f9b76dea)


I can't reproduce it -- when I import `cross-fetch` in a native ESM context locally, I get a module with `fetch` and `default` defined, but I don't really care -- we need to work in next.js. This fixes that twice: first, by using `globalThis.fetch` for our fetch implementation if it is found, which in recent nodes, it is. We used to only check for `window.fetch`, but `globalThis.fetch` is a thing in node (and uses fancy caching smarts in next.js by default too). The second fix is to make the fallback to cross-fetch work if what is returned is a naked ESM module with just the `default` prop that we need to access. 
Yucky.

Annoyingly, the change to start using `globalThis.fetch` breaks our nock-ing setup, because it starts using node's built in fetch, which nock doesn't mock, instead of falling back to `cross-fetch`, which nock does mock as it uses raw `node:http` under the hood. So, to keep knock working, we patch `globalThis.fetch` in the jest env to still use cross-fetch, which gets mocked as before. Nock has forthcoming support for fetch, which I tried, it does not work well yet, so I feel ok about this in the medium term until we can use nock proper.

Extra yucky.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
