### PR TITLE
fix(autoform): throw if the component is passed a findBy prop for a c…

### DIFF
--- a/packages/react/cypress/component/auto/form/PolarisAutoFileInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoFileInput.cy.tsx
@@ -24,7 +24,7 @@ describe("PolarisFileInput", () => {
       modelApiIdentifier: "stadium",
       action: {
         apiIdentifier: "update",
-        operatesWithRecordIdentity: false,
+        operatesWithRecordIdentity: true,
       },
       inputFields: getInputFieldsWithCustomValidations(validations),
     });

--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -30,6 +30,30 @@ describe("PolarisAutoForm", () => {
         loadMockWidgetCreateMetadata();
         expect(getByLabelText("Name")).toBeInTheDocument();
       });
+
+      test("it throws an error if a create action is mixed with a findBy prop", async () => {
+        expect(() => {
+          // @ts-expect-error: mixing a create and a findBy should throw a type error too
+          render(<PolarisAutoForm action={api.widget.create} findBy="1234" />, { wrapper: PolarisMockedProviders });
+          loadMockWidgetCreateMetadata();
+        }).toThrow("The 'findBy' prop is only allowed for update actions.");
+      });
+
+      describe("for a required field", () => {
+        test("it throw an error if you exclude the field", async () => {
+          expect(() => {
+            render(<PolarisAutoForm action={api.widget.create} exclude={["inventoryCount"]} />, { wrapper: PolarisMockedProviders });
+            loadMockWidgetCreateMetadata();
+          }).toThrow("The field inventoryCount is required and cannot be excluded.");
+        });
+
+        test("if you include fields, you must include the required fields", async () => {
+          expect(() => {
+            render(<PolarisAutoForm action={api.widget.create} include={["name"]} />, { wrapper: PolarisMockedProviders });
+            loadMockWidgetCreateMetadata();
+          }).toThrow("The following required fields are missing from the include list: inventoryCount");
+        });
+      });
     });
 
     test("it includes the record ID when submitting a form that updates a record", async () => {

--- a/packages/react/spec/auto/inputs/PolarisAutoBooleanIput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoBooleanIput.spec.tsx
@@ -11,9 +11,12 @@ import { PolarisMockedProviders } from "./PolarisMockedProviders.js";
 
 describe("PolarisBooleanInput", () => {
   it("should automatically set the pre-filled value when the form is pre-filled", async () => {
-    const { getByLabelText } = render(<PolarisAutoForm action={api.widget.update} findBy="42" include={["isChecked"]} />, {
-      wrapper: PolarisMockedProviders,
-    });
+    const { getByLabelText } = render(
+      <PolarisAutoForm action={api.widget.update} findBy="42" include={["isChecked", "name", "inventoryCount"]} />,
+      {
+        wrapper: PolarisMockedProviders,
+      }
+    );
     mockUpdateWidgetFindBy();
     const checkbox = getByLabelText("Is checked");
     expect(checkbox).toBeChecked();

--- a/packages/react/spec/auto/inputs/PolarisAutoJSONInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoJSONInput.spec.tsx
@@ -11,9 +11,12 @@ import { PolarisMockedProviders } from "./PolarisMockedProviders.js";
 
 describe("PolarisJSONInput", () => {
   it("should automatically set the pre-filled value when the form is pre-filled", async () => {
-    const { getByLabelText } = render(<PolarisAutoForm action={api.widget.update} findBy="42" include={["metafields"]} />, {
-      wrapper: PolarisMockedProviders,
-    });
+    const { getByLabelText } = render(
+      <PolarisAutoForm action={api.widget.update} findBy="42" include={["metafields", "name", "inventoryCount"]} />,
+      {
+        wrapper: PolarisMockedProviders,
+      }
+    );
     mockUpdateWidgetFindBy();
     const input = getByLabelText("Metafields");
     expect(input).toHaveValue(`{

--- a/packages/react/spec/auto/inputs/PolarisAutoTextInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoTextInput.spec.tsx
@@ -293,12 +293,13 @@ const mockFindBy = () => {
     },
   });
 
+  const updateMetadata = { ...metadata, action: { ...metadata.action, apiIdentifier: "update", operatesWithRecordIdentity: true } };
   mockUrqlClient.executeQuery.pushResponse("ModelActionMetadata", {
     stale: false,
     hasNext: false,
     data: {
       gadgetMeta: {
-        model: metadata,
+        model: updateMetadata,
         __typename: "GadgetApplicationMeta",
       },
     },

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -167,6 +167,12 @@ export const useAutoForm = <
     }
   }, [isReady, defaultValues, originalFormMethods, modelApiIdentifier]);
 
+  if (!fetchingMetadata) {
+    if (!operatesWithRecordId && "findBy" in props) {
+      throw new Error("The 'findBy' prop is only allowed for update actions.");
+    }
+  }
+
   return {
     metadata,
     fetchingMetadata,


### PR DESCRIPTION
For incorrect configuration errors the best feedback channel for a developer is a thrown error that can bubble up and be handled for example by the vite error harness. 

This also throws if you include or exclude a required field, as the form will not be able to submit.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
