### PR TITLE
refresh session token on every request

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "files": [
     "README.md",
     "dist/**/*"


### PR DESCRIPTION
made a big mistake in https://github.com/gadget-inc/js-clients/pull/373 where we only request a session token from the app bridge once when the provider mounts and then reuse that across it's lifetime; only issue: the token has a 60 second expiry :(

We need to request. a new token each time the client makes a request

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
