### PR TITLE
GGT-6756 Added spinner when a form is submitting

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -173,7 +173,7 @@ describe("PolarisAutoForm", () => {
     test("it should include fields that are not dirty when submitting a create form", async () => {
       const user = userEvent.setup();
 
-      const { getByRole, getByLabelText } = render(<PolarisAutoForm action={api.gizmo.create} exclude={["widget"]} />, {
+      const { getByRole, getByLabelText, queryAllByText } = render(<PolarisAutoForm action={api.gizmo.create} exclude={["widget"]} />, {
         wrapper: PolarisMockedProviders,
       });
 
@@ -209,8 +209,12 @@ describe("PolarisAutoForm", () => {
         await user.clear(nameElement);
         await user.click(nameElement);
         await user.keyboard("updated another test record");
+      });
 
-        await user.click(getByRole("button"));
+      await act(async () => {
+        const submitButton = queryAllByText("Submit")[0];
+        expect(submitButton).toHaveTextContent("Submit");
+        await user.click(submitButton);
       });
 
       mutation = mockUrqlClient.executeMutation.mock.calls[1][0];

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -130,7 +130,7 @@ export const useAutoForm = <
   const {
     submit,
     error: formError,
-    formState: { isSubmitSuccessful, isLoading, isReady },
+    formState: { isSubmitSuccessful, isLoading, isReady, isSubmitting },
     originalFormMethods,
   } = useActionForm(action, {
     defaultValues: defaultValues as any,
@@ -171,6 +171,7 @@ export const useAutoForm = <
     fields,
     submit,
     formError,
+    isSubmitting,
     isSubmitSuccessful,
     isLoading,
     originalFormMethods,

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -35,7 +35,7 @@ export const PolarisAutoForm = <
     findBy,
     ...rest
   } = props as AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action"> & { findBy: any };
-  const { metadata, fetchingMetadata, metadataError, fields, submit, formError, isSubmitSuccessful, isLoading, originalFormMethods } =
+  const { metadata, fetchingMetadata, metadataError, fields, submit, formError, isSubmitting, isSubmitSuccessful, originalFormMethods } =
     useAutoForm(props);
 
   const autoFormMetadataContext: AutoFormMetadataContext = {
@@ -75,7 +75,7 @@ export const PolarisAutoForm = <
             <PolarisAutoInput field={metadata.apiIdentifier} key={metadata.apiIdentifier} />
           ))}
           <div>
-            <PolarisAutoSubmit>{props.submitLabel ?? "Submit"}</PolarisAutoSubmit>
+            <PolarisAutoSubmit isSubmitting={isSubmitting}>{props.submitLabel ?? "Submit"}</PolarisAutoSubmit>
           </div>
         </>
       )}

--- a/packages/react/src/auto/polaris/submit/PolarisAutoSubmit.tsx
+++ b/packages/react/src/auto/polaris/submit/PolarisAutoSubmit.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@shopify/polaris";
-import React, { ReactNode } from "react";
+import type { ReactNode } from "react";
+import React from "react";
 
 /**
  * Button for submitting the AutoForm values
@@ -10,6 +11,10 @@ import React, { ReactNode } from "react";
  * const { submit } = useAutoFormMetadata();
  *
  */
-export const PolarisAutoSubmit = (props: { children?: ReactNode }) => {
-  return <Button submit>{(props.children as any) ?? "Submit"}</Button>;
+export const PolarisAutoSubmit = (props: { children?: ReactNode; isSubmitting?: boolean }) => {
+  return (
+    <Button submit loading={props.isSubmitting}>
+      {(props.children as any) ?? "Submit"}
+    </Button>
+  );
 };


### PR DESCRIPTION
Previously, a user would submit the form, and if a success/error banner did not immediately appear, they wouldn't know what state the form was in: is it a network issue? Is Gadget being slow processing the request? 

This PR adds a loading state to the submit button, so when the form is in the `isSubmitting` state, the button is greyed out, and a spinner appears:

![Screen Recording 2024-07-15 at 1 09 49 PM](https://github.com/user-attachments/assets/9107af5a-edd9-40a0-a7aa-1ac616857f8f)

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
