### PR TITLE
Bump api-client-core to 0.15.27

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.26",
+  "version": "0.15.27",
   "files": [
     "Readme.md",
     "dist/**/*"


### PR DESCRIPTION
Bumps api-client-core to 0.15.27

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
