### PR TITLE
useActionFormm supports rich field types like RichText, StoredFiled a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@gadget-client/full-auth": "^1.9.0",
     "@gadget-client/kitchen-sink": "1.4.0-development.184",
     "@gadget-client/related-products-example": "^1.865.0",
+    "@gadget-client/app-with-file-fields": "^1.5.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",
     "@gadget-client/zxcv-manythrough-example": "1.3.0-development.40",
     "@gadget-client/zxcv-simple-relationship": "^1.23.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/spec/apis.ts
+++ b/packages/react/spec/apis.ts
@@ -1,3 +1,4 @@
+import { Client as FileFieldClient } from "@gadget-client/app-with-file-fields";
 import { Client as NoUserClient } from "@gadget-client/app-with-no-user-model";
 import { Client as BulkClient } from "@gadget-client/bulk-actions-test";
 import { Client as AuthClient } from "@gadget-client/full-auth";
@@ -15,3 +16,4 @@ export const nestedExampleApi = new NestedClient({ environment: "Development" })
 export const simpleExampleApi = new SimpleClient({ environment: "Development" });
 export const kitchenSinkApi = new KitchenSinkClient({ environment: "Development" });
 export const hasManyThroughApi = new ManyThroughClient({ environment: "Development" });
+export const fileFieldApi = new FileFieldClient({ environment: "Development" });

--- a/packages/react/spec/useActionFormRichFields.spec.tsx
+++ b/packages/react/spec/useActionFormRichFields.spec.tsx
@@ -1,0 +1,434 @@
+import { act, renderHook } from "@testing-library/react";
+import { useActionForm } from "../src/useActionForm.js";
+import { fileFieldApi } from "./apis.js";
+import { MockClientWrapper, mockUrqlClient } from "./testWrappers.js";
+
+describe("useActionFormNFiles", () => {
+  test("can handle updating models that have a rich text field", async () => {
+    const { result } = renderHook(() => useActionForm(fileFieldApi.post.update, { findBy: "1" }), {
+      wrapper: MockClientWrapper(fileFieldApi),
+    });
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("post", {
+      data: {
+        post: {
+          __typename: "Post",
+          attachment: null,
+          body: {
+            markdown: "this is a test",
+            truncatedHTML: "<p>this is a test</p> ",
+            __typename: "RichText",
+          },
+          createdAt: "2024-05-17T01:15:14.522Z",
+          id: "1",
+          title: "test post",
+          updatedAt: "2024-05-17T01:15:14.522Z",
+        },
+        gadgetMeta: {
+          hydrations: {
+            publishedAt: "DateTime",
+            createdAt: "DateTime",
+            updatedAt: "DateTime",
+          },
+          __typename: "GadgetApplicationMeta",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current.getValues("post.title")).toBe("test post");
+    expect(result.current.getValues("post.body.markdown")).toBe("this is a test");
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("post.title", "update post");
+      (result.current as any).setValue("post.body.markdown", "this is an updated test");
+      submitPromise = result.current.submit();
+    });
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "1",
+      post: {
+        title: "update post",
+        body: {
+          markdown: "this is an updated test",
+        },
+        attachment: null,
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updatePost", {
+      data: {
+        updatePost: {
+          success: true,
+          post: {
+            __typename: "Post",
+            attachment: null,
+            body: {
+              markdown: "this is an updated test",
+              truncatedHTML: "<p>this is an updated test</p> ",
+              __typename: "RichText",
+            },
+            createdAt: "2024-05-17T01:15:14.522Z",
+            id: "1",
+            title: "update post",
+            updatedAt: "2024-05-17T01:15:14.522Z",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      await submitPromise;
+    });
+
+    expect(result.current.getValues("post.title")).toBe("update post");
+    expect(result.current.getValues("post.body.markdown")).toBe("this is an updated test");
+  });
+
+  test("can handle updating models that have a datetime field", async () => {
+    const { result } = renderHook(() => useActionForm(fileFieldApi.post.update, { findBy: "1" }), {
+      wrapper: MockClientWrapper(fileFieldApi),
+    });
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("post", {
+      data: {
+        post: {
+          __typename: "Post",
+          attachment: null,
+          body: {
+            markdown: "this is a test",
+            truncatedHTML: "<p>this is a test</p> ",
+            __typename: "RichText",
+          },
+          publishedAt: "2024-05-18T01:19:14.522Z",
+          createdAt: "2024-05-17T01:15:14.522Z",
+          id: "1",
+          title: "test post",
+          updatedAt: "2024-05-18T01:32:14.522Z",
+        },
+        gadgetMeta: {
+          hydrations: {
+            publishedAt: "DateTime",
+            createdAt: "DateTime",
+            updatedAt: "DateTime",
+          },
+          __typename: "GadgetApplicationMeta",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current.getValues("post.title")).toBe("test post");
+    expect(result.current.getValues("post.publishedAt")).toEqual(new Date("2024-05-18T01:19:14.522Z"));
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("post.title", "update post");
+      (result.current as any).setValue("post.publishedAt", new Date("2024-06-19T01:19:14.522Z"));
+      submitPromise = result.current.submit();
+    });
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "1",
+      post: {
+        title: "update post",
+        body: {
+          markdown: "this is a test",
+        },
+        publishedAt: new Date("2024-06-19T01:19:14.522Z"),
+        attachment: null,
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updatePost", {
+      data: {
+        updatePost: {
+          success: true,
+          post: {
+            __typename: "Post",
+            attachment: null,
+            body: {
+              markdown: "this is a test",
+              truncatedHTML: "<p>this is a test</p> ",
+              __typename: "RichText",
+            },
+            createdAt: "2024-05-17T01:15:14.522Z",
+            id: "1",
+            title: "update post",
+            updatedAt: "2024-05-17T01:15:14.522Z",
+            publishedAt: "2024-06-19T01:19:14.522Z",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      await submitPromise;
+    });
+
+    expect(result.current.getValues("post.title")).toBe("update post");
+    expect(result.current.getValues("post.publishedAt")).toEqual(new Date("2024-06-19T01:19:14.522Z"));
+  });
+
+  test("can handle updating models that have a datetime field as a string", async () => {
+    const { result } = renderHook(() => useActionForm(fileFieldApi.post.update, { findBy: "1" }), {
+      wrapper: MockClientWrapper(fileFieldApi),
+    });
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("post", {
+      data: {
+        post: {
+          __typename: "Post",
+          attachment: null,
+          body: {
+            markdown: "this is a test",
+            truncatedHTML: "<p>this is a test</p> ",
+            __typename: "RichText",
+          },
+          publishedAt: "2024-05-18T01:19:14.522Z",
+          createdAt: "2024-05-17T01:15:14.522Z",
+          id: "1",
+          title: "test post",
+          updatedAt: "2024-05-18T01:32:14.522Z",
+        },
+        gadgetMeta: {
+          hydrations: {
+            publishedAt: "DateTime",
+            createdAt: "DateTime",
+            updatedAt: "DateTime",
+          },
+          __typename: "GadgetApplicationMeta",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current.getValues("post.title")).toBe("test post");
+    expect(result.current.getValues("post.publishedAt")).toEqual(new Date("2024-05-18T01:19:14.522Z"));
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("post.title", "update post");
+      (result.current as any).setValue("post.publishedAt", "2024-06-19T01:19:14.522Z");
+      submitPromise = result.current.submit();
+    });
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "1",
+      post: {
+        title: "update post",
+        body: {
+          markdown: "this is a test",
+        },
+        publishedAt: "2024-06-19T01:19:14.522Z",
+        attachment: null,
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updatePost", {
+      data: {
+        updatePost: {
+          success: true,
+          post: {
+            __typename: "Post",
+            attachment: null,
+            body: {
+              markdown: "this is a test",
+              truncatedHTML: "<p>this is a test</p> ",
+              __typename: "RichText",
+            },
+            createdAt: "2024-05-17T01:15:14.522Z",
+            id: "1",
+            title: "update post",
+            updatedAt: "2024-05-17T01:15:14.522Z",
+            publishedAt: "2024-06-19T01:19:14.522Z",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      await submitPromise;
+    });
+
+    expect(result.current.getValues("post.title")).toBe("update post");
+    expect(result.current.getValues("post.publishedAt")).toEqual("2024-06-19T01:19:14.522Z");
+  });
+
+  test("can handle updating models that have a rich text field and a file field", async () => {
+    const { result } = renderHook(() => useActionForm(fileFieldApi.post.update, { findBy: "1" }), {
+      wrapper: MockClientWrapper(fileFieldApi),
+    });
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("post", {
+      data: {
+        post: {
+          __typename: "Post",
+          attachment: {
+            mimeType: "image/svg+xml",
+            url: "https://storage.gadget.dev/files/121756/243001/post/attachment/PQid412oxaygdQLifUNlD/icon.svg",
+            __typename: "StoredFile",
+          },
+          body: {
+            markdown: "example _rich_ **text**",
+            truncatedHTML: "<p>example <em>rich</em> <strong>text</strong></p> ",
+            __typename: "RichText",
+          },
+          createdAt: "2024-05-17T02:32:24.421Z",
+          id: "2",
+          title: "example value for title",
+          updatedAt: "2024-05-17T02:32:24.421Z",
+        },
+        gadgetMeta: {
+          hydrations: {
+            publishedAt: "DateTime",
+            createdAt: "DateTime",
+            updatedAt: "DateTime",
+          },
+          __typename: "GadgetApplicationMeta",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current.getValues("post.title")).toBe("example value for title");
+    expect(result.current.getValues("post.body.markdown")).toBe("example _rich_ **text**");
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("post.title", "update post");
+      (result.current as any).setValue("post.body.markdown", "this is an updated test");
+      submitPromise = result.current.submit();
+    });
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      id: "2",
+      post: {
+        title: "update post",
+        body: {
+          markdown: "this is an updated test",
+        },
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("updatePost", {
+      data: {
+        updatePost: {
+          success: true,
+          post: {
+            __typename: "Post",
+            attachment: {
+              mimeType: "image/svg+xml",
+              url: "https://storage.gadget.dev/files/121756/243001/post/attachment/PQid412oxaygdQLifUNlD/icon.svg",
+              __typename: "StoredFile",
+            },
+            body: {
+              markdown: "this is an updated test",
+              truncatedHTML: "<p>this is an updated test</p> ",
+              __typename: "RichText",
+            },
+            createdAt: "2024-05-17T01:15:14.522Z",
+            id: "1",
+            title: "update post",
+            updatedAt: "2024-05-17T01:15:14.522Z",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      await submitPromise;
+    });
+
+    expect(result.current.getValues("post.title")).toBe("update post");
+    expect(result.current.getValues("post.body.markdown")).toBe("this is an updated test");
+  });
+
+  test("can handle creating a model with a file field using the file input field", async () => {
+    const { result } = renderHook(() => useActionForm(fileFieldApi.post.create), {
+      wrapper: MockClientWrapper(fileFieldApi),
+    });
+
+    expect(mockUrqlClient.executeQuery).toBeCalledTimes(0);
+
+    let submitPromise: Promise<any>;
+
+    await act(async () => {
+      (result.current as any).setValue("post.title", "create post");
+      (result.current as any).setValue("post.body.markdown", "this is an created test");
+      (result.current as any).setValue("post.attachment.file", new File([""], "test.svg", { type: "image/svg+xml" }));
+      submitPromise = result.current.submit();
+    });
+
+    expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
+      post: {
+        title: "create post",
+        body: {
+          markdown: "this is an created test",
+        },
+        attachment: {
+          file: expect.any(File),
+        },
+      },
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("createPost", {
+      data: {
+        createPost: {
+          success: true,
+          post: {
+            __typename: "Post",
+            attachment: {
+              mimeType: "image/svg+xml",
+              url: "https://storage.gadget.dev/files/121756/243001/post/attachment/PQid412oxaygdQLifUNlD/icon.svg",
+              __typename: "StoredFile",
+            },
+            body: {
+              markdown: "this is an create test",
+              truncatedHTML: "<p>this is an created test</p> ",
+              __typename: "RichText",
+            },
+            createdAt: "2024-05-17T01:15:14.522Z",
+            id: "1",
+            title: "create post",
+            updatedAt: "2024-05-17T01:15:14.522Z",
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    await act(async () => {
+      await submitPromise;
+    });
+
+    expect(result.current.getValues("post.title")).toBe("create post");
+    expect(result.current.getValues("post.body.markdown")).toBe("this is an created test");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.15.1
         version: 0.15.3
+      '@gadget-client/app-with-file-fields':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@gadget-client/app-with-no-user-model':
         specifier: ^1.10.0
         version: 1.10.0
@@ -1291,6 +1294,12 @@ packages:
   /@eslint/js@8.57.0:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@gadget-client/app-with-file-fields@1.5.0:
+    resolution: {integrity: sha1-3VWVk3ZSxGjZowkSKaHXcHbBl2k=, tarball: https://registry.gadget.dev/npm/_/tarball/121756/243002/7983}
+    dependencies:
+      '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
   /@gadget-client/app-with-no-user-model@1.10.0:


### PR DESCRIPTION
This resolves https://linear.app/gadget-dev/issue/GGT-5349/useactionform-and-file-fields-having-issues; in addition it fixes issues I found with useActionForm and how it works with RichText fields as well as Date fields

fyi @airhorns @DevAOC @rdraward 

I think we need to do a big pass on our `useActionForm` docs soon

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
