### PR TITLE
GGT-6724 - Fix month selection when month is paginated & Persist Time when Date Changes

### DIFF
--- a/packages/react/spec/auto/inputs/PolarisAutoDateTimePicker.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoDateTimePicker.spec.tsx
@@ -6,6 +6,7 @@ import { PolarisAutoDateTimePicker } from "../../../src/auto/polaris/inputs/Pola
 import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoSubmit.js";
 import { testApi as api } from "../../apis.js";
 import { mockUrqlClient } from "../../testWrappers.js";
+import { sleep } from "../../utils.js";
 import { mockWidgetFindBy } from "../support/helper.js";
 import { PolarisMockedProviders } from "./PolarisMockedProviders.js";
 
@@ -37,9 +38,13 @@ describe("PolarisDateTimePicker", () => {
     await act(async () => {
       await user.click(screen.getByLabelText("Time"));
       await user.type(screen.getByLabelText("Time"), "11");
+      await sleep(100);
       await user.type(screen.getByLabelText("Time"), ":");
+      await sleep(100);
       await user.type(screen.getByLabelText("Time"), "00 ");
+      await sleep(100);
       await user.type(screen.getByLabelText("Time"), "AM");
+      await sleep(100);
       await user.click(screen.getByRole("button"));
     });
 
@@ -51,6 +56,10 @@ describe("PolarisDateTimePicker", () => {
 });
 
 const mockUpdateWidgetFindBy = () => {
+  const startsAtDate = new Date();
+  startsAtDate.setHours(11);
+  startsAtDate.setMinutes(0);
+
   mockWidgetFindBy(
     {
       name: "Update",
@@ -59,6 +68,7 @@ const mockUpdateWidgetFindBy = () => {
     },
     {
       id: "42",
+      startsAt: startsAtDate,
     }
   );
 };

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTimePicker.tsx
@@ -59,8 +59,7 @@ const PolarisAutoTimePicker = (props: {
   hideTimePopover?: boolean;
   localTz?: string;
 }) => {
-  const defaultDate = props.fieldProps.value ? props.fieldProps.value : props.localTime;
-  const [timeString, setTimeString] = useState(defaultDate ? getTimeString(getDateTimeObjectFromDate(defaultDate)) : "");
+  const [timeString, setTimeString] = useState(props.localTime ? getTimeString(getDateTimeObjectFromDate(props.localTime)) : "");
   const [timePopoverActive, setTimePopoverActive] = useState(false);
   const [timeParseError, setTimeParseError] = useState(false);
   const setHourSelected = (hour: string) =>


### PR DESCRIPTION
When a user presses the right or left arrow on the date picker popover, a new date is selected. 


https://github.com/gadget-inc/js-clients/assets/168455431/00b7750e-2f14-4abb-9117-30e7675029b7

This is because when the month was changed, the hook, `handleMonthChange` was modifying the variable that stored the date that the user had selected (`fieldProps`). This means that every time `handleMonthChange` was called, `fieldProps` would get redefined. 

The PR also fixes an issue where the time was reset to 12AM every time a user selected a new date.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
