### PR TITLE
Add namespace support to the internal model manager

### DIFF
--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -8,6 +8,7 @@ import {
   internalDeleteMutation,
   internalFindFirstQuery,
   internalFindManyQuery,
+  internalFindOneQuery,
   internalUpdateMutation,
 } from "../src/index.js";
 import { expectValidGraphQLQuery } from "./helpers.js";
@@ -133,6 +134,41 @@ describe("InternalModelManager", () => {
           },
         },
       });
+    });
+  });
+
+  describe("internalFindOneQuery", () => {
+    test("should build a find one query with an id", () => {
+      const plan = internalFindOneQuery("widget", "123");
+      expect(plan).toMatchInlineSnapshot(`
+        {
+          "query": "query InternalFindWidget($id: GadgetID!, $select: [String!]) {
+          internal {
+            widget(id: $id, select: $select)
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {
+            "id": "123",
+          },
+        }
+      `);
+      expectValidGraphQLQuery(plan.query);
+      expect(plan.variables).toEqual({ id: "123" });
+    });
+
+    test("should build a find one query with a select", () => {
+      const plan = internalFindOneQuery("widget", "123", { id: true, foo: true, bar: true, baz: false });
+      expect(plan.variables.select).toEqual(["id", "foo", "bar"]);
+      expectValidGraphQLQuery(plan.query);
+    });
+
+    test("should build a find one query with a select using the shorthand", () => {
+      const plan = internalFindOneQuery("widget", "123", ["id", "foo", "bar"]);
+      expect(plan.variables.select).toEqual(["id", "foo", "bar"]);
+      expectValidGraphQLQuery(plan.query);
     });
   });
 

--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -156,6 +156,9 @@ describe("InternalModelManager", () => {
               }
             }
           }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
         }",
           "variables": {},
         }
@@ -181,6 +184,9 @@ describe("InternalModelManager", () => {
                 node
               }
             }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
           }
         }",
           "variables": {
@@ -214,6 +220,9 @@ describe("InternalModelManager", () => {
               }
             }
           }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
         }",
           "variables": {
             "search": "term",
@@ -241,6 +250,9 @@ describe("InternalModelManager", () => {
                 node
               }
             }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
           }
         }",
           "variables": {
@@ -283,6 +295,9 @@ describe("InternalModelManager", () => {
               }
             }
           }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
         }",
           "variables": {
             "first": 1,
@@ -303,6 +318,9 @@ describe("InternalModelManager", () => {
                 node
               }
             }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
           }
         }",
           "variables": {
@@ -330,6 +348,9 @@ describe("InternalModelManager", () => {
               }
             }
           }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
         }",
           "variables": {
             "first": 1,
@@ -351,6 +372,9 @@ describe("InternalModelManager", () => {
                 node
               }
             }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
           }
         }",
           "variables": {
@@ -381,6 +405,9 @@ describe("InternalModelManager", () => {
               }
             }
           }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
         }",
           "variables": {
             "first": 1,
@@ -393,12 +420,13 @@ describe("InternalModelManager", () => {
       `);
       expectValidGraphQLQuery(plan.query);
     });
+  });
 
-    describe("properly handles apiIdentifiers styled with Snake Case", () => {
-      // snake case example: "api_identifier"
-      test("should build a find first query with no options", () => {
-        const plan = internalFindFirstQuery("widget_model", undefined);
-        expect(plan).toMatchInlineSnapshot(`
+  describe("properly handles apiIdentifiers styled with Snake Case", () => {
+    // snake case example: "api_identifier"
+    test("should build a find first query with no options", () => {
+      const plan = internalFindFirstQuery("widget_model", undefined);
+      expect(plan).toMatchInlineSnapshot(`
           {
             "query": "query InternalFindFirstWidgetModel($first: Int) {
             internal {
@@ -408,18 +436,21 @@ describe("InternalModelManager", () => {
                 }
               }
             }
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
+            }
           }",
             "variables": {
               "first": 1,
             },
           }
         `);
-        expectValidGraphQLQuery(plan.query);
-      });
+      expectValidGraphQLQuery(plan.query);
+    });
 
-      test("should build a find first query with sort", () => {
-        const plan = internalFindFirstQuery("widget_model", { sort: [{ id: "Ascending" }] });
-        expect(plan).toMatchInlineSnapshot(`
+    test("should build a find first query with sort", () => {
+      const plan = internalFindFirstQuery("widget_model", { sort: [{ id: "Ascending" }] });
+      expect(plan).toMatchInlineSnapshot(`
           {
             "query": "query InternalFindFirstWidgetModel($sort: [WidgetModelSort!], $first: Int) {
             internal {
@@ -428,6 +459,9 @@ describe("InternalModelManager", () => {
                   node
                 }
               }
+            }
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
             }
           }",
             "variables": {
@@ -440,12 +474,12 @@ describe("InternalModelManager", () => {
             },
           }
         `);
-        expectValidGraphQLQuery(plan.query);
-      });
+      expectValidGraphQLQuery(plan.query);
+    });
 
-      test("should build a find first query with search", () => {
-        const plan = internalFindFirstQuery("widget_model", { search: "term" });
-        expect(plan).toMatchInlineSnapshot(`
+    test("should build a find first query with search", () => {
+      const plan = internalFindFirstQuery("widget_model", { search: "term" });
+      expect(plan).toMatchInlineSnapshot(`
           {
             "query": "query InternalFindFirstWidgetModel($search: String, $first: Int) {
             internal {
@@ -455,6 +489,9 @@ describe("InternalModelManager", () => {
                 }
               }
             }
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
+            }
           }",
             "variables": {
               "first": 1,
@@ -462,12 +499,12 @@ describe("InternalModelManager", () => {
             },
           }
         `);
-        expectValidGraphQLQuery(plan.query);
-      });
+      expectValidGraphQLQuery(plan.query);
+    });
 
-      test("should build a find first query with filter", () => {
-        const plan = internalFindFirstQuery("widget_model", { filter: [{ id: { equals: "1" } }] });
-        expect(plan).toMatchInlineSnapshot(`
+    test("should build a find first query with filter", () => {
+      const plan = internalFindFirstQuery("widget_model", { filter: [{ id: { equals: "1" } }] });
+      expect(plan).toMatchInlineSnapshot(`
           {
             "query": "query InternalFindFirstWidgetModel($filter: [WidgetModelFilter!], $first: Int) {
             internal {
@@ -476,6 +513,9 @@ describe("InternalModelManager", () => {
                   node
                 }
               }
+            }
+            gadgetMeta {
+              hydrations(modelName: "widget_model")
             }
           }",
             "variables": {
@@ -490,442 +530,326 @@ describe("InternalModelManager", () => {
             },
           }
         `);
-        expectValidGraphQLQuery(plan.query);
-      });
+      expectValidGraphQLQuery(plan.query);
+    });
 
-      test("should build a create record mutation", () => {
-        const result = internalCreateMutation("widget_model");
+    test("should build a create record mutation", () => {
+      const result = internalCreateMutation("widget_model", { title: "foo" });
 
-        expect(result).toMatchInlineSnapshot(`
-          "
-              
-          fragment InternalErrorsDetails on ExecutionError {
-            code
-            message
-            ...on InvalidRecordError {
-              validationErrors {
-                apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+          "mutation InternalCreateWidgetModel($widget_model: InternalWidgetModelInput) {
+            internal {
+              createWidgetModel(widget_model: $widget_model) {
+                success
+                code
                 message
+                ...on InvalidRecordError {
+                  validationErrors {
+                    apiIdentifier
+                    message
+                  }
+                  model {
+                    apiIdentifier
+                  }
+                  record
+                }
+                widget_model
               }
-              model {
-                apiIdentifier
-              }
-              record
             }
-          }
-
-
-              mutation InternalCreateWidgetModel($record: InternalWidgetModelInput) {
-                
             gadgetMeta {
               hydrations(modelName: "widget_model")
             }
-
-                internal {
-                  createWidgetModel(widget_model: $record) {
-                    success
-                    errors {
-                      ... InternalErrorsDetails
-                    }
-                    widget_model
-                  }
-                }
-              }
-            "
+          }"
         `);
-        expectValidGraphQLQuery(result);
-      });
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables.widget_model).toEqual({ title: "foo" });
+    });
 
-      test("should build a bulk create records mutation", () => {
-        const result = internalBulkCreateMutation("widget_model", "widget_models");
+    test("should build a bulk create records mutation", () => {
+      const result = internalBulkCreateMutation("widget_model", "widget_models", [{ foo: "bar" }, { foo: "baz" }]);
 
-        expect(result).toMatchInlineSnapshot(`
-          "
-              
-          fragment InternalErrorsDetails on ExecutionError {
-            code
-            message
-            ...on InvalidRecordError {
-              validationErrors {
-                apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+          "mutation InternalBulkCreateWidgetModels($widget_models: [InternalWidgetModelInput]!) {
+            internal {
+              bulkCreateWidgetModels(widget_models: $widget_models) {
+                success
+                code
                 message
+                ...on InvalidRecordError {
+                  validationErrors {
+                    apiIdentifier
+                    message
+                  }
+                  model {
+                    apiIdentifier
+                  }
+                  record
+                }
+                widget_models
               }
-              model {
-                apiIdentifier
-              }
-              record
             }
-          }
-
-
-              mutation InternalBulkCreateWidgetModels($records: [InternalWidgetModelInput]!) {
-                
             gadgetMeta {
               hydrations(modelName: "widget_model")
             }
-
-                internal {
-                  bulkCreateWidgetModels(widget_models: $records) {
-                    success
-                    errors {
-                      ... InternalErrorsDetails
-                    }
-                    widget_models
-                  }
-                }
-              }
-            "
+          }"
         `);
-        expectValidGraphQLQuery(result);
-      });
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({ widget_models: [{ foo: "bar" }, { foo: "baz" }] });
+    });
 
-      test("should build an update record mutation", () => {
-        const result = internalUpdateMutation("widget_model");
+    test("should build an update record mutation", () => {
+      const result = internalUpdateMutation("widget_model", "123", { title: "foobar" });
 
-        expect(result).toMatchInlineSnapshot(`
-          "
-              
-          fragment InternalErrorsDetails on ExecutionError {
-            code
-            message
-            ...on InvalidRecordError {
-              validationErrors {
-                apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+          "mutation InternalUpdateWidgetModel($id: GadgetID!, $widget_model: InternalWidgetModelInput) {
+            internal {
+              updateWidgetModel(id: $id, widget_model: $widget_model) {
+                success
+                code
                 message
+                ...on InvalidRecordError {
+                  validationErrors {
+                    apiIdentifier
+                    message
+                  }
+                  model {
+                    apiIdentifier
+                  }
+                  record
+                }
+                widget_model
               }
-              model {
-                apiIdentifier
-              }
-              record
             }
-          }
-
-
-              mutation InternalUpdateWidgetModel($id: GadgetID!, $record: InternalWidgetModelInput) {
-                
             gadgetMeta {
               hydrations(modelName: "widget_model")
             }
-
-                internal {
-                  updateWidgetModel(id: $id, widget_model: $record) {
-                    success
-                    errors {
-                      ... InternalErrorsDetails
-                    }
-                    widget_model
-                  }
-                }
-              }
-            "
+          }"
         `);
-        expectValidGraphQLQuery(result);
-      });
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({ id: "123", widget_model: { title: "foobar" } });
+    });
 
-      test("should build a delete record mutation", () => {
-        const result = internalDeleteMutation("widget_model");
+    test("should build a delete record mutation", () => {
+      const result = internalDeleteMutation("widget_model", "123");
 
-        expect(result).toMatchInlineSnapshot(`
-          "
-              
-          fragment InternalErrorsDetails on ExecutionError {
-            code
-            message
-            ...on InvalidRecordError {
-              validationErrors {
-                apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+          "mutation InternalDeleteWidgetModel($id: GadgetID!) {
+            internal {
+              deleteWidgetModel(id: $id) {
+                success
+                code
                 message
-              }
-              model {
-                apiIdentifier
-              }
-              record
-            }
-          }
-
-
-              mutation InternalDeleteWidgetModel($id: GadgetID!) {
-                
-            gadgetMeta {
-              hydrations(modelName: "widget_model")
-            }
-
-                internal {
-                  deleteWidgetModel(id: $id) {
-                    success
-                    errors {
-                      ... InternalErrorsDetails
-                    }
+                ...on InvalidRecordError {
+                  validationErrors {
+                    apiIdentifier
+                    message
                   }
+                  model {
+                    apiIdentifier
+                  }
+                  record
                 }
               }
-            "
+            }
+          }"
         `);
-        expectValidGraphQLQuery(result);
-      });
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({ id: "123" });
+    });
 
-      test("should build a delete many records mutation", () => {
-        const result = internalDeleteManyMutation("widget_model");
+    test("should build a delete many records mutation", () => {
+      const result = internalDeleteManyMutation("widget_model");
 
-        expect(result).toMatchInlineSnapshot(`
-          "
-              
-          fragment InternalErrorsDetails on ExecutionError {
-            code
-            message
-            ...on InvalidRecordError {
-              validationErrors {
-                apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+          "mutation InternalDeleteManyWidgetModel($search: String, $filter: [WidgetModelFilter!]) {
+            internal {
+              deleteManyWidgetModel(search: $search, filter: $filter) {
+                success
+                code
                 message
-              }
-              model {
-                apiIdentifier
-              }
-              record
-            }
-          }
-
-
-              mutation InternalDeleteManyWidgetModel(
-                $search: String
-                $filter: [WidgetModelFilter!]
-              ) {
-                
-            gadgetMeta {
-              hydrations(modelName: "widget_model")
-            }
-
-                internal {
-                  deleteManyWidgetModel(search: $search, filter: $filter) {
-                    success
-                    errors {
-                      ... InternalErrorsDetails
-                    }
+                ...on InvalidRecordError {
+                  validationErrors {
+                    apiIdentifier
+                    message
                   }
+                  model {
+                    apiIdentifier
+                  }
+                  record
                 }
               }
-            "
+            }
+          }"
         `);
-        expectValidGraphQLQuery(result);
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({});
+    });
+
+    test("should build a delete many records mutation with a search and a filter", () => {
+      const result = internalDeleteManyMutation("widget_model", { search: "foobar", filter: [{ title: { equals: "foo" } }] });
+
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({
+        search: "foobar",
+        filter: [{ title: { equals: "foo" } }],
       });
     });
   });
 
   describe("internal actions", () => {
     test("should build a create record mutation", () => {
-      const result = internalCreateMutation("widget");
+      const result = internalCreateMutation("widget", { title: "foo" });
 
-      expect(result).toMatchInlineSnapshot(`
-        "
-            
-        fragment InternalErrorsDetails on ExecutionError {
-          code
-          message
-          ...on InvalidRecordError {
-            validationErrors {
-              apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalCreateWidget($widget: InternalWidgetInput) {
+          internal {
+            createWidget(widget: $widget) {
+              success
+              code
               message
+              ...on InvalidRecordError {
+                validationErrors {
+                  apiIdentifier
+                  message
+                }
+                model {
+                  apiIdentifier
+                }
+                record
+              }
+              widget
             }
-            model {
-              apiIdentifier
-            }
-            record
           }
-        }
-
-
-            mutation InternalCreateWidget($record: InternalWidgetInput) {
-              
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-
-              internal {
-                createWidget(widget: $record) {
-                  success
-                  errors {
-                    ... InternalErrorsDetails
-                  }
-                  widget
-                }
-              }
-            }
-          "
+        }"
       `);
-      expectValidGraphQLQuery(result);
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables.widget).toEqual({ title: "foo" });
     });
 
     test("should build a bulk create records mutation", () => {
-      const result = internalBulkCreateMutation("widget", "widgets");
+      const result = internalBulkCreateMutation("widget", "widgets", [{ foo: "bar" }, { foo: "baz" }]);
 
-      expect(result).toMatchInlineSnapshot(`
-        "
-            
-        fragment InternalErrorsDetails on ExecutionError {
-          code
-          message
-          ...on InvalidRecordError {
-            validationErrors {
-              apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalBulkCreateWidgets($widgets: [InternalWidgetInput]!) {
+          internal {
+            bulkCreateWidgets(widgets: $widgets) {
+              success
+              code
               message
+              ...on InvalidRecordError {
+                validationErrors {
+                  apiIdentifier
+                  message
+                }
+                model {
+                  apiIdentifier
+                }
+                record
+              }
+              widgets
             }
-            model {
-              apiIdentifier
-            }
-            record
           }
-        }
-
-
-            mutation InternalBulkCreateWidgets($records: [InternalWidgetInput]!) {
-              
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-
-              internal {
-                bulkCreateWidgets(widgets: $records) {
-                  success
-                  errors {
-                    ... InternalErrorsDetails
-                  }
-                  widgets
-                }
-              }
-            }
-          "
+        }"
       `);
-      expectValidGraphQLQuery(result);
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({ widgets: [{ foo: "bar" }, { foo: "baz" }] });
     });
 
     test("should build an update record mutation", () => {
-      const result = internalUpdateMutation("widget");
+      const result = internalUpdateMutation("widget", "123", { foo: "bar" });
 
-      expect(result).toMatchInlineSnapshot(`
-        "
-            
-        fragment InternalErrorsDetails on ExecutionError {
-          code
-          message
-          ...on InvalidRecordError {
-            validationErrors {
-              apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalUpdateWidget($id: GadgetID!, $widget: InternalWidgetInput) {
+          internal {
+            updateWidget(id: $id, widget: $widget) {
+              success
+              code
               message
+              ...on InvalidRecordError {
+                validationErrors {
+                  apiIdentifier
+                  message
+                }
+                model {
+                  apiIdentifier
+                }
+                record
+              }
+              widget
             }
-            model {
-              apiIdentifier
-            }
-            record
           }
-        }
-
-
-            mutation InternalUpdateWidget($id: GadgetID!, $record: InternalWidgetInput) {
-              
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-
-              internal {
-                updateWidget(id: $id, widget: $record) {
-                  success
-                  errors {
-                    ... InternalErrorsDetails
-                  }
-                  widget
-                }
-              }
-            }
-          "
+        }"
       `);
-      expectValidGraphQLQuery(result);
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({ id: "123", widget: { foo: "bar" } });
     });
 
     test("should build a delete record mutation", () => {
-      const result = internalDeleteMutation("widget");
+      const result = internalDeleteMutation("widget", "123");
 
-      expect(result).toMatchInlineSnapshot(`
-        "
-            
-        fragment InternalErrorsDetails on ExecutionError {
-          code
-          message
-          ...on InvalidRecordError {
-            validationErrors {
-              apiIdentifier
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalDeleteWidget($id: GadgetID!) {
+          internal {
+            deleteWidget(id: $id) {
+              success
+              code
               message
-            }
-            model {
-              apiIdentifier
-            }
-            record
-          }
-        }
-
-
-            mutation InternalDeleteWidget($id: GadgetID!) {
-              
-          gadgetMeta {
-            hydrations(modelName: "widget")
-          }
-
-              internal {
-                deleteWidget(id: $id) {
-                  success
-                  errors {
-                    ... InternalErrorsDetails
-                  }
+              ...on InvalidRecordError {
+                validationErrors {
+                  apiIdentifier
+                  message
                 }
+                model {
+                  apiIdentifier
+                }
+                record
               }
             }
-          "
+          }
+        }"
       `);
-      expectValidGraphQLQuery(result);
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({ id: "123" });
     });
 
     test("should build a delete many records mutation", () => {
-      const result = internalDeleteManyMutation("widget");
+      const result = internalDeleteManyMutation("widget", {});
 
       expect(result).toMatchInlineSnapshot(`
-        "
-            
-        fragment InternalErrorsDetails on ExecutionError {
-          code
-          message
-          ...on InvalidRecordError {
-            validationErrors {
-              apiIdentifier
+        {
+          "query": "mutation InternalDeleteManyWidget($search: String, $filter: [WidgetFilter!]) {
+          internal {
+            deleteManyWidget(search: $search, filter: $filter) {
+              success
+              code
               message
-            }
-            model {
-              apiIdentifier
-            }
-            record
-          }
-        }
-
-
-            mutation InternalDeleteManyWidget(
-              $search: String
-              $filter: [WidgetFilter!]
-            ) {
-              
-          gadgetMeta {
-            hydrations(modelName: "widget")
-          }
-
-              internal {
-                deleteManyWidget(search: $search, filter: $filter) {
-                  success
-                  errors {
-                    ... InternalErrorsDetails
-                  }
+              ...on InvalidRecordError {
+                validationErrors {
+                  apiIdentifier
+                  message
                 }
+                model {
+                  apiIdentifier
+                }
+                record
               }
             }
-          "
+          }
+        }",
+          "variables": {},
+        }
       `);
-      expectValidGraphQLQuery(result);
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({});
     });
   });
 });

--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -12,6 +12,8 @@ import {
   internalUpdateMutation,
 } from "../src/index.js";
 import { expectValidGraphQLQuery } from "./helpers.js";
+import type { MockUrqlClient } from "./mockUrqlClient.js";
+import { createMockUrqlClient } from "./mockUrqlClient.js";
 
 describe("InternalModelManager", () => {
   describe("getRecordFromData", () => {
@@ -139,34 +141,69 @@ describe("InternalModelManager", () => {
 
   describe("internalFindOneQuery", () => {
     test("should build a find one query with an id", () => {
-      const plan = internalFindOneQuery("widget", "123");
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindWidget($id: GadgetID!, $select: [String!]) {
+      const plan = internalFindOneQuery("widget", "123", []);
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindWidget($id: GadgetID!, $select: [String!]) {
           internal {
             widget(id: $id, select: $select)
           }
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-        }",
-          "variables": {
-            "id": "123",
-          },
-        }
+        }"
       `);
       expectValidGraphQLQuery(plan.query);
       expect(plan.variables).toEqual({ id: "123" });
     });
 
     test("should build a find one query with a select", () => {
-      const plan = internalFindOneQuery("widget", "123", { id: true, foo: true, bar: true, baz: false });
+      const plan = internalFindOneQuery("widget", "123", [], { id: true, foo: true, bar: true, baz: false });
       expect(plan.variables.select).toEqual(["id", "foo", "bar"]);
       expectValidGraphQLQuery(plan.query);
     });
 
     test("should build a find one query with a select using the shorthand", () => {
-      const plan = internalFindOneQuery("widget", "123", ["id", "foo", "bar"]);
+      const plan = internalFindOneQuery("widget", "123", [], ["id", "foo", "bar"]);
+      expect(plan.variables.select).toEqual(["id", "foo", "bar"]);
+      expectValidGraphQLQuery(plan.query);
+    });
+
+    test("should build a find one query for a namespaced model", () => {
+      const plan = internalFindOneQuery("widget", "123", ["namespace"], ["id", "foo", "bar"]);
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindWidget($id: GadgetID!, $select: [String!]) {
+          internal {
+            namespace {
+              widget(id: $id, select: $select)
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "namespace.widget")
+          }
+        }"
+      `);
+      expect(plan.variables.select).toEqual(["id", "foo", "bar"]);
+      expectValidGraphQLQuery(plan.query);
+    });
+
+    test("should build a find one query for a deeply namespaced model", () => {
+      const plan = internalFindOneQuery("widget", "123", ["very", "deep", "namespace"], ["id", "foo", "bar"]);
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindWidget($id: GadgetID!, $select: [String!]) {
+          internal {
+            very {
+              deep {
+                namespace {
+                  widget(id: $id, select: $select)
+                }
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "very.deep.namespace.widget")
+          }
+        }"
+      `);
       expect(plan.variables.select).toEqual(["id", "foo", "bar"]);
       expectValidGraphQLQuery(plan.query);
     });
@@ -174,10 +211,9 @@ describe("InternalModelManager", () => {
 
   describe("internalFindManyQuery", () => {
     test("should build a find many query with no options", () => {
-      const plan = internalFindManyQuery("widget", undefined);
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindManyWidget($after: String, $before: String, $first: Int, $last: Int) {
+      const plan = internalFindManyQuery("widget", [], undefined);
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindManyWidget($after: String, $before: String, $first: Int, $last: Int) {
           internal {
             listWidget(after: $after, before: $before, first: $first, last: $last) {
               pageInfo {
@@ -195,18 +231,15 @@ describe("InternalModelManager", () => {
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-        }",
-          "variables": {},
-        }
+        }"
       `);
       expectValidGraphQLQuery(plan.query);
     });
 
     test("should build a find many query with sort", () => {
-      const plan = internalFindManyQuery("widget", { sort: [{ id: "Ascending" }] });
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindManyWidget($sort: [WidgetSort!], $after: String, $before: String, $first: Int, $last: Int) {
+      const plan = internalFindManyQuery("widget", [], { sort: [{ id: "Ascending" }] });
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindManyWidget($sort: [WidgetSort!], $after: String, $before: String, $first: Int, $last: Int) {
           internal {
             listWidget(sort: $sort, after: $after, before: $before, first: $first, last: $last) {
               pageInfo {
@@ -224,24 +257,16 @@ describe("InternalModelManager", () => {
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-        }",
-          "variables": {
-            "sort": [
-              {
-                "id": "Ascending",
-              },
-            ],
-          },
-        }
+        }"
       `);
       expectValidGraphQLQuery(plan.query);
+      expect(plan.variables).toEqual({ sort: [{ id: "Ascending" }] });
     });
 
     test("should build a find many query with search", () => {
-      const plan = internalFindManyQuery("widget", { search: "term" });
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindManyWidget($search: String, $after: String, $before: String, $first: Int, $last: Int) {
+      const plan = internalFindManyQuery("widget", [], { search: "term" });
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindManyWidget($search: String, $after: String, $before: String, $first: Int, $last: Int) {
           internal {
             listWidget(search: $search, after: $after, before: $before, first: $first, last: $last) {
               pageInfo {
@@ -259,20 +284,16 @@ describe("InternalModelManager", () => {
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-        }",
-          "variables": {
-            "search": "term",
-          },
-        }
+        }"
       `);
       expectValidGraphQLQuery(plan.query);
+      expect(plan.variables).toEqual({ search: "term" });
     });
 
     test("should build a find many query with filter", () => {
-      const plan = internalFindManyQuery("widget", { filter: [{ id: { equals: "1" } }] });
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindManyWidget($filter: [WidgetFilter!], $after: String, $before: String, $first: Int, $last: Int) {
+      const plan = internalFindManyQuery("widget", [], { filter: [{ id: { equals: "1" } }] });
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindManyWidget($filter: [WidgetFilter!], $after: String, $before: String, $first: Int, $last: Int) {
           internal {
             listWidget(filter: $filter, after: $after, before: $before, first: $first, last: $last) {
               pageInfo {
@@ -290,40 +311,97 @@ describe("InternalModelManager", () => {
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-        }",
-          "variables": {
-            "filter": [
-              {
-                "id": {
-                  "equals": "1",
-                },
-              },
-            ],
-          },
-        }
+        }"
       `);
       expectValidGraphQLQuery(plan.query);
+      expect(plan.variables).toEqual({ filter: [{ id: { equals: "1" } }] });
     });
 
     test("should build a find many query with a select", () => {
-      const plan = internalFindManyQuery("widget", { select: { id: true, foo: true, bar: true, baz: false } });
+      const plan = internalFindManyQuery("widget", [], { select: { id: true, foo: true, bar: true, baz: false } });
       expect(plan.variables.select).toEqual(["id", "foo", "bar"]);
       expectValidGraphQLQuery(plan.query);
     });
 
     test("should build a find many query with a select using the shorthand", () => {
-      const plan = internalFindManyQuery("widget", { select: ["id", "foo", "bar"] });
+      const plan = internalFindManyQuery("widget", [], { select: ["id", "foo", "bar"] });
       expect(plan.variables.select).toEqual(["id", "foo", "bar"]);
+      expectValidGraphQLQuery(plan.query);
+    });
+
+    test("should build a find many query for a namespaced model", () => {
+      const plan = internalFindManyQuery("widget", ["deep", "namespace"], undefined);
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindManyWidget($after: String, $before: String, $first: Int, $last: Int) {
+          internal {
+            deep {
+              namespace {
+                listWidget(after: $after, before: $before, first: $first, last: $last) {
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                  edges {
+                    cursor
+                    node
+                  }
+                }
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "deep.namespace.widget")
+          }
+        }"
+      `);
+      expectValidGraphQLQuery(plan.query);
+    });
+
+    test("should build a find many query for a namespaced model with a sort and filter", () => {
+      const plan = internalFindManyQuery("widget", ["deep", "namespace"], {
+        sort: [{ id: "Ascending" }],
+        filter: [{ id: { equals: "123" } }],
+      });
+
+      expect(plan.query).toMatch(/DeepNamespaceWidgetSort/);
+      expect(plan.query).toMatch(/DeepNamespaceWidgetFilter/);
+
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindManyWidget($sort: [DeepNamespaceWidgetSort!], $filter: [DeepNamespaceWidgetFilter!], $after: String, $before: String, $first: Int, $last: Int) {
+          internal {
+            deep {
+              namespace {
+                listWidget(sort: $sort, filter: $filter, after: $after, before: $before, first: $first, last: $last) {
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                  edges {
+                    cursor
+                    node
+                  }
+                }
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "deep.namespace.widget")
+          }
+        }"
+      `);
       expectValidGraphQLQuery(plan.query);
     });
   });
 
   describe("internalFindFirstQuery", () => {
     test("should build a find first query with no options", () => {
-      const plan = internalFindFirstQuery("widget", undefined);
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindFirstWidget($first: Int) {
+      const plan = internalFindFirstQuery("widget", [], undefined);
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindFirstWidget($first: Int) {
           internal {
             listWidget(first: $first) {
               edges {
@@ -334,20 +412,16 @@ describe("InternalModelManager", () => {
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-        }",
-          "variables": {
-            "first": 1,
-          },
-        }
+        }"
       `);
       expectValidGraphQLQuery(plan.query);
+      expect(plan.variables).toEqual({ first: 1 });
     });
 
     test("should build a find first query with sort", () => {
-      const plan = internalFindFirstQuery("widget", { sort: [{ id: "Ascending" }] });
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindFirstWidget($sort: [WidgetSort!], $first: Int) {
+      const plan = internalFindFirstQuery("widget", [], { sort: [{ id: "Ascending" }] });
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindFirstWidget($sort: [WidgetSort!], $first: Int) {
           internal {
             listWidget(sort: $sort, first: $first) {
               edges {
@@ -358,25 +432,16 @@ describe("InternalModelManager", () => {
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-        }",
-          "variables": {
-            "first": 1,
-            "sort": [
-              {
-                "id": "Ascending",
-              },
-            ],
-          },
-        }
+        }"
       `);
       expectValidGraphQLQuery(plan.query);
+      expect(plan.variables).toEqual({ first: 1, sort: [{ id: "Ascending" }] });
     });
 
     test("should build a find first query with search", () => {
-      const plan = internalFindFirstQuery("widget", { search: "term" });
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindFirstWidget($search: String, $first: Int) {
+      const plan = internalFindFirstQuery("widget", [], { search: "term" });
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindFirstWidget($search: String, $first: Int) {
           internal {
             listWidget(search: $search, first: $first) {
               edges {
@@ -387,73 +452,46 @@ describe("InternalModelManager", () => {
           gadgetMeta {
             hydrations(modelName: "widget")
           }
-        }",
-          "variables": {
-            "first": 1,
-            "search": "term",
-          },
-        }
+        }"
       `);
       expectValidGraphQLQuery(plan.query);
+      expect(plan.variables).toEqual({ first: 1, search: "term" });
     });
 
     test("should build a find first query with filter", () => {
-      const plan = internalFindFirstQuery("widget", { filter: [{ id: { equals: "1" } }] });
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindFirstWidget($filter: [WidgetFilter!], $first: Int) {
-          internal {
-            listWidget(filter: $filter, first: $first) {
-              edges {
-                node
-              }
-            }
-          }
-          gadgetMeta {
-            hydrations(modelName: "widget")
-          }
-        }",
-          "variables": {
-            "filter": [
-              {
-                "id": {
-                  "equals": "1",
-                },
-              },
-            ],
-            "first": 1,
-          },
-        }
-      `);
+      const plan = internalFindFirstQuery("widget", [], { filter: [{ id: { equals: "1" } }] });
+
       expectValidGraphQLQuery(plan.query);
+      expect(plan.variables).toEqual({ first: 1, filter: [{ id: { equals: "1" } }] });
     });
 
     test("should build a find first query with select", () => {
-      const plan = internalFindFirstQuery("widget", { select: { foo: true, bar: true } });
-      expect(plan.variables.select).toEqual(["foo", "bar"]);
-      expect(plan).toMatchInlineSnapshot(`
-        {
-          "query": "query InternalFindFirstWidget($select: [String!], $first: Int) {
+      const plan = internalFindFirstQuery("widget", [], { select: { foo: true, bar: true } });
+      expect(plan.variables).toEqual({ first: 1, select: ["foo", "bar"] });
+      expectValidGraphQLQuery(plan.query);
+    });
+
+    test("should build a find first query for a namespaced model", () => {
+      const plan = internalFindFirstQuery("widget", ["deep", "namespace"], { select: { foo: true, bar: true } });
+      expect(plan.query).toMatchInlineSnapshot(`
+        "query InternalFindFirstWidget($select: [String!], $first: Int) {
           internal {
-            listWidget(select: $select, first: $first) {
-              edges {
-                node
+            deep {
+              namespace {
+                listWidget(select: $select, first: $first) {
+                  edges {
+                    node
+                  }
+                }
               }
             }
           }
           gadgetMeta {
-            hydrations(modelName: "widget")
+            hydrations(modelName: "deep.namespace.widget")
           }
-        }",
-          "variables": {
-            "first": 1,
-            "select": [
-              "foo",
-              "bar",
-            ],
-          },
-        }
+        }"
       `);
+      expect(plan.variables).toEqual({ first: 1, select: ["foo", "bar"] });
       expectValidGraphQLQuery(plan.query);
     });
   });
@@ -461,7 +499,7 @@ describe("InternalModelManager", () => {
   describe("properly handles apiIdentifiers styled with Snake Case", () => {
     // snake case example: "api_identifier"
     test("should build a find first query with no options", () => {
-      const plan = internalFindFirstQuery("widget_model", undefined);
+      const plan = internalFindFirstQuery("widget_model", [], undefined);
       expect(plan).toMatchInlineSnapshot(`
           {
             "query": "query InternalFindFirstWidgetModel($first: Int) {
@@ -485,244 +523,234 @@ describe("InternalModelManager", () => {
     });
 
     test("should build a find first query with sort", () => {
-      const plan = internalFindFirstQuery("widget_model", { sort: [{ id: "Ascending" }] });
+      const plan = internalFindFirstQuery("widget_model", [], { sort: [{ id: "Ascending" }] });
       expect(plan).toMatchInlineSnapshot(`
-          {
-            "query": "query InternalFindFirstWidgetModel($sort: [WidgetModelSort!], $first: Int) {
-            internal {
-              listWidgetModel(sort: $sort, first: $first) {
-                edges {
-                  node
-                }
+        {
+          "query": "query InternalFindFirstWidgetModel($sort: [WidgetModelSort!], $first: Int) {
+          internal {
+            listWidgetModel(sort: $sort, first: $first) {
+              edges {
+                node
               }
             }
-            gadgetMeta {
-              hydrations(modelName: "widget_model")
-            }
-          }",
-            "variables": {
-              "first": 1,
-              "sort": [
-                {
-                  "id": "Ascending",
-                },
-              ],
-            },
           }
-        `);
+          gadgetMeta {
+            hydrations(modelName: "widget_model")
+          }
+        }",
+          "variables": {
+            "first": 1,
+            "sort": [
+              {
+                "id": "Ascending",
+              },
+            ],
+          },
+        }
+      `);
       expectValidGraphQLQuery(plan.query);
     });
 
     test("should build a find first query with search", () => {
-      const plan = internalFindFirstQuery("widget_model", { search: "term" });
+      const plan = internalFindFirstQuery("widget_model", [], { search: "term" });
       expect(plan).toMatchInlineSnapshot(`
-          {
-            "query": "query InternalFindFirstWidgetModel($search: String, $first: Int) {
-            internal {
-              listWidgetModel(search: $search, first: $first) {
-                edges {
-                  node
-                }
+        {
+          "query": "query InternalFindFirstWidgetModel($search: String, $first: Int) {
+          internal {
+            listWidgetModel(search: $search, first: $first) {
+              edges {
+                node
               }
             }
-            gadgetMeta {
-              hydrations(modelName: "widget_model")
-            }
-          }",
-            "variables": {
-              "first": 1,
-              "search": "term",
-            },
           }
-        `);
+          gadgetMeta {
+            hydrations(modelName: "widget_model")
+          }
+        }",
+          "variables": {
+            "first": 1,
+            "search": "term",
+          },
+        }
+      `);
       expectValidGraphQLQuery(plan.query);
     });
 
     test("should build a find first query with filter", () => {
-      const plan = internalFindFirstQuery("widget_model", { filter: [{ id: { equals: "1" } }] });
+      const plan = internalFindFirstQuery("widget_model", [], { filter: [{ id: { equals: "1" } }] });
       expect(plan).toMatchInlineSnapshot(`
-          {
-            "query": "query InternalFindFirstWidgetModel($filter: [WidgetModelFilter!], $first: Int) {
-            internal {
-              listWidgetModel(filter: $filter, first: $first) {
-                edges {
-                  node
-                }
+        {
+          "query": "query InternalFindFirstWidgetModel($filter: [WidgetModelFilter!], $first: Int) {
+          internal {
+            listWidgetModel(filter: $filter, first: $first) {
+              edges {
+                node
               }
             }
-            gadgetMeta {
-              hydrations(modelName: "widget_model")
-            }
-          }",
-            "variables": {
-              "filter": [
-                {
-                  "id": {
-                    "equals": "1",
-                  },
-                },
-              ],
-              "first": 1,
-            },
           }
-        `);
+          gadgetMeta {
+            hydrations(modelName: "widget_model")
+          }
+        }",
+          "variables": {
+            "filter": [
+              {
+                "id": {
+                  "equals": "1",
+                },
+              },
+            ],
+            "first": 1,
+          },
+        }
+      `);
       expectValidGraphQLQuery(plan.query);
     });
 
     test("should build a create record mutation", () => {
-      const result = internalCreateMutation("widget_model", { title: "foo" });
+      const result = internalCreateMutation("widget_model", [], { title: "foo" });
 
       expect(result.query).toMatchInlineSnapshot(`
-          "mutation InternalCreateWidgetModel($widget_model: InternalWidgetModelInput) {
-            internal {
-              createWidgetModel(widget_model: $widget_model) {
-                success
-                code
+        "mutation InternalCreateWidgetModel($widget_model: InternalWidgetModelInput) {
+          internal {
+            createWidgetModel(widget_model: $widget_model) {
+              success
+              errors {
                 message
-                ...on InvalidRecordError {
+                code
+                ... on InvalidRecordError {
                   validationErrors {
-                    apiIdentifier
                     message
-                  }
-                  model {
                     apiIdentifier
                   }
-                  record
                 }
-                widget_model
               }
+              widget_model
             }
-            gadgetMeta {
-              hydrations(modelName: "widget_model")
-            }
-          }"
-        `);
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget_model")
+          }
+        }"
+      `);
       expectValidGraphQLQuery(result.query);
       expect(result.variables.widget_model).toEqual({ title: "foo" });
     });
 
     test("should build a bulk create records mutation", () => {
-      const result = internalBulkCreateMutation("widget_model", "widget_models", [{ foo: "bar" }, { foo: "baz" }]);
+      const result = internalBulkCreateMutation("widget_model", "widget_models", [], [{ foo: "bar" }, { foo: "baz" }]);
 
       expect(result.query).toMatchInlineSnapshot(`
-          "mutation InternalBulkCreateWidgetModels($widget_models: [InternalWidgetModelInput]!) {
-            internal {
-              bulkCreateWidgetModels(widget_models: $widget_models) {
-                success
-                code
+        "mutation InternalBulkCreateWidgetModels($widget_models: [InternalWidgetModelInput]!) {
+          internal {
+            bulkCreateWidgetModels(widget_models: $widget_models) {
+              success
+              errors {
                 message
-                ...on InvalidRecordError {
+                code
+                ... on InvalidRecordError {
                   validationErrors {
-                    apiIdentifier
                     message
-                  }
-                  model {
                     apiIdentifier
                   }
-                  record
                 }
-                widget_models
               }
+              widget_models
             }
-            gadgetMeta {
-              hydrations(modelName: "widget_model")
-            }
-          }"
-        `);
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget_model")
+          }
+        }"
+      `);
       expectValidGraphQLQuery(result.query);
       expect(result.variables).toEqual({ widget_models: [{ foo: "bar" }, { foo: "baz" }] });
     });
 
     test("should build an update record mutation", () => {
-      const result = internalUpdateMutation("widget_model", "123", { title: "foobar" });
+      const result = internalUpdateMutation("widget_model", [], "123", { title: "foobar" });
 
       expect(result.query).toMatchInlineSnapshot(`
-          "mutation InternalUpdateWidgetModel($id: GadgetID!, $widget_model: InternalWidgetModelInput) {
-            internal {
-              updateWidgetModel(id: $id, widget_model: $widget_model) {
-                success
-                code
+        "mutation InternalUpdateWidgetModel($id: GadgetID!, $widget_model: InternalWidgetModelInput) {
+          internal {
+            updateWidgetModel(id: $id, widget_model: $widget_model) {
+              success
+              errors {
                 message
-                ...on InvalidRecordError {
+                code
+                ... on InvalidRecordError {
                   validationErrors {
-                    apiIdentifier
                     message
-                  }
-                  model {
                     apiIdentifier
                   }
-                  record
                 }
-                widget_model
               }
+              widget_model
             }
-            gadgetMeta {
-              hydrations(modelName: "widget_model")
-            }
-          }"
-        `);
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget_model")
+          }
+        }"
+      `);
       expectValidGraphQLQuery(result.query);
       expect(result.variables).toEqual({ id: "123", widget_model: { title: "foobar" } });
     });
 
     test("should build a delete record mutation", () => {
-      const result = internalDeleteMutation("widget_model", "123");
+      const result = internalDeleteMutation("widget_model", [], "123");
 
       expect(result.query).toMatchInlineSnapshot(`
-          "mutation InternalDeleteWidgetModel($id: GadgetID!) {
-            internal {
-              deleteWidgetModel(id: $id) {
-                success
-                code
+        "mutation InternalDeleteWidgetModel($id: GadgetID!) {
+          internal {
+            deleteWidgetModel(id: $id) {
+              success
+              errors {
                 message
-                ...on InvalidRecordError {
+                code
+                ... on InvalidRecordError {
                   validationErrors {
-                    apiIdentifier
                     message
-                  }
-                  model {
                     apiIdentifier
                   }
-                  record
                 }
               }
             }
-          }"
-        `);
+          }
+        }"
+      `);
       expectValidGraphQLQuery(result.query);
       expect(result.variables).toEqual({ id: "123" });
     });
 
     test("should build a delete many records mutation", () => {
-      const result = internalDeleteManyMutation("widget_model");
+      const result = internalDeleteManyMutation("widget_model", []);
 
       expect(result.query).toMatchInlineSnapshot(`
-          "mutation InternalDeleteManyWidgetModel($search: String, $filter: [WidgetModelFilter!]) {
-            internal {
-              deleteManyWidgetModel(search: $search, filter: $filter) {
-                success
-                code
+        "mutation InternalDeleteManyWidgetModel($search: String, $filter: [WidgetModelFilter!]) {
+          internal {
+            deleteManyWidgetModel(search: $search, filter: $filter) {
+              success
+              errors {
                 message
-                ...on InvalidRecordError {
+                code
+                ... on InvalidRecordError {
                   validationErrors {
-                    apiIdentifier
                     message
-                  }
-                  model {
                     apiIdentifier
                   }
-                  record
                 }
               }
             }
-          }"
-        `);
+          }
+        }"
+      `);
       expectValidGraphQLQuery(result.query);
       expect(result.variables).toEqual({});
     });
 
     test("should build a delete many records mutation with a search and a filter", () => {
-      const result = internalDeleteManyMutation("widget_model", { search: "foobar", filter: [{ title: { equals: "foo" } }] });
+      const result = internalDeleteManyMutation("widget_model", [], { search: "foobar", filter: [{ title: { equals: "foo" } }] });
 
       expectValidGraphQLQuery(result.query);
       expect(result.variables).toEqual({
@@ -734,24 +762,22 @@ describe("InternalModelManager", () => {
 
   describe("internal actions", () => {
     test("should build a create record mutation", () => {
-      const result = internalCreateMutation("widget", { title: "foo" });
+      const result = internalCreateMutation("widget", [], { title: "foo" });
 
       expect(result.query).toMatchInlineSnapshot(`
         "mutation InternalCreateWidget($widget: InternalWidgetInput) {
           internal {
             createWidget(widget: $widget) {
               success
-              code
-              message
-              ...on InvalidRecordError {
-                validationErrors {
-                  apiIdentifier
-                  message
+              errors {
+                message
+                code
+                ... on InvalidRecordError {
+                  validationErrors {
+                    message
+                    apiIdentifier
+                  }
                 }
-                model {
-                  apiIdentifier
-                }
-                record
               }
               widget
             }
@@ -765,25 +791,58 @@ describe("InternalModelManager", () => {
       expect(result.variables.widget).toEqual({ title: "foo" });
     });
 
+    test("should build a namespaced create record mutation", () => {
+      const result = internalCreateMutation("widget", ["deep", "namespace"], { title: "foo" });
+
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalCreateWidget($widget: InternalDeepNamespaceWidgetInput) {
+          internal {
+            deep {
+              namespace {
+                createWidget(widget: $widget) {
+                  success
+                  errors {
+                    message
+                    code
+                    ... on InvalidRecordError {
+                      validationErrors {
+                        message
+                        apiIdentifier
+                      }
+                    }
+                  }
+                  widget
+                }
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "deep.namespace.widget")
+          }
+        }"
+      `);
+      expectValidGraphQLQuery(result.query);
+      expect(result.query).toMatch(/InternalDeepNamespaceWidgetInput/);
+      expect(result.variables.widget).toEqual({ title: "foo" });
+    });
+
     test("should build a bulk create records mutation", () => {
-      const result = internalBulkCreateMutation("widget", "widgets", [{ foo: "bar" }, { foo: "baz" }]);
+      const result = internalBulkCreateMutation("widget", "widgets", [], [{ foo: "bar" }, { foo: "baz" }]);
 
       expect(result.query).toMatchInlineSnapshot(`
         "mutation InternalBulkCreateWidgets($widgets: [InternalWidgetInput]!) {
           internal {
             bulkCreateWidgets(widgets: $widgets) {
               success
-              code
-              message
-              ...on InvalidRecordError {
-                validationErrors {
-                  apiIdentifier
-                  message
+              errors {
+                message
+                code
+                ... on InvalidRecordError {
+                  validationErrors {
+                    message
+                    apiIdentifier
+                  }
                 }
-                model {
-                  apiIdentifier
-                }
-                record
               }
               widgets
             }
@@ -797,25 +856,58 @@ describe("InternalModelManager", () => {
       expect(result.variables).toEqual({ widgets: [{ foo: "bar" }, { foo: "baz" }] });
     });
 
+    test("should build a namespaced bulk create records mutation", () => {
+      const result = internalBulkCreateMutation("widget", "widgets", ["deep", "namespace"], [{ foo: "bar" }, { foo: "baz" }]);
+
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalBulkCreateWidgets($widgets: [InternalDeepNamespaceWidgetInput]!) {
+          internal {
+            deep {
+              namespace {
+                bulkCreateWidgets(widgets: $widgets) {
+                  success
+                  errors {
+                    message
+                    code
+                    ... on InvalidRecordError {
+                      validationErrors {
+                        message
+                        apiIdentifier
+                      }
+                    }
+                  }
+                  widgets
+                }
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "deep.namespace.widget")
+          }
+        }"
+      `);
+      expectValidGraphQLQuery(result.query);
+      expect(result.query).toMatch(/InternalDeepNamespaceWidgetInput/);
+      expect(result.variables).toEqual({ widgets: [{ foo: "bar" }, { foo: "baz" }] });
+    });
+
     test("should build an update record mutation", () => {
-      const result = internalUpdateMutation("widget", "123", { foo: "bar" });
+      const result = internalUpdateMutation("widget", [], "123", { foo: "bar" });
 
       expect(result.query).toMatchInlineSnapshot(`
         "mutation InternalUpdateWidget($id: GadgetID!, $widget: InternalWidgetInput) {
           internal {
             updateWidget(id: $id, widget: $widget) {
               success
-              code
-              message
-              ...on InvalidRecordError {
-                validationErrors {
-                  apiIdentifier
-                  message
+              errors {
+                message
+                code
+                ... on InvalidRecordError {
+                  validationErrors {
+                    message
+                    apiIdentifier
+                  }
                 }
-                model {
-                  apiIdentifier
-                }
-                record
               }
               widget
             }
@@ -829,25 +921,88 @@ describe("InternalModelManager", () => {
       expect(result.variables).toEqual({ id: "123", widget: { foo: "bar" } });
     });
 
+    test("should build a namespaced update record mutation", () => {
+      const result = internalUpdateMutation("widget", ["deep", "namespace"], "123", { foo: "bar" });
+
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalUpdateWidget($id: GadgetID!, $widget: InternalDeepNamespaceWidgetInput) {
+          internal {
+            deep {
+              namespace {
+                updateWidget(id: $id, widget: $widget) {
+                  success
+                  errors {
+                    message
+                    code
+                    ... on InvalidRecordError {
+                      validationErrors {
+                        message
+                        apiIdentifier
+                      }
+                    }
+                  }
+                  widget
+                }
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "deep.namespace.widget")
+          }
+        }"
+      `);
+      expectValidGraphQLQuery(result.query);
+      expect(result.query).toMatch(/InternalDeepNamespaceWidgetInput/);
+      expect(result.variables).toEqual({ id: "123", widget: { foo: "bar" } });
+    });
+
     test("should build a delete record mutation", () => {
-      const result = internalDeleteMutation("widget", "123");
+      const result = internalDeleteMutation("widget", [], "123");
 
       expect(result.query).toMatchInlineSnapshot(`
         "mutation InternalDeleteWidget($id: GadgetID!) {
           internal {
             deleteWidget(id: $id) {
               success
-              code
-              message
-              ...on InvalidRecordError {
-                validationErrors {
-                  apiIdentifier
-                  message
+              errors {
+                message
+                code
+                ... on InvalidRecordError {
+                  validationErrors {
+                    message
+                    apiIdentifier
+                  }
                 }
-                model {
-                  apiIdentifier
+              }
+            }
+          }
+        }"
+      `);
+      expectValidGraphQLQuery(result.query);
+      expect(result.variables).toEqual({ id: "123" });
+    });
+
+    test("should build a namespaced delete record mutation", () => {
+      const result = internalDeleteMutation("widget", ["deep", "namespace"], "123");
+
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalDeleteWidget($id: GadgetID!) {
+          internal {
+            deep {
+              namespace {
+                deleteWidget(id: $id) {
+                  success
+                  errors {
+                    message
+                    code
+                    ... on InvalidRecordError {
+                      validationErrors {
+                        message
+                        apiIdentifier
+                      }
+                    }
+                  }
                 }
-                record
               }
             }
           }
@@ -858,34 +1013,530 @@ describe("InternalModelManager", () => {
     });
 
     test("should build a delete many records mutation", () => {
-      const result = internalDeleteManyMutation("widget", {});
+      const result = internalDeleteManyMutation("widget", [], {});
 
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "query": "mutation InternalDeleteManyWidget($search: String, $filter: [WidgetFilter!]) {
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalDeleteManyWidget($search: String, $filter: [WidgetFilter!]) {
           internal {
             deleteManyWidget(search: $search, filter: $filter) {
               success
-              code
-              message
-              ...on InvalidRecordError {
-                validationErrors {
-                  apiIdentifier
-                  message
+              errors {
+                message
+                code
+                ... on InvalidRecordError {
+                  validationErrors {
+                    message
+                    apiIdentifier
+                  }
                 }
-                model {
-                  apiIdentifier
-                }
-                record
               }
             }
           }
-        }",
-          "variables": {},
-        }
+        }"
       `);
       expectValidGraphQLQuery(result.query);
       expect(result.variables).toEqual({});
+    });
+
+    test("should build a namespaced delete many records mutation", () => {
+      const result = internalDeleteManyMutation("widget", ["deep", "namespace"], {});
+
+      expect(result.query).toMatchInlineSnapshot(`
+        "mutation InternalDeleteManyWidget($search: String, $filter: [DeepNamespaceWidgetFilter!]) {
+          internal {
+            deep {
+              namespace {
+                deleteManyWidget(search: $search, filter: $filter) {
+                  success
+                  errors {
+                    message
+                    code
+                    ... on InvalidRecordError {
+                      validationErrors {
+                        message
+                        apiIdentifier
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }"
+      `);
+      expectValidGraphQLQuery(result.query);
+      expect(result.query).toMatch(/DeepNamespaceWidgetFilter/);
+      expect(result.variables).toEqual({});
+    });
+
+    test("should build a find many query for a namespaced model with a sort and filter", () => {
+      const result = internalDeleteManyMutation("widget", ["deep", "namespace"], {
+        search: "foobar",
+        filter: [{ title: { equals: "foo" } }],
+      });
+
+      expectValidGraphQLQuery(result.query);
+      expect(result.query).toMatch(/DeepNamespaceWidgetFilter/);
+      expect(result.variables).toEqual({
+        search: "foobar",
+        filter: [{ title: { equals: "foo" } }],
+      });
+    });
+  });
+
+  test("queries for the same model in different namespaces should be different", () => {
+    expect(internalFindOneQuery("widget", "123", ["name", "one"]).query).not.toEqual(
+      internalFindOneQuery("widget", "123", ["name", "two"]).query
+    );
+  });
+
+  describe("executing against level models", () => {
+    let manager: InternalModelManager;
+    let mockUrqlClient: MockUrqlClient;
+    beforeEach(() => {
+      const connection = new GadgetConnection({ endpoint: "https://someapp.gadget.app" });
+      mockUrqlClient = createMockUrqlClient({});
+      jest.spyOn(connection, "currentClient", "get").mockReturnValue(mockUrqlClient as any);
+
+      manager = new InternalModelManager("widget", connection, { pluralApiIdentifier: "widgets" });
+    });
+
+    test("can execute a findOne operation against a model", async () => {
+      const promise = manager.findOne("123");
+
+      mockUrqlClient.executeQuery.pushResponse("InternalFindWidget", {
+        data: {
+          internal: {
+            widget: {
+              id: "123",
+              name: "foo",
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("can execute a findMany operation against a model", async () => {
+      const promise = manager.findMany();
+
+      mockUrqlClient.executeQuery.pushResponse("InternalFindManyWidget", {
+        data: {
+          internal: {
+            listWidget: {
+              edges: [
+                {
+                  node: {
+                    id: "123",
+                    name: "foo",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result[0].id).toBeTruthy();
+      expect(result[0].name).toBeTruthy();
+    });
+
+    test("can execute a findFirst operation against a model", async () => {
+      const promise = manager.findFirst({ search: "foobar" });
+
+      mockUrqlClient.executeQuery.pushResponse("InternalFindFirstWidget", {
+        data: {
+          internal: {
+            listWidget: {
+              edges: [
+                {
+                  node: {
+                    id: "123",
+                    name: "foo",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result?.id).toBeTruthy();
+      expect(result?.name).toBeTruthy();
+    });
+
+    test("can execute a create operation against a model", async () => {
+      const promise = manager.create({ name: "foo" });
+
+      mockUrqlClient.executeMutation.pushResponse("InternalCreateWidget", {
+        data: {
+          internal: {
+            createWidget: {
+              success: true,
+              errors: null,
+              widget: {
+                id: "123",
+                name: "foo",
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("can execute a bulkCreate operation against a model", async () => {
+      const promise = manager.bulkCreate([{ name: "foo" }, { name: "bar" }]);
+
+      mockUrqlClient.executeMutation.pushResponse("InternalBulkCreateWidgets", {
+        data: {
+          internal: {
+            bulkCreateWidgets: {
+              success: true,
+              errors: null,
+              widgets: [
+                {
+                  id: "123",
+                  name: "foo",
+                },
+                {
+                  id: "456",
+                  name: "bar",
+                },
+              ],
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const results = await promise;
+      expect(results.length).toBe(2);
+      expect(results[0].id).toBeTruthy();
+      expect(results[0].name).toBeTruthy();
+    });
+
+    test("can execute an update operation against a model", async () => {
+      const promise = manager.update("123", { name: "foo" });
+
+      mockUrqlClient.executeMutation.pushResponse("InternalUpdateWidget", {
+        data: {
+          internal: {
+            updateWidget: {
+              success: true,
+              errors: null,
+              widget: {
+                id: "123",
+                name: "foo",
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("can execute a delete operation against a model", async () => {
+      const promise = manager.delete("123");
+
+      mockUrqlClient.executeMutation.pushResponse("InternalDeleteWidget", {
+        data: {
+          internal: {
+            deleteWidget: {
+              success: true,
+              errors: null,
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
+    });
+
+    test("can execute a deleteMany operation against a model", async () => {
+      const promise = manager.deleteMany({ filter: { title: { equals: "foo" } } });
+
+      mockUrqlClient.executeMutation.pushResponse("InternalDeleteManyWidget", {
+        data: {
+          internal: {
+            deleteManyWidget: {
+              success: true,
+              errors: null,
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("executing against namespaced models", () => {
+    let manager: InternalModelManager;
+    let mockUrqlClient: MockUrqlClient;
+    beforeEach(() => {
+      const connection = new GadgetConnection({ endpoint: "https://someapp.gadget.app" });
+      mockUrqlClient = createMockUrqlClient({});
+      jest.spyOn(connection, "currentClient", "get").mockReturnValue(mockUrqlClient as any);
+
+      manager = new InternalModelManager("widget", connection, { pluralApiIdentifier: "widgets", namespace: ["inner", "outer"] });
+    });
+
+    test("can execute a findOne operation against a model", async () => {
+      const promise = manager.findOne("123");
+
+      mockUrqlClient.executeQuery.pushResponse("InternalFindWidget", {
+        data: {
+          internal: {
+            inner: {
+              outer: {
+                widget: {
+                  id: "123",
+                  name: "foo",
+                },
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("can execute a findMany operation against a model", async () => {
+      const promise = manager.findMany();
+
+      mockUrqlClient.executeQuery.pushResponse("InternalFindManyWidget", {
+        data: {
+          internal: {
+            inner: {
+              outer: {
+                listWidget: {
+                  edges: [
+                    {
+                      node: {
+                        id: "123",
+                        name: "foo",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result[0].id).toBeTruthy();
+      expect(result[0].name).toBeTruthy();
+    });
+
+    test("can execute a findFirst operation against a model", async () => {
+      const promise = manager.findFirst({ search: "foobar" });
+
+      mockUrqlClient.executeQuery.pushResponse("InternalFindFirstWidget", {
+        data: {
+          internal: {
+            inner: {
+              outer: {
+                listWidget: {
+                  edges: [
+                    {
+                      node: {
+                        id: "123",
+                        name: "foo",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result?.id).toBeTruthy();
+      expect(result?.name).toBeTruthy();
+    });
+
+    test("can execute a create operation against a model", async () => {
+      const promise = manager.create({ name: "foo" });
+
+      mockUrqlClient.executeMutation.pushResponse("InternalCreateWidget", {
+        data: {
+          internal: {
+            inner: {
+              outer: {
+                createWidget: {
+                  success: true,
+                  errors: null,
+                  widget: {
+                    id: "123",
+                    name: "foo",
+                  },
+                },
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("can execute a bulkCreate operation against a model", async () => {
+      const promise = manager.bulkCreate([{ name: "foo" }, { name: "bar" }]);
+
+      mockUrqlClient.executeMutation.pushResponse("InternalBulkCreateWidgets", {
+        data: {
+          internal: {
+            inner: {
+              outer: {
+                bulkCreateWidgets: {
+                  success: true,
+                  errors: null,
+                  widgets: [
+                    {
+                      id: "123",
+                      name: "foo",
+                    },
+                    {
+                      id: "456",
+                      name: "bar",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const results = await promise;
+      expect(results.length).toBe(2);
+      expect(results[0].id).toBeTruthy();
+      expect(results[0].name).toBeTruthy();
+    });
+
+    test("can execute an update operation against a model", async () => {
+      const promise = manager.update("123", { name: "foo" });
+
+      mockUrqlClient.executeMutation.pushResponse("InternalUpdateWidget", {
+        data: {
+          internal: {
+            inner: {
+              outer: {
+                updateWidget: {
+                  success: true,
+                  errors: null,
+                  widget: {
+                    id: "123",
+                    name: "foo",
+                  },
+                },
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("can execute a delete operation against a model", async () => {
+      const promise = manager.delete("123");
+
+      mockUrqlClient.executeMutation.pushResponse("InternalDeleteWidget", {
+        data: {
+          internal: {
+            inner: {
+              outer: {
+                deleteWidget: {
+                  success: true,
+                  errors: null,
+                },
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
+    });
+
+    test("can execute a deleteMany operation against a model", async () => {
+      const promise = manager.deleteMany({ filter: { title: { equals: "foo" } } });
+
+      mockUrqlClient.executeMutation.pushResponse("InternalDeleteManyWidget", {
+        data: {
+          internal: {
+            inner: {
+              outer: {
+                deleteManyWidget: {
+                  success: true,
+                  errors: null,
+                },
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -86,7 +86,7 @@ describe("operation builders", () => {
             }
           }
           gadgetMeta {
-            hydrations(modelName: "widget")
+            hydrations(modelName: "outer.widget")
           }
         }",
           "variables": {
@@ -114,7 +114,7 @@ describe("operation builders", () => {
             }
           }
           gadgetMeta {
-            hydrations(modelName: "widget")
+            hydrations(modelName: "outer.inner.reallyInner.widget")
           }
         }",
           "variables": {
@@ -324,7 +324,7 @@ describe("operation builders", () => {
             }
           }
           gadgetMeta {
-            hydrations(modelName: "widget")
+            hydrations(modelName: "outer.inner.widget")
           }
         }",
           "variables": {
@@ -490,7 +490,7 @@ describe("operation builders", () => {
             }
           }
           gadgetMeta {
-            hydrations(modelName: "widget")
+            hydrations(modelName: "outer.inner.widget")
           }
         }",
           "variables": {

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -41,18 +41,18 @@ describe("operationRunners", () => {
       const promise = findOneRunner({ connection }, "widget", "123", { id: true, name: true }, "widget");
 
       expect(query).toMatchInlineSnapshot(`
-      "query widget($id: GadgetID!) {
-        widget(id: $id) {
-          id
-          name
-          __typename
-        }
-        gadgetMeta {
-          hydrations(modelName: 
-      "widget")
-        }
-      }"
-      `);
+              "query widget($id: GadgetID!) {
+                widget(id: $id) {
+                  id
+                  name
+                  __typename
+                }
+                gadgetMeta {
+                  hydrations(modelName: 
+              "widget")
+                }
+              }"
+            `);
 
       mockUrqlClient.executeQuery.pushResponse("widget", {
         data: {
@@ -77,21 +77,21 @@ describe("operationRunners", () => {
       ]);
 
       expect(query).toMatchInlineSnapshot(`
-      "query widget($id: GadgetID!) {
-        outer {
-          inner {
-            widget(id: $id) {
-              id
-              name
-              __typename
+        "query widget($id: GadgetID!) {
+          outer {
+            inner {
+              widget(id: $id) {
+                id
+                name
+                __typename
+              }
             }
           }
-        }
-        gadgetMeta {
-          hydrations(modelName: 
-      "widget")
-        }
-      }"
+          gadgetMeta {
+            hydrations(modelName: 
+        "outer.inner.widget")
+          }
+        }"
       `);
 
       mockUrqlClient.executeQuery.pushResponse("widget", {
@@ -188,29 +188,29 @@ describe("operationRunners", () => {
       const promise = findManyRunner({ connection } as AnyModelManager, "widgets", { id: true, name: true }, "widget");
 
       expect(query).toMatchInlineSnapshot(`
-      "query widgets($after: String, $first: Int, $before: String, $last: Int) {
-        widgets(after: $after, first: $first, before: $before, last: $last) {
-          pageInfo {
-            hasNextPage
-            hasPreviousPage
-            startCursor
-            endCursor
-          }
-          edges {
-            cursor
-            node {
-              id
-              name
-              __typename
-            }
-          }
-        }
-        gadgetMeta {
-          hydrations(modelName: 
-      "widget")
-        }
-      }"
-      `);
+              "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+                widgets(after: $after, first: $first, before: $before, last: $last) {
+                  pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                  }
+                  edges {
+                    cursor
+                    node {
+                      id
+                      name
+                      __typename
+                    }
+                  }
+                }
+                gadgetMeta {
+                  hydrations(modelName: 
+              "widget")
+                }
+              }"
+            `);
 
       mockUrqlClient.executeQuery.pushResponse("widgets", {
         data: {
@@ -247,32 +247,32 @@ describe("operationRunners", () => {
         ["outer", "inner"]
       );
       expect(query).toMatchInlineSnapshot(`
-      "query widgets($after: String, $first: Int, $before: String, $last: Int) {
-        outer {
-          inner {
-            widgets(after: $after, first: $first, before: $before, last: $last) {
-              pageInfo {
-                hasNextPage
-                hasPreviousPage
-                startCursor
-                endCursor
-              }
-              edges {
-                cursor
-                node {
-                  id
-                  name
-                  __typename
+        "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          outer {
+            inner {
+              widgets(after: $after, first: $first, before: $before, last: $last) {
+                pageInfo {
+                  hasNextPage
+                  hasPreviousPage
+                  startCursor
+                  endCursor
+                }
+                edges {
+                  cursor
+                  node {
+                    id
+                    name
+                    __typename
+                  }
                 }
               }
             }
           }
-        }
-        gadgetMeta {
-          hydrations(modelName: 
-      "widget")
-        }
-      }"
+          gadgetMeta {
+            hydrations(modelName: 
+        "outer.inner.widget")
+          }
+        }"
       `);
 
       mockUrqlClient.executeQuery.pushResponse("widgets", {
@@ -315,30 +315,30 @@ describe("operationRunners", () => {
       );
 
       expect(query).toMatchInlineSnapshot(`
-      "query widgets($after: String, $first: Int, $before: String, $last: Int) {
-        outer {
-          widgets(after: $after, first: $first, before: $before, last: $last) {
-            pageInfo {
-              hasNextPage
-              hasPreviousPage
-              startCursor
-              endCursor
-            }
-            edges {
-              cursor
-              node {
-                id
-                name
-                __typename
+        "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          outer {
+            widgets(after: $after, first: $first, before: $before, last: $last) {
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+              edges {
+                cursor
+                node {
+                  id
+                  name
+                  __typename
+                }
               }
             }
           }
-        }
-        gadgetMeta {
-          hydrations(modelName: 
-      "widget")
-        }
-      }"
+          gadgetMeta {
+            hydrations(modelName: 
+        "outer.widget")
+          }
+        }"
       `);
 
       mockUrqlClient.executeQuery.pushResponse("widgets", {

--- a/packages/api-client-core/src/AnyClient.ts
+++ b/packages/api-client-core/src/AnyClient.ts
@@ -4,6 +4,8 @@ import type { InternalModelManager } from "./InternalModelManager.js";
 
 export const $modelRelationships = Symbol.for("gadget/modelRelationships");
 
+export type InternalModelManagerNamespace = { [key: string]: InternalModelManager | InternalModelManagerNamespace };
+
 /**
  * An instance of any Gadget app's API client object
  */
@@ -12,9 +14,7 @@ export interface AnyClient {
   query(graphQL: string, variables?: Record<string, any>): Promise<any>;
   mutate(graphQL: string, variables?: Record<string, any>): Promise<any>;
   transaction<T>(callback: (transaction: GadgetTransaction) => Promise<T>): Promise<T>;
-  internal: {
-    [key: string]: InternalModelManager;
-  };
+  internal: InternalModelManagerNamespace;
   [$modelRelationships]?: { [modelName: string]: { [apiIdentifier: string]: { type: string; model: string } } };
 }
 

--- a/packages/api-client-core/src/GadgetRecordList.ts
+++ b/packages/api-client-core/src/GadgetRecordList.ts
@@ -14,12 +14,12 @@ type PaginationConfig = {
 
 /** Represents a list of objects returned from the API. Facilitates iterating and paginating. */
 export class GadgetRecordList<Shape extends RecordShape> extends Array<GadgetRecord<Shape>> {
-  modelManager!: AnyModelManager | InternalModelManager;
+  modelManager!: AnyModelManager | InternalModelManager<Shape>;
   pagination!: PaginationConfig;
 
   /** Internal method used to create a list. Should not be used by applications. */
   static boot<Shape extends RecordShape>(
-    modelManager: AnyModelManager | InternalModelManager,
+    modelManager: AnyModelManager | InternalModelManager<Shape>,
     records: GadgetRecord<Shape>[],
     pagination: PaginationConfig
   ) {

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -40,7 +40,7 @@ const internalHydrationPlan = (modelApiIdentifer: string) => ({
   },
 });
 
-const internalFindOneQuery = (apiIdentifier: string, id: string, select?: string[]) => {
+export const internalFindOneQuery = (apiIdentifier: string, id: string, select?: InternalFieldSelection) => {
   const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
 
   return compileWithVariableValues({
@@ -50,7 +50,7 @@ const internalFindOneQuery = (apiIdentifier: string, id: string, select?: string
       internal: {
         [apiIdentifier]: Call({
           id: Var({ value: id, type: "GadgetID!" }),
-          select: Var({ value: select, type: "[String!]" }),
+          select: Var({ value: formatInternalSelectVariable(select), type: `[String!]` }),
         }),
       },
       ...internalHydrationPlan(apiIdentifier),


### PR DESCRIPTION
- Use tiny-graphql-query-compiler for all dynamic internal queries
- Switch the internal model manager over to using tiny-graphql-query-builder
- Adds namespace support to all the generated queries within the internal model manager, as well as the types that it outputs
