### PR TITLE
JSON input error states

### DIFF
--- a/packages/react/cypress/component/auto/form/PolarisAutoJSONInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoJSONInput.cy.tsx
@@ -1,7 +1,10 @@
+/* eslint-disable jest/valid-expect */
 import React from "react";
 import { PolarisAutoForm } from "../../../../src/auto/polaris/PolarisAutoForm.js";
-import { PolarisAutoJSONInput } from "../../../../src/auto/polaris/inputs/PolarisAutoJsonInput.js";
+import { PolarisAutoInput } from "../../../../src/auto/polaris/inputs/PolarisAutoInput.js";
+import { PolarisAutoJSONInput } from "../../../../src/auto/polaris/inputs/PolarisAutoJSONInput.js";
 import { PolarisAutoSubmit } from "../../../../src/auto/polaris/submit/PolarisAutoSubmit.js";
+import { PolarisSubmitResultBanner } from "../../../../src/auto/polaris/submit/PolarisSubmitResultBanner.js";
 import { api } from "../../../support/api.js";
 import { PolarisWrapper } from "../../../support/auto.js";
 
@@ -10,23 +13,88 @@ describe("PolarisJSONInput", () => {
     cy.viewport("macbook-13");
   });
 
-  it("shows a inline error message when the value is not a valid JSON", () => {
+  it("shows a inline error message when the value is not a valid JSON, and allows submission it when it is valid", () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.options.endpoint}?operation=createWidget`,
+        times: 1,
+      },
+      {
+        body: {
+          data: {
+            createWidget: {
+              success: true,
+              errors: null,
+              widget: {
+                id: "1",
+                name: "foobar",
+                inventoryCount: 10,
+                metafields: '{"foo": "bar"}',
+              },
+            },
+          },
+        },
+      }
+    );
+
     cy.mountWithWrapper(
       <PolarisAutoForm action={api.widget.create}>
+        <PolarisSubmitResultBanner />
         <PolarisAutoJSONInput field="metafields" />
+        <PolarisAutoInput field="name" />
+        <PolarisAutoInput field="inventoryCount" />
+        <PolarisAutoSubmit />
       </PolarisAutoForm>,
       PolarisWrapper
     );
 
     cy.get(`textarea[name="widget.metafields"]`).type("not a valid JSON");
-    // The error message only appears when the field is blurred
-    cy.get(`textarea[name="widget.metafields"]`).blur();
+
+    // fill in other required attributes
+    cy.get(`input[name="widget.inventoryCount"]`).type("10");
+    cy.get(`input[name="widget.name"]`).type("foobar");
+
+    // try to submit form, but it shouldn't submit as the json field is invalid
+    cy.get(`button.Polaris-Button[type="submit"]`).click();
+
     cy.contains(`Invalid JSON: Unexpected token 'o', "not a valid JSON" is not valid JSON`);
+
+    cy.get(`textarea[name="widget.metafields"]`).clear().type(`{"foo": "bar"}`, { parseSpecialCharSequences: false });
+
+    cy.get(`button.Polaris-Button[type="submit"]`).click();
+
+    cy.contains(`Saved Widget successfully`);
   });
 
-  it("formats the JSON value when fetching the record", () => {
+  it("formats an existing object JSON value when fetching the record", () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.options.endpoint}?operation=widget`,
+        times: 1,
+      },
+      {
+        body: {
+          data: {
+            widget: {
+              __typename: "Widget",
+              id: "1",
+              createdAt: "2024-06-26T20:01:06.794Z",
+              inventoryCount: 123,
+              metafields: {
+                hello: "world!",
+              },
+              name: "example value for name",
+              updatedAt: "2024-07-03T15:02:12.968Z",
+            },
+          },
+        },
+      }
+    );
+
     cy.mountWithWrapper(
-      <PolarisAutoForm action={api.widget.update} findBy="1368">
+      <PolarisAutoForm action={api.widget.update} findBy="1">
         <PolarisAutoJSONInput field="metafields" />
         <PolarisAutoSubmit />
       </PolarisAutoForm>,
@@ -34,10 +102,185 @@ describe("PolarisJSONInput", () => {
     );
 
     cy.get(`textarea[name="widget.metafields"]`).should(
-      "include.text",
+      "have.value",
       `{
   "hello": "world!"
 }` // The JSON value is formatted with 2 spaces
     );
+  });
+
+  it("formats an existing string JSON value when fetching the record", () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.options.endpoint}?operation=widget`,
+        times: 1,
+      },
+      {
+        body: {
+          data: {
+            widget: {
+              __typename: "Widget",
+              id: "2",
+              createdAt: "2024-06-26T20:01:06.794Z",
+              inventoryCount: 123,
+              metafields: "some stored string",
+              name: "example value for name",
+              updatedAt: "2024-07-03T15:02:12.968Z",
+            },
+          },
+        },
+      }
+    );
+
+    cy.mountWithWrapper(
+      <PolarisAutoForm action={api.widget.update} findBy="2">
+        <PolarisAutoJSONInput field="metafields" />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      PolarisWrapper
+    );
+
+    cy.get(`textarea[name="widget.metafields"]`).should(
+      "have.value",
+      `"some stored string"` // rendered as a JSON encoded string, not the raw contents of it
+    );
+  });
+
+  it("renders when there is no existing JSON value when fetching the record", () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.options.endpoint}?operation=widget`,
+        times: 1,
+      },
+      {
+        body: {
+          data: {
+            widget: {
+              __typename: "Widget",
+              id: "3",
+              createdAt: "2024-06-26T20:01:06.794Z",
+              inventoryCount: 123,
+              name: "example value for name",
+              updatedAt: "2024-07-03T15:02:12.968Z",
+            },
+          },
+        },
+      }
+    );
+
+    cy.mountWithWrapper(
+      <PolarisAutoForm action={api.widget.update} findBy="3">
+        <PolarisAutoJSONInput field="metafields" />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      PolarisWrapper
+    );
+
+    cy.get(`textarea[name="widget.metafields"]`).should("have.value", ``);
+  });
+
+  it("renders when there is a null existing JSON value when fetching the record", () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.options.endpoint}?operation=widget`,
+        times: 1,
+      },
+      {
+        body: {
+          data: {
+            widget: {
+              __typename: "Widget",
+              id: "3",
+              createdAt: "2024-06-26T20:01:06.794Z",
+              inventoryCount: 123,
+              name: "example value for name",
+              updatedAt: "2024-07-03T15:02:12.968Z",
+              metafields: null,
+            },
+          },
+        },
+      }
+    );
+
+    cy.mountWithWrapper(
+      <PolarisAutoForm action={api.widget.update} findBy="3">
+        <PolarisAutoJSONInput field="metafields" />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      PolarisWrapper
+    );
+
+    cy.get(`textarea[name="widget.metafields"]`).should("have.value", ``);
+  });
+
+  it("allows clearing a JSON value by emptying the input", () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.options.endpoint}?operation=widget`,
+        times: 1,
+      },
+      {
+        body: {
+          data: {
+            widget: {
+              __typename: "Widget",
+              id: "1",
+              createdAt: "2024-06-26T20:01:06.794Z",
+              inventoryCount: 123,
+              metafields: {
+                hello: "world!",
+              },
+              name: "example value for name",
+              updatedAt: "2024-07-03T15:02:12.968Z",
+            },
+          },
+        },
+      }
+    );
+
+    cy.mountWithWrapper(
+      <PolarisAutoForm action={api.widget.update} findBy="1">
+        <PolarisAutoJSONInput field="metafields" />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      PolarisWrapper
+    );
+
+    cy.get(`textarea[name="widget.metafields"]`).clear();
+    cy.get(`textarea[name="widget.metafields"]`).should("have.value", "");
+
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.options.endpoint}?operation=createWidget`,
+        times: 1,
+      },
+      (req) => {
+        expect(req.body.variables.input.metafields).to.be.null;
+
+        return {
+          body: {
+            data: {
+              createWidget: {
+                success: true,
+                errors: null,
+                widget: {
+                  id: "1",
+                  name: "foobar",
+                  inventoryCount: 10,
+                  metafields: '{"foo": "bar"}',
+                },
+              },
+            },
+          },
+        };
+      }
+    );
+
+    cy.get(`button.Polaris-Button[type="submit"]`).click();
   });
 });

--- a/packages/react/spec/auto/inputs/PolarisAutoJSONInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoJSONInput.spec.tsx
@@ -2,7 +2,7 @@ import { act, render } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.js";
-import { PolarisAutoJSONInput } from "../../../src/auto/polaris/inputs/PolarisAutoJsonInput.js";
+import { PolarisAutoJSONInput } from "../../../src/auto/polaris/inputs/PolarisAutoJSONInput.js";
 import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoSubmit.js";
 import { testApi as api } from "../../apis.js";
 import { mockUrqlClient } from "../../testWrappers.js";

--- a/packages/react/spec/auto/inputs/PolarisJsonInput.stories.jsx
+++ b/packages/react/spec/auto/inputs/PolarisJsonInput.stories.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Provider } from "../../../src/GadgetProvider.tsx";
 import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.tsx";
-import { PolarisAutoJSONInput } from "../../../src/auto/polaris/inputs/PolarisAutoJsonInput.tsx";
+import { PolarisAutoJSONInput } from "../../../src/auto/polaris/inputs/PolarisAutoJSONInput.tsx";
 import { testApi as api } from "../../apis.ts";
 
 export default {

--- a/packages/react/src/auto/hooks/useStringInputController.tsx
+++ b/packages/react/src/auto/hooks/useStringInputController.tsx
@@ -1,4 +1,5 @@
-import { useController, type Control } from "react-hook-form";
+import type { UseControllerProps } from "react-hook-form";
+import { useController } from "react-hook-form";
 import type { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { FieldType } from "../../metadata.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
@@ -20,11 +21,12 @@ const PlaceholderValues: Partial<Record<GadgetFieldType, string>> = {
   [FieldType.Url]: "example.com",
 } as const;
 
-export const useStringInputController = (props: {
-  field: string; // The field API identifier
-  control?: Control<any>;
-}) => {
-  const { field: fieldApiIdentifier, control } = props;
+export const useStringInputController = (
+  props: {
+    field: string; // The field API identifier
+  } & Omit<UseControllerProps, "name">
+) => {
+  const { field: fieldApiIdentifier, ...rest } = props;
   const { path, metadata } = useFieldMetadata(fieldApiIdentifier);
 
   const {
@@ -32,7 +34,7 @@ export const useStringInputController = (props: {
     fieldState: { error },
   } = useController({
     name: path,
-    control,
+    ...rest,
   });
 
   const placeholder = PlaceholderValues[metadata.fieldType];

--- a/packages/react/src/auto/mui/inputs/MUIAutoJSONInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoJSONInput.tsx
@@ -9,26 +9,25 @@ export const MUIAutoJSONInput = (
   props: {
     field: string; // The field API identifier
     control?: Control<any>;
-  } & Partial<TextFieldProps>
+  } & Partial<Omit<TextFieldProps, "onChange">>
 ) => {
-  const { onStringValueChange, error, stringValue, originalController } = useJSONInputController(props);
   const [isFocused, focusProps] = useFocus();
   const { field: _field, control: _control, ...restOfProps } = props;
+  const { type: _type, errorMessage, ...controller } = useJSONInputController(props);
 
-  const inErrorState = !isFocused && !!error;
+  const inErrorState = !isFocused && !!errorMessage;
 
   return (
     <TextField
       multiline
       maxRows={4}
       inputProps={{ style: { fontFamily: "monospace" } }}
-      {...originalController}
-      value={stringValue}
-      onChange={(event) => onStringValueChange(event.target.value)}
       error={inErrorState}
-      helperText={inErrorState && `Invalid JSON: ${error.message}`}
+      helperText={inErrorState && `Invalid JSON: ${errorMessage}`}
+      {...controller}
       {...focusProps}
       {...restOfProps}
+      onChange={(event) => controller.onChange(event.target.value)}
     />
   );
 };

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -6,7 +6,7 @@ export { PolarisAutoEncryptedStringInput as AutoEncryptedStringInput } from "./i
 export { PolarisAutoFileInput as AutoFileInput } from "./inputs/PolarisAutoFileInput.js";
 export { PolarisAutoHiddenInput as AutoHiddenInput } from "./inputs/PolarisAutoHiddenInput.js";
 export { PolarisAutoInput as AutoInput } from "./inputs/PolarisAutoInput.js";
-export { PolarisAutoJSONInput as AutoJSONInput } from "./inputs/PolarisAutoJsonInput.js";
+export { PolarisAutoJSONInput as AutoJSONInput } from "./inputs/PolarisAutoJSONInput.js";
 export { PolarisAutoPasswordInput as AutoPasswordInput } from "./inputs/PolarisAutoPasswordInput.js";
 export { PolarisAutoBelongsToInput as AutoBelongsToInput } from "./inputs/PolarisAutoRelationshipInput.js";
 export { PolarisAutoRolesInput as AutoRolesInput } from "./inputs/PolarisAutoRolesInput.js";

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
@@ -8,7 +8,7 @@ import { PolarisAutoBooleanInput } from "./PolarisAutoBooleanInput.js";
 import { PolarisAutoDateTimePicker } from "./PolarisAutoDateTimePicker.js";
 import { PolarisAutoEncryptedStringInput } from "./PolarisAutoEncryptedStringInput.js";
 import { PolarisAutoFileInput } from "./PolarisAutoFileInput.js";
-import { PolarisAutoJSONInput } from "./PolarisAutoJsonInput.js";
+import { PolarisAutoJSONInput } from "./PolarisAutoJSONInput.js";
 import { PolarisAutoPasswordInput } from "./PolarisAutoPasswordInput.js";
 import { PolarisAutoRelationshipInput } from "./PolarisAutoRelationshipInput.js";
 import { PolarisAutoRolesInput } from "./PolarisAutoRolesInput.js";

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
@@ -10,23 +10,19 @@ export const PolarisAutoJSONInput = (
   props: {
     field: string; // The field API identifier
     control?: Control<any>;
-  } & Partial<TextFieldProps>
+  } & Partial<Omit<TextFieldProps, "onChange">>
 ) => {
-  const { onStringValueChange, error, stringValue, originalController } = useJSONInputController(props);
   const [isFocused, focusProps] = useFocus();
-
   const { field: _field, control: _control, ...restOfProps } = props;
-  const { type: _type, ...restOfOriginalController } = originalController;
+  const { type: _type, errorMessage, ...controller } = useJSONInputController(props);
 
   return (
     <>
       <TextField
         multiline={4}
         monospaced
-        {...getPropsWithoutRef(restOfOriginalController)}
-        value={stringValue}
-        onChange={onStringValueChange}
-        error={!isFocused && error && `Invalid JSON: ${error.message}`}
+        error={!isFocused && errorMessage && `Invalid JSON: ${errorMessage}`}
+        {...getPropsWithoutRef(controller)}
         {...getPropsWithoutRef(focusProps)}
         {...restOfProps}
       />


### PR DESCRIPTION
Previously, the `useJSONInputController` was tracking its own error from invalid JSON inputs in its own `setState` call. This state was local to the component, so it didn't stop the form from being submitted. Instead, we need to store the error in the form state such that `react-hook-form` knows about it, and can revalidate using the validation schema. This implements that! It's still a little tricky because we need to store the raw input string the user is typing into and store the real JSON value in the form state so that it gets submitted. The controller now queues the validator that there has been a parse error by writing a special object indicating that there has been a parse error into the form state.