### PR TITLE
fix(tiny-qql): lift field call subselect call variables

### DIFF
--- a/packages/tiny-graphql-query-compiler/spec/query.spec.ts
+++ b/packages/tiny-graphql-query-compiler/spec/query.spec.ts
@@ -203,4 +203,65 @@ describe("compiling queries", () => {
       }"
     `);
   });
+
+  test("it should compile a query with a sub field call", () => {
+    const result = compile({
+      type: "query",
+      name: "GetUsers",
+      fields: {
+        user: {
+          sub: Call(
+            { id: Var({ type: "ID" }) },
+            {
+              id: true,
+            }
+          ),
+        },
+      },
+    });
+
+    expectValidGraphQLQuery(result);
+    expect(result).toMatchInlineSnapshot(`
+      "query GetUsers($id: ID) {
+        user {
+          sub(id: $id) {
+            id
+          }
+        }
+      }"
+    `);
+  });
+
+  test("it should compile a query with a top level call and a sub field call", () => {
+    const result = compile({
+      type: "query",
+      name: "GetUsers",
+      fields: {
+        user: Call(
+          { id: Var({ type: "ID" }) },
+          {
+            id: true,
+            sub: Call(
+              { subId: Var({ type: "ID" }) },
+              {
+                id: true,
+              }
+            ),
+          }
+        ),
+      },
+    });
+
+    expectValidGraphQLQuery(result);
+    expect(result).toMatchInlineSnapshot(`
+      "query GetUsers($id: ID, $subId: ID) {
+        user(id: $id) {
+          id
+          sub(subId: $subId) {
+            id
+          }
+        }
+      }"
+    `);
+  });
 });

--- a/packages/tiny-graphql-query-compiler/src/index.ts
+++ b/packages/tiny-graphql-query-compiler/src/index.ts
@@ -59,6 +59,10 @@ const extractVariables = (fields: FieldSelection): Record<string, Variable> => {
           variables[value.name ?? nextName(name)] = value;
         }
       });
+
+      if (value.subselection) {
+        Object.assign(variables, extractVariables(value.subselection));
+      }
     } else if (typeof value === "object" && value !== null) {
       Object.assign(variables, extractVariables(value));
     }


### PR DESCRIPTION
When we compile a FieldCall, we lift the variables up to the top level query inputs.

We handle the case where this happens to a subfield, but we're not handling the case where there is a subfield in the selection of a FieldCall itself which is also a FieldCall.

In that case, we were failing to contribute the variables of the subfield call during `extractVariables`


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
