### PR TITLE
Bump tiny-gql-version to 0.2.3

### DIFF
--- a/packages/tiny-graphql-query-compiler/package.json
+++ b/packages/tiny-graphql-query-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-graphql-query-compiler",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Fixes this bug in tiny-gql-compiler's call parameters: https://github.com/gadget-inc/js-clients/pull/407/files

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
