### PR TITLE
Removed useEffect that caused a type error race condition on Role input components

### DIFF
--- a/packages/react/src/auto/hooks/useRoleInputController.tsx
+++ b/packages/react/src/auto/hooks/useRoleInputController.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Control, useController } from "react-hook-form";
 import { useRolesMetadata } from "../../metadata.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
@@ -18,22 +18,6 @@ export const useRoleInputController = (props: {
     name: path,
   });
 
-  const [selectedRoleKeys, setSelectedRoleKeys] = useState<string[]>([]);
-
-  useEffect(() => {
-    if (!fieldProps.value) {
-      return;
-    }
-
-    const updatedRoleKeys = fieldProps.value.map((role: string | { key: string }) => {
-      // When retrieved from an existing value, fieldProps.value is an array of {key:string, name:string} objects
-      // In order to send the roles to the Gadget app, useController must have them as an array of string keys
-      return typeof role === "string" ? role : role.key;
-    });
-    setSelectedRoleKeys(updatedRoleKeys);
-    fieldProps.onChange(updatedRoleKeys);
-  }, [JSON.stringify(fieldProps.value)]);
-
   const { roles, fetching, error: rolesError } = useRolesMetadata();
 
   const options = useMemo(() => {
@@ -43,14 +27,13 @@ export const useRoleInputController = (props: {
       .map((role) => ({
         value: role.key,
         label: role.name,
-        selected: selectedRoleKeys.includes(role.key),
       }));
   }, [roles]);
 
   const loading = fetching || options.length === 0; // There must always be at least one role option `unauthenticated`
 
   return {
-    selectedRoleKeys,
+    selectedRoleKeys: fieldProps.value ?? [],
     metadata,
     options,
     fieldProps,

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -49,12 +49,26 @@ export const processDefaultValues = (opts: {
 }) => {
   const { modelApiIdentifier, data, defaultValues } = opts;
 
+  convertRoleObjectListIntoStringList(data); // Incoming role objects arrays need to be converted to role key string arrays because the API will only accept role keys
+
   const modelDefaultValues = toDefaultValues(modelApiIdentifier, data);
   const result = opts.hasAmbiguousDefaultValues
     ? { ...defaultValues, [modelApiIdentifier]: modelDefaultValues }
     : { ...defaultValues, ...modelDefaultValues, [modelApiIdentifier]: modelDefaultValues };
 
   return result;
+};
+
+const convertRoleObjectListIntoStringList = (data: any) => {
+  for (const key of Object.keys(data)) {
+    const isArray = Array.isArray(data[key]) && data[key].length;
+    if (isArray) {
+      data[key] = data[key].map((role: any) => {
+        const hasRoleKey = typeof role === "object" && "__typename" in role && role.__typename === "Role" && "key" in role;
+        return hasRoleKey ? role.key : role;
+      });
+    }
+  }
 };
 
 export const toDefaultValues = (modelApiIdentifier: string | undefined, data: any) => {


### PR DESCRIPTION
- **UPDATE**
  - PREVIOUSLY -> Race condition on the removed useEffect.
    - If there was a findBy value corresponding to a record with roles and the submit button was pressed before the useEffect converted the returned role object list to a role key string list, there would be a type error since the API can only accept string arrays for role list fields
    - This was only observed in tests, but would be more likely under conditions where the RolesMetadata comes has a much slower response than the other requests. 
  - NOW 
    - The useEffect has been removed and replaced with direct usage of `useController -> fieldProps.value`
    - The retrieved record will have it's Role object array converted to a role key string array before it gets registered with the hooks
 