### PR TITLE
remove the extra semicolon from the Provider component

### DIFF
--- a/packages/shopify-extensions/README.md
+++ b/packages/shopify-extensions/README.md
@@ -37,7 +37,7 @@ npm install @gadget-client/my-app-slug
 
 Full installation instructions can be found in the Gadget docs at `https://docs.gadget.dev/api/<my-app-slug>/external-api-calls/installing`.
 
-Once you have your JS client installed, you can install the React hooks library and the Shopify App bridge library with `yarn` or `npm`:
+Once you have your JS client installed, you can install this library with `yarn` or `npm`:
 
 ```
 yarn add @gadgetinc/shopify-extensions

--- a/packages/shopify-extensions/package.json
+++ b/packages/shopify-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/shopify-extensions",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "files": [
     "README.md",
     "dist/**/*",

--- a/packages/shopify-extensions/src/react/Provider.tsx
+++ b/packages/shopify-extensions/src/react/Provider.tsx
@@ -19,7 +19,7 @@ export const Provider = ({ api, sessionToken, children }: { api: AnyClient; sess
 
   return (
     <GadgetReactProvider api={api}>
-      <GadgetShopifyUIExtensionContext.Provider value={{ api, ready }}>{children}</GadgetShopifyUIExtensionContext.Provider>;
+      <GadgetShopifyUIExtensionContext.Provider value={{ api, ready }}>{children}</GadgetShopifyUIExtensionContext.Provider>
     </GadgetReactProvider>
   );
 };


### PR DESCRIPTION
Looks like an extra `;` snuck into the Provider

It haunts me. I removed all semi colons from my sample app and tried an extensions sans-Gadget just to make sure
![CleanShot 2024-05-23 at 10 35 55@2x](https://github.com/gadget-inc/js-clients/assets/20960033/79d98b67-e4a6-4038-bef4-b5a2502c160e)

Also a small docs update

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
