### PR TITLE
Fix date picker

### DIFF
--- a/packages/react/cypress/component/auto/form/PolarisDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisDateTimePicker.cy.tsx
@@ -25,6 +25,9 @@ describe("PolarisDateTimePicker", () => {
         PolarisWrapper
       );
       cy.get("#test-date").should("have.value", "");
+
+      cy.get("#test-date").click();
+      cy.get(".Polaris-DatePicker__Title").contains(`${new Date().getFullYear()}`);
     });
 
     it("can show the current value", () => {

--- a/packages/react/cypress/component/auto/form/PolarisDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisDateTimePicker.cy.tsx
@@ -84,6 +84,8 @@ describe("PolarisDateTimePicker", () => {
         </PolarisAutoForm>,
         PolarisWrapper
       );
+      // Test is flaky without waiting for the DOM to load
+      cy.wait(100);
       cy.get("#test-date").should("have.value", "");
       cy.get("#test-time").should("have.value", "");
     });

--- a/packages/react/src/auto/polaris/inputs/PolarisDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisDateTimePicker.tsx
@@ -69,10 +69,9 @@ export const PolarisDateTimePicker = (props: {
 
   const onDateChange = useCallback<Exclude<DatePickerProps["onChange"], undefined>>(
     (range) => {
-      const date = new Date(range.start);
-      fieldProps && copyTime(date, zonedTimeToUtc(new Date(fieldProps.value), localTz));
-      onChange?.(zonedTimeToUtc(date, localTz));
-      fieldProps.onChange(zonedTimeToUtc(date, localTz));
+      fieldProps && copyTime(range.start, zonedTimeToUtc(range.start, localTz));
+      onChange?.(zonedTimeToUtc(range.start, localTz));
+      fieldProps.onChange(zonedTimeToUtc(range.start, localTz));
       setDatePopoverActive(false);
     },
     [onChange, localTz, fieldProps]
@@ -106,8 +105,8 @@ export const PolarisDateTimePicker = (props: {
       >
         <div style={{ padding: "16px" }}>
           <DatePicker
-            month={getDateTimeObjectFromDate(zonedTimeToUtc(new Date(fieldProps.value), localTz)).month}
-            year={getDateTimeObjectFromDate(zonedTimeToUtc(new Date(fieldProps.value), localTz)).year}
+            month={getDateTimeObjectFromDate(zonedTimeToUtc(fieldProps.value ? new Date(fieldProps.value) : new Date(), localTz)).month}
+            year={getDateTimeObjectFromDate(zonedTimeToUtc(fieldProps.value ? new Date(fieldProps.value) : new Date(), localTz)).year}
             allowRange={false}
             onChange={onDateChange}
             onMonthChange={handleMonthChange}


### PR DESCRIPTION
The Polaris date picker is completely broken:

![CleanShot 2024-07-09 at 17 46 27](https://github.com/gadget-inc/js-clients/assets/168455431/e9a17945-ec72-4521-b949-23975c5dad36)

This PR fixes that, and patches some flaky tests.

Previously, it assumed the fieldProps.value must have a value. However, if the input has not been modified or has no default (e.g. when creating a record), fieldProps.value is actually null, making a date an "Invalid Date" and unable to render the calendar.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
