### PR TITLE
Add i18n to ShopifyPolaris app providers to get months into date pickers

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -1,4 +1,5 @@
 import { AppProvider, Card, Page } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Provider } from "../../src/GadgetProvider.tsx";
@@ -17,7 +18,7 @@ export default {
       // 👇 Make it configurable by reading the theme value from parameters
       return (
         <Provider api={api}>
-          <AppProvider>
+          <AppProvider i18n={translations}>
             <FormProvider {...useForm()}>
               <Page>
                 <Card>

--- a/packages/react/spec/auto/inputs/PolarisAutoPasswordInput.stories.jsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoPasswordInput.stories.jsx
@@ -1,4 +1,5 @@
 import { AppProvider, Card, Page } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Provider } from "../../../src/GadgetProvider.tsx";
@@ -6,7 +7,6 @@ import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.tsx";
 import { PolarisPasswordInput } from "../../../src/auto/polaris/inputs/PolarisPasswordInput.tsx";
 import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoSubmit.tsx";
 import { testApi as api } from "../../apis.ts";
-
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
   title: "Polaris/AutoPasswordInput",
@@ -22,7 +22,7 @@ export default {
       // 👇 Make it configurable by reading the theme value from parameters
       return (
         <Provider api={api}>
-          <AppProvider>
+          <AppProvider i18n={translations}>
             <FormProvider {...useForm()}>
               <Page>
                 <Card>

--- a/packages/react/spec/auto/inputs/PolarisBooleanInput.stories.jsx
+++ b/packages/react/spec/auto/inputs/PolarisBooleanInput.stories.jsx
@@ -1,11 +1,11 @@
 import { AppProvider } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Provider } from "../../../src/GadgetProvider.tsx";
 import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.tsx";
 import { PolarisBooleanInput } from "../../../src/auto/polaris/inputs/PolarisBooleanInput.tsx";
 import { testApi as api } from "../../apis.ts";
-
 export default {
   title: "Polaris/BooleanInput",
   component: PolarisBooleanInput,
@@ -13,7 +13,7 @@ export default {
     (Story, { parameters }) => {
       const { theme = "light" } = parameters;
       return (
-        <AppProvider>
+        <AppProvider i18n={translations}>
           <FormProvider {...useForm()}>
             <Provider api={api}>
               <PolarisAutoForm action={api.widget.create}>

--- a/packages/react/spec/auto/inputs/PolarisFileInput.stories.jsx
+++ b/packages/react/spec/auto/inputs/PolarisFileInput.stories.jsx
@@ -1,4 +1,5 @@
 import { AppProvider } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Provider } from "../../../src/GadgetProvider.tsx";
@@ -12,7 +13,7 @@ export default {
   decorators: [
     (Story, { parameters }) => {
       return (
-        <AppProvider>
+        <AppProvider i18n={translations}>
           <FormProvider {...useForm()}>
             <Provider api={api}>
               <PolarisAutoForm action={api.game.stadium.create}>

--- a/packages/react/spec/auto/inputs/PolarisJsonInput.stories.jsx
+++ b/packages/react/spec/auto/inputs/PolarisJsonInput.stories.jsx
@@ -1,4 +1,5 @@
 import { AppProvider, Card, Page } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Provider } from "../../../src/GadgetProvider.tsx";
@@ -14,7 +15,7 @@ export default {
       const { theme = "light" } = parameters;
       return (
         <Provider api={api}>
-          <AppProvider>
+          <AppProvider i18n={translations}>
             <FormProvider {...useForm()}>
               <PolarisAutoForm action={api.widget.create}>
                 <Page>

--- a/packages/react/spec/auto/inputs/PolarisStringInput.stories.jsx
+++ b/packages/react/spec/auto/inputs/PolarisStringInput.stories.jsx
@@ -1,4 +1,5 @@
 import { AppProvider, Card, Page } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Provider } from "../../../src/GadgetProvider.tsx";
@@ -17,7 +18,7 @@ export default {
       const { theme = "light" } = parameters;
       return (
         <Provider api={api}>
-          <AppProvider>
+          <AppProvider i18n={translations}>
             <FormProvider {...useForm()}>
               <PolarisAutoForm action={api.widget.create}>
                 <Page>


### PR DESCRIPTION
- **UPDATE**
  - Previously, in storybook, the month did not appear in the date picker.
    - This was because the 'ApProvider' did not have a "i18n' property passed into it
    - Without the i18n, the date picker doesn't know if it should show `January | Janvier | يناير | 一月` etc...
  - Now, English is explicitly passed in throughout the repo

 