### PR TITLE
Introduce table cell renderers for AutoTable

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.498.0-development.854",
+    "@gadget-client/js-clients-test": "1.498.0-development.1466",
     "@gadget-client/kitchen-sink": "1.5.0-development.200",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/react/cypress/component/auto/table/PolarisAutoTableCellRenderer.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableCellRenderer.cy.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { PolarisAutoTableCellRenderer } from "../../../../src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.js";
+import { FieldType } from "../../../../src/metadata.js";
+import { PolarisWrapper } from "../../../support/auto.js";
+
+describe("PolarisAutoTableCellRenderer", () => {
+  it("picks the correct cell renderer based on the field type", () => {
+    cy.mountWithWrapper(
+      <PolarisAutoTableCellRenderer
+        column={{
+          fieldType: FieldType.String,
+        }}
+        value="Hello, World!"
+      />,
+      PolarisWrapper
+    );
+
+    cy.contains("Hello, World!");
+
+    cy.mountWithWrapper(
+      <PolarisAutoTableCellRenderer
+        column={{
+          fieldType: FieldType.DateTime,
+        }}
+        value={new Date("2024-07-01T01:00:00.000Z")}
+      />,
+      PolarisWrapper
+    );
+
+    cy.contains("Jul 1, 2024 1:00 AM");
+
+    cy.mountWithWrapper(
+      <PolarisAutoTableCellRenderer
+        column={{
+          fieldType: FieldType.Enum,
+        }}
+        value={["foo", "bar"]}
+      />,
+      PolarisWrapper
+    );
+    cy.get(".Polaris-Tag").should("have.length", 2);
+    cy.get(".Polaris-Tag").eq(0).should("have.text", "foo");
+    cy.get(".Polaris-Tag").eq(1).should("have.text", "bar");
+  });
+
+  it("does not render anything if the value is null", () => {
+    cy.mountWithWrapper(
+      <PolarisAutoTableCellRenderer
+        column={{
+          fieldType: FieldType.String,
+        }}
+        value={null}
+      />,
+      PolarisWrapper
+    );
+
+    // .Polaris-Box comes from the PolarisWrapper, and it should not have any children
+    cy.get(".Polaris-ShadowBevel > .Polaris-Box").children().should("have.length", 0);
+  });
+});

--- a/packages/react/cypress/component/auto/table/PolarisAutoTableDateTimeCell.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableDateTimeCell.cy.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { PolarisAutoTableDateTimeCell } from "../../../../src/auto/polaris/tableCells/PolarisAutoTableDateTimeCell.js";
+
+describe("PolarisAutoTableDateTimeCell", () => {
+  it("renders the date as string", () => {
+    cy.mount(<PolarisAutoTableDateTimeCell value={new Date("2024-07-01T01:00:00.000Z")} />);
+    cy.get("span").should("have.text", "Jul 1, 2024 1:00 AM"); // Make sure the format defined in the component is correct
+  });
+});

--- a/packages/react/cypress/component/auto/table/PolarisAutoTableFileCell.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableFileCell.cy.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { PolarisAutoTableFileCell } from "../../../../src/auto/polaris/tableCells/PolarisAutoTableFileCell.js";
+import { PolarisWrapper } from "../../../support/auto.js";
+
+describe("PolarisAutoTableFileCell", () => {
+  it("renders the file value and preview the image", () => {
+    cy.mountWithWrapper(
+      <PolarisAutoTableFileCell
+        value={{
+          url: "https://assets.gadget.dev/assets/icon.svg",
+          fileName: "icon.svg",
+          mimeType: "image/svg+xml",
+          __typename: "StoredFile",
+        }}
+      />,
+      PolarisWrapper
+    );
+
+    cy.get(".Polaris-Thumbnail").get("img").should("have.attr", "src", "https://assets.gadget.dev/assets/icon.svg");
+    cy.contains("icon.svg");
+  });
+
+  it("renders the file value and preview the note icon if it's not an image", () => {
+    cy.mountWithWrapper(
+      <PolarisAutoTableFileCell
+        value={{
+          url: "https://example.com",
+          fileName: "file.pdf",
+          mimeType: "application/pdf",
+          __typename: "StoredFile",
+        }}
+      />,
+      PolarisWrapper
+    );
+
+    cy.get(".Polaris-Thumbnail").should("not.exist");
+    cy.contains("file.pdf");
+  });
+
+  it("truncate the file name and keep the extension if it's too long", () => {
+    cy.mountWithWrapper(
+      <PolarisAutoTableFileCell
+        value={{
+          url: "https://example.com",
+          fileName: "some-super-important-document.pdf",
+          mimeType: "application/pdf",
+          __typename: "StoredFile",
+        }}
+      />,
+      PolarisWrapper
+    );
+
+    cy.contains("some-super-i(..).pdf");
+  });
+});

--- a/packages/react/cypress/component/auto/table/PolarisAutoTableTagCell.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableTagCell.cy.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { PolarisAutoTableTagCell } from "../../../../src/auto/polaris/tableCells/PolarisAutoTableTagCell.js";
+import { PolarisWrapper } from "../../../support/auto.js";
+
+describe("PolarisAutoTableTextCell", () => {
+  it("renders the string value", () => {
+    cy.mountWithWrapper(<PolarisAutoTableTagCell value={"foo"} />, PolarisWrapper);
+    cy.get(".Polaris-Tag").should("have.text", "foo");
+  });
+
+  it("renders an array of string as multiple tags", () => {
+    cy.mountWithWrapper(<PolarisAutoTableTagCell value={["foo", "bar"]} />, PolarisWrapper);
+    cy.get(".Polaris-Tag").should("have.length", 2);
+    cy.get(".Polaris-Tag").eq(0).should("have.text", "foo");
+    cy.get(".Polaris-Tag").eq(1).should("have.text", "bar");
+  });
+
+  it("renders an array of roles as multiple tags", () => {
+    cy.mountWithWrapper(
+      <PolarisAutoTableTagCell
+        value={[
+          { name: "hello", key: "hello", __typename: "Role" },
+          { name: "world", key: "world", __typename: "Role" },
+        ]}
+      />,
+      PolarisWrapper
+    );
+    cy.get(".Polaris-Tag").should("have.length", 2);
+    cy.get(".Polaris-Tag").eq(0).should("have.text", "hello");
+    cy.get(".Polaris-Tag").eq(1).should("have.text", "world");
+  });
+});

--- a/packages/react/cypress/component/auto/table/PolarisAutoTableTextCell.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableTextCell.cy.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { PolarisAutoTableTextCell } from "../../../../src/auto/polaris/tableCells/PolarisAutoTableTextCell.js";
+
+describe("PolarisAutoTableTextCell", () => {
+  it("renders the string value", () => {
+    cy.mount(<PolarisAutoTableTextCell value={"hello"} />);
+    cy.get("span").should("have.text", "hello");
+  });
+
+  it("renders the rich text field value as plain text", () => {
+    cy.mount(<PolarisAutoTableTextCell value={{ markdown: "# hello" }} />);
+    cy.get("span").should("have.text", "# hello");
+  });
+
+  it("renders the JSON value", () => {
+    cy.mount(<PolarisAutoTableTextCell value={{ hello: "world" }} />);
+    cy.get("span").should("have.text", `{"hello":"world"}`);
+
+    cy.mount(<PolarisAutoTableTextCell value={[{ hello: "array" }]} />);
+    cy.get("span").should("have.text", `[{"hello":"array"}]`);
+  });
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,8 +40,8 @@
     "prerelease": "gitpkg publish",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cypress:open": "TZ=UTC cypress open",
+    "cypress:run": "TZ=UTC cypress run"
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.4",

--- a/packages/react/spec/auto/MockTable.tsx
+++ b/packages/react/spec/auto/MockTable.tsx
@@ -1,0 +1,16 @@
+import { AppProvider } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
+import type { ReactNode } from "react";
+import React from "react";
+import { testApi as api } from "../apis.js";
+import { MockClientProvider } from "../testWrappers.js";
+
+export const MockTable = () => {
+  return (props: { children: ReactNode }) => {
+    return (
+      <MockClientProvider api={api}>
+        <AppProvider i18n={translations}>{props.children}</AppProvider>
+      </MockClientProvider>
+    );
+  };
+};

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -1,12 +1,12 @@
-import { Provider } from '../../src/GadgetProvider.tsx';
-import { PolarisAutoTable } from '../../src/auto/polaris/PolarisAutoTable.tsx';
-import { AppProvider, Page, LegacyCard } from '@shopify/polaris';
-import { testApi as api } from '../apis.ts';
-import React from 'react';
+import { AppProvider, Card } from "@shopify/polaris";
+import React from "react";
+import { Provider } from "../../src/GadgetProvider.tsx";
+import { PolarisAutoTable } from "../../src/auto/polaris/PolarisAutoTable.tsx";
+import { testApi as api } from "../apis.ts";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
-  title: 'Polaris/AutoTable',
+  title: "Polaris/AutoTable",
   component: PolarisAutoTable,
   decorators: [
     // 👇 Defining the decorator in the preview file applies it to all stories
@@ -15,30 +15,29 @@ export default {
       return (
         <Provider api={api}>
           <AppProvider>
-              <LegacyCard>
-                <div style={{maxHeight: '70vh', overflow: 'auto'}}>
-                  <Story /> 
-                </div>
-              </LegacyCard>
+            <Card>
+              <div style={{ maxHeight: "70vh", overflow: "auto" }}>
+                <Story />
+              </div>
+            </Card>
           </AppProvider>
         </Provider>
       );
     },
   ],
-  
+
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
-    layout: 'centered',
+    layout: "centered",
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
-
 };
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Primary = {
   args: {
-    model: api.gizmo
+    model: api.widget,
   },
 };

--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -1,0 +1,216 @@
+import { renderHook } from "@testing-library/react";
+import { useTable } from "../../../src/useTable.js";
+import { testApi as api } from "../../apis.js";
+import { mockUrqlClient } from "../../testWrappers.js";
+import { MockTable } from "../MockTable.js";
+import { recordIdInputField } from "../support/shared.js";
+import { widgetModelInputFields } from "../support/widgetModel.js";
+
+describe("useTable hook", () => {
+  const getUseTableResult = () => {
+    const { result } = renderHook(
+      () => {
+        return useTable(api.widget);
+      },
+      {
+        wrapper: MockTable(),
+      }
+    );
+    return result;
+  };
+
+  it("should return the list of data and field information of a table", async () => {
+    const result = getUseTableResult();
+    loadMockWidgetModelMetadata();
+    loadWidgetData();
+
+    expect(result.current[0].rows).toEqual([
+      {
+        id: "7",
+        name: "foo",
+        inventoryCount: 1,
+        gizmos: undefined,
+        anything: null,
+        description: "# foo bar",
+        category: ["foo"],
+        startsAt: "2024-07-01T01:00:00.000Z",
+        isChecked: true,
+        metafields: { hello: "world" },
+        roles: ["unauthenticated"],
+        birthday: "2024-07-01T00:00:00.000Z",
+        color: null,
+        secretKey: "secret",
+        embedding: null,
+        section: undefined,
+        mustBeLongString: "hellllllllllllllllllllllllllllo",
+      },
+    ]);
+    expect(
+      result.current[0].columns?.map((column) => {
+        const { getValue: _getValue, ...rest } = column;
+        return rest;
+      })
+    ).toEqual([
+      {
+        apiIdentifier: "name",
+        fieldType: "String",
+        name: "Name",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "inventoryCount",
+        fieldType: "Number",
+        name: "Inventory count",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "gizmos",
+        fieldType: "HasMany",
+        name: "Gizmos",
+        sortable: false,
+      },
+      {
+        apiIdentifier: "anything",
+        fieldType: "JSON",
+        name: "Anything",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "description",
+        fieldType: "RichText",
+        name: "Description",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "category",
+        fieldType: "Enum",
+        name: "Category",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "startsAt",
+        fieldType: "DateTime",
+        name: "Starts at",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "isChecked",
+        fieldType: "Boolean",
+        name: "Is checked",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "metafields",
+        fieldType: "JSON",
+        name: "Metafields",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "roles",
+        fieldType: "RoleAssignments",
+        name: "Roles",
+        sortable: false,
+      },
+      {
+        apiIdentifier: "birthday",
+        fieldType: "DateTime",
+        name: "Birthday",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "color",
+        fieldType: "Color",
+        name: "Color",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "secretKey",
+        fieldType: "EncryptedString",
+        name: "Secret key",
+        sortable: false,
+      },
+      {
+        apiIdentifier: "embedding",
+        fieldType: "Vector",
+        name: "Embedding",
+        sortable: true,
+      },
+      {
+        apiIdentifier: "section",
+        fieldType: "BelongsTo",
+        name: "Section",
+        sortable: false,
+      },
+      {
+        apiIdentifier: "mustBeLongString",
+        fieldType: "String",
+        name: "Must be long string",
+        sortable: true,
+      },
+    ]);
+  });
+});
+
+const loadMockWidgetModelMetadata = () => {
+  mockUrqlClient.executeQuery.pushResponse("GetModelMetadata", {
+    stale: false,
+    hasNext: false,
+    data: {
+      gadgetMeta: {
+        model: {
+          apiIdentifier: "widget",
+          namespace: [],
+          name: "Widget",
+          fields: [recordIdInputField, ...widgetModelInputFields.configuration.fields],
+          __typename: "GadgetModel",
+        },
+        __typename: "GadgetApplicationMeta",
+      },
+    },
+  });
+};
+
+const loadWidgetData = () => {
+  mockUrqlClient.executeQuery.pushResponse("widgets", {
+    stale: false,
+    hasNext: false,
+    data: {
+      widgets: {
+        edges: [
+          {
+            cursor: "eyJpZCI6IjcifQ==",
+            node: {
+              __typename: "Widget",
+              id: "7",
+              anything: null,
+              birthday: "2024-07-01T00:00:00.000Z",
+              category: ["foo"],
+              color: null,
+              createdAt: "2023-09-07T19:18:50.262Z",
+              description: "# foo bar",
+              embedding: null,
+              inStock: true,
+              inventoryCount: 1,
+              isChecked: true,
+              metafields: { hello: "world" },
+              mustBeLongString: "hellllllllllllllllllllllllllllo",
+              name: "foo",
+              roles: ["unauthenticated"],
+              secretKey: "secret",
+              startsAt: "2024-07-01T01:00:00.000Z",
+              updatedAt: "2023-09-21T17:19:11.197Z",
+            },
+            __typename: "WidgetEdge",
+          },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+          hasPreviousPage: false,
+          startCursor: "eyJpZCI6IjcifQ==",
+          endCursor: "eyJpZCI6IjU2In0=",
+          __typename: "PageInfo",
+        },
+      },
+    },
+  });
+};

--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -1,0 +1,103 @@
+import { jest } from "@jest/globals";
+import { render } from "@testing-library/react";
+import React from "react";
+import { testApi as api } from "../../apis.js";
+import { PolarisMockedProviders } from "../inputs/PolarisMockedProviders.js";
+
+const POLARIS_TABLE_CLASSES = {
+  CONTAINER: "Polaris-IndexTable-ScrollContainer",
+  HEADING: "Polaris-IndexTable__TableHeading",
+  ROW: "Polaris-IndexTable__TableRow",
+  CELL: "Polaris-IndexTable__TableCell",
+} as const;
+
+// The path is relative to the file from the packages/react/spec/jest.setup.ts file, not from this test file
+jest.unstable_mockModule("../src/useTable", () => ({
+  useTable: jest.fn().mockImplementation(() => {
+    return [
+      {
+        rows: [
+          {
+            id: "1",
+            name: "hello",
+            inventoryCount: 1,
+          },
+          {
+            id: "2",
+            name: "cool",
+            inventoryCount: 2,
+          },
+          {
+            id: "3",
+            name: "world",
+            inventoryCount: null,
+          },
+        ],
+        columns: [
+          {
+            apiIdentifier: "name",
+            fieldType: "String",
+            name: "Name",
+            sortable: true,
+          },
+          {
+            apiIdentifier: "inventoryCount",
+            fieldType: "Number",
+            name: "Inventory count",
+            sortable: true,
+          },
+        ],
+        metadata: {
+          name: "Widget",
+        },
+        page: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          goToNextPage: jest.fn(),
+          goToPreviousPage: jest.fn(),
+        },
+        fetching: false,
+      },
+      jest.fn(),
+    ];
+  }),
+}));
+
+// We are mocking the useTable hook that is used by PolarisAutoTable, so we need to import it dynamically
+const { PolarisAutoTable } = await import("../../../src/auto/polaris/PolarisAutoTable.js");
+
+describe("PolarisAutoTable", () => {
+  it("can render a table with records inside", () => {
+    const { container } = render(<PolarisAutoTable model={api.widget} />, { wrapper: PolarisMockedProviders });
+    const table = container.querySelector(`.${POLARIS_TABLE_CLASSES.CONTAINER}`)!;
+
+    const headers = table.getElementsByClassName(POLARIS_TABLE_CLASSES.HEADING);
+    expect(Array.from(headers).map((h) => h.textContent)).toEqual([
+      "Select all Widgets", // The default "select all" checkbox
+      "Name",
+      "Inventory count",
+    ]);
+
+    // The first header column should be a checkbox
+    expect(headers[0].querySelector("input")).toHaveAttribute("type", "checkbox");
+
+    // Three rows should be rendered
+    const rows = table.getElementsByClassName(POLARIS_TABLE_CLASSES.ROW);
+    expect(rows.length).toBe(3);
+
+    const firstRow = rows[0];
+    const firstRowCells = firstRow.getElementsByClassName(POLARIS_TABLE_CLASSES.CELL);
+    expect(firstRowCells[1].textContent).toBe("hello");
+    expect(firstRowCells[2].textContent).toBe("1");
+
+    const secondRow = rows[1];
+    const secondRowCells = secondRow.getElementsByClassName(POLARIS_TABLE_CLASSES.CELL);
+    expect(secondRowCells[1].textContent).toBe("cool");
+    expect(secondRowCells[2].textContent).toBe("2");
+
+    const thirdRow = rows[2];
+    const thirdRowCells = thirdRow.getElementsByClassName(POLARIS_TABLE_CLASSES.CELL);
+    expect(thirdRowCells[1].textContent).toBe("world");
+    expect(thirdRowCells[2].textContent).toBe(""); // Empty cell for null value
+  });
+});

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -1,11 +1,11 @@
 import type { FindManyFunction } from "@gadgetinc/api-client-core";
+import type { IndexTableProps } from "@shopify/polaris";
 import {
   BlockStack,
   DataTable,
   EmptySearchResult,
   IndexFilters,
   IndexTable,
-  IndexTableProps,
   SkeletonBodyText,
   useSetIndexFiltersMode,
 } from "@shopify/polaris";
@@ -14,6 +14,7 @@ import React, { useMemo } from "react";
 import { useTable } from "../../useTable.js";
 import type { OptionsType } from "../../utils.js";
 import type { AutoTableProps } from "../AutoTable.js";
+import { PolarisAutoTableCellRenderer } from "./tableCells/PolarisAutoTableCellRenderer.js";
 
 const PolarisSkeletonTable = (props: { columns: number }) => {
   const count = Array.from(Array(props.columns));
@@ -106,7 +107,11 @@ export const PolarisAutoTable = <
           rows.map((row, index) => (
             <IndexTable.Row key={row.id as string} id={row.id as string} position={index}>
               {columns.map((column) => (
-                <IndexTable.Cell key={column.apiIdentifier}>{row[column.apiIdentifier]}</IndexTable.Cell>
+                <IndexTable.Cell key={column.apiIdentifier}>
+                  <div style={{ maxWidth: "200px" }}>
+                    <PolarisAutoTableCellRenderer column={column} value={row[column.apiIdentifier]} />
+                  </div>
+                </IndexTable.Cell>
               ))}
             </IndexTable.Row>
           ))}

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableBooleanCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableBooleanCell.tsx
@@ -1,0 +1,13 @@
+import { InlineStack } from "@shopify/polaris";
+import { CheckIcon, XIcon } from "@shopify/polaris-icons";
+import React from "react";
+
+export const PolarisAutoTableBooleanCell = (props: { value: boolean }) => {
+  const { value } = props;
+
+  return (
+    <InlineStack blockAlign="center">
+      {value ? <CheckIcon width={20} /> : <XIcon width={20} fill="var(--p-color-icon-disabled)" />}
+    </InlineStack>
+  );
+};

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import type { GadgetFieldType } from "../../../internal/gql/graphql.js";
+import { FieldType } from "../../../metadata.js";
+import type { ColumnValueType } from "../../../utils.js";
+import { PolarisAutoTableBooleanCell } from "./PolarisAutoTableBooleanCell.js";
+import { PolarisAutoTableDateTimeCell } from "./PolarisAutoTableDateTimeCell.js";
+import { PolarisAutoTableFileCell } from "./PolarisAutoTableFileCell.js";
+import { PolarisAutoTablePasswordCell } from "./PolarisAutoTablePasswordCell.js";
+import { PolarisAutoTableTagCell } from "./PolarisAutoTableTagCell.js";
+import { PolarisAutoTableTextCell } from "./PolarisAutoTableTextCell.js";
+
+export const PolarisAutoTableCellRenderer = (props: {
+  column: {
+    fieldType: GadgetFieldType;
+  };
+  value: ColumnValueType;
+}) => {
+  const { column, value } = props;
+
+  if (value === null) {
+    // Don't render anything for null values
+    return null;
+  }
+
+  switch (column.fieldType) {
+    case FieldType.String:
+    case FieldType.Number:
+    case FieldType.Email:
+    case FieldType.Url:
+    case FieldType.RichText:
+    case FieldType.Json: {
+      return <PolarisAutoTableTextCell value={value} />;
+    }
+
+    case FieldType.Password:
+    case FieldType.EncryptedString: {
+      return <PolarisAutoTablePasswordCell />;
+    }
+
+    case FieldType.RoleAssignments:
+    case FieldType.Enum: {
+      return <PolarisAutoTableTagCell value={value as any} />;
+    }
+
+    case FieldType.DateTime: {
+      return <PolarisAutoTableDateTimeCell value={value as any} />;
+    }
+
+    case FieldType.Boolean: {
+      return <PolarisAutoTableBooleanCell value={!!value} />;
+    }
+
+    case FieldType.File: {
+      return <PolarisAutoTableFileCell value={value as any} />;
+    }
+
+    default:
+      return null;
+  }
+};

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableDateTimeCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableDateTimeCell.tsx
@@ -1,0 +1,9 @@
+import { format } from "date-fns";
+import React from "react";
+import { PolarisAutoTableTextCell } from "./PolarisAutoTableTextCell.js";
+
+export const PolarisAutoTableDateTimeCell = (props: { value: Date }) => {
+  const { value } = props;
+
+  return value instanceof Date ? <PolarisAutoTableTextCell value={format(value, "LLL d, y K:mm a")} /> : null;
+};

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableFileCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableFileCell.tsx
@@ -1,0 +1,50 @@
+import { Icon, InlineStack, Text, Thumbnail } from "@shopify/polaris";
+import { NoteIcon } from "@shopify/polaris-icons";
+import React, { useMemo } from "react";
+import type { FileValueType } from "../../../utils.js";
+import { imageFileTypes } from "../../hooks/useFileInputController.js";
+
+const MAX_FILE_NAME_LENGTH = 12;
+
+export const PolarisAutoTableFileCell = (props: { value: FileValueType }) => {
+  const { value } = props;
+
+  const originalFileName = value.fileName;
+
+  const formattedFileName = useMemo(() => {
+    const segments = originalFileName.split(".");
+
+    if (segments.length > 1) {
+      let name = segments.slice(0, -1).join(".");
+      const extension = segments.pop();
+
+      if (name.length > MAX_FILE_NAME_LENGTH) {
+        // Truncate the name if it's too long
+        name = name.substring(0, MAX_FILE_NAME_LENGTH) + "(..)";
+      }
+
+      // Join the name and extension back together
+      return [name, extension].join(".");
+    } else {
+      // Return the original name if there's no extension
+      return originalFileName;
+    }
+  }, [originalFileName]);
+
+  const icon = imageFileTypes.includes(value.mimeType) ? (
+    <Thumbnail size="small" alt={originalFileName} source={value.url} />
+  ) : (
+    <div>
+      <Icon source={NoteIcon} />
+    </div>
+  );
+
+  return (
+    <InlineStack gap="200" blockAlign="center" wrap={false}>
+      {icon}
+      <Text as="span" truncate>
+        {formattedFileName}
+      </Text>
+    </InlineStack>
+  );
+};

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTablePasswordCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTablePasswordCell.tsx
@@ -1,0 +1,12 @@
+import { Tag, Text } from "@shopify/polaris";
+import React from "react";
+
+export const PolarisAutoTablePasswordCell = () => {
+  return (
+    <Tag>
+      <Text as="span" tone="subdued">
+        ••••••••••
+      </Text>
+    </Tag>
+  );
+};

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTagCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTagCell.tsx
@@ -1,0 +1,32 @@
+import { InlineStack, Tag } from "@shopify/polaris";
+import React, { useMemo } from "react";
+import type { RoleAssignmentsValueType } from "../../../utils.js";
+import { isRoleAssignmentsArray } from "../../../utils.js";
+
+export const PolarisAutoTableTagCell = (props: { value: string | string[] | RoleAssignmentsValueType[] }) => {
+  const { value } = props;
+
+  const tags = useMemo(() => {
+    if (Array.isArray(value)) {
+      if (isRoleAssignmentsArray(value)) {
+        return value.map((role) => role.name);
+      } else if (typeof value[0] === "string") {
+        return value;
+      } else {
+        return [];
+      }
+    } else {
+      return [value];
+    }
+  }, [value]);
+
+  return (
+    <InlineStack gap="100" wrap={false}>
+      {tags.map((tag) => (
+        <Tag key={tag} accessibilityLabel={`tag-${tag}`}>
+          {tag}
+        </Tag>
+      ))}
+    </InlineStack>
+  );
+};

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTextCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTextCell.tsx
@@ -1,0 +1,13 @@
+import { Text } from "@shopify/polaris";
+import React from "react";
+
+export const PolarisAutoTableTextCell = (props: { value: any }) => {
+  const { value } = props;
+  const stringifiedValue = typeof value === "object" ? ("markdown" in value ? value.markdown : JSON.stringify(value)) : value;
+
+  return (
+    <Text as="span" truncate>
+      {stringifiedValue}
+    </Text>
+  );
+};

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -377,6 +377,7 @@ const acceptedFieldTypes = new Set([
   FieldType.String,
   FieldType.Url,
   FieldType.Vector, // Not rendered as an input
+  FieldType.RichText,
 
   // Relationships
   FieldType.BelongsTo,

--- a/packages/react/src/useTable.tsx
+++ b/packages/react/src/useTable.tsx
@@ -1,25 +1,24 @@
-import type {
-  DefaultSelection,
-  FindManyFunction,
-  GadgetRecord,
-  GadgetRecordList,
-  LimitToKnownKeys,
-  Select,
+import {
+  type DefaultSelection,
+  type FindManyFunction,
+  type GadgetRecord,
+  type GadgetRecordList,
+  type LimitToKnownKeys,
+  type Select,
 } from "@gadgetinc/api-client-core";
 import type { OperationContext } from "@urql/core";
-import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import type { GadgetFieldType } from "./internal/gql/graphql.js";
 import type { ModelMetadata } from "./metadata.js";
-import { FieldType, filterFieldList, useModelMetadata } from "./metadata.js";
+import { filterFieldList, useModelMetadata } from "./metadata.js";
 import { useFindMany } from "./useFindMany.js";
-import type { ErrorWrapper, OptionsType, ReadOperationOptions } from "./utils.js";
+import type { ColumnValueType, ErrorWrapper, OptionsType, ReadOperationOptions } from "./utils.js";
 
 export interface TableColumn {
   name: string;
   apiIdentifier: string;
   fieldType: GadgetFieldType;
-  getValue: (record: GadgetRecord<any>) => ReactNode;
+  getValue: (record: GadgetRecord<any>) => ColumnValueType;
   sortable: boolean;
 }
 
@@ -50,7 +49,7 @@ export type TableResult<Data> = [
   (
     | {
         columns: TableColumn[];
-        rows: Record<string, ReactNode>[];
+        rows: Record<string, ColumnValueType>[];
         data: Data;
         page: TablePagination;
         metadata: ModelMetadata;
@@ -129,15 +128,7 @@ export const useTable = <
         apiIdentifier: field.apiIdentifier,
         fieldType: field.fieldType,
         getValue: (record: GadgetRecord<any>) => {
-          const value = record[field.apiIdentifier];
-          switch (field.fieldType) {
-            case FieldType.DateTime: {
-              return value?.toLocaleString();
-            }
-            default: {
-              return value;
-            }
-          }
+          return record[field.apiIdentifier];
         },
         sortable: "sortable" in field && field.sortable,
       })),
@@ -175,7 +166,7 @@ export const useTable = <
 
   if (metadata && data && columns) {
     const rows = data.map((record) => {
-      const row: Record<string, ReactNode> = { id: (record as any).id };
+      const row: Record<string, ColumnValueType> = { id: (record as any).id };
       for (const { apiIdentifier, getValue } of columns) {
         row[apiIdentifier] = getValue(record);
       }

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -467,3 +467,38 @@ export const getPropsWithoutRef = <T extends { ref: RefCallback<any> | RefObject
   const { ref: _ref, ...rest } = props;
   return rest;
 };
+
+export type RichTextValueType = {
+  markdown: string;
+  __typename: "RichText";
+};
+
+export type RoleAssignmentsValueType = {
+  key: string;
+  name: string;
+  __typename: "Role";
+};
+
+export type FileValueType = {
+  url: string;
+  mimeType: string;
+  fileName: string;
+  __typename: "StoredFile";
+};
+
+export type ColumnValueType =
+  | string
+  | number
+  | boolean
+  | Date
+  | null
+  | string[]
+  | RoleAssignmentsValueType[]
+  | FileValueType
+  | RichTextValueType;
+
+export const isRoleAssignmentsArray = (value: ColumnValueType): value is RoleAssignmentsValueType[] => {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  if (!value.every((item) => typeof item === "object" && "__typename" in item && item.__typename === "Role")) return false;
+  return true;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.498.0-development.854
-        version: 1.498.0-development.854
+        specifier: 1.498.0-development.1466
+        version: 1.498.0-development.1466
       '@gadget-client/kitchen-sink':
         specifier: 1.5.0-development.200
         version: 1.5.0-development.200
@@ -3344,8 +3344,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.498.0-development.854:
-    resolution: {integrity: sha1-pCcfZuF1wE8ztVWr4RZeDWnPJwE=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8515}
+  /@gadget-client/js-clients-test@1.498.0-development.1466:
+    resolution: {integrity: sha1-zGtUdNJVoKt7T4oVx4glPIWF3d8=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8593}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
This PR does several things related to the AutoTable component:
- Introduces individual table cell renders for each supported field type
- Update the `getValue` function to return the raw value from a record

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
