### PR TITLE
Prevent untouched password fields getting sent null values on update actions

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -205,15 +205,4 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
         submit("Widget");
       });
   });
-
-  it("only allows existing passwords to be replaced, not edited", () => {
-    cy.mountWithWrapper(<AutoForm action={api.user.update} findBy={"1"} include={["password"]} />, wrapper);
-
-    // fill in name but not inventoryCount
-    cy.get(`input[name="user.password"]`).should("be.disabled");
-    cy.get(`button[role="passwordEditPasswordButton"]`).first().click();
-
-    // Enabled after clicking the edit button
-    cy.get(`input[name="user.password"]`).should("be.enabled");
-  });
 });

--- a/packages/react/cypress/component/auto/form/AutoPasswordInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoPasswordInput.cy.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { api } from "../../../support/api.js";
+import { describeForEachAutoAdapter } from "../../../support/auto.js";
+
+describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }) => {
+  beforeEach(() => {
+    cy.viewport("macbook-13");
+  });
+
+  const expectUpdateActionSubmissionVariables = (expectedQueryValue?: any) => {
+    cy.intercept({ method: "POST", url: `${api.connection.endpoint}?operation=updateUser` }, (req) => {
+      // eslint-disable-next-line
+      expect(req.body.variables).to.deep.equal(expectedQueryValue);
+
+      // The response content doesn't matter for the tests
+      req.reply({
+        data: {
+          updateUser: {
+            success: true,
+            errors: null,
+            user: {},
+          },
+        },
+      });
+    }).as("updateUser");
+  };
+
+  const submit = (modelName: string) => {
+    cy.get("form [type=submit][aria-hidden!=true]").click();
+    cy.contains(`Saved ${modelName} successfully`);
+  };
+
+  it("only allows existing passwords to be replaced, not edited", () => {
+    cy.mountWithWrapper(<AutoForm action={api.user.update} findBy={"1"} include={["password"]} />, wrapper);
+
+    cy.get(`input[name="user.password"]`).should("be.disabled");
+    cy.get(`button[role="passwordEditPasswordButton"]`).first().click();
+
+    const updatedPassword = "abcd1234!@#$";
+
+    // Enabled after clicking the edit button
+    cy.get(`input[name="user.password"]`).should("be.enabled");
+    cy.get(`input[name="user.password"]`).type(updatedPassword);
+
+    expectUpdateActionSubmissionVariables({ id: "1", user: { password: updatedPassword } }); // Untouched so the password field is not included
+
+    submit("User");
+  });
+
+  it("does not submit anything when for update actions when the password fields are untouched", () => {
+    cy.mountWithWrapper(<AutoForm action={api.user.update} findBy={"1"} include={["password"]} />, wrapper);
+
+    cy.get(`input[name="user.password"]`).should("be.disabled");
+
+    expectUpdateActionSubmissionVariables({ id: "1", user: {} }); // Untouched so the password field is not included
+
+    submit("User");
+  });
+});

--- a/packages/react/spec/auto/inputs/PolarisAutoPasswordInput.stories.jsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoPasswordInput.stories.jsx
@@ -6,12 +6,14 @@ import { Provider } from "../../../src/GadgetProvider.tsx";
 import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.tsx";
 import { PolarisAutoPasswordInput } from "../../../src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx";
 import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoSubmit.tsx";
+import { PolarisSubmitResultBanner } from "../../../src/auto/polaris/submit/PolarisSubmitResultBanner.tsx";
 import { testApi as api } from "../../apis.ts";
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
   title: "Polaris/AutoPasswordInput",
   component: (props) => (
     <PolarisAutoForm {...props}>
+      <PolarisSubmitResultBanner />
       <PolarisAutoPasswordInput field="password" />
       <PolarisAutoSubmit />
     </PolarisAutoForm>

--- a/packages/react/src/auto/mui/inputs/MUIAutoInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoInput.tsx
@@ -35,17 +35,7 @@ export const MUIAutoFormControl = (props: { field: string; children: ReactElemen
 };
 
 export const MUIAutoInput = (props: { field: string }) => {
-  const { path, metadata } = useFieldMetadata(props.field);
-
-  const {
-    field: fieldProps,
-    fieldState: { error },
-  } = useController({
-    name: path,
-
-    rules: { required: metadata.requiredArgumentForInput },
-  });
-
+  const { metadata } = useFieldMetadata(props.field);
   const config = metadata.configuration;
 
   switch (config.fieldType) {

--- a/packages/react/src/auto/mui/inputs/MUIAutoPasswordInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoPasswordInput.tsx
@@ -1,8 +1,9 @@
 import type { TextFieldProps } from "@mui/material";
 import { IconButton } from "@mui/material";
 import React, { useState } from "react";
-import type { Control } from "react-hook-form";
+import { useController, type Control } from "react-hook-form";
 import { useAutoFormMetadata } from "../../AutoFormContext.js";
+import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { MUIAutoEncryptedStringInput } from "./MUIAutoEncryptedStringInput.js";
 
 /**
@@ -19,10 +20,18 @@ export const MUIAutoPasswordInput = (
   } & Partial<TextFieldProps>
 ) => {
   const { findBy } = useAutoFormMetadata();
+  const { path } = useFieldMetadata(props.field);
+  const { field: fieldProps } = useController({ name: path });
+
   const [isEditing, setIsEditing] = useState(!findBy);
 
+  const startEditing = () => {
+    fieldProps.onChange(""); // Touch the field to mark it as dirty
+    setIsEditing(true);
+  };
+
   const startEditingButton = (
-    <IconButton onClick={() => setIsEditing(true)} role={`${props.field}EditPasswordButton`}>
+    <IconButton onClick={startEditing} role={`${props.field}EditPasswordButton`}>
       {pencilEmoji}
     </IconButton>
   );

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useController } from "react-hook-form";
 import { FieldType } from "../../../metadata.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { PolarisAutoBooleanInput } from "./PolarisAutoBooleanInput.js";
@@ -15,19 +14,9 @@ import { PolarisAutoBelongsToInput } from "./relationships/PolarisAutoBelongsToI
 import { PolarisAutoHasManyInput } from "./relationships/PolarisAutoHasManyInput.js";
 
 export const PolarisAutoInput = (props: { field: string }) => {
-  const { path, metadata } = useFieldMetadata(props.field);
-
-  const {
-    field: fieldProps,
-    fieldState: { error },
-  } = useController({
-    name: path,
-  });
-  // many polaris components don't take refs because they are weenies, see https://github.com/Shopify/polaris/issues/1083
-  // omit the ref from the forwarded along props so that we don't get a warning
-  const { ref: _ref, ...field } = fieldProps;
-
+  const { metadata } = useFieldMetadata(props.field);
   const config = metadata.configuration;
+
   switch (config.fieldType) {
     case FieldType.String:
     case FieldType.Number:

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
@@ -2,8 +2,9 @@ import type { TextFieldProps } from "@shopify/polaris";
 import { Button } from "@shopify/polaris";
 import { EditIcon } from "@shopify/polaris-icons";
 import React, { useState } from "react";
-import type { Control } from "react-hook-form";
+import { useController, type Control } from "react-hook-form";
 import { useAutoFormMetadata } from "../../AutoFormContext.js";
+import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { PolarisAutoEncryptedStringInput } from "./PolarisAutoEncryptedStringInput.js";
 
 /**
@@ -19,11 +20,19 @@ export const PolarisAutoPasswordInput = (
   } & Partial<TextFieldProps>
 ) => {
   const { findBy } = useAutoFormMetadata();
+  const { path } = useFieldMetadata(props.field);
+  const { field: fieldProps } = useController({ name: path });
+
   const [isEditing, setIsEditing] = useState(!findBy);
+
+  const startEditing = () => {
+    fieldProps.onChange(""); // Touch the field to mark it as dirty
+    setIsEditing(true);
+  };
 
   const startEditingButton = (
     <div style={{ display: "flex" }}>
-      <Button variant="plain" size="slim" icon={EditIcon} onClick={() => setIsEditing(true)} role={`${props.field}EditPasswordButton`} />
+      <Button variant="plain" size="slim" icon={EditIcon} onClick={startEditing} role={`${props.field}EditPasswordButton`} />
     </div>
   );
 


### PR DESCRIPTION
- **UPDATE**
  - Previously, untouched password fields for update actions would result in a null value being sent to the DB
    - Most other field types retrieve their record value from the DB and then send them back to the API through the form. Password fields are unique as their record value is not returned by the API, which means they can't send the same record value back to the API if untouched. That unknown record value then becomes null in the API request
    - Sending null to the API will result in the password getting cleared from the record. Big security problem 