### PR TITLE
Update "required" validation error message to be more human readable

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -87,7 +87,7 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     cy.get(`input[name="widget.name"]`).type("test record");
 
     cy.get("form [type=submit][aria-hidden!=true]").click();
-    cy.contains("is a required field");
+    cy.contains("Inventory count is required");
 
     cy.get(`input[name="widget.inventoryCount"]`).type("42");
 

--- a/packages/react/src/validationSchema.tsx
+++ b/packages/react/src/validationSchema.tsx
@@ -134,7 +134,7 @@ const validatorForField = (field: FieldMetadata) => {
   }
 
   if (field.requiredArgumentForInput) {
-    validator = validator.required();
+    validator = validator.required(`${field.name} is required`);
   } else {
     validator = (validator.nullable() as any).default(null);
   }


### PR DESCRIPTION
Right now, when you have a "required" validation error on the client-side, it will show this error like this:
```
model.field is a required field
```

This PR updates the error message to stop showing the raw dot notation path. Instead, the message will be like this:
<img width="496" alt="CleanShot 2024-07-12 at 15 30 19@2x" src="https://github.com/user-attachments/assets/a9fd0709-7e7c-46c1-8f90-f04e3a6c9798">


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
