### PR TITLE
Include array type in field validator

### DIFF
--- a/packages/react/src/validationSchema.tsx
+++ b/packages/react/src/validationSchema.tsx
@@ -122,6 +122,12 @@ const validatorForField = (field: FieldMetadata) => {
       validator = array();
       break;
     }
+
+    case GadgetFieldType.Array: {
+      validator = array();
+      break;
+    }
+
     default: {
       throw new Error(`unknown field type ${field.fieldType} for validator generation`);
     }


### PR DESCRIPTION
Although we don't provide an array model field type, it's possible that people can define an array input type like this:
```js
export const params = {
  p_arr: {type: "array", items: {type: "string"}},
}
```
Right now, If people have an action input with an array type, it throws an error when rendering the form. This PR prevents throwing an error and instead provides a generic array type.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
