### PR TITLE
react-big-commerce

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,9 @@ jobs:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/shopify-extensions/package.json
           access: public
+      - name: Publish @gadgetinc/react-big-commerce
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/react-big-commerce/package.json
+          access: public

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
     "<rootDir>/packages/react-shopify-app-bridge/jest.config.js",
     "<rootDir>/packages/tiny-graphql-query-compiler/jest.config.js",
     "<rootDir>/packages/shopify-extensions/jest.config.js",
+    "<rootDir>/packages/react-big-commerce/jest.config.js",
   ],
 };

--- a/packages/react-big-commerce/jest.config.js
+++ b/packages/react-big-commerce/jest.config.js
@@ -1,0 +1,184 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+export default {
+  displayName: "react-big-commerce",
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: process.env.LAYERCI ? "/tmp/jest-cache" : undefined,
+
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: false,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  // coverageDirectory: undefined,
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: "<rootDir>/../api/spec/jest.globalsetup.ts",
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: undefined,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "json",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: "ts-jest",
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state between every test
+  restoreMocks: true,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  roots: ["<rootDir>"],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: ["./spec/setup.ts"],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: ["<rootDir>/spec/jest.setup.ts"],
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: "setup-polly-jest/jest-environment-jsdom",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  // testMatch: [path.join(__dirname, "spec/(*.)+(spec|test).[tj]s?(x)")],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  testPathIgnorePatterns: ["/node_modules/"],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+  testRunner: "jest-circus/runner",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  // transform: undefined,
+  transform: { "^.+\\.(t|j)sx?$": ["@swc/jest"] },
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+  // transformIgnorePatterns: ["/node_modules/(?!lodash)"],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/packages/react-big-commerce/package.json
+++ b/packages/react-big-commerce/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@gadgetinc/react-big-commerce",
+  "version": "0.0.0",
+  "files": [
+    "README.md",
+    "dist/**/*"
+  ],
+  "license": "MIT",
+  "repository": "github:gadget-inc/js-clients",
+  "homepage": "https://github.com/gadget-inc/js-clients/tree/main/packages/react-big-commerce",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "source": "src/index.ts",
+  "main": "dist/cjs/index.js",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "rm -rf dist && tsc -b tsconfig.cjs.json tsconfig.esm.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json && echo '{\"type\": \"module\"}' > dist/esm/package.json",
+    "watch": "tsc --watch --preserveWatchOutput",
+    "prepublishOnly": "pnpm build",
+    "prerelease": "gitpkg publish"
+  },
+  "dependencies": {
+    "@gadgetinc/api-client-core": "^0.15.26"
+  },
+  "devDependencies": {
+    "@gadgetinc/api-client-core": "workspace:*",
+    "@gadgetinc/react": "workspace:*",
+    "@types/react": "^18.2.79",
+    "@types/react-dom": "^18.2.25",
+    "conditional-type-checks": "^1.0.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "@gadgetinc/react": "^0.15.0"
+  }
+}

--- a/packages/react-big-commerce/spec/Provider.spec.tsx
+++ b/packages/react-big-commerce/spec/Provider.spec.tsx
@@ -1,0 +1,144 @@
+import type { AnyClient } from "@gadgetinc/api-client-core";
+import { GadgetConnection } from "@gadgetinc/api-client-core";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+import { mockUrqlClient } from "../../api-client-core/spec/mockUrqlClient.js";
+import { Provider } from "../src/Provider.js";
+
+describe("GadgetProvider", () => {
+  let mockApiClient: AnyClient;
+  const mockBigCommerceInit = jest.fn();
+  let setAuthenticationModeSpy: jest.SpyInstance;
+  const { location } = window;
+
+  beforeAll(() => {
+    // @ts-expect-error mock
+    delete window.location;
+
+    // @ts-expect-error mock
+    window.location = {
+      search: "",
+    };
+
+    (window as any).Bigcommerce = {
+      init: mockBigCommerceInit,
+    };
+  });
+
+  beforeEach(() => {
+    mockApiClient = {
+      connection: new GadgetConnection({
+        endpoint: "https://test-app.gadget.app/endpoint",
+      }),
+    } as any;
+
+    jest.spyOn(mockApiClient.connection, "currentClient", "get").mockReturnValue(mockUrqlClient);
+    setAuthenticationModeSpy = jest.spyOn(mockApiClient.connection, "setAuthenticationMode");
+  });
+
+  afterEach(() => {
+    mockBigCommerceInit.mockReset();
+  });
+
+  afterAll(() => {
+    window.location = location;
+  });
+
+  test("when there is no signed_payload parameter", () => {
+    const { container } = render(
+      <Provider api={mockApiClient}>
+        <span>hello world</span>
+      </Provider>
+    );
+
+    expect(setAuthenticationModeSpy).not.toHaveBeenCalled();
+    expect(mockUrqlClient.executeQuery.mock.calls.length).toBe(1);
+    expect(mockUrqlClient.executeQuery.mock.calls[0][0].query.loc.source.body).toMatchInlineSnapshot(`
+      "query BigCommerceSession {
+        currentSession {
+          bigCommerceUserId
+          bigCommerceStore {
+            storeHash
+          }
+          roles {
+            key
+          }
+        }
+      }"
+    `);
+    expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toMatchInlineSnapshot(`{}`);
+
+    mockUrqlClient.executeQuery.pushResponse("BigCommerceSession", {
+      data: {
+        currentSession: {
+          bigCommerceUserId: null,
+          bigCommerceStore: null,
+          roles: [
+            {
+              key: "unauthenticated",
+            },
+          ],
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
+    expect(mockBigCommerceInit).not.toHaveBeenCalled();
+  });
+
+  test("when there is a signed_payload parameter", () => {
+    window.location.search = "signed_payload=test-session-token";
+
+    const { container } = render(
+      <Provider api={mockApiClient}>
+        <span>hello world</span>
+      </Provider>
+    );
+
+    expect(setAuthenticationModeSpy).toHaveBeenCalledWith({
+      custom: {
+        processFetch: expect.any(Function),
+        processTransactionConnectionParams: expect.any(Function),
+      },
+    });
+    expect(mockUrqlClient.executeQuery.mock.calls.length).toBe(1);
+    expect(mockUrqlClient.executeQuery.mock.calls[0][0].query.loc.source.body).toMatchInlineSnapshot(`
+      "query BigCommerceSession {
+        currentSession {
+          bigCommerceUserId
+          bigCommerceStore {
+            storeHash
+          }
+          roles {
+            key
+          }
+        }
+      }"
+    `);
+    expect(mockUrqlClient.executeQuery.mock.calls[0][0].variables).toMatchInlineSnapshot(`{}`);
+
+    mockUrqlClient.executeQuery.pushResponse("BigCommerceSession", {
+      data: {
+        currentSession: {
+          bigCommerceUserId: "123",
+          bigCommerceStore: {
+            storeHash: "xyz789",
+          },
+          roles: [
+            {
+              key: "Role-BigCommerce-App",
+            },
+          ],
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><span>hello world</span></div>"`);
+    expect(mockBigCommerceInit).toHaveBeenCalled();
+  });
+});

--- a/packages/react-big-commerce/spec/are-the-types-wrong.spec.ts
+++ b/packages/react-big-commerce/spec/are-the-types-wrong.spec.ts
@@ -1,0 +1,8 @@
+import execa from "execa";
+import path from "path";
+
+describe("package.json types exports", () => {
+  it("should have the correct types exports", async () => {
+    await execa("pnpm", ["exec", "attw", "--pack", "."], { cwd: path.resolve(__dirname, "..") });
+  });
+});

--- a/packages/react-big-commerce/spec/useGadget.spec.tsx
+++ b/packages/react-big-commerce/spec/useGadget.spec.tsx
@@ -1,0 +1,127 @@
+import type { AnyClient } from "@gadgetinc/api-client-core";
+import { GadgetConnection } from "@gadgetinc/api-client-core";
+import "@testing-library/jest-dom";
+import { renderHook } from "@testing-library/react";
+import type { IsExact } from "conditional-type-checks";
+import { assert } from "conditional-type-checks";
+import type { ReactNode } from "react";
+import React from "react";
+import { mockUrqlClient } from "../../api-client-core/spec/mockUrqlClient.js";
+import { Provider } from "../src/Provider.js";
+import { useGadget } from "../src/index.js";
+
+const _TestUseGadgetReturnsAppropriateTypes = () => {
+  const { loading, isAuthenticated, userId, storeHash, error } = useGadget();
+
+  assert<IsExact<typeof loading, boolean>>(true);
+  assert<IsExact<typeof isAuthenticated, boolean>>(true);
+  assert<IsExact<typeof userId, string | undefined>>(true);
+  assert<IsExact<typeof storeHash, string | undefined>>(true);
+  assert<IsExact<typeof error, Error | undefined>>(true);
+};
+
+describe("useGadget", () => {
+  let mockApiClient: AnyClient;
+  const { location } = window;
+
+  beforeAll(() => {
+    // @ts-expect-error mock
+    delete window.location;
+
+    // @ts-expect-error mock
+    window.location = {
+      search: "",
+    };
+  });
+
+  beforeEach(() => {
+    mockApiClient = {
+      connection: new GadgetConnection({
+        endpoint: "https://test-app.gadget.app/endpoint",
+      }),
+    } as any;
+
+    jest.spyOn(mockApiClient.connection, "currentClient", "get").mockReturnValue(mockUrqlClient);
+  });
+
+  afterAll(() => {
+    window.location = location;
+  });
+
+  test("when there is no signed_payload parameter", () => {
+    const { result, rerender } = renderHook(() => useGadget(), {
+      wrapper: (props: { children: ReactNode }) => <Provider api={mockApiClient}>{props.children}</Provider>,
+    });
+
+    const { loading, isAuthenticated, userId, storeHash, error } = result.current;
+    expect(loading).toBe(true);
+    expect(isAuthenticated).toBe(false);
+    expect(userId).toBeUndefined();
+    expect(storeHash).toBeUndefined();
+    expect(error).toBeUndefined();
+
+    mockUrqlClient.executeQuery.pushResponse("BigCommerceSession", {
+      data: {
+        currentSession: {
+          bigCommerceUserId: null,
+          bigCommerceStore: null,
+          roles: [
+            {
+              key: "unauthenticated",
+            },
+          ],
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    rerender();
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.userId).toBeUndefined();
+    expect(result.current.storeHash).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+  });
+
+  test("when there is a signed_payload parameter", () => {
+    window.location.search = "signed_payload=test-session-token";
+    const { result, rerender } = renderHook(() => useGadget(), {
+      wrapper: (props: { children: ReactNode }) => <Provider api={mockApiClient}>{props.children}</Provider>,
+    });
+
+    const { loading, isAuthenticated, userId, storeHash, error } = result.current;
+    expect(loading).toBe(true);
+    expect(isAuthenticated).toBe(false);
+    expect(userId).toBeUndefined();
+    expect(storeHash).toBeUndefined();
+    expect(error).toBeUndefined();
+
+    mockUrqlClient.executeQuery.pushResponse("BigCommerceSession", {
+      data: {
+        currentSession: {
+          bigCommerceUserId: "123",
+          bigCommerceStore: {
+            storeHash: "xyz789",
+          },
+          roles: [
+            {
+              key: "Role-BigCommerce-App",
+            },
+          ],
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    rerender();
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.userId).toEqual("123");
+    expect(result.current.storeHash).toEqual("xyz789");
+    expect(result.current.error).toBeUndefined();
+  });
+});

--- a/packages/react-big-commerce/src/Provider.tsx
+++ b/packages/react-big-commerce/src/Provider.tsx
@@ -1,0 +1,119 @@
+import type { AnyClient } from "@gadgetinc/api-client-core";
+import { Provider as GadgetUrqlProvider, useQuery } from "@gadgetinc/react";
+import type { ReactNode } from "react";
+import React, { useEffect, useMemo } from "react";
+import { GadgetBigCommerceContext } from "./index.js";
+
+type ProviderLocation = {
+  query?: URLSearchParams;
+};
+
+const BigCommerceSessionQuery = `
+  query BigCommerceSession {
+    currentSession {
+      bigCommerceUserId
+      bigCommerceStore {
+        storeHash
+      }
+      roles {
+        key
+      }
+    }
+  }
+`;
+
+const InnerProvider = (props: { children: ReactNode; api: AnyClient; signedPayload: string | undefined }) => {
+  const { api, signedPayload } = props;
+
+  const [{ data, fetching, error }] = useQuery<{
+    currentSession: { bigCommerceUserId: string; bigCommerceStore: { storeHash: string }; roles: { key: string }[] };
+  }>({
+    query: BigCommerceSessionQuery,
+  });
+
+  useEffect(() => {
+    if (!signedPayload) {
+      console.log("[gadget-react-big-commerce] no signed payload, skipping auth setup");
+      return;
+    }
+
+    api.connection.setAuthenticationMode({
+      custom: {
+        async processFetch(_input, init) {
+          const headers = new Headers(init.headers);
+          headers.append("Authorization", `BigCommerceSignedPayload ${signedPayload}`);
+          init.headers ??= {};
+          headers.forEach(function (value, key) {
+            (init.headers as Record<string, string>)[key] = value;
+          });
+        },
+        async processTransactionConnectionParams(params) {
+          params.auth.bigCommerceSignedPayload = signedPayload;
+        },
+      },
+    });
+  }, [api, signedPayload]);
+
+  const isAuthenticated = !!data?.currentSession?.roles?.some((role) => role.key === "Role-BigCommerce-App");
+  const userId = data?.currentSession?.bigCommerceUserId ?? undefined;
+  const storeHash = data?.currentSession?.bigCommerceStore?.storeHash ?? undefined;
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    const BigCommerce = (window as any).Bigcommerce;
+
+    if (!BigCommerce) {
+      console.warn("[gadget-react-big-commerce] BigCommerce global not found, not initializing BigCommerce SDK");
+      return;
+    }
+
+    console.debug("[gadget-react-big-commerce] initializing BigCommerce SDK");
+    BigCommerce.init();
+  }, [isAuthenticated]);
+
+  console.debug("[gadget-react-big-commerce] provider rendering", {
+    signedPayload,
+    data,
+    fetching,
+    error,
+    isAuthenticated,
+    userId,
+    storeHash,
+  });
+
+  return (
+    <GadgetBigCommerceContext.Provider
+      value={{
+        loading: fetching,
+        error,
+        isAuthenticated,
+        userId,
+        storeHash,
+      }}
+    >
+      {props.children}
+    </GadgetBigCommerceContext.Provider>
+  );
+};
+
+export const Provider = ({ children, api }: { children: ReactNode; api: AnyClient }) => {
+  const location = useMemo<ProviderLocation>(() => {
+    return {
+      query: new URLSearchParams(window.location.search),
+    };
+  }, []);
+
+  const { query } = location ?? {};
+  const signed_payload = query?.get("signed_payload") ?? undefined;
+
+  return (
+    <GadgetUrqlProvider api={api}>
+      <InnerProvider api={api} signedPayload={signed_payload}>
+        {children}
+      </InnerProvider>
+    </GadgetUrqlProvider>
+  );
+};

--- a/packages/react-big-commerce/src/context.ts
+++ b/packages/react-big-commerce/src/context.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react";
+
+export type GadgetBigCommerceContextValue = {
+  /** Is the Gadget BigCommerce provider loading */
+  loading: boolean;
+  /** Any error that occurred when booting up the Gadget BigCommerce provider */
+  error?: Error;
+  /** Is this browser window authenticated and ready to make requests to the Gadget backend */
+  isAuthenticated: boolean;
+  /** The hash of the BigCommerce store that has loaded the app */
+  storeHash?: string;
+  /** The id of the user that is currently using the app */
+  userId?: string;
+};
+
+export const GadgetBigCommerceContext = createContext<GadgetBigCommerceContextValue>({
+  loading: true,
+  isAuthenticated: false,
+});
+
+export const useGadget = () => useContext<GadgetBigCommerceContextValue>(GadgetBigCommerceContext);

--- a/packages/react-big-commerce/src/index.ts
+++ b/packages/react-big-commerce/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./Provider.js";
+export * from "./context.js";

--- a/packages/react-big-commerce/tsconfig.base.json
+++ b/packages/react-big-commerce/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2020", "DOM"],
+    "jsx": "react",
+    "baseUrl": "./",
+    "target": "es2020",
+    "types": ["jest", "node"],
+    "importHelpers": true
+  }
+}

--- a/packages/react-big-commerce/tsconfig.cjs.json
+++ b/packages/react-big-commerce/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "CommonJS",
+    "moduleResolution": "node"
+  },
+  "include": ["./src"]
+}

--- a/packages/react-big-commerce/tsconfig.esm.json
+++ b/packages/react-big-commerce/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["./src"]
+}

--- a/packages/react-big-commerce/tsconfig.json
+++ b/packages/react-big-commerce/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2020", "DOM"],
+    "jsx": "react",
+    "baseUrl": "./",
+    "moduleResolution": "nodenext",
+    "module": "nodenext",
+    "target": "es2020",
+    "types": ["jest", "node"],
+    "outDir": "./dist"
+  },
+  "include": ["./src", "./spec"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,31 @@ importers:
         specifier: ^6.3.2
         version: 6.3.2
 
+  packages/react-big-commerce:
+    dependencies:
+      '@gadgetinc/api-client-core':
+        specifier: workspace:*
+        version: link:../api-client-core
+    devDependencies:
+      '@gadgetinc/react':
+        specifier: workspace:*
+        version: link:../react
+      '@types/react':
+        specifier: ^18.2.79
+        version: 18.2.79
+      '@types/react-dom':
+        specifier: ^18.2.25
+        version: 18.2.25
+      conditional-type-checks:
+        specifier: ^1.0.6
+        version: 1.0.6
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+
   packages/react-shopify-app-bridge:
     dependencies:
       '@gadgetinc/api-client-core':


### PR DESCRIPTION
This adds a react provider for our BigCommerce connection. The provider has two jobs:

1. Set up the api client to use the session token passed in a query parameter that we will set when rendering big commerce apps using their `/load` callback and load the session to make sure that it is authenticated
2. If we are in an authenticated context initialize the BigCommerce sdk (this will be loaded on the entry html)

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
