### PR TITLE
Changed timer picker onHover color

### DIFF
--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTimePicker.tsx
@@ -1,5 +1,5 @@
 import type { TextFieldProps } from "@shopify/polaris";
-import { Box, Icon, Listbox, Popover, Scrollable, TextField } from "@shopify/polaris";
+import { Box, Icon, Listbox, Popover, Scrollable, Text, TextField } from "@shopify/polaris";
 import { ClockIcon } from "@shopify/polaris-icons";
 import { zonedTimeToUtc } from "date-fns-tz";
 import React, { useEffect, useState } from "react";
@@ -25,8 +25,10 @@ const createMarkup = (
             {selectedState.padStart(2, "0") == item.padStart(2, "0") ||
             (parseInt(selectedState, 10) == 0 && item == "12") ||
             (selectCoord?.col == colNum && selectCoord.row == i) ? (
-              <Box padding="100" background="bg-surface-secondary-selected" borderRadius="200" minHeight="30px" minWidth="30px">
-                {item}
+              <Box padding="100" background="bg-inverse" borderRadius="200" minHeight="30px" minWidth="30px">
+                <Text as="p" tone="text-inverse">
+                  {item}
+                </Text>
               </Box>
             ) : (
               <Box minHeight="30px" minWidth="30px" padding="100">


### PR DESCRIPTION
The selected color for the custom time picker was different than the date picker, which made the form incohesive. 

This PR fixes that:

![Screen Recording 2024-07-16 at 2 46 46 PM](https://github.com/user-attachments/assets/acf515b4-f233-4f1a-b78b-8f78c8d4c18b)

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
