### PR TITLE
spike(namespaces): add an operation return type to action functions t…

### DIFF
--- a/packages/api-client-core/spec/mockActions.ts
+++ b/packages/api-client-core/spec/mockActions.ts
@@ -8,6 +8,7 @@ export const MockWidgetCreateAction = {
     name: true,
   },
   operationName: "createWidget",
+  operationReturnType: "CreateWidget",
   modelApiIdentifier: "widget",
   modelSelectionField: "widget",
   variables: {
@@ -22,6 +23,7 @@ export const MockWidgetCreateAction = {
 export const MockBulkUpdateWidgetAction = {
   type: "action",
   operationName: "bulkUpdateWidgets",
+  operationReturnType: "UpdateWidget",
   namespace: null,
   modelApiIdentifier: "widget",
   modelSelectionField: "widgets",
@@ -47,6 +49,7 @@ export const MockBulkUpdateWidgetAction = {
 export const MockBulkFlipDownWidgetsAction = {
   type: "action",
   operationName: "bulkFlipDownWidgets",
+  operationReturnType: "FlipDownWidget",
   namespace: null,
   modelApiIdentifier: "widget",
   modelSelectionField: "widgets",
@@ -72,6 +75,7 @@ export const MockGlobalAction = {
   type: "globalAction",
   isBulk: false,
   operationName: "flipAllWidgets",
+  operationReturnType: "FlipAllWidgets",
   variables: {
     toState: {
       type: "String",

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -103,6 +103,7 @@ interface BulkActionWithInputs<OptionsT, VariablesT> {
 export interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, SchemaT, DefaultsT, IsBulk> {
   type: "action";
   operationName: string;
+  operationReturnType?: string;
   namespace: string | string[] | null;
   modelApiIdentifier: string;
   modelSelectionField: string;
@@ -165,6 +166,7 @@ export interface GlobalActionFunction<VariablesT> {
 
   type: "globalAction";
   operationName: string;
+  operationReturnType?: string;
   namespace: string | string[] | null;
   variables: VariablesOptions;
   variablesType: VariablesT;

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -194,17 +194,15 @@ export const backgroundActionResultOperation = <Action extends AnyActionFunction
   let fields: FieldSelection = {};
   let operationName = action.operationName;
   let resultType: string;
-  let backgroundResultType: string;
+
+  if (action.isBulk) {
+    operationName = action.operationName.replace(/^bulk/, "").replace(/s$/, "");
+  }
 
   if (!action.operationReturnType) {
-    if (action.isBulk) {
-      operationName = action.operationName.replace(/^bulk/, "").replace(/s$/, "");
-    }
     resultType = `${camelize(operationName)}Result`;
-    backgroundResultType = capitalizeIdentifier(operationName) + "BackgroundResult";
   } else {
     resultType = `${action.operationReturnType}Result`;
-    backgroundResultType = `${action.operationReturnType}BackgroundResult`;
   }
 
   switch (action.type) {
@@ -225,7 +223,7 @@ export const backgroundActionResultOperation = <Action extends AnyActionFunction
 
   const actionResultOperation: BuilderOperation = {
     type: "subscription",
-    name: backgroundResultType,
+    name: capitalizeIdentifier(operationName) + "BackgroundResult",
     fields: {
       backgroundAction: Call(
         { id: Var({ value: id, type: "String!" }) },


### PR DESCRIPTION
In order to support namespaced models, we need to provide some additional information via the api client generator. 

Previously the return type of an action was computable from it's operation name, i.e. `createWidget -> CreateWidgetResult`. 

Due to the way namespaces work, the operation name is essentially un-namespaced, however, the return type is namespaced, i..e

```
game {
   createPlayer //operationName
}

CreateGamePlayerResult //GQL Result Type
```

We previously didn't have enough information to reliably generate these types in the api client, so this introduces a way for the generation process to pass that information down. In order to make the process of deploying this change easier, I made it backwards compatible and optional, such that it follows the old logic if the new operationResultType parameter is undefined. 

Api side PR here: https://github.com/gadget-inc/gadget/pull/11442
## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
