### PR TITLE
Fallback to current date if date value is undefined in PolarisDateTimePicker

### DIFF
--- a/packages/react/cypress/component/auto/form/PolarisDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisDateTimePicker.cy.tsx
@@ -38,6 +38,18 @@ describe("PolarisDateTimePicker", () => {
       cy.get("#test-date").should("have.value", format(dateInLocalTZ, "yyyy-MM-dd"));
     });
 
+    it("can change the date when the value is undefined", async () => {
+      const onChangeSpy = cy.spy().as("onChangeSpy");
+      cy.mountWithWrapper(
+        <PolarisAutoForm action={api.widget.create}>
+          <PolarisDateTimePicker id="test" onChange={onChangeSpy} field="startsAt" />
+        </PolarisAutoForm>,
+        PolarisWrapper
+      );
+      cy.get("#test-date").click();
+      cy.get(".Polaris-DatePicker__Title").contains(`${new Date().getFullYear()}`);
+    });
+
     it("can change the date", async () => {
       const onChangeSpy = cy.spy().as("onChangeSpy");
       cy.mountWithWrapper(

--- a/packages/react/src/auto/polaris/inputs/PolarisDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisDateTimePicker.tsx
@@ -69,10 +69,9 @@ export const PolarisDateTimePicker = (props: {
 
   const onDateChange = useCallback<Exclude<DatePickerProps["onChange"], undefined>>(
     (range) => {
-      const date = new Date(range.start);
-      fieldProps && copyTime(date, zonedTimeToUtc(new Date(fieldProps.value), localTz));
-      onChange?.(zonedTimeToUtc(date, localTz));
-      fieldProps.onChange(zonedTimeToUtc(date, localTz));
+      fieldProps && copyTime(range.start, zonedTimeToUtc(range.start, localTz));
+      onChange?.(zonedTimeToUtc(range.start, localTz));
+      fieldProps.onChange(zonedTimeToUtc(range.start, localTz));
       setDatePopoverActive(false);
     },
     [onChange, localTz, fieldProps]
@@ -106,8 +105,8 @@ export const PolarisDateTimePicker = (props: {
       >
         <div style={{ padding: "16px" }}>
           <DatePicker
-            month={getDateTimeObjectFromDate(zonedTimeToUtc(new Date(fieldProps.value), localTz)).month}
-            year={getDateTimeObjectFromDate(zonedTimeToUtc(new Date(fieldProps.value), localTz)).year}
+            month={getDateTimeObjectFromDate(zonedTimeToUtc(fieldProps.value ? new Date(fieldProps.value) : new Date(), localTz)).month}
+            year={getDateTimeObjectFromDate(zonedTimeToUtc(fieldProps.value ? new Date(fieldProps.value) : new Date(), localTz)).year}
             allowRange={false}
             onChange={onDateChange}
             onMonthChange={handleMonthChange}


### PR DESCRIPTION
This PR fixes a bug about the PolarisDateTimePicker not providing the current date as a fallback when the input value is undefined.

Previously, it assumed the `fieldProps.value` must have a value. However, if the input has not been modified or has no default (e.g. when creating a record), `fieldProps.value` is actually `null`, making a date an "Invalid Date" and unable to render the calendar.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
