### PR TITLE
Add namespace support in react hooks

### DIFF
--- a/packages/react/src/useFindBy.ts
+++ b/packages/react/src/useFindBy.ts
@@ -56,7 +56,8 @@ export const useFindBy = <
       value,
       finder.defaultSelection,
       finder.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      finder.namespace
     );
   }, [finder, value, memoizedOptions]);
 

--- a/packages/react/src/useFindFirst.ts
+++ b/packages/react/src/useFindFirst.ts
@@ -48,7 +48,8 @@ export const useFindFirst = <
       manager.findFirst.operationName,
       manager.findFirst.defaultSelection,
       manager.findFirst.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findFirst.namespace
     );
   }, [manager, memoizedOptions]);
 

--- a/packages/react/src/useFindMany.ts
+++ b/packages/react/src/useFindMany.ts
@@ -47,7 +47,8 @@ export const useFindMany = <
       manager.findMany.operationName,
       manager.findMany.defaultSelection,
       manager.findMany.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findMany.namespace
     );
   }, [manager, memoizedOptions]);
 

--- a/packages/react/src/useFindOne.ts
+++ b/packages/react/src/useFindOne.ts
@@ -49,7 +49,8 @@ export const useFindOne = <
       id,
       manager.findOne.defaultSelection,
       manager.findOne.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findOne.namespace
     );
   }, [manager, id, memoizedOptions]);
 

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -48,7 +48,8 @@ export const useGet = <
       undefined,
       manager.get.defaultSelection,
       manager.get.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.get.namespace
     );
   }, [manager, memoizedOptions]);
 

--- a/packages/react/src/useMaybeFindFirst.ts
+++ b/packages/react/src/useMaybeFindFirst.ts
@@ -48,7 +48,8 @@ export const useMaybeFindFirst = <
       manager.findFirst.operationName,
       manager.findFirst.defaultSelection,
       manager.findFirst.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findFirst.namespace
     );
   }, [manager, memoizedOptions]);
 

--- a/packages/react/src/useMaybeFindOne.ts
+++ b/packages/react/src/useMaybeFindOne.ts
@@ -49,7 +49,8 @@ export const useMaybeFindOne = <
       id,
       manager.findOne.defaultSelection,
       manager.findOne.modelApiIdentifier,
-      memoizedOptions
+      memoizedOptions,
+      manager.findOne.namespace
     );
   }, [manager, id, memoizedOptions]);
 


### PR DESCRIPTION
This PR includes the missing namespace support in some of the react hooks.

Gadget side to test out the feature: https://github.com/gadget-inc/gadget/pull/11483

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
