### PR TITLE
fix(autoform): use polaris inline error messages

### DIFF
--- a/packages/react/spec/auto/MockForm.tsx
+++ b/packages/react/spec/auto/MockForm.tsx
@@ -6,10 +6,10 @@ import { AutoFormMetadataContext } from "../../src/auto/AutoFormContext.js";
 import { testApi as api } from "../apis.js";
 import { MockClientProvider } from "../testWrappers.js";
 
-export const MockForm = ({ submit, metadata, submitResult }: AutoFormMetadataContext) => {
+export const MockForm = ({ submit, metadata, submitResult, resolver }: AutoFormMetadataContext & { resolver?: any }) => {
   return (props: { children: ReactNode }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const methods = useForm();
+    const methods = useForm({ resolver });
 
     return (
       <MockClientProvider api={api}>

--- a/packages/react/src/auto/hooks/useStringInputController.tsx
+++ b/packages/react/src/auto/hooks/useStringInputController.tsx
@@ -46,7 +46,6 @@ export const useStringInputController = (
     errorMessage: error?.message,
     autoComplete: "off",
     placeholder,
-
     metadata,
     ...fieldProperties,
   };

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
@@ -122,8 +122,7 @@ export const PolarisAutoEnumInput = (props: { field: string; control?: Control<a
           verticalContent={selectedTagsElement}
           onChange={setSearchValue}
           id={`${props.field}-combobox-textfield`}
-          error={isError}
-          helpText={errorMessage}
+          error={errorMessage}
         />
       }
       {...comboboxProps}

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
@@ -19,8 +19,7 @@ export const PolarisAutoTextInput = (
       {...getPropsWithoutRef(stringInputController)}
       requiredIndicator={stringInputController.metadata.requiredArgumentForInput}
       type={stringInputController.type as TextFieldProps["type"]}
-      error={stringInputController.isError}
-      helpText={stringInputController.errorMessage}
+      error={stringInputController.errorMessage}
       {...props}
     />
   );


### PR DESCRIPTION
Previously, we were using the `helpText` property for some Polaris inputs, but to get the nicely styled Polaris errors, we need to pass the error message to the `error` prop. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
