### PR TITLE
GGT-6702 - Show selected date

### DIFF
--- a/packages/react/cypress/component/auto/form/PolarisDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisDateTimePicker.cy.tsx
@@ -84,6 +84,8 @@ describe("PolarisDateTimePicker", () => {
         </PolarisAutoForm>,
         PolarisWrapper
       );
+      // Test is flaky without waiting for the DOM to load
+      cy.wait(100);
       cy.get("#test-date").should("have.value", "");
       cy.get("#test-time").should("have.value", "");
     });

--- a/packages/react/src/auto/polaris/inputs/PolarisDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisDateTimePicker.tsx
@@ -110,7 +110,7 @@ export const PolarisDateTimePicker = (props: {
             allowRange={false}
             onChange={onDateChange}
             onMonthChange={handleMonthChange}
-            selected={props.value}
+            selected={localTime}
             {...props.datePickerProps}
           />
         </div>

--- a/packages/react/src/auto/polaris/inputs/PolarisDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisDateTimePicker.tsx
@@ -69,10 +69,9 @@ export const PolarisDateTimePicker = (props: {
 
   const onDateChange = useCallback<Exclude<DatePickerProps["onChange"], undefined>>(
     (range) => {
-      const date = new Date(range.start);
-      fieldProps && copyTime(date, zonedTimeToUtc(new Date(fieldProps.value), localTz));
-      onChange?.(zonedTimeToUtc(date, localTz));
-      fieldProps.onChange(zonedTimeToUtc(date, localTz));
+      fieldProps && copyTime(range.start, zonedTimeToUtc(range.start, localTz));
+      onChange?.(zonedTimeToUtc(range.start, localTz));
+      fieldProps.onChange(zonedTimeToUtc(range.start, localTz));
       setDatePopoverActive(false);
     },
     [onChange, localTz, fieldProps]
@@ -106,8 +105,8 @@ export const PolarisDateTimePicker = (props: {
       >
         <div style={{ padding: "16px" }}>
           <DatePicker
-            month={getDateTimeObjectFromDate(zonedTimeToUtc(new Date(fieldProps.value), localTz)).month}
-            year={getDateTimeObjectFromDate(zonedTimeToUtc(new Date(fieldProps.value), localTz)).year}
+            month={getDateTimeObjectFromDate(zonedTimeToUtc(fieldProps.value ? new Date(fieldProps.value) : new Date(), localTz)).month}
+            year={getDateTimeObjectFromDate(zonedTimeToUtc(fieldProps.value ? new Date(fieldProps.value) : new Date(), localTz)).year}
             allowRange={false}
             onChange={onDateChange}
             onMonthChange={handleMonthChange}


### PR DESCRIPTION
The Polaris date picker referenced `props.value` as the selected value, but that prop is not updated when a user picks a new date, so it was not showing a selected date when the user selected a new date.

### Before:

https://github.com/gadget-inc/js-clients/assets/168455431/b61475c9-0506-4685-b1ba-2f33a4f36e56

This PR makes the date picker reference `localTime` as the selected value, since this piece of state is updated with the correct date whenever the user uses the date picker. 

### After:

https://github.com/gadget-inc/js-clients/assets/168455431/59659913-b33c-497b-bea9-777e63c888f0

🚧 This PR is blocked by [470](https://github.com/gadget-inc/js-clients/pull/470): it should be merged before this one. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
