### PR TITLE
Introduce `columns` property to select fields

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -42,3 +42,10 @@ export const Primary = {
     model: api.widget,
   },
 };
+
+export const SelectFields = {
+  args: {
+    model: api.widget,
+    columns: ["name", "inventoryCount"],
+  },
+};

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useRef } from "react";
 import type { AnyActionWithId, RecordIdentifier, UseActionFormHookStateData } from "src/use-action-form/types.js";
 import type { GadgetObjectFieldConfig } from "../internal/gql/graphql.js";
 import type { ActionMetadata, FieldMetadata, GlobalActionMetadata } from "../metadata.js";
-import { FieldType, filterFieldList, isActionMetadata, useActionMetadata } from "../metadata.js";
+import { FieldType, filterAutoFormFieldList, isActionMetadata, useActionMetadata } from "../metadata.js";
 import type { FieldValues } from "../useActionForm.js";
 import { useActionForm } from "../useActionForm.js";
 import { get, type OptionsType } from "../utils.js";
@@ -76,7 +76,7 @@ export const useFormFields = (
       : [];
     const nonObjectFields = action.inputFields.filter((field) => field.configuration.__typename !== "GadgetObjectFieldConfig");
 
-    const includedRootLevelFields = filterFieldList(nonObjectFields, options as any).map(
+    const includedRootLevelFields = filterAutoFormFieldList(nonObjectFields, options as any).map(
       (field) =>
         ({
           path: field.apiIdentifier,
@@ -85,7 +85,7 @@ export const useFormFields = (
     );
 
     const includedObjectFields = objectFields.flatMap((objectField) =>
-      filterFieldList((objectField.configuration as unknown as GadgetObjectFieldConfig).fields as any, options as any).map(
+      filterAutoFormFieldList((objectField.configuration as unknown as GadgetObjectFieldConfig).fields as any, options as any).map(
         (innerField) =>
           ({
             path: `${objectField.apiIdentifier}.${innerField.apiIdentifier}`,

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -1,4 +1,5 @@
 import type { FindManyFunction } from "@gadgetinc/api-client-core";
+import type { TableOptions } from "../useTable.js";
 import type { OptionsType } from "../utils.js";
 
 /**
@@ -15,4 +16,5 @@ export type AutoTableProps<
   pageSize?: number;
   initialCursor?: string;
   initialDirection?: string;
+  columns?: TableOptions["columns"];
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -40,23 +40,13 @@ export const PolarisAutoTable = <
 >(
   props: AutoTableProps<GivenOptions, SchemaT, FinderFunction, Options>
 ) => {
-  const [
+  const [{ rows, columns, metadata, fetching, error, page, search }, refresh] = useTable<GivenOptions, SchemaT, FinderFunction, Options>(
+    props.model,
     {
-      rows,
-      columns,
-
-      metadata,
-
-      fetching,
-      error,
-
-      page,
-      search,
-    },
-    refresh,
-  ] = useTable<GivenOptions, SchemaT, FinderFunction, Options>(props.model, {
-    select: props.select,
-  } as any);
+      select: props.select,
+      columns: props.columns,
+    } as any
+  );
 
   const { mode, setMode } = useSetIndexFiltersMode();
 

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -307,7 +307,7 @@ export const useActionMetadata = (actionFunction: ActionFunction<any, any, any, 
 /**
  * @internal
  */
-export const filterFieldList = (
+export const filterAutoFormFieldList = (
   fields: FieldMetadata[] | undefined,
   options?: { include?: string[]; exclude?: string[] }
 ): FieldMetadata[] => {
@@ -357,10 +357,10 @@ export const filterFieldList = (
   }
 
   // Filter out fields that are not supported by the form
-  return subset.filter((field) => acceptedFieldTypes.has(field.fieldType));
+  return subset.filter((field) => acceptedAutoFormFieldTypes.has(field.fieldType));
 };
 
-const acceptedFieldTypes = new Set([
+const acceptedAutoFormFieldTypes = new Set([
   FieldType.Boolean,
   FieldType.Color,
   FieldType.Computed, // Not rendered as an input
@@ -377,6 +377,54 @@ const acceptedFieldTypes = new Set([
   FieldType.String,
   FieldType.Url,
   FieldType.Vector, // Not rendered as an input
+  FieldType.RichText,
+
+  // Relationships
+  FieldType.BelongsTo,
+  FieldType.HasMany,
+  FieldType.HasOne,
+]);
+
+export const filterAutoTableFieldList = (fields: FieldMetadata[] | undefined, options?: { include?: string[] }) => {
+  if (!fields) {
+    return [];
+  }
+
+  let subset = fields;
+
+  if (options?.include) {
+    // When including fields, the order will match the order of the `include` array
+    subset = [];
+    const includes = new Set(options.include);
+
+    for (const includedFieldApiId of Array.from(includes)) {
+      const metadataField = fields.find((field) => field.apiIdentifier === includedFieldApiId);
+      if (metadataField) {
+        subset.push(metadataField);
+      }
+    }
+  }
+
+  // Filter out fields that are not supported by the form
+  return subset.filter((field) => acceptedAutoTableFieldTypes.has(field.fieldType));
+};
+
+const acceptedAutoTableFieldTypes = new Set([
+  FieldType.Boolean,
+  FieldType.Color,
+  FieldType.Computed,
+  FieldType.DateTime,
+  FieldType.Email,
+  FieldType.EncryptedString,
+  FieldType.Enum,
+  FieldType.File,
+  FieldType.Json,
+  FieldType.Number,
+  FieldType.Password,
+  FieldType.RichText,
+  FieldType.RoleAssignments,
+  FieldType.String,
+  FieldType.Url,
   FieldType.RichText,
 
   // Relationships


### PR DESCRIPTION
This PR introduces a new `useTable` property called `columns` that allows you to select a list of fields to include in a table. Right now, this property only accepts strings (field API identifiers) as a value inside the array. In the future, we will also take custom column renderers and pick a field for a relationship.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
