### PR TITLE
Prevent semantically meaningless change reporting

### DIFF
--- a/packages/api-client-core/spec/GadgetRecord.spec.ts
+++ b/packages/api-client-core/spec/GadgetRecord.spec.ts
@@ -119,6 +119,45 @@ describe("GadgetRecord", () => {
     expect(product.changes("name")).toEqual({ changed: true, current: undefined, previous: "A cool product" });
   });
 
+  it("changing a date's timezone shouldn't count as a change, as it is the same moment in time", () => {
+    const product = new GadgetRecord<{ date: Date }>({ date: new Date("2018-10-16T10:02:34+01:00") });
+    expectNoChanges(product, "date");
+
+    product.date = new Date("2018-10-16T09:02:34.000Z");
+    expect(product.changed("date")).toEqual(false);
+
+    product.date = new Date();
+    expect(product.changed("date")).toEqual(true);
+  });
+
+  it("changing a belongsTo field from a string ID to a _link object shouldn't count as a change", () => {
+    const product = new GadgetRecord<{ shop: string | { _link: string } }>({ shop: "123" });
+    expectNoChanges(product, "shop");
+
+    product.shop = { _link: "123" };
+    expect(product.changed("shop")).toEqual(false);
+
+    product.shop = { _link: "124" };
+    expect(product.changed("shop")).toEqual(true);
+
+    product.shop = { _link: "123" };
+    expect(product.changed("shop")).toEqual(false);
+  });
+
+  it("changing a belongsTo field from a _link object to an id string shouldn't count as a change", () => {
+    const product = new GadgetRecord<{ shop: string | { _link: string } }>({ shop: { _link: "123" } });
+    expectNoChanges(product, "shop");
+
+    product.shop = "123";
+    expect(product.changed("shop")).toEqual(false);
+
+    product.shop = "124";
+    expect(product.changed("shop")).toEqual(true);
+
+    product.shop = "123";
+    expect(product.changed("shop")).toEqual(false);
+  });
+
   it("should allow you to ask for changes on the entire object", () => {
     const product = new GadgetRecord<SampleBaseRecord>(productBaseRecord);
     expectNoChanges(product, "name", "body", "count");

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -407,6 +407,9 @@ export const hydrateConnection = <Shape extends RecordShape = any>(response: Res
   return hydrateRecordArray<Shape>(response, nodes);
 };
 
+const objObjType = "[object Object]";
+const stringObjType = "[object String]";
+
 export const toPrimitiveObject = (value: any): any => {
   if (value != null && typeof value.toJSON === "function") value = value.toJSON();
   if (value === undefined) return undefined;
@@ -426,7 +429,7 @@ export const toPrimitiveObject = (value: any): any => {
       return arr;
     }
     if (Object.prototype.toString.call(value) === "[object Error]") return {};
-    if (Object.prototype.toString.call(value) === "[object Object]") {
+    if (Object.prototype.toString.call(value) === objObjType) {
       const obj: any = {};
       for (const key of Object.keys(value)) {
         const parsed = toPrimitiveObject(value[key]);
@@ -491,6 +494,13 @@ const checkEquality = (a: any, b: any, refs: any[]): boolean => {
 
   // save results for circular checks
   refs.push(a, b);
+
+  // gadget-specific check for _link equality -- this is a special case for GadgetRecord
+  if (aType == objObjType && bType == stringObjType && "_link" in a && Object.keys(a).length == 1) {
+    return a._link === b;
+  } else if (bType == objObjType && aType == stringObjType && "_link" in b && Object.keys(b).length == 1) {
+    return b._link === a;
+  }
 
   if (aType != bType) return false; // not the same type of objects
 


### PR DESCRIPTION
There's a bug where GadgetRecord reports changes to fields when the object changed identity but not value. In the case of dates, this happens with assigning dates that are the same instant but from different moments in time, and in the case of BelongsTo fields, this happens when setting `record.shopId = { _link: "123" }`, when the prior value was just "123". In these instances, we change our definition of equality to ensure these are considered the same value.

For `Date` objects, this was actually already the case, so there must be another bug somewhere. I suspect what's happening Gadget side is the value is showing up on the record as a string, and so the special date comparison logic was not kicking in. This PR should fix the belongsto part of the bug for real though.

Partly fixes [GGT-6392](https://linear.app/gadget-dev/issue/GGT-6392)