### PR TITLE
Bump gadget react package version to 0.15.8

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "files": [
     "README.md",
     "dist/**/*"


### PR DESCRIPTION
Bumping the `@gadgetinc/react` package version for the namespace support in react hooks introduced in https://github.com/gadget-inc/js-clients/pull/400

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
