### PR TITLE
Introduce `onSuccess` callback in AutoForm

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -47,6 +47,27 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     ensureFieldInputLabelsExist();
   });
 
+  it("onSuccess callback should return a record result after the form submission", () => {
+    const onSuccessSpy = cy.spy().as("onSuccessSpy");
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} exclude={["gizmos"]} onSuccess={onSuccessSpy} />, wrapper);
+
+    cy.get(`input[name="widget.name"]`).type("test record");
+    cy.get(`input[name="widget.inventoryCount"]`).type("999");
+
+    cy.getSubmitButton().click();
+
+    cy.contains(`Saved Widget successfully`).should("not.exist");
+
+    // eslint-disable-next-line jest/valid-expect-in-promise
+    cy.get("@onSuccessSpy")
+      .should("have.been.called")
+      .then(() => {
+        const record = onSuccessSpy.getCalls()[0].args[0].toJSON();
+        expect(record).property("inventoryCount", 999);
+        expect(record).property("name", "test record");
+      });
+  });
+
   it("should show an error banner and not render a form when it fails to fetch metadata", () => {
     cy.intercept(
       {
@@ -185,7 +206,7 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
       });
   });
 
-  it("Only allows existing passwords to be replaced, not edited", () => {
+  it("only allows existing passwords to be replaced, not edited", () => {
     cy.mountWithWrapper(<AutoForm action={api.user.update} findBy={"1"} include={["password"]} />, wrapper);
 
     // fill in name but not inventoryCount

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -2,7 +2,7 @@ import type { ActionFunction, GadgetRecord, GlobalActionFunction } from "@gadget
 import { yupResolver } from "@hookform/resolvers/yup";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
-import type { AnyActionWithId, RecordIdentifier } from "src/use-action-form/types.js";
+import type { AnyActionWithId, RecordIdentifier, UseActionFormHookStateData } from "src/use-action-form/types.js";
 import type { GadgetObjectFieldConfig } from "../internal/gql/graphql.js";
 import type { ActionMetadata, FieldMetadata, GlobalActionMetadata } from "../metadata.js";
 import { filterFieldList, isActionMetadata, useActionMetadata } from "../metadata.js";
@@ -33,6 +33,8 @@ export type AutoFormProps<
   submitLabel?: ReactNode;
   /** What to show the user once the form has been submitted successfully */
   successContent?: ReactNode;
+  /** Called when the form submission completes successfully on the backend */
+  onSuccess?: (record: UseActionFormHookStateData<ActionFunc>) => void;
 } & (ActionFunc extends AnyActionWithId<GivenOptions>
   ? {
       /**
@@ -107,7 +109,7 @@ export const useAutoForm = <
 >(
   props: AutoFormProps<GivenOptions, SchemaT, ActionFunc, any, any>
 ) => {
-  const { action, record } = props;
+  const { action, record, onSuccess } = props;
   const { metadata, fetching: fetchingMetadata, error: metadataError } = useActionMetadata(props.action);
 
   // filter down the fields to render only what we want to render for this form
@@ -153,6 +155,7 @@ export const useAutoForm = <
       }
       return fieldsToSend;
     },
+    onSuccess,
   });
 
   // we don't have synchronous access to the default values always -- sometimes we need to load them from the metadata. if we do that, then we need to forcibly set them into the form state once they have been loaded

--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -8,7 +8,7 @@ import { useAutoForm, type AutoFormProps } from "../AutoForm.js";
 import { AutoFormMetadataContext } from "../AutoFormContext.js";
 import { MUIAutoInput } from "./inputs/MUIAutoInput.js";
 import { MUIAutoSubmit } from "./submit/MUIAutoSubmit.js";
-import { MUISubmitResultBanner } from "./submit/MUISubmitResultBanner.js";
+import { MUISubmitErrorBanner, MUISubmitResultBanner } from "./submit/MUISubmitResultBanner.js";
 
 export const MUIFormSkeleton = () => (
   <>
@@ -57,7 +57,7 @@ export const MUIAutoForm = <
 
   const formContent = props.children ?? (
     <>
-      <MUISubmitResultBanner />
+      {!props.onSuccess ? <MUISubmitResultBanner /> : <MUISubmitErrorBanner />}
       {fetchingMetadata && <MUIFormSkeleton />}
       {!metadataError && (
         <>

--- a/packages/react/src/auto/mui/submit/MUISubmitResultBanner.tsx
+++ b/packages/react/src/auto/mui/submit/MUISubmitResultBanner.tsx
@@ -3,19 +3,32 @@ import { Alert, Button } from "@mui/material";
 import React from "react";
 import { useResultBannerController } from "../../hooks/useResultBannerController.js";
 
+const MUIBaseSubmitResultBanner = (props: AlertProps) => {
+  const { hide, successful, title } = useResultBannerController();
+
+  return (
+    <Alert severity={successful ? "success" : "error"} {...props}>
+      {title}
+      <Button onClick={hide}>X</Button>
+    </Alert>
+  );
+};
+
 export const MUISubmitResultBanner = (props: { successBannerProps?: AlertProps; errorBannerProps?: AlertProps }) => {
-  const { show, hide, successful, title } = useResultBannerController();
+  return (
+    <>
+      <MUISubmitSuccessfulBanner {...props.successBannerProps} />
+      <MUISubmitErrorBanner {...props.errorBannerProps} />
+    </>
+  );
+};
 
-  if (show) {
-    const bannerProps = successful ? props.successBannerProps : props.errorBannerProps;
+export const MUISubmitSuccessfulBanner = (props: AlertProps) => {
+  const { show, successful } = useResultBannerController();
+  return show && successful ? <MUIBaseSubmitResultBanner {...props} /> : null;
+};
 
-    return (
-      <Alert severity={successful ? "success" : "error"} {...bannerProps}>
-        {title}
-        <Button onClick={hide}>X</Button>
-      </Alert>
-    );
-  }
-
-  return null;
+export const MUISubmitErrorBanner = (props: AlertProps) => {
+  const { show, successful } = useResultBannerController();
+  return show && !successful ? <MUIBaseSubmitResultBanner {...props} /> : null;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -9,7 +9,7 @@ import { useAutoForm } from "../AutoForm.js";
 import { AutoFormMetadataContext } from "../AutoFormContext.js";
 import { PolarisAutoInput } from "./inputs/PolarisAutoInput.js";
 import { PolarisAutoSubmit } from "./submit/PolarisAutoSubmit.js";
-import { PolarisSubmitResultBanner } from "./submit/PolarisSubmitResultBanner.js";
+import { PolarisSubmitErrorBanner, PolarisSubmitResultBanner } from "./submit/PolarisSubmitResultBanner.js";
 
 export const PolarisFormSkeleton = () => (
   <>
@@ -68,7 +68,7 @@ export const PolarisAutoForm = <
 
   const formContent = props.children ?? (
     <>
-      <PolarisSubmitResultBanner />
+      {!props.onSuccess ? <PolarisSubmitResultBanner /> : <PolarisSubmitErrorBanner />}
       {!metadataError && (
         <>
           {fields.map(({ metadata }) => (

--- a/packages/react/src/auto/polaris/submit/PolarisSubmitResultBanner.tsx
+++ b/packages/react/src/auto/polaris/submit/PolarisSubmitResultBanner.tsx
@@ -3,23 +3,37 @@ import { Banner } from "@shopify/polaris";
 import React from "react";
 import { useResultBannerController } from "../../hooks/useResultBannerController.js";
 
+const PolarisBaseSubmitResultBanner = (props: BannerProps) => {
+  const { hide, successful, title } = useResultBannerController();
+
+  return (
+    <Banner
+      title={title}
+      tone={successful ? "success" : "critical"}
+      {...props}
+      onDismiss={() => {
+        hide();
+        props?.onDismiss?.();
+      }}
+    />
+  );
+};
+
 export const PolarisSubmitResultBanner = (props: { successBannerProps?: BannerProps; errorBannerProps?: BannerProps }) => {
-  const { show, hide, successful, title } = useResultBannerController();
+  return (
+    <>
+      <PolarisSubmitSuccessfulBanner {...props.successBannerProps} />
+      <PolarisSubmitErrorBanner {...props.errorBannerProps} />
+    </>
+  );
+};
 
-  if (show) {
-    const bannerProps = successful ? props.successBannerProps : props.errorBannerProps;
-    return (
-      <Banner
-        title={title}
-        tone={successful ? "success" : "critical"}
-        {...bannerProps}
-        onDismiss={() => {
-          hide();
-          bannerProps?.onDismiss?.();
-        }}
-      />
-    );
-  }
+export const PolarisSubmitSuccessfulBanner = (props: BannerProps) => {
+  const { show, successful } = useResultBannerController();
+  return show && successful ? <PolarisBaseSubmitResultBanner {...props} /> : null;
+};
 
-  return null;
+export const PolarisSubmitErrorBanner = (props: BannerProps) => {
+  const { show, successful } = useResultBannerController();
+  return show && !successful ? <PolarisBaseSubmitResultBanner {...props} /> : null;
 };


### PR DESCRIPTION
This PR introduces an `onSuccess` callback in the `<AutoForm />` component. We already have the same callback in our `useActionForm` so we only need to expose it as part of the available property in the React component.

The default banner will not be shown when the `onSuccess` callback exists, so people can override the behaviour.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
