### PR TITLE
Bump gadget react package to 0.15.12

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "files": [
     "README.md",
     "dist/**/*"


### PR DESCRIPTION
Bump the version to apply the fix from https://github.com/gadget-inc/js-clients/pull/434.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
