### PR TITLE
Update Shopify Polaris Icon dependency version

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,7 +70,7 @@
     "@pollyjs/core": "^6.0.6",
     "@pollyjs/persister-fs": "^6.0.6",
     "@shopify/polaris": "^12.0.0",
-    "@shopify/polaris-icons": "^7.9.0",
+    "@shopify/polaris-icons": "^8.1.0",
     "@storybook/addon-essentials": "^8.1.6",
     "@storybook/addon-interactions": "^8.1.6",
     "@storybook/addon-links": "^8.1.6",
@@ -110,7 +110,7 @@
     "@mui/x-data-grid": "^6.12.1",
     "@mui/x-date-pickers": "^6.14.0",
     "@shopify/polaris": "^11.14.0",
-    "@shopify/polaris-icons": "^7.9.0",
+    "@shopify/polaris-icons":"^8.1.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/react/src/auto/polaris/PolarisDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/PolarisDateTimePicker.tsx
@@ -1,6 +1,6 @@
 import type { DatePickerProps } from "@shopify/polaris";
 import { DatePicker, Icon, InlineStack, Popover, TextField } from "@shopify/polaris";
-import { CalendarMajor, ClockMinor } from "@shopify/polaris-icons";
+import { CalendarIcon, ClockIcon } from "@shopify/polaris-icons";
 import { format } from "date-fns";
 import { utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
 import React, { useCallback, useEffect, useState } from "react";
@@ -110,7 +110,7 @@ export const PolarisDateTimePicker = (props: {
           <TextField
             id={props.id ? `${props.id}-date` : undefined}
             label={props.dateLabel ?? "Date"}
-            prefix={<Icon source={CalendarMajor} />}
+            prefix={<Icon source={CalendarIcon} />}
             autoComplete="off"
             value={localTime ? format(localTime, "yyyy-MM-dd") : ""}
             onFocus={toggleDatePopoverActive}
@@ -134,7 +134,7 @@ export const PolarisDateTimePicker = (props: {
         <TextField
           id={props.id ? `${props.id}-time` : undefined}
           label={props.timeLabel ?? "Time"}
-          prefix={<Icon source={ClockMinor} />}
+          prefix={<Icon source={ClockIcon} />}
           autoComplete="off"
           value={timeString}
           onChange={onTimeStringChange}

--- a/packages/react/src/auto/polaris/PolarisFileInput.tsx
+++ b/packages/react/src/auto/polaris/PolarisFileInput.tsx
@@ -1,5 +1,5 @@
 import { DropZone, InlineStack, Text, Thumbnail } from "@shopify/polaris";
-import { NoteMinor } from "@shopify/polaris-icons";
+import { NoteIcon } from "@shopify/polaris-icons";
 import React, { useCallback } from "react";
 
 export interface PolarisFileInputProps {
@@ -21,7 +21,7 @@ export const PolarisFileInput = (props: PolarisFileInputProps) => {
   const fileUpload = !file && <DropZone.FileUpload />;
   const uploadedFiles = file && (
     <InlineStack>
-      <Thumbnail size="small" alt={file.name} source={validImageTypes.includes(file.type) ? window.URL.createObjectURL(file) : NoteMinor} />
+      <Thumbnail size="small" alt={file.name} source={validImageTypes.includes(file.type) ? window.URL.createObjectURL(file) : NoteIcon} />
       <div>
         {file.name}{" "}
         <Text variant="bodySm" as="p">

--- a/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
+++ b/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
@@ -1,6 +1,6 @@
 import type { AutocompleteProps } from "@shopify/polaris";
 import { Autocomplete, Icon, InlineStack, Tag } from "@shopify/polaris";
-import { SearchMinor } from "@shopify/polaris-icons";
+import { SearchIcon } from "@shopify/polaris-icons";
 import React, { useCallback, useMemo, useState } from "react";
 
 export interface EnumOption {
@@ -102,7 +102,7 @@ export const PolarisFixedOptionsCombobox = (props: PolarisFixedOptionsComboboxPr
       onChange={updateText}
       label={label}
       value={inputValue}
-      prefix={allowMultiple ? undefined : <Icon source={SearchMinor} tone="base" />}
+      prefix={allowMultiple ? undefined : <Icon source={SearchIcon} tone="base" />}
       verticalContent={verticalContentMarkup}
       placeholder="Search"
       autoComplete="off"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,8 +312,8 @@ importers:
         specifier: ^12.0.0
         version: 12.27.0(react-dom@18.2.0)(react@18.2.0)
       '@shopify/polaris-icons':
-        specifier: ^7.9.0
-        version: 7.13.0
+        specifier: ^8.1.0
+        version: 8.11.1(react@18.2.0)
       '@storybook/addon-essentials':
         specifier: ^8.1.6
         version: 8.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)
@@ -5378,11 +5378,6 @@ packages:
 
   /@shopify/app-bridge-types@0.0.7:
     resolution: {integrity: sha512-x2A86xSjBPaB4rDufkY+pGH2UK8gR/rvjeXGwttIjir1l70ELHnZj+eGzHShmBitCbVoN3fkBrDnFLZdjWqyLg==}
-    dev: true
-
-  /@shopify/polaris-icons@7.13.0:
-    resolution: {integrity: sha512-+KW2GbEDtw0WzfQlslk3Qo76lf609NvK14eBPCMCYkDP16zPfT4ydui1wRqpRPSCaW1oFOnX3A8bNpwKzOVM0Q==}
-    engines: {node: ^16.17.0 || >=18.12.0}
     dev: true
 
   /@shopify/polaris-icons@8.11.1(react@18.2.0):


### PR DESCRIPTION
- **UPDATES**
  - The Shopify Polaris icons version used here was incompatible with the default Shopify Polaris icons version used in Gadget apps. This was due to a breaking change on their end caused by renaming icons
  - References to the old icon names have been updated to the new replacement icons recommended by the Shopify docs
  - Now, in Gadget apps, there is no need to change the default shopify dependencies in the Shopify template when adding the dependencies to use autoforms 