### PR TITLE
Disable chrome gpu in CI to see if flakiness is reduced

### DIFF
--- a/packages/react/cypress.config.ts
+++ b/packages/react/cypress.config.ts
@@ -11,6 +11,15 @@ export default defineConfig({
         },
       },
     },
+    setupNodeEvents(on, config) {
+      on("before:browser:launch", (_browser, launchOptions) => {
+        if (process.env["CI"]) {
+          // try to fix https://github.com/cypress-io/cypress/issues/29860
+          launchOptions.args.push("--disable-gpu");
+        }
+        return launchOptions;
+      });
+    },
   },
   retries: process.env["CI"] ? 2 : 0,
 });


### PR DESCRIPTION
Ran this 10 times in a row and got the other cypress flake but not the failed to connect flake, I think this will improve things!