### PR TITLE
unwind initial data in disambiguateDefaultValues to fix invalid data

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
@@ -232,13 +232,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 431,
-            "text": "[\"H4sIAAAAAAAAA4SRT2+CQBDF73yKyZxN+WMF5UbSpOmhhzbt2YzsiKQIdHdINcbv3iwgAheP+/a92d+8vTgAqEgIY7g4AADY1IqEk9L8sR5UADRNmrIxGIPohhc3mbWutFXLpigGleZxAMwVxoD+OsLFXRQ+iZWFjUCXMtAhqLHvt2EjeVVORt6HBsuRGQC3WznXXNKR7fXHLTxYrqPRU2+/uDPzzVzfo5I+2TSFdInejxmpjOWdR8UC4OGsNFkQM20m1Wz3TdomXkj4Kz/yePu+kJnhAeNry5DUdZGn7astTofp9DHkk3BpJkhYVJk94UGkNrHrZpk8FXn549oL1195obd2N+tgt/QiLwy9HZHaR1H0rPZ+QGlAKxVRj4+iKeW39pceRiyVc/0HAAD//w==\",\"AwAU/A0olAIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9R+QuEckOqVPXQQ6v2HBm8EFQC1F7URFHevTIQAlxy9Hhm/e34YgGgFCwwhosFAIBdKwVTUus/UpMKgLrLMtIaY2DV0eYmk1KNMmrdVdWkinUcAEuJMaAb7XBzF5lObGQmzTCkNAwIcu777Uhz2dSLkfehnj8zA+B+z+eWanEkc/1xC0+W62z00jsubq18K9f3rKRP0l3FQ2L0YyFkQfxOs2IB8HCWShgQvWwmU2T2TfomXgTTV3mk+fZjISvDA8bXniFp26rM+ld7nAHTGmNIJ6ZaL5CwagpzwgNzq2PbLgp+qsr6xzYXths4oRPZMvWcSDpeHvip44dSBjLI3XznBNvnMNumIz6yEhm99b/0MGKorOs/AAAA//8=\",\"AwAkbPvOlAIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 13 May 2024 18:19:47 GMT"
+              "value": "Fri, 14 Jun 2024 23:48:12 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "0ccbf2008a020e481b1364c52fe4d4c9"
+              "value": "ae1569314cfb0cfa162a1060e560edbf"
             },
             {
               "name": "x-trace-id",
-              "value": "982b3070660baadf7774df12ac2a5d7a"
+              "value": "db208d02f53b036dd5d5f1f705496c4b"
             },
             {
               "name": "strict-transport-security",
@@ -289,26 +289,34 @@
               "value": "DYNAMIC"
             },
             {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=aDsB7JZA5N7f9XVqqjHNgt2NTmwnz%2FZb4cs8Xk5b9KCghbuDQZ3yiDE2bCSk09VKCvhbtput3qtpcfjJODU1bryCxf4JtW4kL5UgMzSoDdBcfxuP3B%2Fp25ZtrNXivAEwWVOcyZecB2tuKa%2FFCafX3QsbSprFRcY4HwnVUQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "8834a89dbcd343ad-EWR"
+              "value": "893e35b97b7a5e82-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 587,
+          "headersSize": 950,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-05-13T18:19:45.985Z",
-        "time": 1274,
+        "startedDateTime": "2024-06-14T23:48:12.270Z",
+        "time": 472,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -316,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1274
+          "wait": 472
         }
       }
     ],

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -74,7 +74,8 @@ const unwindEdges = (input: any): any => {
 };
 
 export const disambiguateDefaultValues = (data: any, initialData: any, action: any) => {
-  const initialKeys = Object.keys(initialData).filter((key) => !OmittedKeys.includes(key as OmittedKey));
+  const unwindedInitialData = unwindEdges(initialData);
+  const initialKeys = Object.keys(unwindedInitialData).filter((key) => !OmittedKeys.includes(key as OmittedKey));
 
   const result = Object.fromEntries(
     Object.entries(data).flatMap(([key, value]) => {
@@ -89,7 +90,7 @@ export const disambiguateDefaultValues = (data: any, initialData: any, action: a
   const modelData = { ...data[action.modelApiIdentifier] };
 
   for (const key of Object.keys(modelData)) {
-    const initialValue = initialData[key];
+    const initialValue = unwindedInitialData[key];
 
     if (
       !!data[action.modelApiIdentifier] &&
@@ -99,7 +100,9 @@ export const disambiguateDefaultValues = (data: any, initialData: any, action: a
     ) {
       modelData[key] = data[action.modelApiIdentifier][key];
     } else if (key in data && initialValue !== data[key]) {
-      modelData[key] = data[key];
+      if (key in data && initialValue !== data[key]) {
+        modelData[key] = data[key];
+      }
     }
   }
 


### PR DESCRIPTION
This took me a lot longer than I'd like to admit to find the fix.

To summarize the issue.

If you used `useActionForm` with any update action alongside a model that had any type of `hasMany`/`hasManyThrough` relationship. And Attempted to register said relationship on a field array. A good example being: `sections` instead of  `widgets.sections`.

`reshapeDataForGraphql` could either return an invalid shape or worst would exclude the values you updated. The issue arose from `disambiguateDefaultValues` comparing against the original fetched results with edges and nodes.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
