### PR TITLE
feat(autocomponents): extract useList from useTable for query controls

### DIFF
--- a/packages/react/spec/useList.spec.ts
+++ b/packages/react/spec/useList.spec.ts
@@ -1,0 +1,115 @@
+import { jest } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react";
+
+let data: any = [{ id: 1 }, { id: 2 }];
+let fetching = false;
+let error = undefined as any;
+jest.unstable_mockModule("../src/useFindMany", () => ({
+  useFindMany: jest.fn<typeof useFindMany>().mockImplementation(() => [{ data, fetching, error, stale: false }, jest.fn()]),
+}));
+
+const { useFindMany } = await import("../src/useFindMany.js");
+const { useList } = await import("../src/useList.js");
+
+describe("useList", () => {
+  const manager = { findMany: jest.fn() } as any;
+  let result: any;
+
+  beforeEach(() => {
+    data = [{ id: 1 }, { id: 2 }];
+    const renderResult = renderHook(() => useList(manager));
+    result = renderResult.result;
+  });
+
+  describe("pagination", () => {
+    it("will return you a list of records", () => {
+      expect(result.current[0].records).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    describe("page size", () => {
+      it("has a default page size of 50", () => {
+        expect(result.current[0].page.pageSize).toEqual(50);
+      });
+
+      it("can accept a page size parameter", () => {
+        const { result } = renderHook(() => useList(manager, { pageSize: 25 }));
+        expect(result.current[0].page.pageSize).toEqual(25);
+      });
+
+      it("will pass the page size to the useFindMany hook", () => {
+        const { result } = renderHook(() => useList(manager, { pageSize: 25 }));
+        expect(useFindMany).toHaveBeenCalledWith(manager, { first: 25, after: undefined });
+      });
+    });
+
+    describe("when a data result has more pages", () => {
+      beforeEach(() => {
+        data.hasNextPage = true;
+        data.endCursor = "endCursor";
+      });
+
+      it("will return hasNextPage - true", () => {
+        const { result } = renderHook(() => useList(manager, { pageSize: 25 }));
+        expect(result.current[0].page.hasNextPage).toEqual(true);
+      });
+
+      test("goToNextPage will use first and after for the cursor", async () => {
+        const { result } = renderHook(() => useList(manager, { pageSize: 25 }));
+
+        await act(async () => {
+          result.current[0].page.goToNextPage();
+        });
+
+        expect(result.current[0].page.variables).toEqual({ first: 25, after: "endCursor" });
+      });
+    });
+
+    describe("when a data result has previous pages", () => {
+      beforeEach(() => {
+        data.hasPreviousPage = true;
+        data.startCursor = "startCursor";
+      });
+
+      it("will return hasPreviousPage - true", () => {
+        const { result } = renderHook(() => useList(manager, { pageSize: 25 }));
+        expect(result.current[0].page.hasPreviousPage).toEqual(true);
+      });
+
+      test("goToPreviousPage will use last and before for the cursor", async () => {
+        const { result } = renderHook(() => useList(manager, { pageSize: 25 }));
+
+        await act(async () => {
+          result.current[0].page.goToPreviousPage();
+        });
+
+        expect(result.current[0].page.variables).toEqual({ last: 25, before: "startCursor" });
+      });
+    });
+  });
+
+  describe("loading state", () => {
+    it("will return you the fetching state", () => {
+      expect(result.current[0].fetching).toEqual(false);
+    });
+
+    it("will return to you the fetching state when fetching", () => {
+      fetching = true;
+      const { result } = renderHook(() => useList(manager));
+      expect(result.current[0].fetching).toEqual(true);
+    });
+  });
+
+  describe("error state", () => {
+    it("will pass errors from the useFindMany hook", () => {
+      error = jest.fn();
+      data = null;
+      fetching = false;
+      const { result } = renderHook(() => useList(manager));
+      expect(result.current[0].error).toEqual(error);
+    });
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks(); // Reset mocks after each test
+  });
+});

--- a/packages/react/src/useList.ts
+++ b/packages/react/src/useList.ts
@@ -1,0 +1,100 @@
+import type { DefaultSelection, FindManyFunction, GadgetRecord, LimitToKnownKeys, Select } from "@gadgetinc/api-client-core";
+import type { OperationContext } from "@urql/core";
+import { useCallback, useState } from "react";
+import { useFindMany } from "./useFindMany.js";
+import type { ErrorWrapper, OptionsType, ReadOperationOptions } from "./utils.js";
+
+export interface PaginationResult {
+  hasNextPage: boolean | undefined;
+  hasPreviousPage: boolean | undefined;
+  variables: {
+    first?: number;
+    after?: string;
+    last?: number;
+    before?: string;
+  };
+  pageSize: number;
+  goToNextPage(): void;
+  goToPreviousPage(): void;
+}
+
+export interface ListOptions {
+  pageSize?: number;
+}
+
+export type ListResult<Data> = [
+  (
+    | {
+        records: Data;
+        page: PaginationResult;
+        fetching: boolean;
+        error?: ErrorWrapper;
+      }
+    | { records: undefined; page: PaginationResult; fetching: boolean; error?: ErrorWrapper }
+  ),
+  (opts?: Partial<OperationContext>) => void
+];
+
+export const useList = <
+  GivenOptions extends OptionsType,
+  SchemaT,
+  F extends FindManyFunction<GivenOptions, any, SchemaT, any>,
+  Options extends F["optionsType"] & ReadOperationOptions & ListOptions
+>(
+  manager: { findMany: F },
+  options?: LimitToKnownKeys<Options, F["optionsType"] & ReadOperationOptions & ListOptions>
+): ListResult<
+  Array<
+    GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>
+  >
+> => {
+  const [cursor, setCursor] = useState<string | undefined>();
+  const [direction, setDirection] = useState<"forward" | "backward">("forward");
+  const pageSize = options?.pageSize ?? 50;
+
+  let variables;
+  if (direction == "forward") {
+    variables = {
+      first: pageSize,
+      after: cursor,
+    };
+  } else {
+    variables = {
+      last: pageSize,
+      before: cursor,
+    };
+  }
+
+  const [{ data, fetching, error }, refresh] = useFindMany(manager, { ...(variables as any) });
+
+  const goToNextPage = useCallback(() => {
+    if (data && data.hasNextPage) {
+      setDirection("forward");
+      setCursor(data.endCursor);
+    } else {
+      console.warn("can't navigate to next page currently, no next page available");
+    }
+  }, [data]);
+
+  const goToPreviousPage = useCallback(() => {
+    if (data && data.hasPreviousPage) {
+      setDirection("backward");
+      setCursor(data.startCursor);
+    } else {
+      console.warn("can't navigate to previous page currently, no previous page available");
+    }
+  }, [data]);
+
+  const records = data?.map((record) => record);
+
+  const page = {
+    pageSize,
+    goToNextPage,
+    goToPreviousPage,
+    hasNextPage: data?.hasNextPage,
+    hasPreviousPage: data?.hasPreviousPage,
+    variables,
+  };
+
+  return [{ records, fetching, page, error }, refresh];
+};


### PR DESCRIPTION
A first pass at extracting a less 'table-y' version of a hook to co-ordinate the searching, filtering, paging, etc of a list of records. 

I will commit this and then refactor the useTable hook to use it in a separate PR rather than cause a bunch of merge conflicts with the currently inflight work.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
