### PR TITLE
Implement hidden input for auto component

### DIFF
--- a/packages/react/spec/auto/hooks/useFieldMetadata.spec.tsx
+++ b/packages/react/spec/auto/hooks/useFieldMetadata.spec.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { useFieldMetadata } from "../../../src/auto/hooks/useFieldMetadata.js";
-import { ActionMetadata } from "../../../src/metadata.js";
+import type { ActionMetadata } from "../../../src/metadata.js";
 import { MockForm } from "../MockForm.js";
 
 describe("useFieldMetadata hook", () => {

--- a/packages/react/spec/auto/inputs/PolarisAutoHiddenInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoHiddenInput.spec.tsx
@@ -1,0 +1,140 @@
+import { AppProvider } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
+import { act, render } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import React from "react";
+import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.js";
+import { PolarisAutoHiddenInput } from "../../../src/auto/polaris/inputs/PolarisAutoHiddenInput.js";
+import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoSubmit.js";
+import { testApi as api } from "../../apis.js";
+import { MockClientProvider, mockUrqlClient } from "../../testWrappers.js";
+import { mockWidgetFindBy } from "../support/helper.js";
+import { getWidgetModelMetadata } from "../support/widgetModel.js";
+
+const PolarisMockedProviders = (props: { children: ReactNode }) => {
+  return (
+    <MockClientProvider api={api}>
+      <AppProvider i18n={translations}>{props.children}</AppProvider>
+    </MockClientProvider>
+  );
+};
+
+describe("PolarisAutoHiddenInput", () => {
+  it("should set the value", async () => {
+    const user = userEvent.setup();
+
+    const { getByRole } = render(
+      <PolarisAutoForm action={api.widget.create}>
+        <PolarisAutoHiddenInput field="name" value="Bob" />
+        <PolarisAutoHiddenInput field="inventoryCount" value={42} />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      { wrapper: PolarisMockedProviders }
+    );
+
+    loadMockWidgetCreateMetadata();
+
+    await act(async () => {
+      await user.click(getByRole("button"));
+    });
+
+    const mutation = mockUrqlClient.executeMutation.mock.calls[0][0];
+    const mutationName = mutation.query.definitions[0].name.value;
+    const variables = mutation.variables.widget;
+
+    expect(mutationName).toEqual("createWidget");
+    expect(variables.inventoryCount).toEqual(42);
+    expect(variables.name).toEqual("Bob");
+  });
+
+  it("should override the pre-filled value", async () => {
+    const user = userEvent.setup();
+
+    const { getByRole } = render(
+      <PolarisAutoForm action={api.widget.update} findBy="42">
+        <PolarisAutoHiddenInput field="name" value="Bob" />
+        <PolarisAutoHiddenInput field="inventoryCount" value={9999} />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      { wrapper: PolarisMockedProviders }
+    );
+
+    mockUpdateWidgetFindBy();
+
+    await act(async () => {
+      await user.click(getByRole("button"));
+    });
+
+    const mutation = mockUrqlClient.executeMutation.mock.calls[0][0];
+    const mutationName = mutation.query.definitions[0].name.value;
+    const variables = mutation.variables.widget;
+    const id = mutation.variables.id;
+
+    expect(mutationName).toEqual("updateWidget");
+    expect(variables.inventoryCount).toEqual(9999);
+    // The name in the mocked data is "Alice", the value from the hidden input should override it
+    expect(variables.name).toEqual("Bob");
+    expect(id).toEqual("42");
+  });
+
+  it("the second AutoHiddenInput should override the first input when they point to the same field API identifier", async () => {
+    const user = userEvent.setup();
+
+    const { getByRole } = render(
+      <PolarisAutoForm action={api.widget.update} findBy="42">
+        <PolarisAutoHiddenInput field="name" value="Bob" />
+        <PolarisAutoHiddenInput field="name" value="Alice" />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      { wrapper: PolarisMockedProviders }
+    );
+
+    mockUpdateWidgetFindBy();
+
+    await act(async () => {
+      await user.click(getByRole("button"));
+    });
+
+    const mutation = mockUrqlClient.executeMutation.mock.calls[0][0];
+    const mutationName = mutation.query.definitions[0].name.value;
+    const variables = mutation.variables.widget;
+
+    expect(mutationName).toEqual("updateWidget");
+    expect(variables.name).toEqual("Alice");
+  });
+});
+
+function loadMockWidgetCreateMetadata() {
+  expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toEqual({
+    modelApiIdentifier: "widget",
+    modelNamespace: null,
+    action: "create",
+  });
+
+  mockUrqlClient.executeQuery.pushResponse("ModelActionMetadata", {
+    stale: false,
+    hasNext: false,
+    data: getWidgetModelMetadata({
+      name: "Create",
+      apiIdentifier: "create",
+      operatesWithRecordIdentity: false,
+    }),
+  });
+}
+
+const mockUpdateWidgetFindBy = () => {
+  mockWidgetFindBy(
+    {
+      name: "Update",
+      apiIdentifier: "update",
+      operatesWithRecordIdentity: true,
+    },
+    {
+      id: "42",
+      isChecked: true,
+      inventoryCount: 1234,
+      name: "Alice",
+    }
+  );
+};

--- a/packages/react/spec/auto/inputs/PolarisBooleanIput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisBooleanIput.spec.tsx
@@ -6,8 +6,8 @@ import React from "react";
 import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.js";
 import { PolarisBooleanInput } from "../../../src/auto/polaris/inputs/PolarisBooleanInput.js";
 import { testApi as api } from "../../apis.js";
-import { MockClientProvider, mockUrqlClient } from "../../testWrappers.js";
-import { getWidgetModelMetadata, getWidgetRecord } from "../support/widgetModel.js";
+import { MockClientProvider } from "../../testWrappers.js";
+import { mockWidgetFindBy } from "../support/helper.js";
 
 const PolarisMockedProviders = (props: { children: ReactNode }) => {
   return (
@@ -20,7 +20,7 @@ const PolarisMockedProviders = (props: { children: ReactNode }) => {
 describe("PolarisBooleanInput", () => {
   it("should automatically set the pre-filled value when the form is pre-filled", async () => {
     const { getByLabelText } = render(<PolarisAutoForm action={api.widget.create} findBy="42" />, { wrapper: PolarisMockedProviders });
-    mockWidgetFindBy();
+    mockUpdateWidgetFindBy();
     const checkbox = getByLabelText("Is checked");
     expect(checkbox).toBeChecked();
   });
@@ -32,28 +32,21 @@ describe("PolarisBooleanInput", () => {
       </PolarisAutoForm>,
       { wrapper: PolarisMockedProviders }
     );
-    mockWidgetFindBy();
+    mockUpdateWidgetFindBy();
     const checkbox = getByLabelText("I agree to do something");
     expect(checkbox).toBeChecked();
   });
 });
 
-const mockWidgetFindBy = () => {
-  mockUrqlClient.executeQuery.pushResponse("ModelActionMetadata", {
-    stale: false,
-    hasNext: false,
-    data: getWidgetModelMetadata({
+const mockUpdateWidgetFindBy = () => {
+  mockWidgetFindBy(
+    {
       name: "Update",
       apiIdentifier: "update",
       operatesWithRecordIdentity: true,
-    }),
-  });
-
-  mockUrqlClient.executeQuery.pushResponse("widget", {
-    stale: false,
-    hasNext: false,
-    data: getWidgetRecord({
+    },
+    {
       isChecked: true,
-    }),
-  });
+    }
+  );
 };

--- a/packages/react/spec/auto/support/helper.ts
+++ b/packages/react/spec/auto/support/helper.ts
@@ -1,0 +1,22 @@
+import { mockUrqlClient } from "../../testWrappers.js";
+import { getWidgetModelMetadata, getWidgetRecord } from "./widgetModel.js";
+
+/**
+ * Helper function to mock the response of a typical form operation with an "update" action.
+ */
+export const mockWidgetFindBy = (
+  action: Parameters<typeof getWidgetModelMetadata>[0],
+  overridesRecord?: Parameters<typeof getWidgetRecord>[0]
+) => {
+  mockUrqlClient.executeQuery.pushResponse("ModelActionMetadata", {
+    stale: false,
+    hasNext: false,
+    data: getWidgetModelMetadata(action),
+  });
+
+  mockUrqlClient.executeQuery.pushResponse("widget", {
+    stale: false,
+    hasNext: false,
+    data: getWidgetRecord(overridesRecord),
+  });
+};

--- a/packages/react/spec/auto/support/widgetModel.ts
+++ b/packages/react/spec/auto/support/widgetModel.ts
@@ -279,11 +279,17 @@ export const getWidgetModelMetadata = (
   };
 };
 
-export const getWidgetRecord = (overrides?: { id?: string; isChecked?: boolean }) => {
+export const getWidgetRecord = (overrides?: { id?: string; isChecked?: boolean; inventoryCount?: number; name?: string }) => {
+  // Default values
+  const isChecked = overrides?.isChecked ?? null;
+  const inventoryCount = overrides?.inventoryCount ?? 1234;
+  const name = overrides?.name ?? "Widget";
+  const id = overrides?.id ?? "1145";
+
   return {
     widget: {
       __typename: "Widget",
-      id: overrides?.id ?? "1145",
+      id,
       anything: {
         key: "value",
         example: true,
@@ -299,11 +305,11 @@ export const getWidgetRecord = (overrides?: { id?: string; isChecked?: boolean }
       },
       embedding: null,
       inStock: true,
-      inventoryCount: 1234,
-      isChecked: overrides?.isChecked ?? null,
+      inventoryCount,
+      isChecked,
       metafields: null,
       mustBeLongString: null,
-      name: "updated test record",
+      name,
       roles: [],
       secretKey: null,
       startsAt: null,

--- a/packages/react/src/auto/hooks/useHiddenInput.tsx
+++ b/packages/react/src/auto/hooks/useHiddenInput.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import { useFieldMetadata } from "./useFieldMetadata.js";
+
+export const useHiddenInput = (props: { field: string; value: any }) => {
+  const { field, value } = props;
+  const { path, metadata } = useFieldMetadata(field);
+  const form = useFormContext();
+
+  useEffect(() => {
+    form.setValue(path, value);
+  }, [form, path, value]);
+
+  return {
+    value,
+    name: metadata.name,
+  };
+};

--- a/packages/react/src/auto/mui/index.ts
+++ b/packages/react/src/auto/mui/index.ts
@@ -1,4 +1,8 @@
 export * from "./MUIAutoForm.js";
 export { MUIAutoForm as AutoForm } from "./MUIAutoForm.js";
+export { MUIAutoHiddenInput as AutoHiddenInput } from "./inputs/MUIAutoHiddenInput.js";
 export { MUIAutoInput as AutoInput } from "./inputs/MUIAutoInput.js";
 export { MUIAutoTextInput as AutoTextInput } from "./inputs/MUIAutoTextInput.js";
+export { MUIBooleanInput as AutoBooleanInput } from "./inputs/MUIBooleanInput.js";
+export { MUIAutoSubmit as AutoSubmit } from "./submit/MUIAutoSubmit.js";
+export { MUISubmitResultBanner as SubmitResultBanner } from "./submit/MUISubmitResultBanner.js";

--- a/packages/react/src/auto/mui/inputs/MUIAutoHiddenInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoHiddenInput.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { useHiddenInput } from "../../hooks/useHiddenInput.js";
+
+export const MUIAutoHiddenInput = (props: {
+  field: string; // The field API identifier
+  value: any;
+}) => {
+  const fieldProps = useHiddenInput(props);
+
+  return <input type="hidden" {...fieldProps} />;
+};

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -1,5 +1,6 @@
 export * from "./PolarisAutoForm.js";
 export { PolarisAutoForm as AutoForm } from "./PolarisAutoForm.js";
+export { PolarisAutoHiddenInput as AutoHiddenInput } from "./inputs/PolarisAutoHiddenInput.js";
 export { PolarisAutoInput as AutoInput } from "./inputs/PolarisAutoInput.js";
 export { PolarisAutoTextInput as AutoTextInput } from "./inputs/PolarisAutoTextInput.js";
 export { PolarisBooleanInput as AutoBooleanInput } from "./inputs/PolarisBooleanInput.js";

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoHiddenInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoHiddenInput.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { useHiddenInput } from "../../hooks/useHiddenInput.js";
+
+export const PolarisAutoHiddenInput = (props: {
+  field: string; // The field API identifier
+  value: any;
+}) => {
+  const fieldProps = useHiddenInput(props);
+
+  return <input type="hidden" {...fieldProps} />;
+};


### PR DESCRIPTION
This PR introduces `AutoHiddenInput` for the auto component. Underneath is a `<input type="hidden">` for users to debug the value in a browser development tool.

<img width="413" alt="CleanShot 2024-06-26 at 18 07 19@2x" src="https://github.com/gadget-inc/js-clients/assets/34646302/5de69fc8-002c-4eb7-b08f-67423bac64d5">


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
