### PR TITLE
Fixed belongsTo relationship component always having red label text for create actions

### DIFF
--- a/packages/react/src/auto/hooks/useBelongsToInputController.tsx
+++ b/packages/react/src/auto/hooks/useBelongsToInputController.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useController } from "react-hook-form";
+import { useAutoFormMetadata } from "../AutoFormContext.js";
 import { AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModelOptions.js";
@@ -8,6 +9,7 @@ export const useBelongsToInputController = (props: AutoRelationshipInputProps) =
   const { field, control } = props;
   const fieldMetadata = useFieldMetadata(field);
   const { path } = fieldMetadata;
+  const { findBy } = useAutoFormMetadata();
 
   const relatedModelOptions = useRelatedModelOptions(props);
   const { selected, relatedModel } = relatedModelOptions;
@@ -27,9 +29,13 @@ export const useBelongsToInputController = (props: AutoRelationshipInputProps) =
     return !selected.fetching && selected.records && selected.records.length ? selected.records[0][`${field}Id`] : null;
   }, [selected.fetching]);
 
-  const retrievedSelectedRecordIdExists = useMemo(() => {
-    return !selected.fetching && selected.records && selected.records.length ? !!selected.records[0][field] : false;
-  }, [selected.fetching]);
+  const selectedRelatedModelRecordMissing = useMemo(() => {
+    if (!findBy) {
+      // Without a find by, there is no retrieved record ID
+      return false;
+    }
+    return !selected.fetching && selected.records && selected.records.length ? !selected.records[0][field] : true;
+  }, [findBy, selected.fetching]);
 
   useEffect(() => {
     // Initializing the controller with the selected record ID from the DB
@@ -54,7 +60,7 @@ export const useBelongsToInputController = (props: AutoRelationshipInputProps) =
     onRemoveRecord,
 
     selectedRecordId: fieldProps.value,
-    retrievedSelectedRecordIdExists,
+    selectedRelatedModelRecordMissing,
 
     isLoading,
     errorMessage,

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
@@ -15,7 +15,7 @@ export const PolarisAutoBelongsToInput = (props: AutoRelationshipInputProps) => 
     errorMessage,
 
     selectedRecordId,
-    retrievedSelectedRecordIdExists,
+    selectedRelatedModelRecordMissing,
 
     onSelectRecord,
     onRemoveRecord,
@@ -27,7 +27,7 @@ export const PolarisAutoBelongsToInput = (props: AutoRelationshipInputProps) => 
 
   const selectedRecordTag = selectedRecordId ? (
     <Tag onRemove={onRemoveRecord} key={`selectedRecordTag_${selectedRecordId}`}>
-      <p style={{ color: !retrievedSelectedRecordIdExists ? "red" : undefined }} id={`${selectedRecordId}_${selectedRecordLabel}`}>
+      <p style={{ color: selectedRelatedModelRecordMissing ? "red" : undefined }} id={`${selectedRecordId}_${selectedRecordLabel}`}>
         {selectedRecordLabel}
       </p>
     </Tag>


### PR DESCRIPTION
- **UPDATE**
  - Previously, there was a bug with belongsTo fields on create actions where the label text would always be red
    - The label should only be red when the current record's value does points to an ID that does not exist in the related model 
    - The fix is to only do that check when there is a selected record with findBy