### PR TITLE
Fix namespaced model not working for findBy... operation

### DIFF
--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -121,7 +121,7 @@ export const findOneByFieldRunner = <Shape extends RecordShape = any, Options ex
   throwOnEmptyData = true,
   namespace?: string | string[] | null
 ) => {
-  const plan = findOneByFieldOperation(operation, fieldName, fieldValue, defaultSelection, modelApiIdentifier, options);
+  const plan = findOneByFieldOperation(operation, fieldName, fieldValue, defaultSelection, modelApiIdentifier, options, namespace);
   const dataPath = namespaceDataPath([operation], namespace);
   const $results = modelManager.connection.currentClient.query(plan.query, plan.variables);
 


### PR DESCRIPTION
This PR fixes an issue of namespaced model not working when running `findBy...` operations like `findById` or `findBy{unique_field}`.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
