### PR TITLE
add support for fragments to tiny-graphql-query-compiler

### DIFF
--- a/packages/tiny-graphql-query-compiler/package.json
+++ b/packages/tiny-graphql-query-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-graphql-query-compiler",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/tiny-graphql-query-compiler/spec/fragment.spec.ts
+++ b/packages/tiny-graphql-query-compiler/spec/fragment.spec.ts
@@ -1,0 +1,157 @@
+import { Call, On, Var, compile } from "../src/index.js";
+import { expectValidGraphQLQuery } from "./helpers.js";
+
+describe("compiling with fragments", () => {
+  test("it should compile a query that has fragments", () => {
+    const result = compile({
+      type: "query",
+      fields: {
+        post: {
+          __typename: true,
+          TypeWithName: On({
+            id: true,
+            name: true,
+          }),
+          TypeWithDescription: On({
+            id: true,
+            description: true,
+          }),
+        },
+      },
+    });
+
+    expectValidGraphQLQuery(result);
+    expect(result).toMatchInlineSnapshot(`
+      "query  {
+        post {
+          __typename
+          ... on TypeWithName {
+            id
+            name
+          }
+          ... on TypeWithDescription {
+            id
+            description
+          }
+        }
+      }"
+    `);
+  });
+
+  test("it should compile a query that has fragments that make field calls", () => {
+    const result = compile({
+      type: "query",
+      fields: {
+        post: {
+          __typename: true,
+          TypeWithName: On({
+            id: true,
+            name: true,
+          }),
+          TypeWithDescription: On({
+            id: true,
+            description: Call({ length: Var({ type: "Int" }) }),
+          }),
+        },
+      },
+    });
+
+    expectValidGraphQLQuery(result);
+    expect(result).toMatchInlineSnapshot(`
+      "query ($length: Int) {
+        post {
+          __typename
+          ... on TypeWithName {
+            id
+            name
+          }
+          ... on TypeWithDescription {
+            id
+            description(length: $length)
+          }
+        }
+      }"
+    `);
+  });
+
+  test("it should compile a query that has fragments that make field calls with a required value", () => {
+    const result = compile({
+      type: "query",
+      fields: {
+        post: {
+          __typename: true,
+          TypeWithName: On({
+            id: true,
+            name: true,
+          }),
+          TypeWithDescription: On({
+            id: true,
+            description: Call({ length: Var({ type: "Int", required: true }) }, { truncated: true }),
+          }),
+        },
+      },
+    });
+
+    expectValidGraphQLQuery(result);
+    expect(result).toMatchInlineSnapshot(`
+      "query ($length: Int!) {
+        post {
+          __typename
+          ... on TypeWithName {
+            id
+            name
+          }
+          ... on TypeWithDescription {
+            id
+            description(length: $length) {
+              truncated
+            }
+          }
+        }
+      }"
+    `);
+  });
+
+  test("it should compile a mutation that has fragments", () => {
+    const result = compile({
+      type: "mutation",
+      name: "UpsertPost",
+      fields: {
+        upsertPost: Call(
+          {
+            on: Var({ type: "[String!]" }),
+            post: Var({ type: "PostInput" }),
+          },
+          {
+            __typename: true,
+            UpsertPostCreate: On({
+              result: true,
+            }),
+            UpsertPostUpdate: On({
+              id: true,
+              title: true,
+              body: true,
+            }),
+          }
+        ),
+      },
+    });
+
+    expectValidGraphQLQuery(result);
+    expect(result).toMatchInlineSnapshot(`
+      "mutation UpsertPost($on: [String!], $post: PostInput) {
+        upsertPost(on: $on, post: $post) {
+          __typename
+          ... on UpsertPostCreate {
+            result
+          }
+          ... on UpsertPostUpdate {
+            id
+            title
+            body
+          }
+        }
+      }"
+    `);
+  });
+});


### PR DESCRIPTION
As part of the upsert api work I need selections to work with union types; this adds support for specifying fields as inline fragments. I didn't do the work to support named fragments, but lmk if you think we should do that now

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
