### PR TITLE
filter out `__typename` when figuring out whether a belongsTo field needs a link

### DIFF
--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -317,7 +317,7 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
       }
 
       const inputHasId = "id" in input;
-      const inputHasMoreFields = Object.keys(input).length > 1;
+      const inputHasMoreFields = Object.keys(input).filter((field) => field !== "__typename").length > 1;
       const inputUpdateId = updates[path!]?.[0];
 
       switch (fieldType.type) {


### PR DESCRIPTION


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
