### PR TITLE
Added key to autoforms to make the contents re-render upon actions and findBy value changes

### DIFF
--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -33,6 +33,20 @@ export const MUIAutoForm = <
 >(
   props: MUIAutoFormProps<GivenOptions, SchemaT, ActionFunc>
 ) => {
+  const { action, findBy } = props as MUIAutoFormProps<GivenOptions, SchemaT, ActionFunc> & { findBy: any };
+
+  // Component key to force re-render when the action or findBy changes
+  const componentKey = `${action.modelApiIdentifier}.${action.operationName}.${findBy}`;
+
+  return <MUIAutoFormComponent key={componentKey} {...props} />;
+};
+export const MUIAutoFormComponent = <
+  GivenOptions extends OptionsType,
+  SchemaT,
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>
+>(
+  props: MUIAutoFormProps<GivenOptions, SchemaT, ActionFunc>
+) => {
   const { record: _record, action, findBy, ...rest } = props as MUIAutoFormProps<GivenOptions, SchemaT, ActionFunc> & { findBy: any };
   const { metadata, fetchingMetadata, metadataError, fields, submit, formError, isSubmitSuccessful, isLoading, originalFormMethods } =
     useAutoForm(props);
@@ -75,7 +89,10 @@ export const MUIAutoForm = <
   );
 
   return (
-    <AutoFormMetadataContext.Provider value={autoFormMetadataContext}>
+    <AutoFormMetadataContext.Provider
+      value={autoFormMetadataContext}
+      key={`${action.modelApiIdentifier}.${action.operationName}.${findBy}`}
+    >
       <FormProvider {...originalFormMethods}>
         <Grid container component="form" spacing={2} onSubmit={submit as any} {...rest}>
           {formContent}

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -29,6 +29,28 @@ export const PolarisAutoForm = <
   //polaris form props also take an 'action' property, which we need to omit here.
   props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action">
 ) => {
+  const { action, findBy } = props as AutoFormProps<GivenOptions, SchemaT, ActionFunc> &
+    Omit<Partial<FormProps>, "action"> & { findBy: any };
+
+  // Component key to force re-render when the action or findBy changes
+  const componentKey = `${action.modelApiIdentifier}.${action.operationName}.${findBy}`;
+
+  return (
+    <PolarisAutoFormComponent
+      key={componentKey}
+      {...(props as AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action"> & { findBy: any })}
+    />
+  );
+};
+
+const PolarisAutoFormComponent = <
+  GivenOptions extends OptionsType,
+  SchemaT,
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>
+>(
+  //polaris form props also take an 'action' property, which we need to omit here.
+  props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action">
+) => {
   const {
     record: _record,
     action,


### PR DESCRIPTION
![CleanShot 2024-07-16 at 17 28 32](https://github.com/user-attachments/assets/ebc7b322-b433-4180-94a3-ca79d52073f7)


- **UPDATE**
  - Previously, dynamically changing the action or findBy value did not cause a re-render. This was a problem because you may end up thinking that you are editing the wrong value
  - Now, changing the action or the findBy value will force a re-render, causing all of the fields to be reset to the defaults or the corresponding record values

 