### PR TITLE
Fix field values not being sent when having a "include" prop in the AutoForm

### DIFF
--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -138,15 +138,15 @@ export const useAutoForm = <
     resolver: useValidationResolver(metadata),
     send: () => {
       const fieldsToSend = fields
-        .map(({ path }) => path)
-        .filter((item) => {
+        .filter(({ metadata }) => {
           if (props.include) {
-            return props.include?.includes(item);
+            return props.include?.includes(metadata.apiIdentifier);
           } else if (props.exclude) {
-            return !props.exclude?.includes(item);
+            return !props.exclude?.includes(metadata.apiIdentifier);
           }
           return true;
-        });
+        })
+        .map(({ path }) => path);
 
       if (operatesWithRecordId) {
         fieldsToSend.push("id");


### PR DESCRIPTION
Right now, when you set fields to include using the `include` property in the AutoForm, none of the field values are sent. This PR fixes this issue. The details are in the comment below.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
