### PR TITLE
fix(autoform): remove search icon prefix from multiselects

### DIFF
--- a/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
+++ b/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
@@ -1,6 +1,5 @@
 import type { AutocompleteProps } from "@shopify/polaris";
-import { Autocomplete, Icon, InlineStack, Tag } from "@shopify/polaris";
-import { SearchIcon } from "@shopify/polaris-icons";
+import { Autocomplete, InlineStack, Tag } from "@shopify/polaris";
 import React, { useCallback, useMemo, useState } from "react";
 
 export interface EnumOption {
@@ -102,7 +101,6 @@ export const PolarisFixedOptionsCombobox = (props: PolarisFixedOptionsComboboxPr
       onChange={updateText}
       label={label}
       value={inputValue}
-      prefix={allowMultiple ? undefined : <Icon source={SearchIcon} tone="base" />}
       verticalContent={verticalContentMarkup}
       placeholder="Search"
       autoComplete="off"

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
@@ -1,6 +1,5 @@
 import type { ComboboxProps } from "@shopify/polaris";
-import { AutoSelection, Box, Combobox, Icon, InlineStack, Listbox, Tag, Text } from "@shopify/polaris";
-import { SearchIcon } from "@shopify/polaris-icons";
+import { AutoSelection, Box, Combobox, InlineStack, Listbox, Tag, Text } from "@shopify/polaris";
 import React, { useCallback } from "react";
 import { type Control } from "react-hook-form";
 import { useEnumInputController } from "../../hooks/useEnumInputController.js";
@@ -115,7 +114,6 @@ export const PolarisAutoEnumInput = (props: { field: string; control?: Control<a
       activator={
         <Combobox.TextField
           autoComplete="off"
-          prefix={<Icon source={SearchIcon} />}
           label={inputLabel}
           value={searchValue}
           placeholder="Search"

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
@@ -1,5 +1,4 @@
-import { Combobox, Icon, Tag } from "@shopify/polaris";
-import { SearchIcon } from "@shopify/polaris-icons";
+import { Combobox, Tag } from "@shopify/polaris";
 import React from "react";
 import { useBelongsToInputController } from "../../../hooks/useBelongsToInputController.js";
 import { optionRecordsToLoadCount } from "../../../hooks/useRelatedModelOptions.js";
@@ -46,7 +45,6 @@ export const PolarisAutoBelongsToInput = (props: AutoRelationshipInputProps) => 
       <Combobox
         activator={
           <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
             onChange={search.set}
             value={search.value}
             name={path}

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
@@ -1,6 +1,5 @@
 import { GadgetRecordList } from "@gadgetinc/api-client-core";
-import { Banner, Combobox, Icon } from "@shopify/polaris";
-import { SearchIcon } from "@shopify/polaris-icons";
+import { Banner, Combobox } from "@shopify/polaris";
 import React from "react";
 import { useHasManyInputController } from "../../../hooks/useHasManyInputController.js";
 import { optionRecordsToLoadCount } from "../../../hooks/useRelatedModelOptions.js";
@@ -32,7 +31,6 @@ export const PolarisAutoHasManyInput = (props: AutoRelationshipInputProps) => {
       <Combobox
         activator={
           <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
             onChange={search.set}
             value={search.value}
             label={metadata.name}

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
@@ -1,5 +1,4 @@
-import { Banner, Combobox, Icon } from "@shopify/polaris";
-import { SearchIcon } from "@shopify/polaris-icons";
+import { Banner, Combobox } from "@shopify/polaris";
 import React from "react";
 import { useHasOneInputController } from "../../../hooks/useHasOneInputController.js";
 import { optionRecordsToLoadCount } from "../../../hooks/useRelatedModelOptions.js";
@@ -37,7 +36,6 @@ export const PolarisAutoHasOneInput = (props: AutoRelationshipInputProps) => {
       <Combobox
         activator={
           <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
             onChange={search.set}
             value={search.value}
             label={metadata.name}


### PR DESCRIPTION
When using vertical content + a prefix in the polaris combo box, the vertical alignment of the prefix icon can't be controlled easily to keep it vertically aligned with the placeholder text i.e. "Search", so it ends up looking bad. 

In the polaris docs examples, they either use vertical content + no prefix or they use a prefix and append tag pills below the input. 

According to @mike-briggs we should prefer the vertical content approach + no prefix. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
