### PR TITLE
fix(autoform): 12px padding for trash icon in file upload input

### DIFF
--- a/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
@@ -41,8 +41,8 @@ export const PolarisAutoFileInput = (props: { field: string; control?: Control<a
     if (!value || !isAutoFileFieldValue(value)) return null;
 
     return (
-      <Box padding="100">
-        <InlineStack align="space-between">
+      <Box padding="100" paddingInlineEnd={"400"}>
+        <InlineStack align="space-between" gap="400">
           <InlineStack gap="200" blockAlign="center">
             <Thumbnail
               size="small"


### PR DESCRIPTION
Added a bit more padding around the 'trash' icon in the file upload input interface


![CleanShot 2024-07-15 at 13 26 00@2x](https://github.com/user-attachments/assets/327c8933-c2e6-4149-934b-c29ee9e1da6b)

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
