### PR TITLE
design(autoform): ensure 16px spacing between form elements

### DIFF
--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -1,6 +1,6 @@
 import type { ActionFunction } from "@gadgetinc/api-client-core";
 import type { FormProps } from "@shopify/polaris";
-import { Form, FormLayout, SkeletonBodyText, SkeletonDisplayText } from "@shopify/polaris";
+import { BlockStack, Form, FormLayout, SkeletonBodyText, SkeletonDisplayText } from "@shopify/polaris";
 import React from "react";
 import { FormProvider } from "react-hook-form";
 import type { OptionsType } from "../../utils.js";
@@ -74,7 +74,9 @@ export const PolarisAutoForm = <
           {fields.map(({ metadata }) => (
             <PolarisAutoInput field={metadata.apiIdentifier} key={metadata.apiIdentifier} />
           ))}
-          <PolarisAutoSubmit>{props.submitLabel ?? "Submit"}</PolarisAutoSubmit>
+          <div>
+            <PolarisAutoSubmit>{props.submitLabel ?? "Submit"}</PolarisAutoSubmit>
+          </div>
         </>
       )}
     </>
@@ -84,7 +86,7 @@ export const PolarisAutoForm = <
     <AutoFormMetadataContext.Provider value={autoFormMetadataContext}>
       <FormProvider {...originalFormMethods}>
         <Form {...rest} onSubmit={submit}>
-          <FormLayout>{formContent}</FormLayout>
+          <BlockStack gap="400">{formContent}</BlockStack>
         </Form>
       </FormProvider>
     </AutoFormMetadataContext.Provider>


### PR DESCRIPTION
Add better form input spacing, 16px vertical between each form input. 

I also noticed that we were wrapping the entire form body in a FormLayout component which I don't think is the intended use of that component -- it should be for grouping elements onto the same line. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
