### PR TITLE
Dynamic import the live query implementation for smaller initial bundle size

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -28,6 +28,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
+    "@0no-co/graphql.web": "^1.0.4",
     "@n1ru4l/graphql-live-query": "^0.10.0",
     "@n1ru4l/json-patch-plus": "^0.2.0",
     "@n1ru4l/push-pull-async-iterable-iterator": "^3.2.0",

--- a/packages/api-client-core/spec/helpers.ts
+++ b/packages/api-client-core/spec/helpers.ts
@@ -1,4 +1,4 @@
-import { parse } from "graphql";
+import { parse } from "@0no-co/graphql.web";
 import { defaults } from "lodash";
 import pRetry from "p-retry";
 

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -1,6 +1,6 @@
+import { GraphQLError } from "@0no-co/graphql.web";
 import { diff } from "@n1ru4l/json-patch-plus";
 import { CombinedError } from "@urql/core";
-import { GraphQLError } from "graphql";
 import nock from "nock";
 import { BackgroundActionHandle } from "../src/BackgroundActionHandle.js";
 import type { AnyModelManager, GadgetErrorGroup } from "../src/index.js";

--- a/packages/api-client-core/spec/support.spec.ts
+++ b/packages/api-client-core/spec/support.spec.ts
@@ -1,5 +1,5 @@
+import { GraphQLError } from "@0no-co/graphql.web";
 import { CombinedError } from "@urql/core";
-import { GraphQLError } from "graphql";
 import {
   assertMutationSuccess,
   assertNullableOperationSuccess,

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { isLiveQueryOperationDefinitionNode } from "@n1ru4l/graphql-live-query";
+import type { DefinitionNode, DirectiveNode, OperationDefinitionNode } from "@0no-co/graphql.web";
 import type { ClientOptions, RequestPolicy } from "@urql/core";
 import { Client, cacheExchange, fetchExchange, subscriptionExchange } from "@urql/core";
 import type { ExecutionResult } from "graphql";
 import type { Sink, Client as SubscriptionClient, ClientOptions as SubscriptionClientOptions } from "graphql-ws";
 import { CloseCode, createClient as createSubscriptionClient } from "graphql-ws";
+import type { Maybe } from "graphql/jsutils/Maybe.js";
 import WebSocket from "isomorphic-ws";
 import type { AuthenticationModeOptions, BrowserSessionAuthenticationModeOptions, Exchanges } from "./ClientOptions.js";
 import { BrowserSessionStorageType } from "./ClientOptions.js";
@@ -382,7 +383,7 @@ export class GadgetConnection {
       // live queries pass through the same WS client, but use jsondiffs for patching in results
       subscriptionExchange({
         isSubscriptionOperation: (request) => {
-          return request.query.definitions.some((definition) => isLiveQueryOperationDefinitionNode(definition, request.variables as any));
+          return request.query.definitions.some((definition) => isLiveQueryOperationDefinitionNode(definition));
         },
         forwardSubscription: (request) => {
           return {
@@ -390,8 +391,8 @@ export class GadgetConnection {
               let unsubscribe: (() => void) | undefined = undefined;
 
               // dynamic import on first subscription the live utils to keep the base bundle size small
-              const loadAndSubscribe = import("./graphql-live-query-utils/index.js").then(
-                ({ applyAsyncIterableIteratorToSink, applyLiveQueryJSONDiffPatch, makeAsyncIterableIteratorFromSink }) => {
+              const loadAndSubscribe = import("./graphql-live-query-utils/index.js")
+                .then(({ applyAsyncIterableIteratorToSink, applyLiveQueryJSONDiffPatch, makeAsyncIterableIteratorFromSink }) => {
                   const input = { ...request, query: request.query || "" };
                   unsubscribe = applyAsyncIterableIteratorToSink(
                     applyLiveQueryJSONDiffPatch(
@@ -402,15 +403,19 @@ export class GadgetConnection {
                     sink
                   );
                   return unsubscribe;
-                }
-              );
+                })
+                .catch((error) => sink.error(error));
 
               return {
                 unsubscribe: () => {
                   if (unsubscribe) {
                     unsubscribe();
                   } else {
-                    void loadAndSubscribe.then((unsubscribe) => unsubscribe());
+                    void loadAndSubscribe.then((unsubscribe) => {
+                      if (unsubscribe) {
+                        unsubscribe();
+                      }
+                    });
                   }
                 },
               };
@@ -597,3 +602,14 @@ function processMaybeRelativeInput(input: RequestInfo | URL, endpoint: string): 
 function isRelativeUrl(url: string) {
   return url.startsWith("/") && !url.startsWith("//");
 }
+
+const getLiveDirectiveNode = (input: DefinitionNode): Maybe<DirectiveNode> => {
+  if (input.kind !== "OperationDefinition" || input.operation !== "query") {
+    return null;
+  }
+  return input.directives?.find((d) => d.name.value === "live");
+};
+
+const isLiveQueryOperationDefinitionNode = (input: DefinitionNode): input is OperationDefinitionNode => {
+  return !!getLiveDirectiveNode(input);
+};

--- a/packages/api-client-core/src/graphql-live-query-utils/index.ts
+++ b/packages/api-client-core/src/graphql-live-query-utils/index.ts
@@ -14,3 +14,4 @@ export const applyJSONDiffPatch: ApplyPatchFunction<Delta> = (left, delta): Reco
   });
 
 export const applyLiveQueryJSONDiffPatch = createApplyLiveQueryPatch(applyJSONDiffPatch);
+export { applyAsyncIterableIteratorToSink, makeAsyncIterableIteratorFromSink } from "@n1ru4l/push-pull-async-iterable-iterator";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,8 @@
     "react-fast-compare": "^3.2.2",
     "react-hook-form": "~7.48.2",
     "tslib": "^2.6.2",
-    "urql": "^4.0.4"
+    "urql": "^4.0.4",
+    "@0no-co/graphql.web": "^1.0.4"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",
@@ -53,7 +54,6 @@
     "@types/setup-polly-jest": "^0.5.5",
     "@urql/core": "^4.0.10",
     "conditional-type-checks": "^1.0.6",
-    "graphql": "^16.8.1",
     "graphql-ws": "^5.13.1",
     "lodash": "^4.17.21",
     "react": "^18.2.0",

--- a/packages/react/spec/liveQueries.spec.tsx
+++ b/packages/react/spec/liveQueries.spec.tsx
@@ -20,8 +20,8 @@ describe("live queries", () => {
     expect(result.current[0].error).toBeFalsy();
     expect(result.current[0].data).toBeFalsy();
 
-    await Promise.resolve();
-    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
     const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
     expect(subscription.payload.query).toContain("@live");
 
@@ -74,8 +74,8 @@ describe("live queries", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    await Promise.resolve();
-    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
     const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
     expect(subscription.payload.query).toContain("@live");
 
@@ -136,8 +136,7 @@ describe("live queries", () => {
 
     expect(container).toHaveTextContent("Users: <none>, Products: <none>");
 
-    await Promise.resolve();
-    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(2);
+    await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(2));
     const users = mockGraphQLWSClient.subscribe.subscriptions[0];
     const products = mockGraphQLWSClient.subscribe.subscriptions[1];
 

--- a/packages/react/spec/useFindBy.spec.ts
+++ b/packages/react/spec/useFindBy.spec.ts
@@ -182,8 +182,8 @@ describe("useFindBy", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    await Promise.resolve();
-    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
     const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
     expect(subscription.payload.query).toContain("@live");
 

--- a/packages/react/spec/useFindFirst.spec.ts
+++ b/packages/react/spec/useFindFirst.spec.ts
@@ -232,8 +232,8 @@ describe("useFindFirst", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    await Promise.resolve();
-    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
     const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
     expect(subscription.payload.query).toContain("@live");
 

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -1,10 +1,10 @@
+import { GraphQLError } from "@0no-co/graphql.web";
 import { Client } from "@gadget-client/related-products-example";
 import type { GadgetRecordList } from "@gadgetinc/api-client-core";
 import { diff } from "@n1ru4l/json-patch-plus";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
-import { GraphQLError } from "graphql";
 import { useFindMany } from "../src/useFindMany.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { relatedProductsApi } from "./apis.js";

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -286,8 +286,8 @@ describe("useFindMany", () => {
       expect(result.current[0].fetching).toBe(true);
       expect(result.current[0].error).toBeFalsy();
 
-      await Promise.resolve();
-      expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+      await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
       const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
       expect(subscription.payload.query).toContain("@live");
 
@@ -374,8 +374,8 @@ describe("useFindMany", () => {
       expect(result.current[0].fetching).toBe(true);
       expect(result.current[0].error).toBeFalsy();
 
-      await Promise.resolve();
-      expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+      await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
       const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
 
       subscription.push({

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -174,8 +174,8 @@ describe("useFindOne", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    await Promise.resolve();
-    expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1);
+    await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
     const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
     expect(subscription.payload.query).toContain("@live");
 

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from "@0no-co/graphql.web";
 import type {
   AnyActionFunction,
   AnyBulkActionFunction,
@@ -10,7 +11,6 @@ import type {
 } from "@gadgetinc/api-client-core";
 import { gadgetErrorFor, getNonNullableError } from "@gadgetinc/api-client-core";
 import type { CombinedError, RequestPolicy } from "@urql/core";
-import { GraphQLError } from "graphql";
 import { useMemo } from "react";
 import type { AnyVariables, Operation, OperationContext, UseQueryArgs, UseQueryState } from "urql";
 

--- a/packages/tiny-graphql-query-compiler/package.json
+++ b/packages/tiny-graphql-query-compiler/package.json
@@ -27,12 +27,12 @@
     "prerelease": "gitpkg publish"
   },
   "devDependencies": {
+    "@0no-co/graphql.web": "^1.0.4",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@types/jest": "^29.5.12",
     "@types/prettier": "^2.7.3",
     "conditional-type-checks": "^1.0.6",
-    "graphql": "16.5.0",
     "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/tiny-graphql-query-compiler/spec/helpers.ts
+++ b/packages/tiny-graphql-query-compiler/spec/helpers.ts
@@ -1,4 +1,4 @@
-import { parse } from "graphql";
+import { parse } from "@0no-co/graphql.web";
 import parserGraphql from "prettier/parser-graphql";
 import prettier from "prettier/standalone";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
 
   packages/api-client-core:
     dependencies:
+      '@0no-co/graphql.web':
+        specifier: ^1.0.4
+        version: 1.0.4(graphql@16.8.1)
       '@n1ru4l/graphql-live-query':
         specifier: ^0.10.0
         version: 0.10.0(graphql@16.8.1)
@@ -211,6 +214,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@0no-co/graphql.web':
+        specifier: ^1.0.4
+        version: 1.0.4(graphql@16.8.1)
       '@gadgetinc/api-client-core':
         specifier: workspace:*
         version: link:../api-client-core
@@ -278,9 +284,6 @@ importers:
       conditional-type-checks:
         specifier: ^1.0.6
         version: 1.0.6
-      graphql:
-        specifier: ^16.8.1
-        version: 16.8.1
       graphql-ws:
         specifier: ^5.13.1
         version: 5.13.1(graphql@16.8.1)
@@ -370,6 +373,9 @@ importers:
 
   packages/tiny-graphql-query-compiler:
     devDependencies:
+      '@0no-co/graphql.web':
+        specifier: ^1.0.4
+        version: 1.0.4(graphql@16.8.1)
       '@testing-library/jest-dom':
         specifier: ^5.17.0
         version: 5.17.0
@@ -385,9 +391,6 @@ importers:
       conditional-type-checks:
         specifier: ^1.0.6
         version: 1.0.6
-      graphql:
-        specifier: 16.5.0
-        version: 16.5.0
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -4594,11 +4597,6 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.8.1
-
-  /graphql@16.5.0:
-    resolution: {integrity: sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: true
 
   /graphql@16.8.1:
     resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}


### PR DESCRIPTION
Most Gadget users don't execute live queries, and the code to power them is kinda big, it's about 10% of our bundle size. To try to help folks keep their LCPs down, I think we should defer loading it until someone executes the first live query. It's a quick request for that JS at that time, and live queries are already set up to stream results, so the deferred loading can be managed pretty easily. 

While working on this, I also noticed that the live query utils were importing all of `graphql`! `urql` uses a slimmed down version of `graphql` internally called `@0no-co/graphql` that has a much smaller bundle size, and we were accidentally including both it and the mainline graphql via `graphql-live-query`. We were only using one very small function from the latter library, so I just vendored it into Gadget and now we can avoid that dep at runtime altogether. Woop woop!

The result: 25% reduction in initial bundle size for the plain api-client, 21% reduction overall if you do load a live query! Woo! 