### PR TITLE
Fix auto password input cypress test flake

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoPasswordInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoPasswordInput.cy.tsx
@@ -25,35 +25,40 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     }).as("updateUser");
   };
 
-  const submit = (modelName: string) => {
+  const submit = (modelName: string, expectedQueryValue?: any) => {
     cy.get("form [type=submit][aria-hidden!=true]").click();
+
+    cy.wait("@updateUser");
+    cy.get("@updateUser").its("request.body.variables").should("deep.equal", expectedQueryValue);
+
     cy.contains(`Saved ${modelName} successfully`);
   };
 
   it("only allows existing passwords to be replaced, not edited", () => {
+    const updatedPassword = "abcd1234!@#$";
+    const expectedVariables = { id: "1", user: { password: updatedPassword } };
+    expectUpdateActionSubmissionVariables(expectedVariables); // Password field is changed and included
+
     cy.mountWithWrapper(<AutoForm action={api.user.update} findBy={"1"} include={["password"]} />, wrapper);
 
     cy.get(`input[name="user.password"]`).should("be.disabled");
     cy.get(`button[role="passwordEditPasswordButton"]`).first().click();
 
-    const updatedPassword = "abcd1234!@#$";
-
     // Enabled after clicking the edit button
     cy.get(`input[name="user.password"]`).should("be.enabled");
     cy.get(`input[name="user.password"]`).type(updatedPassword);
 
-    expectUpdateActionSubmissionVariables({ id: "1", user: { password: updatedPassword } }); // Untouched so the password field is not included
-
-    submit("User");
+    submit("User", expectedVariables);
   });
 
   it("does not submit anything when for update actions when the password fields are untouched", () => {
+    const expectedVariables = { id: "1", user: {} };
+    expectUpdateActionSubmissionVariables(expectedVariables); // Untouched so the password field is not included
+
     cy.mountWithWrapper(<AutoForm action={api.user.update} findBy={"1"} include={["password"]} />, wrapper);
 
     cy.get(`input[name="user.password"]`).should("be.disabled");
 
-    expectUpdateActionSubmissionVariables({ id: "1", user: {} }); // Untouched so the password field is not included
-
-    submit("User");
+    submit("User", expectedVariables);
   });
 });


### PR DESCRIPTION
This cypress test would occasionally flake due to the wrong request getting to the wrong test. My best guess is that this was caused by the intercept being un-awaited. I added an intercept awaiter, moved the intercept definition before the render, and added another check to ensure that the endpoint was called with the expected value
