### PR TITLE
Prevent null values for text input components

### DIFF
--- a/packages/react/src/auto/hooks/useStringInputController.tsx
+++ b/packages/react/src/auto/hooks/useStringInputController.tsx
@@ -37,6 +37,8 @@ export const useStringInputController = (
     ...rest,
   });
 
+  const { value, ...restOfFieldProperties } = fieldProperties;
+
   const placeholder = PlaceholderValues[metadata.fieldType];
 
   return {
@@ -47,6 +49,12 @@ export const useStringInputController = (
     autoComplete: "off",
     placeholder,
     metadata,
-    ...fieldProperties,
+    value: getValue(value, metadata.fieldType),
+    ...restOfFieldProperties,
   };
+};
+
+const getValue = (value: any, fieldType: GadgetFieldType) => {
+  // JSON fields can have null value which is different from an empty string. In that case, use null directly
+  return fieldType === FieldType.Json ? value : value ?? "";
 };


### PR DESCRIPTION
- **UPDATE**
  - Previously, there was a console error when a null DB record value was passed to text fields. 
  - Now, an empty string will be sent to the text inputs when there is a null DB value
    - This does not trigger the controller's onChange function which will ensure that that value is still null if untouched when sent back to the API, thus leaving that record field unchanged