### PR TITLE
we need the react-shopify-app-bridge Provider to show a loading state…

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
+++ b/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
@@ -4,6 +4,7 @@ import * as AppBridgeReact from "@shopify/app-bridge-react";
 import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
+import { act } from "react-dom/test-utils";
 import { mockUrqlClient } from "../../api-client-core/spec/mockUrqlClient.js";
 import { AppType, Provider } from "../src/Provider.js";
 
@@ -14,6 +15,7 @@ describe("GadgetProvider", () => {
   const mockOpen = jest.fn();
   const mockApiKey = "some-api-key";
   let useAppBridgeMock: jest.SpyInstance;
+  let resolveIdToken: (value: string) => void;
 
   describe.each([true, false])("as install request: %s", (isInstallRequest) => {
     beforeAll(() => {
@@ -41,7 +43,10 @@ describe("GadgetProvider", () => {
           shop: "example.myshopify.com",
           locale: "en",
         },
-        idToken: () => Promise.resolve("mock-id-token"),
+        idToken: () =>
+          new Promise((resolve) => {
+            resolveIdToken = resolve;
+          }),
       };
 
       useAppBridgeMock = jest.spyOn(AppBridgeReact, "useAppBridge").mockImplementation(() => window.shopify);
@@ -92,7 +97,10 @@ describe("GadgetProvider", () => {
         </Provider>
       );
 
-      await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+      await act(async () => {
+        resolveIdToken("mock-id-token");
+        await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+      });
 
       mockUrqlClient.executeMutation.pushResponse("ShopifyFetchOrInstallShop", {
         data: {
@@ -172,7 +180,10 @@ describe("GadgetProvider", () => {
         </Provider>
       );
 
-      await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+      await act(async () => {
+        resolveIdToken("mock-id-token");
+        await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+      });
 
       mockUrqlClient.executeMutation.pushResponse("ShopifyFetchOrInstallShop", {
         data: {
@@ -209,7 +220,10 @@ describe("GadgetProvider", () => {
         </Provider>
       );
 
-      await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+      await act(async () => {
+        resolveIdToken("mock-id-token");
+        await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+      });
 
       mockUrqlClient.executeMutation.pushResponse("ShopifyFetchOrInstallShop", {
         data: {
@@ -240,7 +254,10 @@ describe("GadgetProvider", () => {
         </Provider>
       );
 
-      await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+      await act(async () => {
+        resolveIdToken("mock-id-token");
+        await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+      });
 
       mockUrqlClient.executeMutation.pushResponse("ShopifyFetchOrInstallShop", {
         data: {


### PR DESCRIPTION
@DevAOC noticed that when using `0.15.1` there is an annoying flash in our default Shopify template where we show the unauthenticated app very quickly. This happens when `useGadget` returns `{isAuthenticated: false, loading: false}`

On closer inspection it looks like this flash has been with us for awhile; here are the state updates:

`0.14.2`:

<img width="912" alt="Screen Shot 2024-05-03 at 9 05 18 PM" src="https://github.com/gadget-inc/js-clients/assets/4368488/69a700c5-0e60-4c7a-b9d0-dee2a0c99460">

`0.15.1`:

<img width="922" alt="Screen Shot 2024-05-03 at 9 08 42 PM" src="https://github.com/gadget-inc/js-clients/assets/4368488/84d0339b-9244-47ab-8d60-d246536d16d7">


Notice that in `0.14.1` it is only there for one render; in `0.15.1` for two renders, this is because there are two reasons for this:

1. `loading` could never be true if `isRootFrameRequest` is true; in both versions on first render `isRootFrameRequest` is true because in the outer provider we haven't yet `setLocation`; when the inner provider renders its `useEffect`s run first and trigger a state update with `isRootFrameRequest: true`, which leads to a render with `loading: false` 😢 
2. In `0.15` we moved to authentication happening with `useMutation` and not `useQuery`; as a result when the provider first mounts the mutation to do auth isn't running; we need to use a ref to keep us in a loading state until the first time that the auth mutation runs; blerg

I don't really see why `isRootframeRequest` stopped us from being in a loading state, I think it could be a hold over from before we split the providers out. In any case the `InnerGadgetProvider` is only used is the shopify app bridge is defined and the app type is embedded so I think it makes good sense that we are in a loading state until the auth mutation resolves.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
