### PR TITLE
Ensure adding more url params to a websocket endpoint correctly appends them

### DIFF
--- a/packages/api-client-core/spec/GadgetConnection.browser.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnection.browser.spec.ts
@@ -1,6 +1,9 @@
 /**
  * @jest-environment jsdom
  */
+jest.mock("graphql-ws", () => {
+  return { createClient: jest.fn(), CloseCode: { ConnectionAcknowledgementTimeout: 1, ConnectionInitialisationTimeout: 2 } };
+});
 import { AuthenticationMode, BrowserSessionStorageType, GadgetConnection, InMemoryStorage } from "../src/index.js";
 import { GadgetConnectionSharedSuite } from "./GadgetConnection-suite.js";
 import { withWindowMissingSupport } from "./helpers.js";

--- a/packages/api-client-core/spec/GadgetConnection.node.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnection.node.spec.ts
@@ -1,3 +1,6 @@
+jest.mock("graphql-ws", () => {
+  return { createClient: jest.fn(), CloseCode: { ConnectionAcknowledgementTimeout: 1, ConnectionInitialisationTimeout: 2 } };
+});
 import { AuthenticationMode, BrowserSessionStorageType, GadgetConnection, InMemoryStorage } from "../src/index.js";
 import { GadgetConnectionSharedSuite } from "./GadgetConnection-suite.js";
 

--- a/packages/api-client-core/spec/GadgetConnection.remote-ui.spec.ts
+++ b/packages/api-client-core/spec/GadgetConnection.remote-ui.spec.ts
@@ -2,6 +2,9 @@
  * @jest-environment ./spec/remote-ui-environment.ts
  */
 jest.mock("isomorphic-ws", () => null); // mimic browser environment for remote-ui where the websocket global is not available
+jest.mock("graphql-ws", () => {
+  return { createClient: jest.fn(), CloseCode: { ConnectionAcknowledgementTimeout: 1, ConnectionInitialisationTimeout: 2 } };
+});
 import { GadgetConnection } from "../src/GadgetConnection.js";
 import { GadgetConnectionSharedSuite } from "./GadgetConnection-suite.js";
 

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -13,7 +13,7 @@ import { GadgetTransaction, TransactionRolledBack } from "./GadgetTransaction.js
 import type { BrowserStorage } from "./InMemoryStorage.js";
 import { InMemoryStorage } from "./InMemoryStorage.js";
 import { operationNameExchange } from "./exchanges/operationNameExchange.js";
-import { urlParamExchange } from "./exchanges/urlParamExchange.js";
+import { addUrlParams, urlParamExchange } from "./exchanges/urlParamExchange.js";
 import {
   GadgetTooManyRequestsError,
   GadgetUnexpectedCloseError,
@@ -437,7 +437,7 @@ export class GadgetConnection {
     return client;
   }
 
-  private newSubscriptionClient(overrides: GadgetSubscriptionClientOptions) {
+  newSubscriptionClient(overrides?: GadgetSubscriptionClientOptions) {
     if (!this.websocketImplementation) {
       throw new Error(
         "Can't use this GadgetClient for this subscription-based operation as there's no global WebSocket implementation available. Please pass one as the `websocketImplementation` option to the GadgetClient constructor."
@@ -446,13 +446,7 @@ export class GadgetConnection {
 
     let url = this.websocketsEndpoint;
     if (overrides?.urlParams) {
-      const params = new URLSearchParams();
-      for (const [key, value] of Object.entries(overrides.urlParams)) {
-        if (value) {
-          params.set(key, value);
-        }
-      }
-      url += "?" + params.toString();
+      url = addUrlParams(url, overrides.urlParams);
     }
 
     return createSubscriptionClient({

--- a/packages/api-client-core/src/exchanges/urlParamExchange.ts
+++ b/packages/api-client-core/src/exchanges/urlParamExchange.ts
@@ -1,14 +1,20 @@
 import type { Exchange } from "@urql/core";
 import { mapExchange } from "@urql/core";
 
+export const addUrlParams = (url: string, paramsToAdd: Record<string, any>) => {
+  const [start, params] = url.split("?");
+  const paramsObj = new URLSearchParams(params);
+  for (const [key, value] of Object.entries(paramsToAdd)) {
+    paramsObj.set(key, value);
+  }
+  return `${start}?${paramsObj.toString()}`;
+};
+
 export const urlParamExchange: Exchange = mapExchange({
   onOperation: (operation) => {
     if (operation.context.url && operation.context.operationName) {
       try {
-        const [start, params] = operation.context.url.split("?");
-        const paramsObj = new URLSearchParams(params);
-        paramsObj.set("operation", operation.context.operationName);
-        operation.context.url = `${start}?${paramsObj.toString()}`;
+        operation.context.url = addUrlParams(operation.context.url, { operation: operation.context.operationName });
       } catch (error) {
         // not able to parse URL params, just don't add this optional param and let the rest of the system react to the invalid URL
       }


### PR DESCRIPTION
If the base websocket endpoint already had url params, the naive approach we were using before incorrectly appended `?` twice. This uses the browser builtin for adding url params that we actually already have code for to do so.
