### PR TITLE
GGT-6770 - Temporarily removed the MUI autocomponents 

### DIFF
--- a/packages/react/cypress/support/auto.tsx
+++ b/packages/react/cypress/support/auto.tsx
@@ -7,7 +7,7 @@ import type { ComponentType, ReactNode } from "react";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import type { AutoAdapter } from "../../src/auto/index.js";
-import * as MUIAdapter from "../../src/auto/mui/index.js";
+import * as MUIAdapter from "../../src/auto/mui/test-index.js";
 import * as PolarisAdapter from "../../src/auto/polaris/index.js";
 
 interface AutoSuiteConfig {

--- a/packages/react/spec/imports/cjs-auto-import.js
+++ b/packages/react/spec/imports/cjs-auto-import.js
@@ -2,4 +2,3 @@
 const { AutoForm: PolarisAutoForm } = require("@gadgetinc/react/auto/polaris");
 const { AutoForm: MUIAutoForm } = require("@gadgetinc/react/auto/mui");
 if (typeof PolarisAutoForm == "undefined") throw new Error("PolarisAutoForm is undefined");
-if (typeof MUIAutoForm == "undefined") throw new Error("MUIAutoForm is undefined");

--- a/packages/react/spec/imports/esm-auto-import.mjs
+++ b/packages/react/spec/imports/esm-auto-import.mjs
@@ -1,2 +1,1 @@
 import { AutoForm as PolarisAutoForm } from "@gadgetinc/react/auto/polaris";
-import { AutoForm as MUIAutoForm } from "@gadgetinc/react/auto/mui";

--- a/packages/react/src/auto/mui/index.ts
+++ b/packages/react/src/auto/mui/index.ts
@@ -1,22 +1,2 @@
-export * from "./MUIAutoForm.js";
-export { MUIAutoForm as AutoForm } from "./MUIAutoForm.js";
-export { MUIAutoBooleanInput as AutoBooleanInput } from "./inputs/MUIAutoBooleanInput.js";
-export { MUIAutoDateTimePicker as DateTimePicker } from "./inputs/MUIAutoDateTimePicker.js";
-export { MUIAutoEnumInput as AutoEnumInput } from "./inputs/MUIAutoEnumInput.js";
-export { MUIAutoFileInput as AutoFileInput } from "./inputs/MUIAutoFileInput.js";
-export { MUIAutoHiddenInput as AutoHiddenInput } from "./inputs/MUIAutoHiddenInput.js";
-export { MUIAutoInput as AutoInput } from "./inputs/MUIAutoInput.js";
-export { MUIAutoJSONInput as AutoJSONInput } from "./inputs/MUIAutoJSONInput.js";
-export { MUIAutoRolesInput as AutoRolesInput } from "./inputs/MUIAutoRolesInput.js";
-export {
-  MUIAutoTextInput as AutoColorInput,
-  MUIAutoTextInput as AutoEmailInput,
-  MUIAutoTextInput as AutoNumberInput,
-  MUIAutoTextInput as AutoStringInput,
-  MUIAutoTextInput as AutoTextInput,
-  MUIAutoTextInput as AutoUrlInput,
-} from "./inputs/MUIAutoTextInput.js";
-export { MUIAutoBelongsToInput as AutoBelongsToInput } from "./inputs/relationships/MUIAutoBelongsToInput.js";
-export { MUIAutoHasManyInput as AutoHasManyInput } from "./inputs/relationships/MUIAutoHasManyInput.js";
-export { MUIAutoSubmit as AutoSubmit } from "./submit/MUIAutoSubmit.js";
-export { MUISubmitResultBanner as SubmitResultBanner } from "./submit/MUISubmitResultBanner.js";
+// The MUI auto components have been temporarily removed.
+// When the autocomponents are ready for pre-release, they will be exported from this file.

--- a/packages/react/src/auto/mui/test-index.ts
+++ b/packages/react/src/auto/mui/test-index.ts
@@ -1,0 +1,23 @@
+// The index to be used by the jest and cypress tests until MUI components are ready for pre-release
+export * from "./MUIAutoForm.js";
+export { MUIAutoForm as AutoForm } from "./MUIAutoForm.js";
+export { MUIAutoBooleanInput as AutoBooleanInput } from "./inputs/MUIAutoBooleanInput.js";
+export { MUIAutoDateTimePicker as DateTimePicker } from "./inputs/MUIAutoDateTimePicker.js";
+export { MUIAutoEnumInput as AutoEnumInput } from "./inputs/MUIAutoEnumInput.js";
+export { MUIAutoFileInput as AutoFileInput } from "./inputs/MUIAutoFileInput.js";
+export { MUIAutoHiddenInput as AutoHiddenInput } from "./inputs/MUIAutoHiddenInput.js";
+export { MUIAutoInput as AutoInput } from "./inputs/MUIAutoInput.js";
+export { MUIAutoJSONInput as AutoJSONInput } from "./inputs/MUIAutoJSONInput.js";
+export { MUIAutoRolesInput as AutoRolesInput } from "./inputs/MUIAutoRolesInput.js";
+export {
+  MUIAutoTextInput as AutoColorInput,
+  MUIAutoTextInput as AutoEmailInput,
+  MUIAutoTextInput as AutoNumberInput,
+  MUIAutoTextInput as AutoStringInput,
+  MUIAutoTextInput as AutoTextInput,
+  MUIAutoTextInput as AutoUrlInput,
+} from "./inputs/MUIAutoTextInput.js";
+export { MUIAutoBelongsToInput as AutoBelongsToInput } from "./inputs/relationships/MUIAutoBelongsToInput.js";
+export { MUIAutoHasManyInput as AutoHasManyInput } from "./inputs/relationships/MUIAutoHasManyInput.js";
+export { MUIAutoSubmit as AutoSubmit } from "./submit/MUIAutoSubmit.js";
+export { MUISubmitResultBanner as SubmitResultBanner } from "./submit/MUISubmitResultBanner.js";


### PR DESCRIPTION
The MUI autocomponents are not ready to be used by alpha testers, so they have been commented out in this PR. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
