### PR TITLE
chore(client-core): bump api client core version to 0.15.23

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.22",
+  "version": "0.15.23",
   "files": [
     "Readme.md",
     "dist/**/*"


### PR DESCRIPTION
A new version of api-client core that contains support for internal api namespacing and awaiting the result of a namespaced background action.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
