### PR TITLE
React hooks for namespaced models / global actions tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
+    "@gadget-client/kitchen-sink": "1.4.0-development.184",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",
     "@gadget-client/zxcv-simple-relationship": "^1.23.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,12 +28,12 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
+    "@0no-co/graphql.web": "^1.0.4",
     "@gadgetinc/api-client-core": "^0.15.22",
     "react-fast-compare": "^3.2.2",
     "react-hook-form": "~7.48.2",
     "tslib": "^2.6.2",
-    "urql": "^4.0.4",
-    "@0no-co/graphql.web": "^1.0.4"
+    "urql": "^4.0.4"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",

--- a/packages/react/spec/apis.ts
+++ b/packages/react/spec/apis.ts
@@ -1,6 +1,7 @@
 import { Client as NoUserClient } from "@gadget-client/app-with-no-user-model";
 import { Client as BulkClient } from "@gadget-client/bulk-actions-test";
 import { Client as AuthClient } from "@gadget-client/full-auth";
+import { Client as KitchenSinkClient } from "@gadget-client/kitchen-sink";
 import { Client } from "@gadget-client/related-products-example";
 import { Client as NestedClient } from "@gadget-client/zxcv-deeply-nested";
 import { Client as SimpleClient } from "@gadget-client/zxcv-simple-relationship";
@@ -11,3 +12,4 @@ export const fullAuthApi = new AuthClient({ environment: "Development" });
 export const noUserModelApi = new NoUserClient({ environment: "Development" });
 export const nestedExampleApi = new NestedClient({ environment: "Development" });
 export const simpleExampleApi = new SimpleClient({ environment: "Development" });
+export const kitchenSinkApi = new KitchenSinkClient({ environment: "Development" });

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -8,7 +8,7 @@ import type { AnyVariables } from "urql";
 import { Provider } from "../src/GadgetProvider.js";
 import { useAction } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
-import { fullAuthApi, relatedProductsApi } from "./apis.js";
+import { fullAuthApi, kitchenSinkApi, relatedProductsApi } from "./apis.js";
 import { MockClientWrapper, createMockUrqlClient, mockUrqlClient } from "./testWrappers.js";
 
 describe("useAction", () => {
@@ -103,6 +103,35 @@ describe("useAction", () => {
       data.id;
       data.email;
     }
+  };
+
+  const _TestUseActionCanRunAgainstNamespacedModel = () => {
+    const [_, mutate] = useAction(kitchenSinkApi.game.player.update);
+
+    // can call with variables
+    void mutate({ id: "123", player: { name: "Caitlin Clark" } });
+
+    // can call with no model variables
+    void mutate({ id: "123" });
+
+    // @ts-expect-error can't call with no arguments
+    void mutate();
+
+    // @ts-expect-error can't call with no id
+    void mutate({});
+
+    // @ts-expect-error can't call with variables that don't belong to the model
+    void mutate({ foo: "123" });
+  };
+
+  const _TestUseActionCanRunAgainstDeeplyNamespacedModel = () => {
+    const [_, mutate] = useAction(kitchenSinkApi.game.inner.test.create);
+
+    // can call with variables
+    void mutate({ test: { foo: "bar" } });
+
+    // @ts-expect-error can't call with variables that don't belong to the model
+    void mutate({ notAProp: "123" });
   };
 
   test("returns no data, not fetching, and no error when the component is first mounted", () => {
@@ -254,6 +283,112 @@ describe("useAction", () => {
     expect(result.current[0]).toBe(beforeObject);
   });
 
+  test("returns no data, fetching=true, and no error when the mutation is run, and then the successful data if the mutation succeeds for a namespaced model", async () => {
+    const { result } = renderHook(() => useAction(kitchenSinkApi.game.player.update), { wrapper: MockClientWrapper(kitchenSinkApi) });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ id: "123", player: { name: "Caitlin Clark" } });
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeMutation).toHaveBeenCalledTimes(1);
+
+    mockUrqlClient.executeMutation.pushResponse("updatePlayer", {
+      data: {
+        game: {
+          updatePlayer: {
+            success: true,
+            player: {
+              id: "123",
+              name: "Caitlin Clark",
+            },
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data!.id).toEqual("123");
+      expect(promiseResult.data!.name).toEqual("Caitlin Clark");
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeFalsy();
+    });
+
+    expect(result.current[0].data!.id).toEqual("123");
+    expect(result.current[0].data!.name).toEqual("Caitlin Clark");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("returns an error when the mutation is run and the server responds with success: false for a namespaced model", async () => {
+    const { result } = renderHook(
+      () => {
+        return useAction(kitchenSinkApi.game.player.update);
+      },
+      { wrapper: MockClientWrapper(kitchenSinkApi) }
+    );
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ id: "123", player: { name: "Invalid name" } });
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
+
+    mockUrqlClient.executeMutation.pushResponse("updatePlayer", {
+      data: {
+        game: {
+          updatePlayer: {
+            success: false,
+            errors: [
+              {
+                message: "Record is invalid, one error needs to be corrected. Email is not unique.",
+                code: "GGT_INVALID_RECORD",
+                validationErrors: [{ apiIdentifier: "name", message: "is not unique." }],
+              },
+            ],
+            player: {
+              id: "123",
+              name: "Caitlin Clark",
+            },
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeTruthy();
+      expect(promiseResult.data).toBeFalsy();
+    });
+
+    expect(result.current[0].fetching).toBe(false);
+    const error = result.current[0].error;
+    expect(error).toBeTruthy();
+    expect(error!.validationErrors).toMatchInlineSnapshot(`
+      [
+        {
+          "apiIdentifier": "name",
+          "message": "is not unique.",
+        },
+      ]
+    `);
+    expect(result.current[0].data).toBeFalsy();
+  });
   test("returns a second mutation response if called a second time", async () => {
     const { result } = renderHook(() => useAction(relatedProductsApi.user.update), { wrapper: MockClientWrapper(relatedProductsApi) });
 

--- a/packages/react/spec/useEnqueue.spec.tsx
+++ b/packages/react/spec/useEnqueue.spec.tsx
@@ -192,7 +192,16 @@ describe("useEnqueue", () => {
   });
 
   test("returns no handle, fetching=true, and no error when the mutation is run, and then the action handle if the mutation succeeds", async () => {
-    const { result } = renderHook(() => useEnqueue(relatedProductsApi.user.update), { wrapper: MockClientWrapper(relatedProductsApi) });
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      mutationAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
+    const { result } = renderHook(() => useEnqueue(relatedProductsApi.user.update), {
+      wrapper: MockClientWrapper(relatedProductsApi, client),
+    });
 
     let mutationPromise: any;
     act(() => {
@@ -203,9 +212,26 @@ describe("useEnqueue", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
+    expect(query).toMatchInlineSnapshot(`
+      "mutation enqueueUpdateUser($id: GadgetID!, $user: UpdateUserInput, $backgroundOptions: EnqueueBackgroundActionOptions) {
+        background {
+          updateUser(id: $id, user: $user, backgroundOptions: $backgroundOptions) {
+            success
+            errors {
+              message
+              code
+            }
+            backgroundAction {
+              id
+            }
+          }
+        }
+      }"
+    `);
 
-    mockUrqlClient.executeMutation.pushResponse("enqueueUpdateUser", {
+    expect(client.executeMutation).toBeCalledTimes(1);
+
+    client.executeMutation.pushResponse("enqueueUpdateUser", {
       data: {
         background: {
           updateUser: {
@@ -233,7 +259,16 @@ describe("useEnqueue", () => {
   });
 
   test("returns no handle, fetching=true, and no error when the mutation is run, and then the action handle if the mutation succeeds for a namespaced model", async () => {
-    const { result } = renderHook(() => useEnqueue(kitchenSinkApi.game.player.update), { wrapper: MockClientWrapper(kitchenSinkApi) });
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      mutationAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
+    const { result } = renderHook(() => useEnqueue(kitchenSinkApi.game.player.update), {
+      wrapper: MockClientWrapper(kitchenSinkApi, client),
+    });
 
     let mutationPromise: any;
     act(() => {
@@ -244,9 +279,28 @@ describe("useEnqueue", () => {
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
+    expect(query).toMatchInlineSnapshot(`
+      "mutation enqueueUpdatePlayer($id: GadgetID!, $player: UpdateGamePlayerInput, $backgroundOptions: EnqueueBackgroundActionOptions) {
+        background {
+          game {
+            updatePlayer(id: $id, player: $player, backgroundOptions: $backgroundOptions) {
+              success
+              errors {
+                message
+                code
+              }
+              backgroundAction {
+                id
+              }
+            }
+          }
+        }
+      }"
+    `);
 
-    mockUrqlClient.executeMutation.pushResponse("enqueueUpdatePlayer", {
+    expect(client.executeMutation).toBeCalledTimes(1);
+
+    client.executeMutation.pushResponse("enqueueUpdatePlayer", {
       data: {
         background: {
           game: {

--- a/packages/react/spec/useFindBy.spec.ts
+++ b/packages/react/spec/useFindBy.spec.ts
@@ -6,7 +6,13 @@ import { assert } from "conditional-type-checks";
 import { useFindBy } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { kitchenSinkApi, relatedProductsApi } from "./apis.js";
-import { MockClientWrapper, MockGraphQLWSClientWrapper, mockGraphQLWSClient, mockUrqlClient } from "./testWrappers.js";
+import {
+  MockClientWrapper,
+  MockGraphQLWSClientWrapper,
+  createMockUrqlClient,
+  mockGraphQLWSClient,
+  mockUrqlClient,
+} from "./testWrappers.js";
 
 describe("useFindBy", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -48,17 +54,62 @@ describe("useFindBy", () => {
   };
 
   test("it can find one record by a field value", async () => {
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
     const { result } = renderHook(() => useFindBy(relatedProductsApi.user.findByEmail, "test@test.com"), {
-      wrapper: MockClientWrapper(relatedProductsApi),
+      wrapper: MockClientWrapper(relatedProductsApi, client),
     });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+    expect(client.executeQuery).toBeCalledTimes(1);
 
-    mockUrqlClient.executeQuery.pushResponse("users", {
+    expect(query).toMatchInlineSnapshot(`
+      "query users($after: String, $first: Int, $before: String, $last: Int, $filter: [UserFilter!]) {
+        users(
+          after: $after
+          first: $first
+          before: $before
+          last: $last
+          filter: $filter
+        ) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              __typename
+              id
+              state
+              createdAt
+              email
+              roles {
+                key
+                name
+              }
+              updatedAt
+            }
+          }
+        }
+        gadgetMeta {
+          hydrations(modelName: 
+      "user")
+        }
+      }"
+    `);
+
+    client.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],
@@ -115,17 +166,60 @@ describe("useFindBy", () => {
   });
 
   test("it can find one record by a field value on a namespaced model", async () => {
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
     const { result } = renderHook(() => useFindBy(kitchenSinkApi.game.player.findByName, "Caitlin Clark"), {
-      wrapper: MockClientWrapper(kitchenSinkApi),
+      wrapper: MockClientWrapper(kitchenSinkApi, client),
     });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+    expect(client.executeQuery).toBeCalledTimes(1);
 
-    mockUrqlClient.executeQuery.pushResponse("players", {
+    expect(query).toMatchInlineSnapshot(`
+      "query players($after: String, $first: Int, $before: String, $last: Int, $filter: [GamePlayerFilter!]) {
+        game {
+          players(
+            after: $after
+            first: $first
+            before: $before
+            last: $last
+            filter: $filter
+          ) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                __typename
+                id
+                createdAt
+                name
+                number
+                updatedAt
+              }
+            }
+          }
+        }
+        gadgetMeta {
+          hydrations(modelName: 
+      "game.player")
+        }
+      }"
+    `);
+
+    client.executeQuery.pushResponse("players", {
       data: {
         game: {
           players: {

--- a/packages/react/spec/useFindFirst.spec.ts
+++ b/packages/react/spec/useFindFirst.spec.ts
@@ -6,7 +6,13 @@ import { assert } from "conditional-type-checks";
 import { useFindFirst } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { kitchenSinkApi, relatedProductsApi } from "./apis.js";
-import { MockClientWrapper, MockGraphQLWSClientWrapper, mockGraphQLWSClient, mockUrqlClient } from "./testWrappers.js";
+import {
+  MockClientWrapper,
+  MockGraphQLWSClientWrapper,
+  createMockUrqlClient,
+  mockGraphQLWSClient,
+  mockUrqlClient,
+} from "./testWrappers.js";
 
 describe("useFindFirst", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -49,17 +55,56 @@ describe("useFindFirst", () => {
   };
 
   test("it can find the first record", async () => {
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
     const { result } = renderHook(() => useFindFirst(relatedProductsApi.user), {
-      wrapper: MockClientWrapper(relatedProductsApi),
+      wrapper: MockClientWrapper(relatedProductsApi, client),
     });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+    expect(client.executeQuery).toBeCalledTimes(1);
 
-    mockUrqlClient.executeQuery.pushResponse("users", {
+    expect(query).toMatchInlineSnapshot(`
+      "query users($after: String, $first: Int, $before: String, $last: Int) {
+        users(after: $after, first: $first, before: $before, last: $last) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              __typename
+              id
+              state
+              createdAt
+              email
+              roles {
+                key
+                name
+              }
+              updatedAt
+            }
+          }
+        }
+        gadgetMeta {
+          hydrations(modelName: 
+      "user")
+        }
+      }"
+    `);
+
+    client.executeQuery.pushResponse("users", {
       data: {
         users: {
           edges: [{ cursor: "123", node: { id: "123", email: "test@test.com" } }],
@@ -82,17 +127,55 @@ describe("useFindFirst", () => {
   });
 
   test("it can find the first record of a namespaced model", async () => {
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
     const { result } = renderHook(() => useFindFirst(kitchenSinkApi.game.player), {
-      wrapper: MockClientWrapper(kitchenSinkApi),
+      wrapper: MockClientWrapper(kitchenSinkApi, client),
     });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+    expect(client.executeQuery).toBeCalledTimes(1);
 
-    mockUrqlClient.executeQuery.pushResponse("players", {
+    // the "players" should be under the "game" namespace
+    expect(query).toMatchInlineSnapshot(`
+      "query players($after: String, $first: Int, $before: String, $last: Int) {
+        game {
+          players(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                __typename
+                id
+                createdAt
+                name
+                number
+                updatedAt
+              }
+            }
+          }
+        }
+        gadgetMeta {
+          hydrations(modelName: 
+      "game.player")
+        }
+      }"
+    `);
+
+    client.executeQuery.pushResponse("players", {
       data: {
         game: {
           players: {

--- a/packages/react/spec/useFindMany.spec.ts
+++ b/packages/react/spec/useFindMany.spec.ts
@@ -7,7 +7,7 @@ import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
 import { useFindMany } from "../src/useFindMany.js";
 import type { ErrorWrapper } from "../src/utils.js";
-import { relatedProductsApi } from "./apis.js";
+import { kitchenSinkApi, relatedProductsApi } from "./apis.js";
 import { MockClientWrapper, MockGraphQLWSClientWrapper, mockGraphQLWSClient, mockUrqlClient } from "./testWrappers.js";
 
 describe("useFindMany", () => {
@@ -33,6 +33,15 @@ describe("useFindMany", () => {
     if (data) {
       data[0].id;
       data[0].email;
+    }
+  };
+
+  const _TestFindManyNamespacedModel = () => {
+    const [{ data }] = useFindMany(kitchenSinkApi.game.player);
+
+    if (data) {
+      data[0].id;
+      data[0].name;
     }
   };
 
@@ -175,6 +184,47 @@ describe("useFindMany", () => {
     });
 
     expect(result.current[0].data!.length).toEqual(0);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("can find a list of records for a namespaced model", async () => {
+    const { result } = renderHook(() => useFindMany(kitchenSinkApi.game.player), { wrapper: MockClientWrapper(kitchenSinkApi) });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("players", {
+      data: {
+        game: {
+          players: {
+            edges: [
+              { cursor: "123", node: { id: "123", name: "Caitlin Clark" } },
+              { cursor: "abc", node: { id: "124", email: "Paige Buckets" } },
+            ],
+            pageInfo: {
+              startCursor: "123",
+              endCursor: "abc",
+              hasNextPage: false,
+              hasPreviousPage: false,
+            },
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current[0].data![0].id).toEqual("123");
+    expect(result.current[0].data![1].id).toEqual("124");
+    expect(result.current[0].data!.length).toEqual(2);
+    expect(result.current[0].data!.hasNextPage).toEqual(false);
+    expect(result.current[0].data!.hasPreviousPage).toEqual(false);
+    expect(result.current[0].data!.startCursor).toEqual("123");
+    expect(result.current[0].data!.endCursor).toEqual("abc");
     expect(result.current[0].fetching).toBe(false);
     expect(result.current[0].error).toBeFalsy();
   });
@@ -361,6 +411,98 @@ describe("useFindMany", () => {
       expect(result.current[0].data![1].email).toEqual("test@gadget.dev");
       expect(result.current[0].data![2].id).toEqual("789");
       expect(result.current[0].data![2].email).toBe(null);
+      expect(result.current[0].fetching).toBe(false);
+      expect(result.current[0].error).toBeFalsy();
+    });
+
+    test("can query for live data on a namespaced model", async () => {
+      const { result } = renderHook(() => useFindMany(kitchenSinkApi.game.player, { live: true }), {
+        wrapper: MockGraphQLWSClientWrapper(kitchenSinkApi),
+      });
+
+      expect(result.current[0].data).toBeFalsy();
+      expect(result.current[0].fetching).toBe(true);
+      expect(result.current[0].error).toBeFalsy();
+
+      await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
+      const subscription = mockGraphQLWSClient.subscribe.subscriptions[0];
+      expect(subscription.payload.query).toContain("@live");
+
+      const initial = {
+        game: {
+          players: {
+            edges: [
+              {
+                node: {
+                  id: "123",
+                  name: "Caitlin Clark",
+                },
+              },
+              {
+                node: {
+                  id: "456",
+                  name: "Paige Buckets",
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      subscription.push({
+        data: initial,
+        revision: 1,
+      } as any);
+
+      await waitFor(() => expect(result.current[0].fetching).toBe(false));
+
+      expect(result.current[0].data![0].id).toEqual("123");
+      expect(result.current[0].data![0].name).toEqual("Caitlin Clark");
+      expect(result.current[0].data![1].id).toEqual("456");
+      expect(result.current[0].data![1].name).toEqual("Paige Buckets");
+      expect(result.current[0].error).toBeFalsy();
+
+      const next = {
+        game: {
+          players: {
+            edges: [
+              {
+                node: {
+                  id: "123",
+                  name: "Caitlin 'Goat' Clark",
+                },
+              },
+              {
+                node: {
+                  id: "456",
+                  name: "Paige Buckets",
+                },
+              },
+              {
+                node: {
+                  id: "789",
+                  name: null,
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      subscription.push({
+        patch: diff({ left: initial, right: next }),
+        revision: 2,
+      } as any);
+
+      await waitFor(() => expect(result.current[0].data![2]).toBeDefined());
+
+      expect(result.current[0].data![0].id).toEqual("123");
+      expect(result.current[0].data![0].name).toEqual("Caitlin 'Goat' Clark");
+      expect(result.current[0].data![1].id).toEqual("456");
+      expect(result.current[0].data![1].name).toEqual("Paige Buckets");
+      expect(result.current[0].data![2].id).toEqual("789");
+      expect(result.current[0].data![2].name).toBe(null);
       expect(result.current[0].fetching).toBe(false);
       expect(result.current[0].error).toBeFalsy();
     });

--- a/packages/react/spec/useFindOne.spec.ts
+++ b/packages/react/spec/useFindOne.spec.ts
@@ -5,7 +5,13 @@ import { assert } from "conditional-type-checks";
 import { useFindOne } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
 import { kitchenSinkApi, relatedProductsApi } from "./apis.js";
-import { MockClientWrapper, MockGraphQLWSClientWrapper, mockGraphQLWSClient, mockUrqlClient } from "./testWrappers.js";
+import {
+  MockClientWrapper,
+  MockGraphQLWSClientWrapper,
+  createMockUrqlClient,
+  mockGraphQLWSClient,
+  mockUrqlClient,
+} from "./testWrappers.js";
 
 describe("useFindOne", () => {
   // these functions are typechecked but never run to avoid actually making API calls
@@ -45,15 +51,45 @@ describe("useFindOne", () => {
   };
 
   test("can find one record by id", async () => {
-    const { result } = renderHook(() => useFindOne(relatedProductsApi.user, "123"), { wrapper: MockClientWrapper(relatedProductsApi) });
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
+    const { result } = renderHook(() => useFindOne(relatedProductsApi.user, "123"), {
+      wrapper: MockClientWrapper(relatedProductsApi, client),
+    });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+    expect(client.executeQuery).toBeCalledTimes(1);
 
-    mockUrqlClient.executeQuery.pushResponse("user", {
+    expect(query).toMatchInlineSnapshot(`
+      "query user($id: GadgetID!) {
+        user(id: $id) {
+          __typename
+          id
+          state
+          createdAt
+          email
+          roles {
+            key
+            name
+          }
+          updatedAt
+        }
+        gadgetMeta {
+          hydrations(modelName: 
+      "user")
+        }
+      }"
+    `);
+
+    client.executeQuery.pushResponse("user", {
       data: {
         user: {
           id: "123",
@@ -102,15 +138,43 @@ describe("useFindOne", () => {
   });
 
   test("can find one record by id for a namespaced model", async () => {
-    const { result } = renderHook(() => useFindOne(kitchenSinkApi.game.player, "123"), { wrapper: MockClientWrapper(kitchenSinkApi) });
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
+    const { result } = renderHook(() => useFindOne(kitchenSinkApi.game.player, "123"), {
+      wrapper: MockClientWrapper(kitchenSinkApi, client),
+    });
 
     expect(result.current[0].data).toBeFalsy();
     expect(result.current[0].fetching).toBe(true);
     expect(result.current[0].error).toBeFalsy();
 
-    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+    expect(client.executeQuery).toBeCalledTimes(1);
 
-    mockUrqlClient.executeQuery.pushResponse("player", {
+    expect(query).toMatchInlineSnapshot(`
+      "query player($id: GadgetID!) {
+        game {
+          player(id: $id) {
+            __typename
+            id
+            createdAt
+            name
+            number
+            updatedAt
+          }
+        }
+        gadgetMeta {
+          hydrations(modelName: 
+      "game.player")
+        }
+      }"
+    `);
+
+    client.executeQuery.pushResponse("player", {
       data: {
         game: {
           player: {

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -4,13 +4,27 @@ import { assert } from "conditional-type-checks";
 import { act } from "react-dom/test-utils";
 import { useGlobalAction } from "../src/index.js";
 import type { ErrorWrapper } from "../src/utils.js";
-import { bulkExampleApi } from "./apis.js";
+import { bulkExampleApi, kitchenSinkApi } from "./apis.js";
 import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
 
 describe("useGlobalAction", () => {
   // these functions are typechecked but never run to avoid actually making API calls
   const _TestUseGlobalActionCanRunGlobalActionsWithVariables = () => {
     const [{ data, fetching, error }, mutate] = useGlobalAction(bulkExampleApi.flipAll);
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+    assert<IsExact<typeof data, any>>(true);
+    assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+
+    // can call with variables
+    void mutate({ why: "foobar" });
+
+    // @ts-expect-error can't call with variables that don't belong to the model
+    void mutate({ foo: "123" });
+  };
+
+  const _TestUseNamespacedGlobalAction = () => {
+    const [{ data, fetching, error }, mutate] = useGlobalAction(kitchenSinkApi.game.calculateScore);
 
     assert<IsExact<typeof fetching, boolean>>(true);
     assert<IsExact<typeof data, any>>(true);
@@ -107,6 +121,47 @@ describe("useGlobalAction", () => {
     expect(result.current[0].fetching).toBe(false);
     const error = result.current[0].error;
     expect(error).toBeTruthy();
+  });
+
+  test("returns no data, fetching=true, and no error when the mutation is run, and then the successful data if the mutation succeeds for a namespaced global action", async () => {
+    const { result } = renderHook(() => useGlobalAction(kitchenSinkApi.game.calculateScore), {
+      wrapper: MockClientWrapper(kitchenSinkApi),
+    });
+
+    let mutationPromise: any;
+    act(() => {
+      mutationPromise = result.current[1]({ why: "foobar" });
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
+
+    mockUrqlClient.executeMutation.pushResponse("calculateScore", {
+      data: {
+        game: {
+          calculateScore: {
+            success: true,
+            result: { score: 10 },
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      const promiseResult = await mutationPromise;
+      expect(promiseResult.data).toEqual({ score: 10 });
+      expect(promiseResult.fetching).toBe(false);
+      expect(promiseResult.error).toBeFalsy();
+    });
+
+    expect(result.current[0].data).toEqual({ score: 10 });
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
   });
 
   test("returns the same data after executing the mutation and rerendering", async () => {

--- a/packages/react/src/useFindBy.ts
+++ b/packages/react/src/useFindBy.ts
@@ -56,7 +56,8 @@ export const useFindBy = <
       value,
       finder.defaultSelection,
       finder.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      finder.namespace
     );
   }, [finder, value, memoizedOptions]);
 

--- a/packages/react/src/useFindFirst.ts
+++ b/packages/react/src/useFindFirst.ts
@@ -48,7 +48,8 @@ export const useFindFirst = <
       manager.findFirst.operationName,
       manager.findFirst.defaultSelection,
       manager.findFirst.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findFirst.namespace
     );
   }, [manager, memoizedOptions]);
 

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -47,7 +47,8 @@ export const useFindMany = <
       manager.findMany.operationName,
       manager.findMany.defaultSelection,
       manager.findMany.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findMany.namespace
     );
   }, [manager, memoizedOptions]);
 

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -49,7 +49,8 @@ export const useFindOne = <
       id,
       manager.findOne.defaultSelection,
       manager.findOne.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findOne.namespace
     );
   }, [manager, id, memoizedOptions]);
 

--- a/packages/react/src/useMaybeFindFirst.ts
+++ b/packages/react/src/useMaybeFindFirst.ts
@@ -48,7 +48,8 @@ export const useMaybeFindFirst = <
       manager.findFirst.operationName,
       manager.findFirst.defaultSelection,
       manager.findFirst.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findFirst.namespace
     );
   }, [manager, memoizedOptions]);
 

--- a/packages/react/src/useMaybeFindOne.ts
+++ b/packages/react/src/useMaybeFindOne.ts
@@ -49,7 +49,8 @@ export const useMaybeFindOne = <
       id,
       manager.findOne.defaultSelection,
       manager.findOne.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findOne.namespace
     );
   }, [manager, id, memoizedOptions]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@gadget-client/full-auth':
         specifier: ^1.9.0
         version: 1.9.0
+      '@gadget-client/kitchen-sink':
+        specifier: 1.4.0-development.184
+        version: 1.4.0-development.184
       '@gadget-client/related-products-example':
         specifier: ^1.865.0
         version: 1.865.0
@@ -1282,6 +1285,12 @@ packages:
 
   /@gadget-client/full-auth@1.9.0:
     resolution: {integrity: sha1-OwbBpfV6H7znY3DkZB/Vd3ZnQGY=, tarball: https://registry.gadget.dev/npm/_/tarball/66538/131725/7454}
+    dependencies:
+      '@gadgetinc/api-client-core': link:packages/api-client-core
+    dev: true
+
+  /@gadget-client/kitchen-sink@1.4.0-development.184:
+    resolution: {integrity: sha1-i7YwY2AKf+vNQu/xQTJwEOfqors=, tarball: https://registry.gadget.dev/npm/_/tarball/97394/193776/7739}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
Adds tests for the functionality added to the react hooks in https://github.com/gadget-inc/js-clients/pull/353 that didn't have tests

## PR Checklist

- [X] Important or complicated code is tested
- [X] Any user facing changes are documented in the Gadget-side changelog
- [X] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [X] Versions within this monorepo are matching and there's a valid upgrade path
