### PR TITLE
Background action result types

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.23",
+  "version": "0.15.24",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/mockActions.ts
+++ b/packages/api-client-core/spec/mockActions.ts
@@ -18,7 +18,13 @@ export const MockWidgetCreateAction = {
     },
   },
   hasReturnType: false,
-} as unknown as ActionFunction<any, any, any, any, any>;
+} as unknown as ActionFunction<
+  { select?: { id?: boolean; name?: boolean } },
+  any,
+  { id?: boolean; name?: boolean },
+  { id: string; name: string },
+  { id: true; name: true }
+>;
 
 export const MockBulkUpdateWidgetAction = {
   type: "action",

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -1182,7 +1182,7 @@ describe("operationRunners", () => {
   describe("actionResultRunner", () => {
     describe("action", () => {
       test("waits for background action with a completed result", async () => {
-        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, undefined);
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -1223,12 +1223,12 @@ describe("operationRunners", () => {
         const result = await promise;
 
         expect(result.outcome).toEqual("completed");
-        expect(result.result.id).toBeTruthy();
-        expect(result.result.name).toBeTruthy();
+        expect(result.result?.id).toEqual("123");
+        expect(result.result?.name).toEqual("foo");
       });
 
       test("waits for background action with failed result", async () => {
-        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, { select: { id: true } });
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -1274,7 +1274,7 @@ describe("operationRunners", () => {
 
     describe("globalAction", () => {
       test("waits for completed background action response", async () => {
-        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockGlobalAction, {});
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockGlobalAction);
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -1315,7 +1315,7 @@ describe("operationRunners", () => {
       });
 
       test("waits for failed background action response", async () => {
-        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockGlobalAction, {});
+        const promise = backgroundActionResultRunner(connection, "app-job-123456", MockGlobalAction);
 
         expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
         expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({
@@ -1408,7 +1408,7 @@ describe("operationRunners", () => {
     });
 
     test("permission error", async () => {
-      const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction);
+      const promise = backgroundActionResultRunner(connection, "app-job-123456", MockWidgetCreateAction, { select: { id: true } });
 
       expect(mockUrqlClient.executeSubscription.mock.calls.length).toEqual(1);
       expect(mockUrqlClient.executeSubscription.mock.calls[0][0].variables).toEqual({

--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -2,16 +2,25 @@ import type { GadgetConnection } from "./GadgetConnection.js";
 import type { ActionFunction, ActionFunctionMetadata, GlobalActionFunction } from "./GadgetFunctions.js";
 import type { GadgetRecord } from "./GadgetRecord.js";
 import { backgroundActionResultRunner } from "./operationRunners.js";
-import type { DefaultSelection, Select } from "./types.js";
+import type { ActionFunctionOptions, DefaultSelection, Select } from "./types.js";
 
-export type BackgroundActionResultData<F extends ActionFunctionMetadata<any, any, any, any, any, any> | GlobalActionFunction<any>> =
-  F extends ActionFunction<any, any, any, any, any>
-    ? F["hasReturnType"] extends true
-      ? any
-      : GadgetRecord<
-          Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], F["optionsType"], F["defaultSelection"]>>
+export type BackgroundActionResultData<
+  F extends ActionFunctionMetadata<any, any, any, any, any, any> | GlobalActionFunction<any>,
+  Selection
+> = F extends ActionFunction<any, any, any, any, any>
+  ? F["hasReturnType"] extends true
+    ? any
+    : GadgetRecord<
+        Select<
+          Exclude<F["schemaType"], null | undefined>,
+          DefaultSelection<
+            F["selectionType"],
+            Selection extends { select?: F["selectionType"] | null | undefined } ? Selection : never,
+            F["defaultSelection"]
+          >
         >
-    : any;
+      >
+  : any;
 
 export type BackgroundActionResult<Data = any> = {
   id: string;
@@ -22,13 +31,13 @@ export type BackgroundActionResult<Data = any> = {
 /** Represents a handle to a background action which has been enqueued */
 export class BackgroundActionHandle<
   SchemaT,
-  Action extends ActionFunctionMetadata<any, any, any, SchemaT, any, any> | GlobalActionFunction<any>,
-  ResultData = BackgroundActionResultData<Action>
+  Action extends ActionFunctionMetadata<any, any, any, SchemaT, any, any> | GlobalActionFunction<any>
 > {
   constructor(readonly connection: GadgetConnection, readonly action: Action, readonly id: string) {}
 
   /** Wait for this background action to complete and return the result. */
-  async result(options?: Action extends ActionFunctionMetadata<any, any, any, any, any, any> ? Action["optionsType"] : never) {
-    return (await backgroundActionResultRunner<SchemaT, Action, ResultData>(this.connection, this.id, this.action, options)).result;
+  async result<Options extends ActionFunctionOptions<Action>, ResultData = BackgroundActionResultData<Action, Options>>(options?: Options) {
+    return (await backgroundActionResultRunner<SchemaT, Action, Options, ResultData>(this.connection, this.id, this.action, options))
+      .result;
   }
 }

--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -28,7 +28,7 @@ export class BackgroundActionHandle<
   constructor(readonly connection: GadgetConnection, readonly action: Action, readonly id: string) {}
 
   /** Wait for this background action to complete and return the result. */
-  async result(options?: any) {
+  async result(options?: Action extends ActionFunctionMetadata<any, any, any, any, any, any> ? Action["optionsType"] : never) {
     return (await backgroundActionResultRunner<SchemaT, Action, ResultData>(this.connection, this.id, this.action, options)).result;
   }
 }

--- a/packages/api-client-core/src/BackgroundActionHandle.ts
+++ b/packages/api-client-core/src/BackgroundActionHandle.ts
@@ -1,20 +1,34 @@
 import type { GadgetConnection } from "./GadgetConnection.js";
-import type { AnyActionFunction } from "./GadgetFunctions.js";
+import type { ActionFunction, ActionFunctionMetadata, GlobalActionFunction } from "./GadgetFunctions.js";
+import type { GadgetRecord } from "./GadgetRecord.js";
 import { backgroundActionResultRunner } from "./operationRunners.js";
-import type { ActionFunctionOptions } from "./types.js";
+import type { DefaultSelection, Select } from "./types.js";
 
-export type BackgroundActionResult<R = any> = {
+export type BackgroundActionResultData<F extends ActionFunctionMetadata<any, any, any, any, any, any> | GlobalActionFunction<any>> =
+  F extends ActionFunction<any, any, any, any, any>
+    ? F["hasReturnType"] extends true
+      ? any
+      : GadgetRecord<
+          Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], F["optionsType"], F["defaultSelection"]>>
+        >
+    : any;
+
+export type BackgroundActionResult<Data = any> = {
   id: string;
   outcome: string | null;
-  result: R | null;
+  result: Data | null;
 };
 
 /** Represents a handle to a background action which has been enqueued */
-export class BackgroundActionHandle<Action extends AnyActionFunction> {
+export class BackgroundActionHandle<
+  SchemaT,
+  Action extends ActionFunctionMetadata<any, any, any, SchemaT, any, any> | GlobalActionFunction<any>,
+  ResultData = BackgroundActionResultData<Action>
+> {
   constructor(readonly connection: GadgetConnection, readonly action: Action, readonly id: string) {}
 
   /** Wait for this background action to complete and return the result. */
-  async result<Options extends ActionFunctionOptions<Action>>(options?: Options) {
-    return (await backgroundActionResultRunner(this.connection, this.id, this.action, options)).result;
+  async result(options?: any) {
+    return (await backgroundActionResultRunner<SchemaT, Action, ResultData>(this.connection, this.id, this.action, options)).result;
   }
 }

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -37,7 +37,7 @@ import {
   namespaceDataPath,
   setVariableOptionValues,
 } from "./support.js";
-import type { BaseFindOptions, EnqueueBackgroundActionOptions, FindManyOptions, VariablesOptions } from "./types.js";
+import type { ActionFunctionOptions, BaseFindOptions, EnqueueBackgroundActionOptions, FindManyOptions, VariablesOptions } from "./types.js";
 
 type LiveResultForOptions<T, LiveOptions extends { live?: boolean | null }> = LiveOptions extends { live: true }
   ? AsyncIterable<T>
@@ -376,12 +376,13 @@ export async function enqueueActionRunner<SchemaT, Action extends AnyActionFunct
 export const backgroundActionResultRunner = async <
   SchemaT,
   Action extends ActionFunctionMetadata<any, any, any, SchemaT, any, any> | GlobalActionFunction<any>,
-  ResultData = BackgroundActionResultData<Action>
+  Options extends ActionFunctionOptions<Action>,
+  ResultData = BackgroundActionResultData<Action, Options>
 >(
   connection: GadgetConnection,
   id: string,
   action: Action,
-  options?: Action extends ActionFunctionMetadata<any, any, any, SchemaT, any, any> ? Action["optionsType"] : never
+  options?: Options
 ): Promise<BackgroundActionResult<ResultData>> => {
   const plan = backgroundActionResultOperation(id, action, options);
   const subscription = connection.currentClient.subscription(plan.query, plan.variables);

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -1,12 +1,12 @@
 import { filter, pipe, take, toAsyncIterable, toPromise } from "wonka";
-import type { BackgroundActionResult } from "./BackgroundActionHandle.js";
+import type { BackgroundActionResult, BackgroundActionResultData } from "./BackgroundActionHandle.js";
 import { BackgroundActionHandle } from "./BackgroundActionHandle.js";
 /* eslint-disable @typescript-eslint/ban-types */
 import type { OperationResult } from "@urql/core";
 import type { Source } from "wonka";
 import type { FieldSelection } from "./FieldSelection.js";
 import type { GadgetConnection } from "./GadgetConnection.js";
-import type { ActionFunctionMetadata, AnyActionFunction, AnyBulkActionFunction } from "./GadgetFunctions.js";
+import type { ActionFunctionMetadata, AnyActionFunction, AnyBulkActionFunction, GlobalActionFunction } from "./GadgetFunctions.js";
 import type { GadgetRecord, RecordShape } from "./GadgetRecord.js";
 import { GadgetRecordList } from "./GadgetRecordList.js";
 import type { AnyModelManager } from "./ModelManager.js";
@@ -37,7 +37,7 @@ import {
   namespaceDataPath,
   setVariableOptionValues,
 } from "./support.js";
-import type { ActionFunctionOptions, BaseFindOptions, EnqueueBackgroundActionOptions, FindManyOptions, VariablesOptions } from "./types.js";
+import type { BaseFindOptions, EnqueueBackgroundActionOptions, FindManyOptions, VariablesOptions } from "./types.js";
 
 type LiveResultForOptions<T, LiveOptions extends { live?: boolean | null }> = LiveOptions extends { live: true }
   ? AsyncIterable<T>
@@ -331,24 +331,24 @@ export const globalActionRunner = async (
   return assertMutationSuccess(response, dataPath).result;
 };
 
-export async function enqueueActionRunner<Action extends AnyBulkActionFunction>(
+export async function enqueueActionRunner<SchemaT, Action extends AnyBulkActionFunction, Result = BackgroundActionHandle<SchemaT, Action>>(
   connection: GadgetConnection,
   action: Action,
   variables: Action["variablesType"],
   options?: EnqueueBackgroundActionOptions<Action>
-): Promise<BackgroundActionHandle<Action>[]>;
-export async function enqueueActionRunner<Action extends AnyActionFunction>(
+): Promise<Result[]>;
+export async function enqueueActionRunner<SchemaT, Action extends AnyActionFunction, Result = BackgroundActionHandle<SchemaT, Action>>(
   connection: GadgetConnection,
   action: Action,
   variables: Action["variablesType"],
   options?: EnqueueBackgroundActionOptions<Action>
-): Promise<BackgroundActionHandle<Action>>;
-export async function enqueueActionRunner<Action extends AnyActionFunction>(
+): Promise<Result>;
+export async function enqueueActionRunner<SchemaT, Action extends AnyActionFunction, Result = BackgroundActionHandle<SchemaT, Action>>(
   connection: GadgetConnection,
   action: Action,
   variables: Action["variablesType"],
   options: EnqueueBackgroundActionOptions<Action> = {}
-): Promise<BackgroundActionHandle<Action> | BackgroundActionHandle<Action>[]> {
+): Promise<Result | Result[]> {
   const normalizedVariableValues = action.isBulk
     ? disambiguateBulkActionVariables(action as ActionFunctionMetadata<any, any, any, any, any, true>, variables)
     : disambiguateActionVariables(action, variables);
@@ -363,22 +363,26 @@ export async function enqueueActionRunner<Action extends AnyActionFunction>(
     if (action.isBulk) {
       return result.backgroundActions.map((result: { id: string }) => new BackgroundActionHandle(connection, action, result.id));
     } else {
-      return new BackgroundActionHandle(connection, action, result.backgroundAction.id);
+      return new BackgroundActionHandle(connection, action, result.backgroundAction.id) as Result;
     }
   } catch (error: any) {
     if ("code" in error && error.code == "GGT_DUPLICATE_BACKGROUND_ACTION_ID" && options?.id && options.onDuplicateID == "ignore") {
-      return new BackgroundActionHandle(connection, action, options.id);
+      return new BackgroundActionHandle(connection, action, options.id) as Result;
     }
     throw error;
   }
 }
 
-export const backgroundActionResultRunner = async <Action extends AnyActionFunction, Options extends ActionFunctionOptions<Action>>(
+export const backgroundActionResultRunner = async <
+  SchemaT,
+  Action extends ActionFunctionMetadata<any, any, any, SchemaT, any, any> | GlobalActionFunction<any>,
+  ResultData = BackgroundActionResultData<Action>
+>(
   connection: GadgetConnection,
   id: string,
   action: Action,
-  options?: Options
-): Promise<BackgroundActionResult> => {
+  options?: Action extends ActionFunctionMetadata<any, any, any, SchemaT, any, any> ? Action["optionsType"] : never
+): Promise<BackgroundActionResult<ResultData>> => {
   const plan = backgroundActionResultOperation(id, action, options);
   const subscription = connection.currentClient.subscription(plan.query, plan.variables);
 
@@ -410,7 +414,7 @@ export const backgroundActionResultRunner = async <Action extends AnyActionFunct
     }
   }
 
-  return backgroundAction;
+  return backgroundAction as BackgroundActionResult<ResultData>;
 };
 
 /** @deprecated previous export name, @see backgroundActionResultRunner */

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.8",
+  "version": "0.15.9",
   "files": [
     "README.md",
     "dist/**/*"
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.4",
-    "@gadgetinc/api-client-core": "^0.15.22",
+    "@gadgetinc/api-client-core": "^0.15.24",
     "react-fast-compare": "^3.2.2",
     "react-hook-form": "~7.48.2",
     "tslib": "^2.6.2",

--- a/packages/react/spec/useEnqueue.spec.tsx
+++ b/packages/react/spec/useEnqueue.spec.tsx
@@ -161,7 +161,12 @@ describe("useEnqueue", () => {
     const [{ handle, fetching, error }, _enqueue] = useEnqueue(relatedProductsApi.user.update);
 
     assert<IsExact<typeof fetching, boolean>>(true);
-    assert<IsExact<typeof handle, null | BackgroundActionHandle<typeof relatedProductsApi.user.update>>>(true);
+    assert<
+      IsExact<
+        typeof handle,
+        null | BackgroundActionHandle<(typeof relatedProductsApi.user.update)["schemaType"], typeof relatedProductsApi.user.update>
+      >
+    >(true);
     assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
     // data is accessible via dot access
@@ -174,7 +179,13 @@ describe("useEnqueue", () => {
     const [{ handles, fetching, error }, _enqueue] = useEnqueue(relatedProductsApi.user.bulkUpdate);
 
     assert<IsExact<typeof fetching, boolean>>(true);
-    assert<IsExact<typeof handles, BackgroundActionHandle<typeof relatedProductsApi.user.bulkUpdate>[] | null>>(true);
+    assert<
+      IsExact<
+        typeof handles,
+        | BackgroundActionHandle<(typeof relatedProductsApi.user.bulkUpdate)["schemaType"], typeof relatedProductsApi.user.bulkUpdate>[]
+        | null
+      >
+    >(true);
     assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
 
     // data is accessible via dot access

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -136,11 +136,11 @@ export type ActionHookResult<Data = any, Variables extends AnyVariables = AnyVar
 /**
  * The inner result object returned from a mutation result
  */
-export type EnqueueHookState<Action extends AnyActionFunction> = Action extends AnyBulkActionFunction
+export type EnqueueHookState<SchemaT, Action extends AnyActionFunction> = Action extends AnyBulkActionFunction
   ? {
       fetching: boolean;
       stale: boolean;
-      handles: BackgroundActionHandle<Action>[] | null;
+      handles: BackgroundActionHandle<SchemaT, Action>[] | null;
       error?: ErrorWrapper;
       extensions?: Record<string, any>;
       operation?: Operation<{ backgroundAction: { id: string } }, Action["variablesType"]>;
@@ -148,7 +148,7 @@ export type EnqueueHookState<Action extends AnyActionFunction> = Action extends 
   : {
       fetching: boolean;
       stale: boolean;
-      handle: BackgroundActionHandle<Action> | null;
+      handle: BackgroundActionHandle<SchemaT, Action> | null;
       error?: ErrorWrapper;
       extensions?: Record<string, any>;
       operation?: Operation<{ backgroundAction: { id: string } }, Action["variablesType"]>;
@@ -160,24 +160,24 @@ export type EnqueueHookState<Action extends AnyActionFunction> = Action extends 
  *  - the result object, with the keys like `handle`, `fetching`, and `error`
  *  - and a function for running the enqueue mutation.
  **/
-export type EnqueueHookResult<Action extends AnyActionFunction> = RequiredKeysOf<
+export type EnqueueHookResult<SchemaT, Action extends AnyActionFunction> = RequiredKeysOf<
   Exclude<Action["variablesType"], null | undefined>
 > extends never
   ? [
-      EnqueueHookState<Action>,
+      EnqueueHookState<SchemaT, Action>,
       (
         variables?: Action["variablesType"],
         backgroundOptions?: EnqueueBackgroundActionOptions<Action>,
         context?: Partial<OperationContext>
-      ) => Promise<EnqueueHookState<Action>>
+      ) => Promise<EnqueueHookState<SchemaT, Action>>
     ]
   : [
-      EnqueueHookState<Action>,
+      EnqueueHookState<SchemaT, Action>,
       (
         variables: Action["variablesType"],
         backgroundOptions?: EnqueueBackgroundActionOptions<Action>,
         context?: Partial<OperationContext>
-      ) => Promise<EnqueueHookState<Action>>
+      ) => Promise<EnqueueHookState<SchemaT, Action>>
     ];
 
 export const noProviderErrorMessage = `Could not find a client in the context of Provider. Please ensure you wrap the root component in a <Provider>`;


### PR DESCRIPTION
Adds typing to background action handles that determines the result type based on the Action being passed in. This means that actions such as `MockWidgetCreateAction` will be typed as a `GadgetRecord`. I had to follow a similar pattern to what is in `useActionForm` and pass through a `SchemaT` type otherwise the typescript compiler complains when inferring the `GadgetRecord` shape. This type also has to be propagated back up into the `useEnqueue` react package in order to properly construct the correct `BackgroundHandle` and result type. 

I added additional typing to the `MockWidgetCreateAction` to better reflect the types that an actual action will have when constructed by gadget.

Note: I still need to test it with gadget codebase but that has been causing me some difficulties...

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
