### PR TITLE
Exclude non-dirty fields when submitting an AutoForm

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -9,6 +9,7 @@ import { PolarisAutoInput } from "../../src/auto/polaris/inputs/PolarisAutoInput
 import { PolarisAutoSubmit } from "../../src/auto/polaris/submit/PolarisAutoSubmit.js";
 import { testApi as api } from "../apis.js";
 import { MockClientProvider, mockUrqlClient } from "../testWrappers.js";
+import { getGizmoModelMetadata } from "./support/gizmoModel.js";
 import { getWidgetModelMetadata, getWidgetRecord } from "./support/widgetModel.js";
 
 const PolarisMockedProviders = (props: { children: ReactNode }) => {
@@ -135,7 +136,148 @@ describe("PolarisAutoForm", () => {
       });
     });
   });
+
+  describe("dirty fields", () => {
+    test("it should not include fields that are not dirty when submitting a form", async () => {
+      const user = userEvent.setup();
+
+      const { getByRole, getByLabelText } = render(<PolarisAutoForm action={api.gizmo.create} exclude={["widget"]} />, {
+        wrapper: PolarisMockedProviders,
+      });
+
+      loadMockGizmoCreateMetadata();
+
+      const submitButton = getByRole("button");
+      expect(submitButton).toHaveTextContent("Submit");
+
+      // Inside the "gizmo" model, there are two fields: "Name" and "Orientation", both are not required.
+      // We first modify the "Name" field and submit the form to ensure that only the "Name" field is included in the mutation.
+
+      await act(async () => {
+        const nameElement = getByLabelText("Name");
+        await user.clear(nameElement);
+        await user.click(nameElement);
+        await user.keyboard("updated test record");
+
+        await user.click(getByRole("button"));
+      });
+
+      let mutation = mockUrqlClient.executeMutation.mock.calls[0][0];
+      let mutationName = mutation.query.definitions[0].name.value;
+      let variables = mutation.variables.gizmo;
+
+      expect(mutationName).toEqual("createGizmo");
+      expect(variables).toEqual({
+        name: "updated test record",
+      });
+
+      // Now modify the other field and submit again to ensure that the other field is also included.
+
+      await act(async () => {
+        const nameElement = getByLabelText("Orientation");
+        await user.clear(nameElement);
+        await user.click(nameElement);
+        await user.keyboard("updated another test record");
+
+        await user.click(getByRole("button"));
+      });
+
+      mutation = mockUrqlClient.executeMutation.mock.calls[1][0];
+      mutationName = mutation.query.definitions[0].name.value;
+      variables = mutation.variables.gizmo;
+
+      expect(mutationName).toEqual("createGizmo");
+      expect(variables).toEqual({
+        name: "updated test record",
+        orientation: "updated another test record",
+      });
+    });
+
+    test("it should not include fields that are not dirty when submitting a form that updates a record", async () => {
+      const user = userEvent.setup();
+
+      const { getByRole, getByLabelText } = render(<PolarisAutoForm action={api.widget.update} exclude={["gizmos"]} findBy="1145" />, {
+        wrapper: PolarisMockedProviders,
+      });
+
+      loadMockWidgetUpdateMetadata();
+
+      const submitButton = getByRole("button");
+      expect(submitButton).toHaveTextContent("Submit");
+
+      await act(async () => {
+        const inventoryCountElement = getByLabelText("Inventory count");
+        await user.clear(inventoryCountElement);
+        await user.click(inventoryCountElement);
+        // The fetched record has an inventory count of 42. We will update it to 1234.
+        await user.keyboard("1234");
+
+        await user.click(getByRole("button"));
+      });
+
+      const mutation = mockUrqlClient.executeMutation.mock.calls[0][0];
+      const mutationName = mutation.query.definitions[0].name.value;
+      const variables = mutation.variables.widget;
+      const recordId = mutation.variables.id;
+
+      expect(mutationName).toEqual("updateWidget");
+      // Since we only modified the inventory count field, only that field should be included in the mutation.
+      expect(variables).toEqual({
+        inventoryCount: 1234,
+      });
+      expect(recordId).toEqual("1145");
+    });
+
+    test("it should still count as a dirty field when the field has typed something then cleared", async () => {
+      const user = userEvent.setup();
+
+      const { getByRole, getByLabelText } = render(<PolarisAutoForm action={api.gizmo.create} exclude={["widget"]} />, {
+        wrapper: PolarisMockedProviders,
+      });
+
+      loadMockGizmoCreateMetadata();
+
+      const submitButton = getByRole("button");
+      expect(submitButton).toHaveTextContent("Submit");
+
+      await act(async () => {
+        const nameElement = getByLabelText("Name");
+        await user.click(nameElement);
+        await user.keyboard("updated test record");
+        await user.clear(nameElement);
+
+        await user.click(getByRole("button"));
+      });
+
+      const mutation = mockUrqlClient.executeMutation.mock.calls[0][0];
+      const mutationName = mutation.query.definitions[0].name.value;
+      const variables = mutation.variables.gizmo;
+
+      expect(mutationName).toEqual("createGizmo");
+      expect(variables).toEqual({
+        name: "",
+      });
+    });
+  });
 });
+
+function loadMockGizmoCreateMetadata() {
+  expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toEqual({
+    modelApiIdentifier: "gizmo",
+    modelNamespace: null,
+    action: "create",
+  });
+
+  mockUrqlClient.executeQuery.pushResponse("ModelActionMetadata", {
+    stale: false,
+    hasNext: false,
+    data: getGizmoModelMetadata({
+      name: "Create",
+      apiIdentifier: "create",
+      operatesWithRecordIdentity: false,
+    }),
+  });
+}
 
 function loadMockWidgetCreateMetadata() {
   expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toEqual({
@@ -165,7 +307,10 @@ function loadMockWidgetUpdateMetadata() {
   mockUrqlClient.executeQuery.pushResponse("widget", {
     stale: false,
     hasNext: false,
-    data: getWidgetRecord(),
+    data: getWidgetRecord({
+      name: "Test Widget",
+      inventoryCount: 42,
+    }),
   });
 
   mockUrqlClient.executeQuery.pushResponse("ModelActionMetadata", {

--- a/packages/react/spec/auto/inputs/PolarisAutoHiddenInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoHiddenInput.spec.tsx
@@ -134,7 +134,7 @@ const mockUpdateWidgetFindBy = () => {
       id: "42",
       isChecked: true,
       inventoryCount: 1234,
-      name: "Alice",
+      name: "Foo",
     }
   );
 };

--- a/packages/react/spec/auto/support/gizmoModel.ts
+++ b/packages/react/spec/auto/support/gizmoModel.ts
@@ -1,0 +1,95 @@
+import { recordIdInputField } from "./shared.js";
+
+export const gizmoModelInputFields = {
+  name: "Gizmo",
+  apiIdentifier: "gizmo",
+  fieldType: "Object",
+  requiredArgumentForInput: false,
+  configuration: {
+    __typename: "GadgetObjectFieldConfig",
+    fieldType: "Object",
+    name: null,
+    fields: [
+      {
+        name: "Widget",
+        apiIdentifier: "widget",
+        fieldType: "BelongsTo",
+        requiredArgumentForInput: false,
+        sortable: false,
+        filterable: true,
+        configuration: {
+          __typename: "GadgetBelongsToConfig",
+          fieldType: "BelongsTo",
+          relatedModel: {
+            apiIdentifier: "widget",
+            namespace: [],
+          },
+        },
+      },
+      {
+        name: "Name",
+        apiIdentifier: "name",
+        fieldType: "String",
+        requiredArgumentForInput: false,
+        sortable: true,
+        filterable: true,
+        configuration: {
+          __typename: "GadgetGenericFieldConfig",
+          fieldType: "String",
+        },
+      },
+      {
+        name: "Orientation",
+        apiIdentifier: "orientation",
+        fieldType: "String",
+        requiredArgumentForInput: false,
+        sortable: true,
+        filterable: true,
+        configuration: {
+          __typename: "GadgetGenericFieldConfig",
+          fieldType: "String",
+        },
+      },
+    ],
+  },
+};
+
+export const getGizmoModelMetadata = (
+  action: { name: string; apiIdentifier: string; operatesWithRecordIdentity: boolean },
+  inputFields = [gizmoModelInputFields]
+) => {
+  return {
+    gadgetMeta: {
+      model: {
+        name: "Widget",
+        action: {
+          ...action,
+          inputFields: action.operatesWithRecordIdentity ? [recordIdInputField, ...inputFields] : inputFields,
+          __typename: "GadgetAction",
+        },
+        __typename: "GadgetModel",
+      },
+      __typename: "GadgetApplicationMeta",
+    },
+  };
+};
+
+export const getGizmoRecord = () => {
+  return {
+    gizmo: {
+      __typename: "Gizmo",
+      id: "1088",
+      createdAt: "2023-09-07T19:18:50.742Z",
+      name: "gizmo 0",
+      orientation: "right side up",
+      updatedAt: "2023-09-07T19:18:50.742Z",
+    },
+    gadgetMeta: {
+      hydrations: {
+        updatedAt: "DateTime",
+        createdAt: "DateTime",
+      },
+      __typename: "GadgetApplicationMeta",
+    },
+  };
+};

--- a/packages/react/spec/auto/support/shared.ts
+++ b/packages/react/spec/auto/support/shared.ts
@@ -1,0 +1,11 @@
+export const recordIdInputField = {
+  name: "Id",
+  apiIdentifier: "id",
+  fieldType: "ID",
+  requiredArgumentForInput: true,
+  configuration: {
+    __typename: "GadgetGenericFieldConfig",
+    fieldType: "ID",
+  },
+  __typename: "GadgetObjectField",
+};

--- a/packages/react/spec/auto/support/widgetModel.ts
+++ b/packages/react/spec/auto/support/widgetModel.ts
@@ -1,3 +1,5 @@
+import { recordIdInputField } from "./shared.js";
+
 export const widgetModelInputFields = {
   name: "Widget",
   apiIdentifier: "widget",
@@ -247,18 +249,6 @@ export const widgetModelInputFields = {
   __typename: "GadgetObjectField",
 };
 
-export const recordIdInputField = {
-  name: "Id",
-  apiIdentifier: "id",
-  fieldType: "ID",
-  requiredArgumentForInput: true,
-  configuration: {
-    __typename: "GadgetGenericFieldConfig",
-    fieldType: "ID",
-  },
-  __typename: "GadgetObjectField",
-};
-
 export const getWidgetModelMetadata = (
   action: { name: string; apiIdentifier: string; operatesWithRecordIdentity: boolean },
   inputFields = [widgetModelInputFields]
@@ -283,7 +273,7 @@ export const getWidgetRecord = (overrides?: { id?: string; isChecked?: boolean; 
   // Default values
   const isChecked = overrides?.isChecked ?? null;
   const inventoryCount = overrides?.inventoryCount ?? 1234;
-  const name = overrides?.name ?? "Widget";
+  const name = overrides?.name ?? "Widget 1";
   const id = overrides?.id ?? "1145";
 
   return {

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -7,7 +7,7 @@ import type { GadgetObjectFieldConfig } from "../internal/gql/graphql.js";
 import type { ActionMetadata, FieldMetadata } from "../metadata.js";
 import { filterFieldList, useActionMetadata } from "../metadata.js";
 import { useActionForm } from "../useActionForm.js";
-import type { OptionsType } from "../utils.js";
+import { get, type OptionsType } from "../utils.js";
 import { validationSchema } from "../validationSchema.js";
 
 /** The props that any <AutoForm/> component accepts */
@@ -103,7 +103,7 @@ export const useAutoForm = <
   const {
     submit,
     error: formError,
-    formState: { isSubmitSuccessful, isLoading },
+    formState: { isSubmitSuccessful, isLoading, dirtyFields },
     originalFormMethods,
   } = useActionForm(action, {
     defaultValues: {
@@ -112,7 +112,19 @@ export const useAutoForm = <
     },
     findBy,
     resolver: useValidationResolver(metadata),
-    send: [...fields.map(({ path }) => path), operatesWithRecordId ? "id" : undefined].filter((item) => !!item) as string[],
+    send: () => {
+      const fieldsToSend = fields
+        .map(({ path }) => path)
+        .filter((item) => {
+          const isDirty = get(dirtyFields, item);
+          return isDirty;
+        });
+
+      if (operatesWithRecordId) {
+        fieldsToSend.push("id");
+      }
+      return fieldsToSend;
+    },
   });
 
   return {

--- a/packages/react/src/auto/hooks/useHiddenInput.tsx
+++ b/packages/react/src/auto/hooks/useHiddenInput.tsx
@@ -5,11 +5,13 @@ import { useFieldMetadata } from "./useFieldMetadata.js";
 export const useHiddenInput = (props: { field: string; value: any }) => {
   const { field, value } = props;
   const { path, metadata } = useFieldMetadata(field);
-  const form = useFormContext();
+  const { setValue, formState } = useFormContext();
 
   useEffect(() => {
-    form.setValue(path, value);
-  }, [form, path, value]);
+    setValue(path, value, {
+      shouldDirty: true,
+    });
+  }, [formState.defaultValues, path, setValue, value]);
 
   return {
     value,

--- a/packages/react/src/internal/gql/graphql.ts
+++ b/packages/react/src/internal/gql/graphql.ts
@@ -1347,6 +1347,15 @@ export type GadgetHasManyConfig = GadgetFieldConfigInterface & {
   relatedModelKey?: Maybe<Scalars["String"]["output"]>;
 };
 
+export type GadgetHasOneConfig = GadgetFieldConfigInterface & {
+  __typename?: "GadgetHasOneConfig";
+  fieldType: GadgetFieldType;
+  isConfigured: Scalars["Boolean"]["output"];
+  isInverseConfigured: Scalars["Boolean"]["output"];
+  relatedModel?: Maybe<GadgetModel>;
+  relatedModelKey?: Maybe<Scalars["String"]["output"]>;
+};
+
 export type GadgetModel = {
   __typename?: "GadgetModel";
   action?: Maybe<GadgetAction>;
@@ -1854,6 +1863,10 @@ export type GizmoSort = {
   orientation?: InputMaybe<SortOrder>;
   /** Sort the results by the updatedAt field. Defaults to ascending (smallest value first). */
   updatedAt?: InputMaybe<SortOrder>;
+};
+
+export type IdEqualsFilter = {
+  equals?: InputMaybe<Scalars["GadgetID"]["input"]>;
 };
 
 export type IdFilter = {
@@ -2602,6 +2615,10 @@ export type InternalMutationsDeleteManySectionArgs = {
   search?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+export type InternalMutationsDeleteManySessionArgs = {
+  filter?: InputMaybe<Array<SessionFilter>>;
+};
+
 export type InternalMutationsDeleteManyUserArgs = {
   filter?: InputMaybe<Array<UserFilter>>;
   search?: InputMaybe<Scalars["String"]["input"]>;
@@ -2853,6 +2870,7 @@ export type InternalQueriesListSectionArgs = {
 export type InternalQueriesListSessionArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>;
   before?: InputMaybe<Scalars["String"]["input"]>;
+  filter?: InputMaybe<Array<SessionFilter>>;
   first?: InputMaybe<Scalars["Int"]["input"]>;
   last?: InputMaybe<Scalars["Int"]["input"]>;
   select?: InputMaybe<Array<Scalars["String"]["input"]>>;
@@ -3608,6 +3626,7 @@ export type QuerySessionArgs = {
 export type QuerySessionsArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>;
   before?: InputMaybe<Scalars["String"]["input"]>;
+  filter?: InputMaybe<Array<SessionFilter>>;
   first?: InputMaybe<Scalars["Int"]["input"]>;
   last?: InputMaybe<Scalars["Int"]["input"]>;
 };
@@ -3792,6 +3811,12 @@ export type SessionEdge = {
   cursor: Scalars["String"]["output"];
   /** The item at the end of the edge */
   node: Session;
+};
+
+export type SessionFilter = {
+  id?: InputMaybe<IdEqualsFilter>;
+  user?: InputMaybe<IdEqualsFilter>;
+  userId?: InputMaybe<IdEqualsFilter>;
 };
 
 export type SignInUserResult = {
@@ -4280,6 +4305,7 @@ type FieldMetadata_GadgetModelField_Fragment = {
         fieldType: GadgetFieldType;
         relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
       }
+    | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
     | { __typename: "GadgetObjectFieldConfig"; fieldType: GadgetFieldType };
 };
 
@@ -4308,6 +4334,7 @@ type FieldMetadata_GadgetObjectField_Fragment = {
         fieldType: GadgetFieldType;
         relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
       }
+    | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
     | { __typename: "GadgetObjectFieldConfig"; fieldType: GadgetFieldType };
 };
 
@@ -4354,6 +4381,7 @@ export type GetModelMetadataQuery = {
               fieldType: GadgetFieldType;
               relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
             }
+          | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
           | { __typename: "GadgetObjectFieldConfig"; fieldType: GadgetFieldType };
       }>;
     } | null;
@@ -4368,6 +4396,7 @@ type SubFields_GadgetModelField_Fragment = {
     | { __typename: "GadgetEnumConfig" }
     | { __typename: "GadgetGenericFieldConfig" }
     | { __typename: "GadgetHasManyConfig" }
+    | { __typename: "GadgetHasOneConfig" }
     | {
         __typename: "GadgetObjectFieldConfig";
         name?: string | null;
@@ -4398,6 +4427,7 @@ type SubFields_GadgetModelField_Fragment = {
                 fieldType: GadgetFieldType;
                 relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
               }
+            | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
             | {
                 __typename: "GadgetObjectFieldConfig";
                 name?: string | null;
@@ -4429,6 +4459,7 @@ type SubFields_GadgetModelField_Fragment = {
                         fieldType: GadgetFieldType;
                         relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
                       }
+                    | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
                     | {
                         __typename: "GadgetObjectFieldConfig";
                         name?: string | null;
@@ -4468,6 +4499,7 @@ type SubFields_GadgetModelField_Fragment = {
                                   namespace?: Array<string> | null;
                                 } | null;
                               }
+                            | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
                             | { __typename: "GadgetObjectFieldConfig"; fieldType: GadgetFieldType };
                         }>;
                       };
@@ -4485,6 +4517,7 @@ type SubFields_GadgetObjectField_Fragment = {
     | { __typename: "GadgetEnumConfig" }
     | { __typename: "GadgetGenericFieldConfig" }
     | { __typename: "GadgetHasManyConfig" }
+    | { __typename: "GadgetHasOneConfig" }
     | {
         __typename: "GadgetObjectFieldConfig";
         name?: string | null;
@@ -4515,6 +4548,7 @@ type SubFields_GadgetObjectField_Fragment = {
                 fieldType: GadgetFieldType;
                 relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
               }
+            | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
             | {
                 __typename: "GadgetObjectFieldConfig";
                 name?: string | null;
@@ -4546,6 +4580,7 @@ type SubFields_GadgetObjectField_Fragment = {
                         fieldType: GadgetFieldType;
                         relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
                       }
+                    | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
                     | {
                         __typename: "GadgetObjectFieldConfig";
                         name?: string | null;
@@ -4585,6 +4620,7 @@ type SubFields_GadgetObjectField_Fragment = {
                                   namespace?: Array<string> | null;
                                 } | null;
                               }
+                            | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
                             | { __typename: "GadgetObjectFieldConfig"; fieldType: GadgetFieldType };
                         }>;
                       };
@@ -4639,6 +4675,7 @@ export type ModelActionMetadataQuery = {
                 fieldType: GadgetFieldType;
                 relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
               }
+            | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
             | {
                 __typename: "GadgetObjectFieldConfig";
                 name?: string | null;
@@ -4670,6 +4707,7 @@ export type ModelActionMetadataQuery = {
                         fieldType: GadgetFieldType;
                         relatedModel?: { __typename?: "GadgetModel"; apiIdentifier: string; namespace?: Array<string> | null } | null;
                       }
+                    | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
                     | {
                         __typename: "GadgetObjectFieldConfig";
                         name?: string | null;
@@ -4709,6 +4747,7 @@ export type ModelActionMetadataQuery = {
                                   namespace?: Array<string> | null;
                                 } | null;
                               }
+                            | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
                             | {
                                 __typename: "GadgetObjectFieldConfig";
                                 name?: string | null;
@@ -4748,6 +4787,7 @@ export type ModelActionMetadataQuery = {
                                           namespace?: Array<string> | null;
                                         } | null;
                                       }
+                                    | { __typename: "GadgetHasOneConfig"; fieldType: GadgetFieldType }
                                     | { __typename: "GadgetObjectFieldConfig"; fieldType: GadgetFieldType };
                                 }>;
                               };

--- a/packages/react/src/useActionForm.ts
+++ b/packages/react/src/useActionForm.ts
@@ -60,8 +60,9 @@ export const useActionForm = <
     select?: ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> ? ActionFunc["optionsType"]["select"] : never;
     /**
      * Which fields to send from the form's values when sending it from the backend.
+     * It can be a list of field API identifiers, or a function that returns a list of field API identifiers.
      */
-    send?: string[];
+    send?: string[] | (() => string[]);
     /**
      * Called when the form submits
      */
@@ -190,7 +191,7 @@ export const useActionForm = <
           if (options?.send) {
             const unmasked = variables;
             variables = {};
-            for (const key of options.send) {
+            for (const key of typeof options.send === "function" ? options.send() : options.send) {
               set(variables, key, get(unmasked, key));
             }
           }


### PR DESCRIPTION
This PR excludes model fields that are not "dirty" when submitting the form. In the react-hook-form standard, a "dirty field" is a field the user has modified.

Previously, when the field was not dirty, its value was `null`. However, there is a semantic difference between `undefined` and `null`. If the field has a default value set in the Gadget editor and is not required, the backend cannot apply the default value to it.

By only including the dirty fields in the action parameters, excluded fields are considered `undefined`, and the backend can apply the default value to them.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
