### PR TITLE
Don't run assertion check when there is an error fetching metadata

### DIFF
--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -59,14 +59,18 @@ export const MUIAutoForm = <
     <>
       <MUISubmitResultBanner />
       {fetchingMetadata && <MUIFormSkeleton />}
-      {fields.map(({ metadata }) => (
-        <Grid item key={metadata.apiIdentifier} xs={12}>
-          <MUIAutoInput field={metadata.apiIdentifier} />
-        </Grid>
-      ))}
-      <Grid item xs={12}>
-        <MUIAutoSubmit loading={isLoading}>{props.submitLabel ?? "Submit"}</MUIAutoSubmit>
-      </Grid>
+      {!metadataError && (
+        <>
+          {fields.map(({ metadata }) => (
+            <Grid item key={metadata.apiIdentifier} xs={12}>
+              <MUIAutoInput field={metadata.apiIdentifier} />
+            </Grid>
+          ))}
+          <Grid item xs={12}>
+            <MUIAutoSubmit loading={isLoading}>{props.submitLabel ?? "Submit"}</MUIAutoSubmit>
+          </Grid>
+        </>
+      )}
     </>
   );
 

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -69,10 +69,14 @@ export const PolarisAutoForm = <
   const formContent = props.children ?? (
     <>
       <PolarisSubmitResultBanner />
-      {fields.map(({ metadata }) => (
-        <PolarisAutoInput field={metadata.apiIdentifier} key={metadata.apiIdentifier} />
-      ))}
-      <PolarisAutoSubmit>{props.submitLabel ?? "Submit"}</PolarisAutoSubmit>
+      {!metadataError && (
+        <>
+          {fields.map(({ metadata }) => (
+            <PolarisAutoInput field={metadata.apiIdentifier} key={metadata.apiIdentifier} />
+          ))}
+          <PolarisAutoSubmit>{props.submitLabel ?? "Submit"}</PolarisAutoSubmit>
+        </>
+      )}
     </>
   );
 

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -285,7 +285,7 @@ export const useActionMetadata = (actionFunction: ActionFunction<any, any, any, 
 
   let metadata: ActionMetadata | GlobalActionMetadata | undefined = undefined;
 
-  if (data) {
+  if (data && !error) {
     if (actionFunction.type === "globalAction") {
       metadata = assert(data.gadgetMeta.globalAction, "no global action metadata found from Gadget API");
     } else {


### PR DESCRIPTION
Right now, when the field has an invalid default value defined in the Gadget editor or any other errors, it throws a `no model metadata found from Gadget API` assertion error and not being able to render the whole page. However, it's unclear to the user that something went wrong when fetching the metadata to render the form.

This PR fixes this issue by showing the error banner when it fails to fetch the metadata due to an error and does not render the submit button. Note that this PR only handles the case where the user doesn't put children inside the `<AutoForm/>` component since we can't really control what the user is doing.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
