### PR TITLE
Swap the file size validation message

### DIFF
--- a/packages/react/cypress/component/auto/form/PolarisAutoFileInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoFileInput.cy.tsx
@@ -226,6 +226,8 @@ describe("PolarisFileInput", () => {
 
         cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
 
+        cy.get(".Polaris-DropZone-FileUpload").should("contain", "Accepts larger than 10 MB");
+
         cy.get(".Polaris-DropZone-FileUpload").selectFile("./cypress/support/assets/ottawa-stadium.jpg", {
           action: "drag-drop",
         });
@@ -248,6 +250,8 @@ describe("PolarisFileInput", () => {
         ]);
 
         cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+
+        cy.get(".Polaris-DropZone-FileUpload").should("contain", "Accepts smaller than 100 B");
 
         cy.get(".Polaris-DropZone-FileUpload").selectFile("./cypress/support/assets/ottawa-stadium.jpg", {
           action: "drag-drop",

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
@@ -27,8 +27,8 @@ export const PolarisAutoFileInput = (props: { field: string; control?: Control<a
       const validation = validations.fileSize;
       const message = getFileSizeValidationMessage(validation, {
         inRange: (min, max) => `between ${filesize(min)} and ${filesize(max)}`,
-        max: (max) => `larger than ${filesize(max)}`,
-        min: (min) => `smaller than ${filesize(min)}`,
+        max: (max) => `smaller than ${filesize(max)}`,
+        min: (min) => `larger than ${filesize(min)}`,
       });
       if (message) actionHintParts.push(message);
     }


### PR DESCRIPTION
This PR fixes an issue when rendering the file input with size validation. It shows the "Accepts larger than xyz" when the validation is set to "min = undefined and max = xyz", which is incorrect.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
