### PR TITLE
Add new behaviour for updating actions

### DIFF
--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -74,29 +74,29 @@ export interface MaybeFindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT
   schemaType: SchemaT | null;
 }
 
-interface ActionWithIdAndVariables<OptionsT, VariablesT> {
+export interface ActionWithIdAndVariables<OptionsT, VariablesT> {
   <Options extends OptionsT>(id: string, variables: VariablesT, options?: LimitToKnownKeys<Options, OptionsT>):
     | AsyncRecord<any>
     | Promise<void>;
 }
 
-interface ActionWithNoIdAndVariables<OptionsT, VariablesT> {
+export interface ActionWithNoIdAndVariables<OptionsT, VariablesT> {
   <Options extends OptionsT>(variables: VariablesT, options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;
 }
 
-interface ActionWithIdAndNoVariables<OptionsT> {
+export interface ActionWithIdAndNoVariables<OptionsT> {
   <Options extends OptionsT>(id: string, options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any> | Promise<void>;
 }
 
-interface ActionWithNoIdAndNoVariables<OptionsT> {
+export interface ActionWithNoIdAndNoVariables<OptionsT> {
   <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;
 }
 
-interface BulkActionWithIdsAndNoVariables<OptionsT> {
+export interface BulkActionWithIdsAndNoVariables<OptionsT> {
   <Options extends OptionsT>(ids: string[], options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;
 }
 
-interface BulkActionWithInputs<OptionsT, VariablesT> {
+export interface BulkActionWithInputs<OptionsT, VariablesT> {
   <Options extends OptionsT>(inputs: VariablesT, options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;
 }
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -572,6 +572,44 @@ export const UpdatePost = (props: { id: string }) => {
 const [{ data, fetching, error }, _refetch] = useFindBy(api.blogPost.findBySlug, "some-slug", { select: { id: true, title: true } });
 ```
 
+### `useActionForm(actionFunction: ModelActionFunction | GlobalActionFunction, options: UseActionFormOptions = {}): UseActionFormResult`
+
+`useActionForm` manages form state for calling actions in your Gadget backend. `useActionForm` can fetch the record for editing, manage the state of the fields as the user changes them in a form, track validations and errors, and then call the action with the form data when the user submits the form. `useActionForm` can call Actions on models as well as Global Actions. See the [Gadget Reference Docs](https://docs.gadget.dev/reference/react#useactionform) for more information.
+
+- `actionFunction`: The model action or action function from your application's API client. Gadget generates these action functions for each action or model action defined in your project. Required. Example: `api.widget.create`, or `api.user.update` or `api.blogPost.publish`.
+- `options`: options for controlling the behavior of the form not an exhaustive list, for additonal properties see [gadget reference docs](https://docs.gadget.dev/reference/react#useactionform) for more information.
+  - `defaultValues`: Default values to seed the form inputs with. Can be omitted. Mutually exclusive with the `findBy`. Optional.
+  - `findBy`: Details for automatically finding a record to seed the form values with. When passed as a string, will look up a record with that `id`. When passed an object, will call a `findBy<Field>` function on the api object to retrieve a record by that field.
+  - `select`: Which fields to select from the backend when retrieving initial data with `findBy`. See [docs on the select option](https://docs.gadget.dev/reference/react#the-select-option) for more information. Optional.
+  - `send`: Which fields to send from the form values to the backend for the action. Useful if you want to include fields in your form state for driving UI that shouldn't be sent with the submission. Optional.
+  - `onSubmit`: Callback called right before data is submitted to the backend action. Optional.
+  - `onSuccess`: Callback called after a successful submission to the backend action. Passed the action result, which is the object with `{data, error, fetching}` keys. Optional.
+  - `onError`: Callback called after an error occurs finding the initial record or during submission to the backend action. Passed the error, which can be a transport error from a broken network, or a list of validation errors returned by the backend. Optional.
+
+`useActionForm` returns an object with properties from [`react-hook-form` (see docs)](https://react-hook-form.com/docs/useform) and additional properties for handling the action see [gadget docs](https://docs.gadget.dev/reference/react#useactionform) for an exhaustive list.
+
+Example:
+
+```javascript
+import { useActionForm } from "@gadgetinc/react";
+import { api } from "../api";
+
+const PostForm = () => {
+  const { register, submit } = useActionForm(api.post.create);
+
+  return (
+    <form onSubmit={submit}>
+      <label htmlFor="title">Title</label>
+      <input id="title" type="text" {...register("post.title")} />
+
+      <label htmlFor="content">Content</label>
+      <textarea id="content" {...register("post.content")} />
+      <input type="submit" />
+    </form>
+  );
+};
+```
+
 ### `useGlobalAction(actionFunction: GlobalActionFunction, options: UseGlobalActionOptions = {}): [{data, fetching, error}, refetch]`
 
 `useGlobalAction` is a hook for running a backend Global Action. `useGlobalAction(api.someGlobalAction)` is the React equivalent of `await api.someGlobalAction({...})`. `useGlobalAction` doesn't immediately dispatch a request to run an action server side, but instead returns a result object and a function which runs the action, similar to [`urql`'s `useMutation` hook](https://formidable.com/open-source/urql/docs/api/urql/#usemutation). `useGlobalAction` must be passed one of the global action functions from an instance of your application's generated API client. Options:

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.13",
+  "version": "0.15.14",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
@@ -168,11 +168,11 @@
         }
       },
       {
-        "_id": "4b671f1a34bd357917534a4aae89f43f",
+        "_id": "97b8775df5d78996afc33b4d54480992",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 723,
+          "bodySize": 715,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +193,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "723"
+              "value": "715"
             },
             {
               "_fromType": "array",
@@ -216,7 +216,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      question {\\n        id\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"question\":{\"update\":{\"id\":123}},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
+            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      question {\\n        id\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"question\":{\"_link\":123},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
           },
           "queryString": [
             {
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateAnswer"
         },
         "response": {
-          "bodySize": 431,
+          "bodySize": 368,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 431,
-            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9R+QuEckOqVPXQQ6v2HBm8EFQC1F7URFHevTIQAlxy9Hhm/e34YgGgFCwwhosFAIBdKwVTUus/UpMKgLrLMtIaY2DV0eYmk1KNMmrdVdWkinUcAEuJMaAb7XBzF5lObGQmzTCkNAwIcu777Uhz2dSLkfehnj8zA+B+z+eWanEkc/1xC0+W62z00jsubq18K9f3rKRP0l3FQ2L0YyFkQfxOs2IB8HCWShgQvWwmU2T2TfomXgTTV3mk+fZjISvDA8bXniFp26rM+ld7nAHTGmNIJ6ZaL5CwagpzwgNzq2PbLgp+qsr6xzYXths4oRPZMvWcSDpeHvip44dSBjLI3XznBNvnMNumIz6yEhm99b/0MGKorOs/AAAA//8=\",\"AwAkbPvOlAIAAA==\"]"
+            "size": 368,
+            "text": "[\"H4sIAAAAAAAAA4SQQU+DQBCF/0oz541QsBT3RmJiPHjQ6LlZdx+USAF3htim4b+bhVYNF4/z9tv33syZnBFD+kxD74ygaPkLPsw8WAtm0uIHKIL3nWfS7dA0iswPVjvStM63pEhwFNIkYFnNAK9mV0eKPgew1F37+ylJSdFuJ6cerTmAND1fmXHxcKm1lN/+dH4BD40EpDKugjxh3mt/ct4EUw6T9Qh9ilD03ghe6wNIXZZfyMu0h8m36PumtpPjFDGOinAUtHzNaLqKSdNepGcdRVUlN03dfkRBj9abOIvzqDS3GbbxprQZbJ6nNr1zKPP3BGkCTJcRbywew6X+hcfxGwAA//8DAFoun5XIAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 14 Jun 2024 23:48:12 GMT"
+              "value": "Mon, 08 Jul 2024 16:28:35 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "ae1569314cfb0cfa162a1060e560edbf"
+              "value": "b66118c5a7cd1ddfbfc7664920d19fd2"
             },
             {
               "name": "x-trace-id",
-              "value": "db208d02f53b036dd5d5f1f705496c4b"
+              "value": "fa46e705fc6ec883c39def8b2e32ee23"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=aDsB7JZA5N7f9XVqqjHNgt2NTmwnz%2FZb4cs8Xk5b9KCghbuDQZ3yiDE2bCSk09VKCvhbtput3qtpcfjJODU1bryCxf4JtW4kL5UgMzSoDdBcfxuP3B%2Fp25ZtrNXivAEwWVOcyZecB2tuKa%2FFCafX3QsbSprFRcY4HwnVUQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=EbwkI3b59lDvRmUD3W6zuI2eLwX7r5xVEf6hassCQwX5kWVamUbZRvVg3UJCnSi4Z9egadxzvLN3yWF5EK%2BSIm9uLjuQ0F2b6rj2LHIBnsCeJrhap7B5Kmdys5YbFCtuQUCCM%2B7Hee1uiWCOdlasAt%2BHETXNZpnhJ%2B%2BI%2Fw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "893e35b97b7a5e82-EWR"
+              "value": "8a0172c29b3e17ad-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 950,
+          "headersSize": 956,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-06-14T23:48:12.270Z",
-        "time": 472,
+        "startedDateTime": "2024-07-08T16:28:35.507Z",
+        "time": 451,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 472
+          "wait": 451
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 619,
+          "bodySize": 488,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 619,
-            "text": "[\"H4sIAAAAAAAAA9RVTW+bQBC98ytGc06KjcEyvlltFeWQQ6r2VFXRhh0IKlkIO6j5UP57tdgQPnZlye0hOfJ4782b2V3NiweAUrDALbx4AADYVFIwXTf5c48BoG6ShLTGLXDd0FkHU12XtUFVUxQ9+jAWA2AucQu4jAM8ewOZHtnATJrBaGBfWw5JDw1pzkulR4amtMzIgD8HIIwoLU2VkibSUaYgXA3KubLtM3T54ByWNpFQ+g/V2lrOmdiV/HgH0+lubKHsHe2THumnl97c8FNFStybHLhrteigv7p8rC5fZUZ2J4fPf5hScPqUgnc3JQv6y+Zt9f1cKkWJudlzd0vCicf14VVMtTOlQzfvaqI84S2Hp7zl4F/e8geetue4Mw4HW/5B9Zkqf+54PWvC+dGvmm+km4L3/AMbMyEz4isaLCcAvHuStZgvBExqMse5a0/6i2D6nt/TcJEczntCOJLwos2wq6oiT9qqbRyvG18rQ3pkUnoUCYsyM194x1zpre9nGX8qcvXbNz/8ZbQ=\",\"WC82fkrxKohXURyl6Sa8TYNlGAmKw7WIFuv0ttuDyLVI6LK94kclJpX3+hcAAP//AwCUrfQF2AcAAA==\"]"
+            "size": 488,
+            "text": "[\"H4sIAAAAAAAAA7STT2+CQBDFvwqZMy0uKsjeTNs0PfRg054aY1Z2RFJc6O6Q+id892ZBPQBq0qRHZt783u7b4QBSkAB+gLKQgnBWpnv7Zco4RmOAky7RBdQ61wa4KrPMhe+jKJXAgUU+uEC4JeBAaMixbafBSbBqNJTmytgRlAka4J8HULnEM8QfDTuQZuoEcu4cBi4IZX5QX0OxCWuhmpkWaLGgXYFKbBA4TGsFVL3lJ5kgVG7Hxr9l4//BZt7be8iVwtjG0RmeHXO62Og/vj8a3Q7c7w/8v844v9C9Sk73neLHeZPf0JQZWUEiZIL0is2ur3dSi/NOxhrthac2ikdB+J5uENzjD9Eqt72ea+60KLI0rom1RVW5gFtCZU4eWZ4Y4LAmKgz3vCSh+yxVX56te2w8CAYTT2IYBJMgGo4HIYYrjALGmFiJZSjkUPiRfTAtYnyxD3hTXFW/AAAA//8DAEz/bhPcAwAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:59 GMT"
+              "value": "Tue, 09 Jul 2024 18:48:40 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "8a45e1ad921881842795e26da8a4b0a1"
+              "value": "fa59a18c8ccd79edcb78b47da9db6af1"
             },
             {
               "name": "x-trace-id",
-              "value": "fe93293595ff84bf2145ae946a506fbd"
+              "value": "de7668693507e7fe96111afab7ad3a29"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=zIZMepAznpYm6Do2VqD92AdbP0i%2Bv6IFwaFFRvN%2FuhlDB1v2t64kVCNJlWtB3u7jjm8ZfVef%2FcqWYd6MwXCMcjwBanuxDd05%2BrLF3gXMbmbtpOfDhJpRNGyIJCSeDdbDbFTjVPqLeIDoJEH0dglzhCZeBFOwu3t%2BPlxKoQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=idQMorIDIoGAepTyQ1y52cKwhtfxeFJ1QX5NXt0A8Lkp2sqTjtrlirb7rD3GCBQOaLf28lNg6JYTckC4M8E8OBqORo%2Fe3yekvVg8TYHUCSpLRTwJeLwTSVQepQk8R%2B8ARyksuhz8sUnPb7jcLMqxwkngJw29g6aGHgSMtw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0d0504b1c4233-EWR"
+              "value": "8a0a7d4f6e030cac-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 943,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:59.620Z",
-        "time": 290,
+        "startedDateTime": "2024-07-09T18:48:39.521Z",
+        "time": 539,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 290
+          "wait": 539
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 492,
+          "bodySize": 412,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 492,
-            "text": "[\"H4sIAAAAAAAAA4SST2+CQBDF73yKyZxNARVquZm2aXrowaY9NY1Zd0ckRUB2SPwTv3uziHTBGo/79v32vczOwQFAJVhgBAcHAACrQgmmWZXsWw0AdSUlaY0RcFnR4CxTWealUbMqTVt104UBMFEYAfrhGAd/ItOWjcykGQwDp2xlmzYVaU7yTHceNNEqJiN+WSJ0LLUtyxX10E6noRdacde6nTr8068F5nPeFZSJtUnDWUNgz3jsk1e4ZxVTlz1ap2/7lSsvPOZZRrLbwUq/oJL92de6ep7PdjHeSVcpn/yNG2OhYuI3slYJAFc7VYrL70NZkhnktJ7xk2D6SNZkf3sz6Z7hRsOXusO0KNJE1ql1Hec8vhpD2jJlulMJ0zw2J1wxFzpy3TjmuzTJflxz4fqBF3oTNxiNJsMJhQ+BEgsKx74IpL+UchF4tPTug6Y+cikkvdbLdRMxrZzjLwAAAP//AwBhnnuQhgMAAA==\"]"
+            "size": 412,
+            "text": "[\"H4sIAAAAAAAAA4SRT0/DMAzFv8rkc0X/sJY2twkQ4sBhCE4ITVniZhFdWhJX2lb1u6O0ZUKbKo7xe/45fu5AcuLAOmgbyQnXrT75l2uFQOeAkW0xALS2tg6YaasqgO/JpCUwiLMlBEB4IGBA6Gjh5cWIk+Dd6EjXxvkWlAodsI8OTC3xDEmi7Aoydv0BbTZ0bNDwPQKD9aRDPyM8SoXQf86o97UxKGYA+nRVfD+n84qurcgbFJcK6QXH/HZHafl5T2HR/3rl93nghG96jxBMIV+UL2c9DdxV01RaDMRhRN8HgAdC435nVLVywGBH1DgWhkrRTaXNV+jrYZxGWZSHRZIWvMyXyTYr0+IuSyMZR6W8xUKUeZkMp7Nc4LO/wr/mvv8BAAD//wMACv6fADACAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:58 GMT"
+              "value": "Tue, 09 Jul 2024 18:48:38 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "f0a458ef48ef52c70d6de0c06ecaca89"
+              "value": "5e2a85639454117b5fdbd777d210522a"
             },
             {
               "name": "x-trace-id",
-              "value": "533828e695dabe641a5c1fccb50ef075"
+              "value": "9259af842b6f597650d10fd3e9cf8f24"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=4xq0HL8yQrzU4BxdbLOPCLyPhneIEa6iuWZYvckabNin2TRUxF6RmxlxiNDqxFdyDb4zzbedEFBK21SDcIyO5fPK9INmb5xSnO970IwXtwU6%2BENbJ1BMciUZI9uRtgEZ0aOu3ASsP9nlrGCKRqD9UJrv5HQADoJy1hcL1g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=eaWZYTzkZrUmjv2EFjuoEG3Z6J0jw%2BfyDNXUMpPkurwupr4XqkjcIRpPvizmjABYLcBq8wtvcVV4jrVKzguxFQNL2coQexBKbHuYIAnyOxjRMNnNwIp5L%2BGzAfZIHwpt3S9oOjle2inX5O%2BNlL%2FxKSo8ZlTgvjAfk8k%2BZg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0d0435cee43a0-EWR"
+              "value": "8a0a7d3b196a4262-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 941,
+          "headersSize": 949,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:57.556Z",
-        "time": 410,
+        "startedDateTime": "2024-07-09T18:48:36.224Z",
+        "time": 2343,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 410
+          "wait": 2343
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 519,
+          "bodySize": 432,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 519,
-            "text": "[\"H4sIAAAAAAAAA8RTTU+DQBC98ysmc67C9kvk1qgxHjzU6MmYZt0dKZECZYekH+l/N0sLArVp0ovHffvevDeTma0DgFqyxAC2DgAAFpmWTNMi2tQYAJpCKTIGA+C8oF4FU56nuUWTIo5rdNkWA2CkMQAUYx97vyDTii3MZBisBvbeuklaFmQ4ShPTKmitdUgWfG+A0KKUtCTV1JG2MvWF17A7lW2focoHVyD+Es1mvM4okQvriNODCjvEXVd5QvegQ2prO8oLehWX9Nr/l14br49mlRMV7tIkIdXO0HA/UkWbilezOpy3+hBeyBQx7/kHNoZSh8TP1DgdAJyvdS6P1xVVTnaYk3LO95LpNVpQc80P0+4QziR8LDNMsiyOVOlaxnGq8ZUypBVTYlqRME5D+8I5c2YC1w1Dvo6j5Nu1H64YeWPPd2/lYCjUp6dGSnvDGzEafGnpCV/0B0P/xqtOGTmXip7KBTsrsamc3Q8AAAD//w==\",\"AwClog3CdgQAAA==\"]"
+            "size": 432,
+            "text": "[\"H4sIAAAAAAAAA5yRy2rDMBBFf8XMWq3t2Iod7UJbShddpLSrUoKQBkXUkV1pDHngfy/Ka5EQAllq5s65o7lb0JIkiC30nZaEs95u4iv0SmEIIMj3yAC9b30A4fqmYfB3EFkNAvJxDQwIVwQCCAMlsZ3scRqiGgPZ1oU4gtpgAPG9BddqPEFGeXYB2U8dQclDkgOD+ZzWHTq5RBAwO2hguNJ40QZhYBdm+W2z0Z1mP1e6T61zqK4A7Oai+HWK4wND31AUGKkN0jvuA1ustZenwyqPcfNp/NOzJPy0SwR2SPWsfO71uuNOu66xakfcWQwDA1wRunD0aFoTQMCCqAsiTY2hx8a63zTW05xn46xO64LXNedcqiofl5msJ0WZ8VJNFFYVr4p4eS8VvsUkboqH4R8AAP//AwDhgr6loQIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 13 May 2024 19:44:24 GMT"
+              "value": "Tue, 09 Jul 2024 18:48:39 GMT"
             },
             {
               "name": "content-type",
@@ -250,7 +250,7 @@
             },
             {
               "name": "connection",
-              "value": "keep-alive"
+              "value": "close"
             },
             {
               "name": "vary",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "5eacf6d93011895083ea7b10030abc41"
+              "value": "01d8a5d123b645b39abb754bb1cd3198"
             },
             {
               "name": "x-trace-id",
-              "value": "9a341cb0c5cd047153fda01812348708"
+              "value": "83588555ac71640a8934054c9ce77573"
             },
             {
               "name": "strict-transport-security",
@@ -289,26 +289,34 @@
               "value": "DYNAMIC"
             },
             {
+              "name": "report-to",
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=BDYsKww2wxdlQmJrfFv%2B49365lsiA44O6DbEl3jbz2JPxiHpk8wUfspG7UXJnjuBq2h1xjiQjVccGHrP1uXgbQ5Tbm0uUsVcW5voKLW%2BOcibZ2yhlGF5PlkXgFWQYwqhyBFTctVVefTq%2Fi7jDKhudJ800M6%2Ft5m6SeKKkg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
+              "name": "nel",
+              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+            },
+            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "8835248b2cc242c0-EWR"
+              "value": "8a0a7d4c5a877cf6-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 587,
+          "headersSize": 947,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-05-13T19:44:22.147Z",
-        "time": 2573,
+        "startedDateTime": "2024-07-09T18:48:39.035Z",
+        "time": 412,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -316,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2573
+          "wait": 412
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
@@ -227,18 +227,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 512,
+          "bodySize": 432,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 512,
-            "text": "[\"H4sIAAAAAAAAA8STTU+DQBCG7/yKyZyrfJSSyq1RYzx4qNGTMc1md6RECpQdkn6k/90sBQRq06QXj/vu++y8M5ndWwCoBAsMYW8BAGCZK8E0L+NdqwGgLqUkrTEELkoaNTIVRVYYNS2TpFXXfRgAY4UhoBtMcfQrMm3YyEyawTBwrK26pnVJmuMs1b0HTWkVkRE/OiL0LJUtzRQN0F4mz3U65c5lO2Zo8sENuH9BiwVvc0rFylTEeU3hwHgYkme4RxVRnx2QV/TqXtOr9y+9dk6f3VfOvHCfpSnJfoZO9RMq3jW+1jXwvLcf4ZV0mfDRX7sxEioifqHO1wHA5VYV4nRdURZkhjmr5vwgmN7iFXXXvJ72wHAh4VOVYZbnSSyrqlUcqxlfhSFtmFLdi4RJFpkTLplzHdp2FPFtEqfftrmw3YkTOFNbyTupXOl4Uz+QE1eqie+4nj+ejn3HC75kHR+5EJKeqwW7iJhU1uEHAAD//wMAKFDOu3YEAAA=\"]"
+            "size": 432,
+            "text": "[\"H4sIAAAAAAAAA5yST08CMRDFv8pmztX9E1hKb0SN8eABoydjSGnH0rh013Y2ATb73U1h4QAhJB478+b3pn3tQEuSIDpoGy0J563dxVNolcIQQJBvkQF6X/sAwrVVxeB3EFkNAvKSAwPCDYEAwkBJbCcHnIaoxkC2diGOoDYYQHx24GqNJ0iRZxeQw9QRlNwlOTBYLGjboJNrBAHzQQP9lcaTNgg9uzDLb5sV/zT7utJ9qJ1DdQVgdxfFj1McbxjaiqLASG2QXvEQ2GqrvTw9rPIYN5/FOz1Kwne7RmBDqmflc6/nPXfWNJVVe+Leou8Z4IbQhaNHVZsAAlZETRBpagzdV9b9pLGe5uOszHg6zfh4OZ2U5VhN+IgXfDmd4OhbS67KcsTjhyAvFb7EJG6K+/4PAAD//wMA6/HxfKECAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:58 GMT"
+              "value": "Tue, 09 Jul 2024 18:48:38 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +270,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "2abe5512328ea3a4d189dc177e18f9d9"
+              "value": "cbb309e01864ddea724b8557106c5074"
             },
             {
               "name": "x-trace-id",
-              "value": "dc9cd1c02846c51cd5401243834026fc"
+              "value": "9085b97665c784828b97e4fda8c6648d"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ufnEMwcU1aaPT47YD7bI%2FFxjyYkVfxYvzFdn2gVJ918Dx6U9uSAQq5qnlfP2Sk8o9JJJ0YJgxsQb96yFVpH%2BFfW6VPiVdRa2iAlsJsdO573WrI0S1%2FEaLmXM59d04V%2BD%2FUQclLS1cIJq8KRpZNuNdeeLmVuLB7w0RbmVZg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=3GKfAGTFV6YwwKvrWv6SJNGhRTa%2BFSBARoyg46jju9xATagFmGi%2BG8GZhqvpuKEwnpiBqYSV7AaPJrMDqjCH97ovgVcqvLRXEZlEeGWp2%2F6oNO%2FGdkW3E%2FLGQxdRDMPtpMMTETnGsMlbJTHwOm00mQwLW0%2Fm44zPw6TnPA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
             },
             {
               "name": "nel",
@@ -302,21 +302,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "87a0d047cac443c3-EWR"
+              "value": "8a0a7d49dd3e42e1-EWR"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 951,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:58.256Z",
-        "time": 483,
+        "startedDateTime": "2024-07-09T18:48:38.638Z",
+        "time": 327,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 483
+          "wait": 327
         }
       }
     ],

--- a/packages/react/spec/useActionFormNested.spec.tsx
+++ b/packages/react/spec/useActionFormNested.spec.tsx
@@ -2984,6 +2984,91 @@ describe("useActionFormNested", () => {
         });
       });
 
+      test("can update multiple BelongsTo link", async () => {
+        const queryResponse = {
+          data: {
+            answer: {
+              __typename: "Answer",
+              id: "123",
+              text: "Answer create",
+              question: {
+                __typename: "Question",
+                id: "1",
+              },
+            },
+          },
+        };
+
+        const { result: useActionFormHook } = renderHook(
+          () =>
+            useActionForm(nestedExampleApi.answer.update, {
+              findBy: "123",
+              select: {
+                id: true,
+                text: true,
+                question: {
+                  id: true,
+                },
+              },
+              onError: (error) => {
+                expect(error).toBeUndefined();
+              },
+            }),
+          {
+            wrapper: MockClientWrapper(nestedExampleApi),
+          }
+        );
+
+        expect(mockUrqlClient.executeQuery).toBeCalledTimes(1);
+
+        mockUrqlClient.executeQuery.pushResponse("answer", {
+          stale: false,
+          hasNext: false,
+          data: queryResponse.data,
+        });
+
+        let formValues: any;
+
+        await act(async () => {
+          formValues = useActionFormHook.current.getValues();
+        });
+
+        expect(formValues.answer).toBeDefined();
+
+        await act(async () => {
+          (useActionFormHook.current as any).setValue("answer.question.id", "2");
+        });
+
+        let submitPromise: Promise<any>;
+
+        await act(async () => {
+          submitPromise = useActionFormHook.current.submit();
+        });
+
+        expect(mockUrqlClient.executeMutation).toHaveBeenCalledTimes(1);
+        expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toMatchInlineSnapshot(`
+          {
+            "answer": {
+              "question": {
+                "_link": "2",
+              },
+              "text": "Answer create",
+            },
+            "id": "123",
+          }
+        `);
+
+        mockUrqlClient.executeMutation.pushResponse("updateAnswer", {
+          data: {},
+          stale: false,
+          hasNext: false,
+        });
+
+        await act(async () => {
+          await submitPromise;
+        });
+      });
+
       test("can update BelongsTo", async () => {
         const queryResponse = {
           data: {

--- a/packages/react/src/use-action-form/types.ts
+++ b/packages/react/src/use-action-form/types.ts
@@ -104,3 +104,5 @@ export type UseActionFormState<
 type Increment<A extends number[]> = [...A, 0];
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
+
+export type ContextAwareSelect<T> = T extends boolean | null | undefined ? T | "ReadOnly" : { [K in keyof T]: ContextAwareSelect<T[K]> };

--- a/packages/react/src/use-action-form/types.ts
+++ b/packages/react/src/use-action-form/types.ts
@@ -1,4 +1,13 @@
-import type { ActionFunction, DefaultSelection, GadgetRecord, GlobalActionFunction, Select } from "@gadgetinc/api-client-core";
+import type {
+  ActionFunction,
+  ActionWithIdAndNoVariables,
+  ActionWithIdAndVariables,
+  BulkActionWithIdsAndNoVariables,
+  DefaultSelection,
+  GadgetRecord,
+  GlobalActionFunction,
+  Select,
+} from "@gadgetinc/api-client-core";
 import type { FieldValues, UseFormReturn } from "react-hook-form";
 import type { useAction } from "../useAction.js";
 import type { useGlobalAction } from "../useGlobalAction.js";
@@ -106,3 +115,8 @@ type Increment<A extends number[]> = [...A, 0];
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
 export type ContextAwareSelect<T> = T extends boolean | null | undefined ? T | "ReadOnly" : { [K in keyof T]: ContextAwareSelect<T[K]> };
+
+export type AnyActionWithId<OptionsT> =
+  | ActionWithIdAndNoVariables<OptionsT>
+  | ActionWithIdAndVariables<OptionsT, any>
+  | BulkActionWithIdsAndNoVariables<OptionsT>;

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -420,7 +420,7 @@ export function getReadOnlyPaths(obj?: any, prefix = ""): string[] {
  * Uses the `select` object to remove any fields that are marked as `ReadOnly` from the `data` object.
  * Also removes any fields that isn't in the `send` array.
  */
-export function applyDataMask(opts: { select?: any; send?: string[]; data: Record<string, any>; modelApiIdentifier: string }) {
+export function applyDataMask(opts: { select?: any; send?: string[]; data: Record<string, any>; modelApiIdentifier?: string }) {
   const { select, send, data, modelApiIdentifier } = opts;
 
   const readOnlyPaths = getReadOnlyPaths(select, modelApiIdentifier);
@@ -432,11 +432,13 @@ export function applyDataMask(opts: { select?: any; send?: string[]; data: Recor
   const dataToSend = {};
   if (send) {
     for (const key of send) {
-      const value = get(data, key);
+      const value = modelApiIdentifier ? get(data, `${modelApiIdentifier}.${key}`) : undefined ?? get(data, key);
       if (value != null) {
-        set(dataToSend, key, value);
+        set(dataToSend, modelApiIdentifier ? `${modelApiIdentifier}.${key}` : key, value);
       }
     }
+
+    return dataToSend;
   }
 
   return data;

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -2,7 +2,7 @@ import type { AnyClient, AnyModelManager, GadgetRecord } from "@gadgetinc/api-cl
 import { $modelRelationships, camelize, isEqual } from "@gadgetinc/api-client-core";
 import { useFindBy } from "../useFindBy.js";
 import { useFindOne } from "../useFindOne.js";
-import type { ErrorWrapper } from "../utils.js";
+import { get, set, unset, type ErrorWrapper } from "../utils.js";
 
 /** Finds a given record from the backend database by either id or a `{[field: string]: value}` slug */
 export const useFindExistingRecord = (
@@ -39,6 +39,22 @@ const omitKeys = (data: any) => {
     delete newData[key];
   }
   return newData;
+};
+
+export const processDefaultValues = (opts: {
+  hasAmbiguousDefaultValues: boolean;
+  modelApiIdentifier: string;
+  data: any;
+  defaultValues?: any;
+}) => {
+  const { modelApiIdentifier, data, defaultValues } = opts;
+
+  const modelDefaultValues = toDefaultValues(modelApiIdentifier, data);
+  const result = opts.hasAmbiguousDefaultValues
+    ? { ...defaultValues, [modelApiIdentifier]: modelDefaultValues }
+    : { ...defaultValues, ...modelDefaultValues, [modelApiIdentifier]: modelDefaultValues };
+
+  return result;
 };
 
 export const toDefaultValues = (modelApiIdentifier: string | undefined, data: any) => {
@@ -366,3 +382,62 @@ const isPlainObject = (obj: any) => {
 
   return Object.getPrototypeOf(obj) === proto;
 };
+
+export function transformContextAwareToSelect<T>(obj?: T) {
+  if (typeof obj !== "object" || obj == null) {
+    return obj === "ReadOnly" ? true : obj;
+  }
+
+  const result: any = Array.isArray(obj) ? [] : {};
+  for (const key in obj) {
+    const value = obj[key];
+    result[key] = transformContextAwareToSelect(value);
+  }
+  return result;
+}
+
+export function getReadOnlyPaths(obj?: any, prefix = ""): string[] {
+  if (!obj) {
+    return [];
+  }
+
+  let paths: string[] = [];
+  for (const key of Object.keys(obj)) {
+    let currentPath = prefix ? `${prefix}.${key}` : key;
+    if (currentPath.includes("edges.node")) {
+      currentPath = currentPath.replace("edges.node", "*");
+    }
+    if (obj[key] === "ReadOnly") {
+      paths.push(currentPath);
+    } else if (typeof obj[key] === "object" && obj[key] != null) {
+      paths = paths.concat(getReadOnlyPaths(obj[key], currentPath));
+    }
+  }
+  return paths;
+}
+
+/**
+ * Uses the `select` object to remove any fields that are marked as `ReadOnly` from the `data` object.
+ * Also removes any fields that isn't in the `send` array.
+ */
+export function applyDataMask(opts: { select?: any; send?: string[]; data: Record<string, any>; modelApiIdentifier: string }) {
+  const { select, send, data, modelApiIdentifier } = opts;
+
+  const readOnlyPaths = getReadOnlyPaths(select, modelApiIdentifier);
+
+  for (const path of readOnlyPaths) {
+    unset(data, path);
+  }
+
+  const dataToSend = {};
+  if (send) {
+    for (const key of send) {
+      const value = get(data, key);
+      if (value != null) {
+        set(dataToSend, key, value);
+      }
+    }
+  }
+
+  return data;
+}

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -402,6 +402,19 @@ export const set = (obj: any, path: string, value: any) => {
   }, obj);
 };
 
+/**
+ * Removes the property at path of object.
+ * From https://youmightnotneed.com/lodash
+ */
+export const unset = (obj: any, path: string) => {
+  const pathArray = pathToPathArray(path);
+
+  pathArray.reduce((acc, key, i) => {
+    if (i === pathArray.length - 1) delete acc[key];
+    return acc[key];
+  }, obj);
+};
+
 export const getModelManager = (
   apiClient: AnyClient,
   apiIdentifier: string,


### PR DESCRIPTION
This PR addresses a handful of shitty experiences a user in the discord had.

1. When updating a `belongsTo` relationship, you may want to update the link AND also display information returned from a `findby` associated with the child.
2. Send wasn't filtering out data being pushed into reshape
3. Adds the ability to mark fields as `ReadOnly` using a select which will be excluded from reshaping

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
