### PR TITLE
Implement enum input for auto component

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.498.0-development.749",
+    "@gadget-client/js-clients-test": "1.498.0-development.854",
     "@gadget-client/kitchen-sink": "1.5.0-development.200",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/react/cypress/component/auto/form/PolarisAutoEnumInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoEnumInput.cy.tsx
@@ -1,0 +1,345 @@
+import React from "react";
+import { getStadiumRecord } from "../../../../spec/auto/support/stadiumModel.js";
+import { PolarisAutoForm } from "../../../../src/auto/polaris/PolarisAutoForm.js";
+import { api } from "../../../support/api.js";
+import { PolarisWrapper } from "../../../support/auto.js";
+
+describe("PolarisEnumInput", () => {
+  const blurComboboxes = () => {
+    cy.get("#type-combobox-textfield").blur({ force: true });
+    cy.get("#tags-combobox-textfield").blur({ force: true });
+  };
+
+  beforeEach(() => {
+    cy.viewport("macbook-13");
+
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.endpoint}?operation=createStadium`,
+      },
+      {
+        data: {
+          game: {
+            createStadium: {
+              success: true,
+              errors: null,
+              stadium: {}, // The response content doesn't matter for the tests
+              __typename: "CreateGameStadiumResult",
+            },
+            __typename: "GameMutations",
+          },
+        },
+      }
+    ).as("createStadium");
+
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.endpoint}?operation=updateStadium`,
+      },
+      {
+        data: {
+          game: {
+            createStadium: {
+              success: true,
+              errors: null,
+              stadium: {}, // The response content doesn't matter for the tests
+              __typename: "CreateGameStadiumResult",
+            },
+            __typename: "GameMutations",
+          },
+        },
+      }
+    ).as("updateStadium");
+  });
+
+  it("should include the enum options in the dropdown", () => {
+    cy.mockModelActionMetadata(api, baseModelActionMetadata);
+
+    cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+    cy.get("#type-combobox-textfield").click();
+    cy.contains("football").should("exist");
+    cy.contains("basketball").should("exist");
+    cy.contains("baseball").should("exist");
+    // Close the "type" dropdown
+    blurComboboxes();
+
+    cy.get("#tags-combobox-textfield").click();
+    cy.contains("hello").should("exist");
+    cy.contains("world").should("exist");
+  });
+
+  describe("searching for an option", () => {
+    it("should show the selected value in the dropdown for single select enum", () => {
+      cy.mockModelActionMetadata(api, baseModelActionMetadata);
+
+      cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      cy.get("#type-combobox-textfield").click();
+      cy.contains("football").click();
+      cy.get(".Polaris-InlineStack").should("contain", "football");
+
+      cy.get("#tags-combobox-textfield").click();
+      cy.contains("hello").parent().parent().click();
+      cy.get(".Polaris-InlineStack").should("contain", "hello");
+      cy.get(".Polaris-InlineStack").should("not.contain", "world");
+
+      blurComboboxes();
+
+      cy.getSubmitButton().click();
+      cy.get("@createStadium")
+        .its("request.body.variables.stadium")
+        .should("deep.equal", {
+          type: "football",
+          tags: ["hello"],
+        });
+    });
+
+    it("should allow searching for options in the dropdown", () => {
+      cy.mockModelActionMetadata(api, baseModelActionMetadata);
+
+      cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      // For single select enums
+      cy.get("#type-combobox-textfield").type("foot");
+
+      // The dropdown items should be filtered
+      cy.contains("football").should("exist");
+      cy.contains("basketball").should("not.exist");
+      cy.contains("baseball").should("not.exist");
+
+      cy.contains("football").click();
+      cy.get(".Polaris-InlineStack").should("contain", "football");
+
+      // For multi-select enums
+      cy.get("#tags-combobox-textfield").type("hel");
+
+      // The dropdown items should be filtered
+      cy.contains("hello").should("exist");
+      cy.contains("world").should("not.exist");
+
+      cy.contains("hello").parent().parent().click();
+      cy.get(".Polaris-InlineStack").should("contain", "hello");
+
+      blurComboboxes();
+
+      cy.getSubmitButton().click();
+      cy.get("@createStadium")
+        .its("request.body.variables.stadium")
+        .should("deep.equal", {
+          type: "football",
+          tags: ["hello"],
+        });
+    });
+  });
+
+  describe("allow other options", () => {
+    it("should allow adding an option if allowOther is enabled", () => {
+      cy.mockModelActionMetadata(api, {
+        ...baseModelActionMetadata,
+        inputFields: [
+          {
+            ...baseTypeInputField,
+            configuration: {
+              ...baseTypeInputField.configuration,
+              allowOther: true,
+            },
+          },
+          {
+            ...baseTagsInputField,
+            configuration: {
+              ...baseTagsInputField.configuration,
+              allowOther: true,
+            },
+          },
+        ],
+      });
+
+      cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      cy.get("#type-combobox-textfield").type("extra");
+      cy.contains(`Add "extra"`).click();
+      cy.get(".Polaris-InlineStack").should("contain", "extra");
+
+      cy.get("#tags-combobox-textfield").type("more");
+      cy.contains(`Add "more"`).click();
+      cy.get(".Polaris-InlineStack").should("contain", "more");
+
+      blurComboboxes();
+
+      cy.getSubmitButton().click();
+      cy.get("@createStadium")
+        .its("request.body.variables.stadium")
+        .should("deep.equal", {
+          type: "extra",
+          tags: ["more"],
+        });
+    });
+
+    it("should not allow adding an option if allowOther is disabled", () => {
+      cy.mockModelActionMetadata(api, {
+        ...baseModelActionMetadata,
+        inputFields: [
+          {
+            ...baseTypeInputField,
+            configuration: {
+              ...baseTypeInputField.configuration,
+              allowOther: false,
+            },
+          },
+          {
+            ...baseTagsInputField,
+            configuration: {
+              ...baseTagsInputField.configuration,
+              allowOther: false,
+            },
+          },
+        ],
+      });
+
+      cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      cy.get("#type-combobox-textfield").type("hello");
+      cy.contains(`Add "hello"`).should("not.exist");
+      cy.contains(`No options found matching "hello"`).should("exist");
+
+      blurComboboxes();
+
+      cy.get("#tags-combobox-textfield").type("nope");
+      cy.contains(`Add "nope"`).should("not.exist");
+      cy.contains(`No options found matching "nope"`).should("exist");
+    });
+  });
+
+  describe("pre-filled value", () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: "POST",
+          url: `${api.connection.endpoint}?operation=stadium`,
+        },
+        {
+          data: getStadiumRecord({
+            type: "football",
+            tags: ["hello", "world"],
+          }),
+        }
+      ).as("getStadium");
+    });
+
+    it("should automatically set the pre-filled value when the form is pre-filled", () => {
+      cy.mockModelActionMetadata(api, {
+        ...baseModelActionMetadata,
+        action: {
+          apiIdentifier: "update",
+          operatesWithRecordIdentity: true,
+        },
+      });
+
+      cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.update} findBy="42" />, PolarisWrapper);
+      cy.get(".Polaris-InlineStack").should("contain", "football");
+      cy.get(".Polaris-InlineStack").should("contain", "hello");
+      cy.get(".Polaris-InlineStack").should("contain", "world");
+    });
+
+    it("should be able to clear the value", () => {
+      cy.mockModelActionMetadata(api, {
+        ...baseModelActionMetadata,
+        action: {
+          apiIdentifier: "update",
+          operatesWithRecordIdentity: true,
+        },
+      });
+
+      cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.update} findBy="42" />, PolarisWrapper);
+      cy.get("#type-combobox-textfield").click();
+      cy.get('[aria-label="Remove football"]').click();
+
+      blurComboboxes();
+
+      cy.get("#tags-combobox-textfield").click();
+      cy.get('[aria-label="Remove hello"]').click();
+      cy.get('[aria-label="Remove world"]').click();
+
+      blurComboboxes();
+
+      cy.getSubmitButton().click();
+      cy.get("@updateStadium").its("request.body.variables.stadium").should("deep.equal", {
+        type: null,
+        tags: [],
+      });
+    });
+  });
+});
+
+const baseTypeInputField = {
+  name: "Type",
+  apiIdentifier: "type",
+  fieldType: "Enum",
+  requiredArgumentForInput: false,
+  sortable: true,
+  filterable: true,
+  configuration: {
+    __typename: "GadgetEnumConfig",
+    fieldType: "Enum",
+    validations: [],
+    allowMultiple: false,
+    allowOther: true,
+    options: [
+      {
+        name: "football",
+      },
+      {
+        name: "basketball",
+      },
+      {
+        name: "baseball",
+      },
+    ],
+  },
+};
+
+const baseTagsInputField = {
+  name: "Tags",
+  apiIdentifier: "tags",
+  fieldType: "Enum",
+  requiredArgumentForInput: false,
+  sortable: true,
+  filterable: true,
+  configuration: {
+    __typename: "GadgetEnumConfig",
+    fieldType: "Enum",
+    validations: [],
+    allowMultiple: true,
+    allowOther: true,
+    options: [
+      {
+        name: "hello",
+      },
+      {
+        name: "world",
+      },
+    ],
+  },
+};
+
+const baseModelActionMetadata = {
+  modelName: "Stadium",
+  action: {
+    apiIdentifier: "create",
+    operatesWithRecordIdentity: false,
+  },
+  inputFields: [
+    {
+      name: "Stadium",
+      apiIdentifier: "stadium",
+      fieldType: "Object",
+      requiredArgumentForInput: false,
+      configuration: {
+        __typename: "GadgetObjectFieldConfig",
+        fieldType: "Object",
+        validations: [],
+        name: null,
+        fields: [baseTypeInputField, baseTagsInputField],
+      },
+      __typename: "GadgetObjectField",
+    },
+  ],
+};

--- a/packages/react/spec/auto/inputs/PolarisAutoEnumInput.stories.jsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoEnumInput.stories.jsx
@@ -1,0 +1,56 @@
+import { AppProvider, Card, Page } from "@shopify/polaris";
+import React from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { Provider } from "../../../src/GadgetProvider.tsx";
+import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.tsx";
+import { PolarisAutoEnumInput } from "../../../src/auto/polaris/inputs/PolarisAutoEnumInput.tsx";
+import { testApi as api } from "../../apis.ts";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+export default {
+  title: "Polaris/EnumInput",
+  component: PolarisAutoEnumInput,
+  decorators: [
+    // 👇 Defining the decorator in the preview file applies it to all stories
+    (Story, { parameters }) => {
+      // 👇 Make it configurable by reading the theme value from parameters
+      const { theme = "light" } = parameters;
+      return (
+        <Provider api={api}>
+          <AppProvider>
+            <FormProvider {...useForm()}>
+              <PolarisAutoForm action={api.game.stadium.create}>
+                <Page>
+                  <Card>
+                    <Story />
+                  </Card>
+                </Page>
+              </PolarisAutoForm>
+            </FormProvider>
+          </AppProvider>
+        </Provider>
+      );
+    },
+  ],
+
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: "centered",
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+};
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Primary = {
+  args: {
+    field: "type",
+  },
+};
+
+export const MultiSelect = {
+  args: {
+    field: "tags",
+  },
+};

--- a/packages/react/spec/auto/support/stadiumModel.ts
+++ b/packages/react/spec/auto/support/stadiumModel.ts
@@ -113,12 +113,16 @@ export const getStadiumRecord = (overrides?: {
   id?: string;
   name?: string;
   photo?: { url?: string; fileName?: string; mimeType?: string };
+  tags?: string[];
+  type?: string;
 }) => {
   const id = overrides?.id ?? "433";
   const name = overrides?.name ?? "Testing Stadium";
   const photoUrl = overrides?.photo?.url ?? "https://assets.gadget.dev/assets/icon.svg";
   const photoFileName = overrides?.photo?.fileName ?? "icon.svg";
   const photoMimeType = overrides?.photo?.mimeType ?? "image/svg+xml";
+  const tags = overrides?.tags ?? ["foo", "bar"];
+  const type = overrides?.type ?? "football";
 
   return {
     game: {
@@ -133,6 +137,8 @@ export const getStadiumRecord = (overrides?: {
           mimeType: photoMimeType,
           __typename: "StoredFile",
         },
+        tags,
+        type,
         updatedAt: "2024-07-08T15:33:18.861Z",
       },
       __typename: "GameQueries",

--- a/packages/react/src/auto/hooks/useEnumInputController.tsx
+++ b/packages/react/src/auto/hooks/useEnumInputController.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useMemo, useState } from "react";
+import { useController, type Control } from "react-hook-form";
+import { useFieldMetadata } from "./useFieldMetadata.js";
+
+export const useEnumInputController = (props: {
+  field: string; // The field API identifier
+  control?: Control<any>;
+}) => {
+  const { field: fieldApiIdentifier, control } = props;
+  const { path, metadata } = useFieldMetadata(fieldApiIdentifier);
+
+  const config = metadata.configuration;
+  if (config.__typename !== "GadgetEnumConfig") {
+    throw new Error("Field is not an enum type");
+  }
+
+  const {
+    field: fieldProps,
+    fieldState: { error },
+  } = useController({
+    control,
+    name: path,
+  });
+  const [searchValue, setSearchValue] = useState(typeof fieldProps.value === "string" ? fieldProps.value : "");
+
+  const selectedOptions = useMemo(
+    () => (typeof fieldProps.value === "string" ? [fieldProps.value] : fieldProps.value ?? []) as string[],
+    [fieldProps.value]
+  );
+  const providedOptions = useMemo(() => config.options.map((option) => option.name), [config.options]);
+  const allOptions = useMemo(() => [...new Set([...selectedOptions, ...providedOptions])], [providedOptions, selectedOptions]);
+  const filteredOptions = useMemo(
+    () =>
+      allOptions.filter((option) => {
+        return !searchValue || option.toLocaleLowerCase().includes(searchValue.trim().toLocaleLowerCase());
+      }),
+    [allOptions, searchValue]
+  );
+
+  const onSelectionChange = useCallback(
+    (selected: string | null) => {
+      setSearchValue("");
+      if (config.allowMultiple) {
+        if (selected === null) {
+          fieldProps.onChange([]);
+          return;
+        }
+
+        const nextSelectedTags = new Set([...selectedOptions]);
+        if (nextSelectedTags.has(selected)) {
+          nextSelectedTags.delete(selected);
+        } else {
+          nextSelectedTags.add(selected);
+        }
+
+        fieldProps.onChange([...nextSelectedTags]);
+      } else {
+        if (selected === null || selectedOptions.includes(selected)) {
+          fieldProps.onChange(null);
+        } else {
+          fieldProps.onChange(selected);
+        }
+      }
+    },
+    [config.allowMultiple, fieldProps, selectedOptions]
+  );
+
+  return {
+    allowMultiple: config.allowMultiple,
+    allowOther: config.allowOther,
+    /** The list of selected options. */
+    selectedOptions,
+    /** The list of options that are provided by the configuration. */
+    providedOptions,
+    /** The list of options that are currently visible based on the search query. */
+    filteredOptions,
+    /** The list of all options that are available to select by combining the selected and provided options. */
+    allOptions,
+    searchQuery: {
+      value: searchValue,
+      setValue: setSearchValue,
+    },
+    /** The callback to handle the selection change */
+    onSelectionChange,
+    label: metadata.name,
+    metadata,
+    fieldProps,
+    isError: !!error,
+    errorMessage: error?.message,
+  };
+};

--- a/packages/react/src/auto/mui/index.ts
+++ b/packages/react/src/auto/mui/index.ts
@@ -2,6 +2,7 @@ export * from "./MUIAutoForm.js";
 export { MUIAutoForm as AutoForm } from "./MUIAutoForm.js";
 export { MUIAutoBooleanInput as AutoBooleanInput } from "./inputs/MUIAutoBooleanInput.js";
 export { MUIAutoDateTimePicker as DateTimePicker } from "./inputs/MUIAutoDateTimePicker.js";
+export { MUIAutoEnumInput as AutoEnumInput } from "./inputs/MUIAutoEnumInput.js";
 export { MUIAutoFileInput as AutoFileInput } from "./inputs/MUIAutoFileInput.js";
 export { MUIAutoHiddenInput as AutoHiddenInput } from "./inputs/MUIAutoHiddenInput.js";
 export { MUIAutoInput as AutoInput } from "./inputs/MUIAutoInput.js";

--- a/packages/react/src/auto/mui/inputs/MUIAutoEnumInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoEnumInput.tsx
@@ -1,0 +1,40 @@
+import type { AutocompleteProps, ChipTypeMap } from "@mui/material";
+import { Autocomplete, TextField } from "@mui/material";
+import React from "react";
+import { useEnumInputController } from "../../hooks/useEnumInputController.js";
+
+export const MUIAutoEnumInput = <
+  Value,
+  Multiple extends boolean | undefined = false,
+  DisableClearable extends boolean | undefined = false,
+  FreeSolo extends boolean | undefined = false,
+  ChipComponent extends React.ElementType = ChipTypeMap["defaultComponent"]
+>(
+  props: { field: string } & Partial<AutocompleteProps<Value, Multiple, DisableClearable, FreeSolo, ChipComponent>>
+) => {
+  const { allowMultiple, selectedOptions, onSelectionChange, allOptions, label } = useEnumInputController(props);
+
+  return (
+    <Autocomplete
+      disablePortal
+      multiple={allowMultiple}
+      options={allOptions}
+      renderInput={(params) => <TextField {...params} label={label} />}
+      value={allowMultiple ? selectedOptions : selectedOptions[0]}
+      onChange={(event, value) => {
+        if (value === null || (Array.isArray(value) && value.length === 0)) {
+          onSelectionChange(null);
+          return;
+        }
+
+        if (typeof value === "string") {
+          onSelectionChange(value);
+        } else {
+          for (const option of value) {
+            onSelectionChange(option);
+          }
+        }
+      }}
+    />
+  );
+};

--- a/packages/react/src/auto/mui/inputs/MUIAutoInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoInput.tsx
@@ -1,13 +1,13 @@
-import { Autocomplete, FormControl, FormControlLabel, FormGroup, FormHelperText, TextField } from "@mui/material";
+import { FormControl, FormControlLabel, FormGroup, FormHelperText } from "@mui/material";
 import type { ReactElement } from "react";
 import React from "react";
 import { useController } from "react-hook-form";
-import type { GadgetEnumConfig } from "../../../internal/gql/graphql.js";
 import { FieldType } from "../../../metadata.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { MUIAutoBooleanInput } from "./MUIAutoBooleanInput.js";
 import MUIAutoDateTimePicker from "./MUIAutoDateTimePicker.js";
 import { MUIAutoEncryptedStringInput } from "./MUIAutoEncryptedStringInput.js";
+import { MUIAutoEnumInput } from "./MUIAutoEnumInput.js";
 import { MUIAutoFileInput } from "./MUIAutoFileInput.js";
 import { MUIAutoJSONInput } from "./MUIAutoJSONInput.js";
 import { MUIAutoPasswordInput } from "./MUIAutoPasswordInput.js";
@@ -71,16 +71,7 @@ export const MUIAutoInput = (props: { field: string }) => {
       return <MUIAutoJSONInput field={props.field} />;
     }
     case FieldType.Enum: {
-      const config = metadata.configuration as GadgetEnumConfig;
-      return (
-        <Autocomplete
-          disablePortal
-          multiple={config.allowMultiple}
-          options={config.options.map((option) => ({ id: option.name, label: option.name }))}
-          {...fieldProps}
-          renderInput={(params) => <TextField {...params} label={metadata.name} />}
-        />
-      );
+      return <MUIAutoEnumInput field={props.field} />;
     }
     case FieldType.File: {
       return <MUIAutoFileInput field={props.field} />;

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -3,6 +3,7 @@ export { PolarisAutoForm as AutoForm } from "./PolarisAutoForm.js";
 export { PolarisAutoBooleanInput as AutoBooleanInput } from "./inputs/PolarisAutoBooleanInput.js";
 export { PolarisAutoDateTimePicker as DateTimePicker } from "./inputs/PolarisAutoDateTimePicker.js";
 export { PolarisAutoEncryptedStringInput as AutoEncryptedStringInput } from "./inputs/PolarisAutoEncryptedStringInput.js";
+export { PolarisAutoEnumInput as AutoEnumInput } from "./inputs/PolarisAutoEnumInput.js";
 export { PolarisAutoFileInput as AutoFileInput } from "./inputs/PolarisAutoFileInput.js";
 export { PolarisAutoHiddenInput as AutoHiddenInput } from "./inputs/PolarisAutoHiddenInput.js";
 export { PolarisAutoInput as AutoInput } from "./inputs/PolarisAutoInput.js";

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
@@ -1,0 +1,134 @@
+import type { ComboboxProps } from "@shopify/polaris";
+import { AutoSelection, Box, Combobox, Icon, InlineStack, Listbox, Tag, Text } from "@shopify/polaris";
+import { SearchIcon } from "@shopify/polaris-icons";
+import React, { useCallback } from "react";
+import { type Control } from "react-hook-form";
+import { useEnumInputController } from "../../hooks/useEnumInputController.js";
+
+export const PolarisAutoEnumInput = (props: { field: string; control?: Control<any> } & Partial<ComboboxProps>) => {
+  const { field: fieldApiIdentifier, control, ...comboboxProps } = props;
+  const {
+    allowMultiple,
+    allowOther,
+    onSelectionChange,
+    selectedOptions,
+    allOptions,
+    filteredOptions,
+    searchQuery,
+    label,
+    metadata,
+    isError,
+    errorMessage,
+  } = useEnumInputController({ field: fieldApiIdentifier, control });
+  const { value: searchValue, setValue: setSearchValue } = searchQuery;
+
+  let selectedTagsElement = null;
+  if (selectedOptions.length > 0) {
+    selectedTagsElement = (
+      <InlineStack gap="150">
+        {selectedOptions.map((tag) => (
+          <Tag key={`option-${tag}`} onRemove={() => onSelectionChange(tag)}>
+            {tag}
+          </Tag>
+        ))}
+      </InlineStack>
+    );
+  }
+
+  const formatOptionText = useCallback(
+    (option: string) => {
+      const trimValue = searchValue.trim().toLocaleLowerCase();
+      const matchIndex = option.toLocaleLowerCase().indexOf(trimValue);
+
+      if (!searchValue || matchIndex === -1) return option;
+
+      const start = option.slice(0, matchIndex);
+      const highlight = option.slice(matchIndex, matchIndex + trimValue.length);
+      const end = option.slice(matchIndex + trimValue.length, option.length);
+
+      return (
+        <p>
+          {start}
+          <Text fontWeight="bold" as="span">
+            {highlight}
+          </Text>
+          {end}
+        </p>
+      );
+    },
+    [searchValue]
+  );
+
+  let optionItemElement = null;
+  if (allOptions.length > 0) {
+    optionItemElement = filteredOptions.map((option) => {
+      return (
+        <Listbox.Option key={option} value={option} selected={selectedOptions.includes(option)} accessibilityLabel={option}>
+          <Listbox.TextOption selected={selectedOptions.includes(option)}>{formatOptionText(option)}</Listbox.TextOption>
+        </Listbox.Option>
+      );
+    });
+  }
+
+  let addExtraOptionElement = null;
+  if (allowOther && searchValue && !allOptions.includes(searchValue) && searchValue.trim().length > 0) {
+    addExtraOptionElement = <Listbox.Action value={searchValue}>{`Add "${searchValue}"`}</Listbox.Action>;
+  }
+
+  let emptyStateElement = null;
+  if (!allowOther && (!optionItemElement || optionItemElement.length === 0) && searchValue) {
+    emptyStateElement = (
+      <Box padding="100">
+        <Text as="span" alignment="center" tone="subdued">{`No options found matching "${searchValue}"`}</Text>
+      </Box>
+    );
+  }
+
+  let listBoxElement = null;
+  if (optionItemElement || addExtraOptionElement || emptyStateElement) {
+    listBoxElement = (
+      <Listbox
+        autoSelection={AutoSelection.None}
+        onSelect={(selected) => {
+          onSelectionChange(selected);
+          if (allowMultiple) {
+            setSearchValue("");
+          }
+        }}
+      >
+        {emptyStateElement}
+        {addExtraOptionElement}
+        {optionItemElement}
+      </Listbox>
+    );
+  }
+
+  const inputLabel = (
+    <>
+      {label} {metadata.requiredArgumentForInput ? <span style={{ color: "var(--p-color-text-critical)" }}>*</span> : null}
+    </>
+  );
+
+  return (
+    <Combobox
+      allowMultiple={allowMultiple}
+      activator={
+        <Combobox.TextField
+          autoComplete="off"
+          prefix={<Icon source={SearchIcon} />}
+          label={inputLabel}
+          value={searchValue}
+          placeholder="Search"
+          verticalContent={selectedTagsElement}
+          onChange={setSearchValue}
+          id={`${props.field}-combobox-textfield`}
+          error={isError}
+          helpText={errorMessage}
+        />
+      }
+      {...comboboxProps}
+    >
+      {listBoxElement}
+    </Combobox>
+  );
+};

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { useController } from "react-hook-form";
-import type { GadgetEnumConfig } from "../../../internal/gql/graphql.js";
 import { FieldType } from "../../../metadata.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
-import { PolarisFixedOptionsCombobox } from "../PolarisFixedOptionsCombobox.js";
 import { PolarisAutoBooleanInput } from "./PolarisAutoBooleanInput.js";
 import { PolarisAutoDateTimePicker } from "./PolarisAutoDateTimePicker.js";
 import { PolarisAutoEncryptedStringInput } from "./PolarisAutoEncryptedStringInput.js";
+import { PolarisAutoEnumInput } from "./PolarisAutoEnumInput.js";
 import { PolarisAutoFileInput } from "./PolarisAutoFileInput.js";
 import { PolarisAutoJSONInput } from "./PolarisAutoJsonInput.js";
 import { PolarisAutoPasswordInput } from "./PolarisAutoPasswordInput.js";
@@ -52,15 +51,7 @@ export const PolarisAutoInput = (props: { field: string }) => {
       return <PolarisAutoJSONInput field={props.field} />;
     }
     case FieldType.Enum: {
-      const config = metadata.configuration as GadgetEnumConfig;
-      return (
-        <PolarisFixedOptionsCombobox
-          label={metadata.name}
-          options={config.options.map((option) => ({ value: option.name, label: option.name }))}
-          allowMultiple={config.allowMultiple}
-          {...field}
-        />
-      );
+      return <PolarisAutoEnumInput field={props.field} />;
     }
     case FieldType.File: {
       return <PolarisAutoFileInput field={props.field} />;

--- a/packages/react/src/validationSchema.tsx
+++ b/packages/react/src/validationSchema.tsx
@@ -45,11 +45,11 @@ const validatorForField = (field: FieldMetadata) => {
     }
     case GadgetFieldType.Enum: {
       const config = field.configuration as GadgetEnumConfig;
-      const element = string().oneOf(config.options.map((option) => option.name));
-      if (config.allowMultiple) {
-        validator = array(element);
+      if (config.allowOther) {
+        validator = config.allowMultiple ? array(string()) : string();
       } else {
-        validator = element;
+        const element = string().oneOf(config.options.map((option) => option.name));
+        validator = config.allowMultiple ? array(element) : element;
       }
       break;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.498.0-development.749
-        version: 1.498.0-development.749
+        specifier: 1.498.0-development.854
+        version: 1.498.0-development.854
       '@gadget-client/kitchen-sink':
         specifier: 1.5.0-development.200
         version: 1.5.0-development.200
@@ -3347,8 +3347,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.498.0-development.749:
-    resolution: {integrity: sha1-B0VS8woXX+1Ab9NjirbCrDr1Cng=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8461}
+  /@gadget-client/js-clients-test@1.498.0-development.854:
+    resolution: {integrity: sha1-pCcfZuF1wE8ztVWr4RZeDWnPJwE=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8515}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
This PR introduces `AutoEnumInput` for the auto component.
When the input allows adding additional values, it provides an "Add ..." button, and when the input allows multiple selections, it becomes a multi-select dropdown.

The Polaris component version is based on the example from Polaris with modifications for our needs:
https://polaris.shopify.com/components/selection-and-input/combobox

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
