### PR TITLE
Convert field value to Date in time picker

### DIFF
--- a/packages/react/cypress/component/auto/form/PolarisAutoDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoDateTimePicker.cy.tsx
@@ -102,6 +102,59 @@ describe("PolarisDateTimePicker", () => {
       cy.get("#test-time").should("have.value", "");
     });
 
+    it("can show the default field value", () => {
+      cy.mockModelActionMetadata(api, {
+        modelName: "Widget",
+        modelApiIdentifier: "widget",
+        action: {
+          apiIdentifier: "create",
+          operatesWithRecordIdentity: false,
+        },
+        inputFields: [
+          {
+            name: "Widget",
+            apiIdentifier: "widget",
+            fieldType: "Object",
+            requiredArgumentForInput: false,
+            configuration: {
+              __typename: "GadgetObjectFieldConfig",
+              fieldType: "Object",
+              validations: [],
+              name: null,
+              fields: [
+                {
+                  name: "Starts at",
+                  apiIdentifier: "startsAt",
+                  fieldType: "DateTime",
+                  requiredArgumentForInput: false,
+                  sortable: true,
+                  filterable: true,
+                  configuration: {
+                    __typename: "GadgetDateTimeConfig",
+                    fieldType: "DateTime",
+                    validations: [],
+                  },
+                },
+              ],
+            },
+            __typename: "GadgetObjectField",
+          },
+        ],
+        defaultRecord: {
+          startsAt: "2024-07-10T04:00:00.000Z",
+        },
+      });
+      cy.mountWithWrapper(
+        <PolarisAutoForm action={api.widget.create}>
+          <PolarisAutoDateTimePicker id="test" includeTime field="startsAt" />
+        </PolarisAutoForm>,
+        PolarisWrapper
+      );
+
+      cy.get("#test-date").should("have.value", "2024-07-10");
+      cy.get("#test-time").should("have.value", "4:00 AM");
+    });
+
     it("can show the current value", () => {
       const onChangeSpy = cy.spy().as("onChangeSpy");
       cy.mountWithWrapper(

--- a/packages/react/cypress/support/commands.ts
+++ b/packages/react/cypress/support/commands.ts
@@ -3,7 +3,7 @@ import "cypress-each";
 import { recordIdInputField } from "../../spec/auto/support/shared.js";
 
 Cypress.Commands.add("mockModelActionMetadata", (api: AnyClient, props) => {
-  const { modelName, modelApiIdentifier, action, inputFields } = props;
+  const { modelName, modelApiIdentifier, action, inputFields, defaultRecord } = props;
 
   cy.intercept(
     {
@@ -22,6 +22,7 @@ Cypress.Commands.add("mockModelActionMetadata", (api: AnyClient, props) => {
               inputFields: action.operatesWithRecordIdentity ? [recordIdInputField, ...inputFields] : inputFields,
               __typename: "GadgetAction",
             },
+            defaultRecord,
             __typename: "GadgetModel",
           },
           __typename: "GadgetApplicationMeta",

--- a/packages/react/cypress/support/cypress-commands.d.ts
+++ b/packages/react/cypress/support/cypress-commands.d.ts
@@ -12,6 +12,7 @@ declare namespace Cypress {
           operatesWithRecordIdentity: boolean;
         };
         inputFields: any[];
+        defaultRecord?: Record<string, any>;
       }
     ): Chainable<void>;
 

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTimePicker.tsx
@@ -161,7 +161,7 @@ const PolarisAutoTimePicker = (props: {
 
   useEffect(() => {
     if (!props.fieldProps.value || valueProp) return;
-    setTimeString(getTimeString(getDateTimeObjectFromDate(props.fieldProps.value)));
+    setTimeString(getTimeString(getDateTimeObjectFromDate(new Date(props.fieldProps.value))));
   }, [props.fieldProps.value, valueProp, setTimeString]);
 
   return (
@@ -195,7 +195,7 @@ const PolarisAutoTimePicker = (props: {
                       valueProp
                         ? `${getDateTimeObjectFromDate(valueProp)[timeComponentProps.key]}`
                         : props.fieldProps.value
-                        ? `${getDateTimeObjectFromDate(props.fieldProps.value)[timeComponentProps.key]}`
+                        ? `${getDateTimeObjectFromDate(new Date(props.fieldProps.value))[timeComponentProps.key]}`
                         : timeComponentProps.array[0]
                     )}
                   </Listbox>


### PR DESCRIPTION
We recently put the default field value into the form, but for the date time field type, the default value type is actually a string instead of a date, so it throws an error when there's a default value. This PR fixes it.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
