### PR TITLE
Set file value to null instead of undefined when clearing file

### DIFF
--- a/packages/react/src/auto/hooks/useFileInputController.tsx
+++ b/packages/react/src/auto/hooks/useFileInputController.tsx
@@ -60,7 +60,7 @@ export const useFileInputController = (props: {
   }, [metadata]);
 
   const clearFileValue = useCallback(() => {
-    fieldProps.onChange(undefined);
+    fieldProps.onChange(null);
     setImageThumbnailURL(undefined);
     clearErrors(path);
   }, [clearErrors, fieldProps, path]);


### PR DESCRIPTION
Right now, in some rare situations, the file is not being removed when the user clicks the "delete file" button. This PR should fix this issue by setting the value to null instead of undefined.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
