### PR TITLE
Add support for an install state hint passed from the server side to the client that allows the provider to fast-path

### DIFF
--- a/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
+++ b/packages/react-shopify-app-bridge/spec/Provider.spec.tsx
@@ -10,18 +10,63 @@ import { AppType, Provider } from "../src/Provider.js";
 
 describe("GadgetProvider", () => {
   let mockApiClient: AnyClient;
-  const { location } = window;
   const mockNavigate = jest.fn();
   const mockOpen = jest.fn();
   const mockApiKey = "some-api-key";
   let useAppBridgeMock: jest.SpyInstance;
   let resolveIdToken: (value: string) => void;
 
-  describe.each([true, false])("as install request: %s", (isInstallRequest) => {
-    beforeAll(() => {
-      // @ts-expect-error mock
-      delete window.location;
+  beforeEach(() => {
+    // @ts-expect-error mock
+    delete window.location;
 
+    delete window.gadgetConfig;
+
+    window.open = mockOpen;
+
+    // @ts-expect-error mock
+    window.location = {
+      assign: mockNavigate,
+      origin: "https://test-app.gadget.app",
+      pathname: "/",
+      search: "",
+    };
+
+    window.shopify = {
+      // @ts-expect-error mock
+      environment: {
+        embedded: false,
+        mobile: false,
+      },
+      config: {
+        apiKey: mockApiKey,
+        shop: "example.myshopify.com",
+        locale: "en",
+      },
+      idToken: () =>
+        new Promise((resolve) => {
+          resolveIdToken = resolve;
+        }),
+    };
+
+    useAppBridgeMock = jest.spyOn(AppBridgeReact, "useAppBridge").mockImplementation(() => window.shopify);
+
+    mockApiClient = {
+      connection: new GadgetConnection({
+        endpoint: "https://test-app.gadget.app/endpoint",
+      }),
+    } as any;
+
+    jest.spyOn(mockApiClient.connection, "currentClient", "get").mockReturnValue(mockUrqlClient);
+  });
+
+  afterEach(() => {
+    mockNavigate.mockClear();
+    useAppBridgeMock.mockClear();
+  });
+
+  describe.each([true, false])("as install request: %s", (isInstallRequest) => {
+    beforeEach(() => {
       // @ts-expect-error mock
       window.location = {
         assign: mockNavigate,
@@ -29,46 +74,6 @@ describe("GadgetProvider", () => {
         pathname: "/",
         search: isInstallRequest ? "?shop=example.myshopify.com&hmac=abcdefg&host=abcdfg" : "",
       };
-
-      window.open = mockOpen;
-
-      window.shopify = {
-        // @ts-expect-error mock
-        environment: {
-          embedded: false,
-          mobile: false,
-        },
-        config: {
-          apiKey: mockApiKey,
-          shop: "example.myshopify.com",
-          locale: "en",
-        },
-        idToken: () =>
-          new Promise((resolve) => {
-            resolveIdToken = resolve;
-          }),
-      };
-
-      useAppBridgeMock = jest.spyOn(AppBridgeReact, "useAppBridge").mockImplementation(() => window.shopify);
-    });
-
-    beforeEach(() => {
-      mockApiClient = {
-        connection: new GadgetConnection({
-          endpoint: "https://test-app.gadget.app/endpoint",
-        }),
-      } as any;
-
-      jest.spyOn(mockApiClient.connection, "currentClient", "get").mockReturnValue(mockUrqlClient);
-    });
-
-    afterEach(() => {
-      mockNavigate.mockClear();
-      useAppBridgeMock.mockClear();
-    });
-
-    afterAll(() => {
-      window.location = location;
     });
 
     test("can render a standalone app type", () => {
@@ -166,8 +171,6 @@ describe("GadgetProvider", () => {
         expect(mockNavigate).not.toHaveBeenCalled();
         expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
       }
-
-      window.shopify.environment.mobile = false;
     });
 
     test("can render an embedded app type in embedded context", async () => {
@@ -210,103 +213,159 @@ describe("GadgetProvider", () => {
         expect(mockOpen).not.toHaveBeenCalled();
       }
     });
+  });
 
-    test("can render an embedded app when is not authenticated and not redirecting to oauth", async () => {
-      window.shopify.environment.embedded = true;
+  test("can render an embedded app when is not authenticated and not redirecting to oauth", async () => {
+    window.shopify.environment.embedded = true;
 
-      const { container } = render(
+    const { container } = render(
+      <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
+        <span>hello world</span>
+      </Provider>
+    );
+
+    await act(async () => {
+      resolveIdToken("mock-id-token");
+      await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("ShopifyFetchOrInstallShop", {
+      data: {
+        shopifyConnection: {
+          fetchOrInstallShop: {
+            isAuthenticated: false,
+            redirectToOauth: false,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
+    expect(mockOpen).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test("can render an embedded app type that's already authenticated", async () => {
+    window.shopify.environment.embedded = true;
+
+    const { container } = render(
+      <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
+        <span>hello world</span>
+      </Provider>
+    );
+
+    await act(async () => {
+      resolveIdToken("mock-id-token");
+      await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
+    });
+
+    mockUrqlClient.executeMutation.pushResponse("ShopifyFetchOrInstallShop", {
+      data: {
+        shopifyConnection: {
+          fetchOrInstallShop: {
+            isAuthenticated: true,
+            redirectToOauth: false,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    window.shopify.environment.embedded = false;
+  });
+
+  test("can render an embedded app with an install state hint saying we're installed", async () => {
+    window.shopify.environment.embedded = true;
+    window.gadgetConfig = {
+      shopifyInstallState: {
+        redirectToOauth: false,
+        isAuthenticated: true,
+        missingScopes: [],
+      },
+    };
+
+    const { container } = render(
+      <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
+        <span>hello world</span>
+      </Provider>
+    );
+
+    await act(async () => {
+      resolveIdToken("mock-id-token");
+    });
+
+    // we are already rendering the app, before the `ShopifyFetchOrInstallShop` request has been made, because the hint tells us we're authenticated
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // we expect a request for the fetch or install to double check that the hint is correct
+    expect(mockUrqlClient.executeMutation.subjects["ShopifyFetchOrInstallShop"]).toBeTruthy();
+
+    window.shopify.environment.embedded = false;
+  });
+
+  test("can render an embedded app with an install state hint saying we're not installed", async () => {
+    window.shopify.environment.embedded = true;
+    window.gadgetConfig = {
+      shopifyInstallState: {
+        redirectToOauth: true,
+        isAuthenticated: false,
+        missingScopes: [],
+      },
+    };
+
+    const { container } = render(
+      <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
+        <span>hello world</span>
+      </Provider>
+    );
+
+    await act(async () => {
+      resolveIdToken("mock-id-token");
+    });
+
+    // we are already rendering the app, before the `ShopifyFetchOrInstallShop` request has been made, because the hint tells us we're authenticated
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // we expect a request for the fetch or install to double check that the hint is correct
+    expect(mockUrqlClient.executeMutation.subjects["ShopifyFetchOrInstallShop"]).toBeTruthy();
+  });
+
+  test("should throw if embedded app type is in embedded context and shopify global is not defined", () => {
+    // @ts-expect-error mock
+    const windowSelf = jest.spyOn(window, "self", "get").mockImplementation(() => ({}));
+    const documentMock = jest
+      .spyOn(document, "referrer", "get")
+      .mockImplementation(() => "https://admin.shopify.com/store/some-test-shop/apps/fake-app");
+    // @ts-expect-error reset mock
+    window.shopify = undefined;
+
+    expect(() =>
+      render(
         <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
           <span>hello world</span>
         </Provider>
-      );
+      )
+    ).toThrow(
+      "Expected app bridge to be defined in embedded context, but it was not. This is likely due to a missing script tag, see https://shopify.dev/docs/api/app-bridge-library"
+    );
 
-      await act(async () => {
-        resolveIdToken("mock-id-token");
-        await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
-      });
-
-      mockUrqlClient.executeMutation.pushResponse("ShopifyFetchOrInstallShop", {
-        data: {
-          shopifyConnection: {
-            fetchOrInstallShop: {
-              isAuthenticated: false,
-              redirectToOauth: false,
-            },
-          },
-        },
-        stale: false,
-        hasNext: false,
-      });
-
-      expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
-      expect(mockOpen).not.toHaveBeenCalled();
-      expect(mockNavigate).not.toHaveBeenCalled();
-
-      window.shopify.environment.embedded = false;
-    });
-
-    test("can render an embedded app type that's already authenticated", async () => {
-      window.shopify.environment.embedded = true;
-
-      const { container } = render(
-        <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
-          <span>hello world</span>
-        </Provider>
-      );
-
-      await act(async () => {
-        resolveIdToken("mock-id-token");
-        await mockUrqlClient.executeMutation.waitForSubject("ShopifyFetchOrInstallShop");
-      });
-
-      mockUrqlClient.executeMutation.pushResponse("ShopifyFetchOrInstallShop", {
-        data: {
-          shopifyConnection: {
-            fetchOrInstallShop: {
-              isAuthenticated: true,
-              redirectToOauth: false,
-            },
-          },
-        },
-        stale: false,
-        hasNext: false,
-      });
-
-      expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
-      expect(mockNavigate).not.toHaveBeenCalled();
-
-      window.shopify.environment.embedded = false;
-    });
-
-    test("should throw if embedded app type is in embedded context and shopify global is not defined", () => {
+    // resetting the mocked values
+    windowSelf.mockRestore();
+    documentMock.mockRestore();
+    window.shopify = {
       // @ts-expect-error mock
-      const windowSelf = jest.spyOn(window, "self", "get").mockImplementation(() => ({}));
-      const documentMock = jest
-        .spyOn(document, "referrer", "get")
-        .mockImplementation(() => "https://admin.shopify.com/store/some-test-shop/apps/fake-app");
-      // @ts-expect-error reset mock
-      window.shopify = undefined;
-
-      expect(() =>
-        render(
-          <Provider api={mockApiClient} shopifyApiKey={mockApiKey} type={AppType.Embedded}>
-            <span>hello world</span>
-          </Provider>
-        )
-      ).toThrow(
-        "Expected app bridge to be defined in embedded context, but it was not. This is likely due to a missing script tag, see https://shopify.dev/docs/api/app-bridge-library"
-      );
-
-      // resetting the mocked values
-      windowSelf.mockRestore();
-      documentMock.mockRestore();
-      window.shopify = {
-        // @ts-expect-error mock
-        environment: {
-          embedded: false,
-          mobile: false,
-        },
-      };
-    });
+      environment: {
+        embedded: false,
+        mobile: false,
+      },
+    };
   });
 });

--- a/packages/react-shopify-app-bridge/src/global.d.ts
+++ b/packages/react-shopify-app-bridge/src/global.d.ts
@@ -1,0 +1,14 @@
+interface Window {
+  /**
+   * A global constant exported by the gadget backend to pass data to the frontend
+   * Only available in gadget-backend powered deployments of this provider
+   * @internal
+   */
+  gadgetConfig?: {
+    shopifyInstallState?: {
+      redirectToOauth: boolean;
+      isAuthenticated: boolean;
+      missingScopes: string[];
+    };
+  };
+}


### PR DESCRIPTION
In order to lower app LCP, we want to avoid having to do a whole other roundtrip to the server every time the page loads to check the installed state of a shop. We need to do this in some circumstances -- for off-platform apps, or to trigger the install of a shop the very first time a shop using managed installs is seen. So, we can't just remove this request, but, we can avoid blocking on it if the backend says its ok to. The backend already needs to check install state when rendering the page in order to inject the right shopify api key, so we can have it pass a little bit more info about the install state when it does that.
