### PR TITLE
add useFieldMetadata hook & context providers to MUI

### DIFF
--- a/packages/react/spec/auto/MockForm.tsx
+++ b/packages/react/spec/auto/MockForm.tsx
@@ -1,0 +1,31 @@
+import { AppProvider } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
+import React, { ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { AutoFormMetadataContext } from "../../src/auto/AutoFormContext.js";
+import { ActionMetadata } from "../../src/metadata.js";
+import { testApi as api } from "../apis.js";
+import { MockClientProvider } from "../testWrappers.js";
+
+export const MockForm = (saveData: () => void, metadata: ActionMetadata) => {
+  return (props: { children: ReactNode }) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const methods = useForm();
+
+    return (
+      <MockClientProvider api={api}>
+        <FormProvider {...methods}>
+          <AutoFormMetadataContext.Provider value={{ submit: saveData as any, metadata }}>
+            <AppProvider i18n={translations}>
+              {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+              <form onSubmit={methods.handleSubmit(saveData)}>
+                {props.children}
+                <button type="submit">Submit</button>
+              </form>
+            </AppProvider>
+          </AutoFormMetadataContext.Provider>
+        </FormProvider>
+      </MockClientProvider>
+    );
+  };
+};

--- a/packages/react/spec/auto/hooks/useFieldMetadata.spec.tsx
+++ b/packages/react/spec/auto/hooks/useFieldMetadata.spec.tsx
@@ -1,0 +1,114 @@
+import { renderHook } from "@testing-library/react";
+import { useFieldMetadata } from "../../../src/auto/hooks/useFieldMetadata.js";
+import { ActionMetadata } from "../../../src/metadata.js";
+import { MockForm } from "../MockForm.js";
+
+describe("useFieldMetadata hook", () => {
+  const getUseFieldMetadataResult = (fieldApiId: string) => {
+    const { result } = renderHook(() => useFieldMetadata(fieldApiId), {
+      wrapper: MockForm(jest.fn(), metadata),
+    });
+
+    return result.current;
+  };
+
+  describe("for widget create", () => {
+    test("Returns the path and field metadata when given the field api id for belongsTo fields", () => {
+      const { path, fieldMetadata } = getUseFieldMetadataResult("section");
+      expect(path).toEqual("widget.section");
+      expect(fieldMetadata).toMatchInlineSnapshot(`
+        {
+          "__typename": "GadgetModelField",
+          "apiIdentifier": "section",
+          "configuration": {
+            "__typename": "GadgetBelongsToConfig",
+            "fieldType": "BelongsTo",
+            "relatedModel": {
+              "__typename": "GadgetModel",
+              "apiIdentifier": "section",
+            },
+          },
+          "fieldType": "BelongsTo",
+          "filterable": true,
+          "name": "Section",
+          "requiredArgumentForInput": false,
+          "sortable": false,
+        }
+      `);
+    });
+
+    test("Returns the path and field metadata when given the field api id for string fields", () => {
+      const { path, fieldMetadata } = getUseFieldMetadataResult("stringField");
+      expect(path).toEqual("widget.stringField");
+      expect(fieldMetadata).toMatchInlineSnapshot(`
+        {
+          "__typename": "GadgetModelField",
+          "apiIdentifier": "stringField",
+          "configuration": {},
+          "fieldType": "String",
+          "filterable": true,
+          "name": "stringField",
+          "requiredArgumentForInput": false,
+          "sortable": false,
+        }
+      `);
+    });
+
+    test("Throws an error when given a field api id that does not exist", () => {
+      expect(() => getUseFieldMetadataResult("fakeField")).toThrowErrorMatchingInlineSnapshot(`"Field fakeField not found in metadata"`);
+    });
+  });
+});
+
+const metadata: ActionMetadata = {
+  name: "Widget",
+  action: {
+    name: "Create",
+    apiIdentifier: "create",
+    inputFields: [
+      {
+        name: "Widget",
+        apiIdentifier: "widget",
+        fieldType: "Object",
+        requiredArgumentForInput: false,
+        configuration: {
+          __typename: "GadgetObjectFieldConfig",
+          fieldType: "Object",
+          name: null,
+          fields: [
+            {
+              name: "Section",
+              apiIdentifier: "section",
+              fieldType: "BelongsTo",
+              requiredArgumentForInput: false,
+              sortable: false,
+              filterable: true,
+              __typename: "GadgetModelField",
+              configuration: {
+                __typename: "GadgetBelongsToConfig",
+                fieldType: "BelongsTo",
+                relatedModel: {
+                  apiIdentifier: "section",
+                  __typename: "GadgetModel",
+                },
+              },
+            },
+            {
+              name: "stringField",
+              apiIdentifier: "stringField",
+              fieldType: "String",
+              requiredArgumentForInput: false,
+              sortable: false,
+              filterable: true,
+              __typename: "GadgetModelField",
+              configuration: {},
+            },
+          ],
+        },
+        __typename: "GadgetObjectField",
+      },
+    ],
+    __typename: "GadgetAction",
+  },
+  __typename: "GadgetModel",
+} as ActionMetadata;

--- a/packages/react/spec/auto/inputs/PolarisBelongsToInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisBelongsToInput.spec.tsx
@@ -1,42 +1,15 @@
-import { AppProvider } from "@shopify/polaris";
-import translations from "@shopify/polaris/locales/en.json";
 import { RenderResult, act, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import React, { ReactNode } from "react";
-import { FormProvider, useForm } from "react-hook-form";
-import { AutoFormMetadataContext } from "../../../src/auto/AutoFormContext.js";
+import React from "react";
 import { PolarisBelongsToInput } from "../../../src/auto/polaris/inputs/PolarisBelongsToInput.js";
 import { ActionMetadata } from "../../../src/metadata.js";
-import { testApi as api } from "../../apis.js";
-import { MockClientProvider, mockUrqlClient } from "../../testWrappers.js";
-
-const MockForm = (saveData: () => void) => {
-  return (props: { children: ReactNode }) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const methods = useForm();
-
-    return (
-      <MockClientProvider api={api}>
-        <FormProvider {...methods}>
-          <AutoFormMetadataContext.Provider value={{ submit: saveData as any, metadata }}>
-            <AppProvider i18n={translations}>
-              {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
-              <form onSubmit={methods.handleSubmit(saveData)}>
-                {props.children}
-                <button type="submit">Submit</button>
-              </form>
-            </AppProvider>
-          </AutoFormMetadataContext.Provider>
-        </FormProvider>
-      </MockClientProvider>
-    );
-  };
-};
+import { mockUrqlClient } from "../../testWrappers.js";
+import { MockForm } from "../MockForm.js";
 
 describe("PolarisBelongsToInput", () => {
   describe("for widget create", () => {
     test("it preloads the first findMany result", async () => {
-      render(<PolarisBelongsToInput field="section" />, { wrapper: MockForm(jest.fn()) });
+      render(<PolarisBelongsToInput field="section" />, { wrapper: MockForm(jest.fn(), metadata) });
 
       expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toEqual({
         first: 25,
@@ -50,7 +23,7 @@ describe("PolarisBelongsToInput", () => {
 
       beforeEach(() => {
         mockHandleSubmit = jest.fn();
-        result = render(<PolarisBelongsToInput field="section" />, { wrapper: MockForm(mockHandleSubmit) });
+        result = render(<PolarisBelongsToInput field="section" />, { wrapper: MockForm(mockHandleSubmit, metadata) });
         mockUrqlClient.executeQuery.pushResponse("sections", sectionsQueryResponse);
       });
 

--- a/packages/react/src/auto/hooks/useFieldMetadata.tsx
+++ b/packages/react/src/auto/hooks/useFieldMetadata.tsx
@@ -1,0 +1,16 @@
+import { useFormFields } from "../AutoForm.js";
+import { useAutoFormMetadata } from "../AutoFormContext.js";
+
+export const useFieldMetadata = (fieldApiIdentifier: string) => {
+  const { metadata: autoFormMetadata } = useAutoFormMetadata();
+  const fields = useFormFields(autoFormMetadata, {});
+  const targetFieldMetadata = fields.find((field) => field[1].apiIdentifier === fieldApiIdentifier);
+
+  if (!targetFieldMetadata) {
+    throw new Error(`Field ${fieldApiIdentifier} not found in metadata`);
+  }
+  const path = targetFieldMetadata[0];
+  const fieldMetadata = targetFieldMetadata[1];
+
+  return { path, fieldMetadata };
+};

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -31,7 +31,7 @@ export const PolarisAutoForm = <
   //polaris form props also take an 'action' property, which we need to omit here.
   props: AutoFormProps<GivenOptions, SchemaT, ActionFunc, Options> & Omit<Partial<FormProps>, "action">
 ) => {
-  const { action, include: _include, exclude: _exclude, fields: _fields, submitLabel: _submitLabel, record, findBy, ...rest } = props;
+  const { action, record, findBy, ...rest } = props;
 
   // fetch metadata describing this actions inputs and outputs from the backend
   const { metadata, fetching: fetchingMetadata, error: metadataError } = useActionMetadata(action);

--- a/packages/react/src/auto/polaris/inputs/PolarisBelongsToInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisBelongsToInput.tsx
@@ -5,33 +5,22 @@ import { useController } from "react-hook-form";
 import { GadgetBelongsToConfig } from "src/internal/gql/graphql.js";
 import { useApi } from "../../../GadgetProvider.js";
 import { useFindMany } from "../../../useFindMany.js";
-import { useFormFields } from "../../AutoForm.js";
-import { useAutoFormMetadata } from "../../AutoFormContext.js";
+import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 
 export const PolarisBelongsToInput = (props: { field: string }) => {
-  const { metadata } = useAutoFormMetadata();
   const api = useApi();
-  const fields = useFormFields(metadata, {});
-
-  const fieldMetadata = fields.find((field) => field[1].apiIdentifier === props.field);
-
-  if (!fieldMetadata) {
-    throw new Error(`Field ${props.field} not found in metadata`);
-  }
-
-  const path = fieldMetadata[0];
-  const _field = fieldMetadata[1];
+  const { path, fieldMetadata } = useFieldMetadata(props.field);
 
   const {
     field: fieldProps,
     fieldState: { error: fieldError },
   } = useController({
     name: path + ".id",
-    rules: { required: _field.requiredArgumentForInput },
+    rules: { required: fieldMetadata.requiredArgumentForInput },
   });
 
   const { ref: _ref, ...field } = fieldProps;
-  const config = _field.configuration as GadgetBelongsToConfig;
+  const config = fieldMetadata.configuration as GadgetBelongsToConfig;
 
   if (!config || !config.relatedModel) {
     throw new Error(`Field ${props.field} not found in metadata`);
@@ -52,5 +41,5 @@ export const PolarisBelongsToInput = (props: { field: string }) => {
     return { label: record.name, value: record.id };
   });
 
-  return <Select label={_field.name} options={options} {...field} error={fieldError?.message} />;
+  return <Select label={fieldMetadata.name} options={options} {...field} error={fieldError?.message} />;
 };

--- a/packages/react/src/auto/polaris/inputs/PolarisHasManyInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisHasManyInput.tsx
@@ -6,30 +6,19 @@ import { useFieldArray, useFormContext } from "react-hook-form";
 import type { GadgetBelongsToConfig } from "src/internal/gql/graphql.js";
 import { useApi } from "../../../GadgetProvider.js";
 import { useFindMany } from "../../../useFindMany.js";
-import { useFormFields } from "../../AutoForm.js";
-import { useAutoFormMetadata } from "../../AutoFormContext.js";
+import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 
 export const PolarisHasManyInput = (props: { field: string }) => {
-  const { metadata } = useAutoFormMetadata();
+  const { path, fieldMetadata } = useFieldMetadata(props.field);
+
   const api = useApi();
-  const gadgetFields = useFormFields(metadata, {});
-
-  const fieldMetadata = gadgetFields.find((field) => field[1].apiIdentifier === props.field);
-
-  if (!fieldMetadata) {
-    throw new Error(`Field ${props.field} not found in metadata`);
-  }
-
-  const path = fieldMetadata[0];
-  const _field = fieldMetadata[1];
-
   const { getValues } = useFormContext();
 
   const { fields, remove, replace } = useFieldArray({
     name: path,
   });
 
-  const config = _field.configuration as GadgetBelongsToConfig;
+  const config = fieldMetadata.configuration as GadgetBelongsToConfig;
 
   if (!config || !config.relatedModel) {
     throw new Error(`Field ${props.field} not found in metadata`);
@@ -80,7 +69,7 @@ export const PolarisHasManyInput = (props: { field: string }) => {
   const textField = (
     <Autocomplete.TextField
       onChange={updateText}
-      label={_field.name}
+      label={fieldMetadata.name}
       value={inputValue}
       verticalContent={verticalContentMarkup}
       autoComplete="off"
@@ -96,7 +85,7 @@ export const PolarisHasManyInput = (props: { field: string }) => {
       onSelect={(selection) => {
         replace(selection.map((id) => ({ id: id })));
       }}
-      listTitle={_field.name}
+      listTitle={fieldMetadata.name}
     />
   );
 };


### PR DESCRIPTION
- **UPDATE**
  - Added a shared `useFieldMetadata` hook for commonly used process of turning a field api identifier into a path and field metadata
    - This PR is a small subset of https://github.com/gadget-inc/js-clients/pull/423 - If that PR is blocked, this smaller PR can be merged so that other component work can be unblocked
      - This PR before the other one or not at all

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
