### PR TITLE
fix belongsTo relationship linking with additional fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@gadget-client/kitchen-sink": "1.5.0-development.200",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",
-    "@gadget-client/zxcv-manythrough-example": "1.3.0-development.40",
+    "@gadget-client/zxcv-manythrough-example": "1.3.0-nick-dev.3",
     "@gadget-client/zxcv-simple-relationship": "^1.23.0",
     "@gadgetinc/api-client-core": "workspace:*",
     "@gadgetinc/eslint-config": "^0.6.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.15.14",
+  "version": "0.15.15",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -325,7 +325,7 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
       }
 
       if (belongsTo) {
-        return depth <= 1 ? { ...rest, ...belongsTo } : { ...rest, create: { ...belongsTo } }; // when we're in the root, we need to return the belongsTo object as part of the result otherwise wrap it in a create
+        return depth <= 1 ? { ...rest, ...belongsTo } : { create: { ...rest, ...belongsTo } }; // when we're in the root, we need to return the belongsTo object as part of the result otherwise wrap it in a create
       }
 
       if (depth <= 1 || fieldType == null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^1.212.0
         version: 1.212.0
       '@gadget-client/zxcv-manythrough-example':
-        specifier: 1.3.0-development.40
-        version: 1.3.0-development.40
+        specifier: 1.3.0-nick-dev.3
+        version: 1.3.0-nick-dev.3
       '@gadget-client/zxcv-simple-relationship':
         specifier: ^1.23.0
         version: 1.23.0
@@ -1369,8 +1369,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/zxcv-manythrough-example@1.3.0-development.40:
-    resolution: {integrity: sha1-XCn9yCwa3uW7VOmjzHweDoV6IfQ=, tarball: https://registry.gadget.dev/npm/_/tarball/114722/228808/7560}
+  /@gadget-client/zxcv-manythrough-example@1.3.0-nick-dev.3:
+    resolution: {integrity: sha1-Yr9R0+RxpzsxoAINzzh+66js9jY=, tarball: https://registry.gadget.dev/npm/_/tarball/114722/281903/8561}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
To unblock @DevAOC. He ran into a broken edge case where he was updating multiple `belongsTo` relationships with an additional field in one model. The "additional field" would always be excluded improperly.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
