### PR TITLE
move @gadgetinc/react to peer dependency of @gadgetinc/shopify-extens…

### DIFF
--- a/packages/shopify-extensions/README.md
+++ b/packages/shopify-extensions/README.md
@@ -69,7 +69,7 @@ Within a Shopify React extension, you can use `useGadget` to access your api cli
 
 ```tsx
 import { Client } from "@gadget-client/my-app-slug";
-import { Provider } from "@gadgetinc/shopify-extensions/react";
+import { Provider, useGadget } from "@gadgetinc/shopify-extensions/react";
 import { reactExtension, useApi } from "@shopify/ui-extensions-react/customer-account";
 
 const api = new Client();

--- a/packages/shopify-extensions/package.json
+++ b/packages/shopify-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/shopify-extensions",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "files": [
     "README.md",
     "dist/**/*",
@@ -33,8 +33,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.23",
-    "@gadgetinc/react": "^0.15.8"
+    "@gadgetinc/api-client-core": "^0.15.23"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",
@@ -47,6 +46,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "@gadgetinc/react": "^0.15.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,10 +354,10 @@ importers:
       '@gadgetinc/api-client-core':
         specifier: workspace:*
         version: link:../api-client-core
+    devDependencies:
       '@gadgetinc/react':
         specifier: workspace:*
         version: link:../react
-    devDependencies:
       '@types/react':
         specifier: ^18.2.79
         version: 18.2.79


### PR DESCRIPTION
Ran into an issue with 2 react contexts when the dependency on `@gadgetinc/react` were mismatching between a top gadget app and a shopify extension. This makes `@gadgetinc/react` a peer dependency of `@gadgetinc/shopify-extensions` to avoid that situation

Since our documentation for building extensions on gadget puts the extension in the same project, we should always have one available. For extensions that are built outside of a gadget project we will need to instruct that `@gadgetinc/react` be added as a dependency as well

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
