### PR TITLE
useActionForm: ensure both shorthand and fully-qualified field names can be passed to send

### DIFF
--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -429,17 +429,22 @@ export function applyDataMask(opts: { select?: any; send?: string[]; data: Recor
     unset(data, path);
   }
 
+  if (!send) return data;
   const dataToSend = {};
-  if (send) {
-    for (const key of send) {
-      const value = modelApiIdentifier ? get(data, `${modelApiIdentifier}.${key}`) : undefined ?? get(data, key);
+
+  for (const key of send) {
+    const candidates = [key];
+    if (modelApiIdentifier) {
+      candidates.push(`${modelApiIdentifier}.${key}`);
+    }
+    for (const key of candidates) {
+      const value = get(data, key);
       if (value != null) {
-        set(dataToSend, modelApiIdentifier ? `${modelApiIdentifier}.${key}` : key, value);
+        set(dataToSend, key, value);
+        break;
       }
     }
-
-    return dataToSend;
   }
 
-  return data;
+  return dataToSend;
 }


### PR DESCRIPTION
The new data-masking functionality in `useActionForm` should be compatible with people using either shorthand field keys or longhand field keys for both create and update actions. This wasn't quite the case before for two reasons: we were only telling the data masker to try both keys for update actions, and we were only passing in pre-disambiguated data to try for update actions. This fixes both of those small issues and adds tests!
