### PR TITLE
changes to api client core to support the upsert api

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.26",
+  "version": "0.15.27",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/mockActions.ts
+++ b/packages/api-client-core/spec/mockActions.ts
@@ -10,6 +10,8 @@ export const MockWidgetCreateAction = {
   operationName: "createWidget",
   operationReturnType: "CreateWidget",
   modelApiIdentifier: "widget",
+  operatesWithRecordIdentity: false,
+  acceptsModelInput: true,
   modelSelectionField: "widget",
   variables: {
     widget: {
@@ -26,12 +28,68 @@ export const MockWidgetCreateAction = {
   { id: true; name: true }
 >;
 
+export const MockWidgetUpdateAction = {
+  type: "action",
+  isBulk: false,
+  defaultSelection: {
+    id: true,
+    name: true,
+  },
+  operationName: "updateWidget",
+  operationReturnType: "UpdateWidget",
+  modelApiIdentifier: "widget",
+  operatesWithRecordIdentity: true,
+  acceptsModelInput: true,
+  modelSelectionField: "widget",
+  variables: {
+    widget: {
+      type: "UpdateWidgetInput",
+      required: true,
+    },
+  },
+  hasReturnType: false,
+} as unknown as ActionFunction<
+  { select?: { id?: boolean; name?: boolean } },
+  any,
+  { id?: boolean; name?: boolean },
+  { id: string; name: string },
+  { id: true; name: true }
+>;
+
+export const MockBulkCreateWidgetAction = {
+  type: "action",
+  operationName: "bulkCreateWidgets",
+  operationReturnType: "CreateWidget",
+  namespace: null,
+  modelApiIdentifier: "widget",
+  operatesWithRecordIdentity: false,
+  modelSelectionField: "widgets",
+  isBulk: true,
+  defaultSelection: {
+    id: true,
+    name: true,
+  },
+  selectionType: {},
+  optionsType: {},
+  schemaType: null,
+  variablesType: void 0,
+  variables: {
+    inputs: {
+      required: true,
+      type: "[BulkCreateeWidgetsInput!]",
+    },
+  },
+  acceptsModelInput: true,
+  hasReturnType: false,
+} as unknown as BulkActionFunction<any, any, any, any, any>;
+
 export const MockBulkUpdateWidgetAction = {
   type: "action",
   operationName: "bulkUpdateWidgets",
   operationReturnType: "UpdateWidget",
   namespace: null,
   modelApiIdentifier: "widget",
+  operatesWithRecordIdentity: true,
   modelSelectionField: "widgets",
   isBulk: true,
   defaultSelection: {
@@ -58,6 +116,7 @@ export const MockBulkFlipDownWidgetsAction = {
   operationReturnType: "FlipDownWidget",
   namespace: null,
   modelApiIdentifier: "widget",
+  operatesWithRecordIdentity: true,
   modelSelectionField: "widgets",
   isBulk: true,
   defaultSelection: {

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -667,6 +667,119 @@ describe("operation builders", () => {
       `);
     });
 
+    test("actionOperation should build a mutation query for an object hasReturnType", async () => {
+      expect(
+        actionOperation(
+          "upsertWidget",
+          { __typename: true, id: true, name: true, eventAt: true },
+          "widget",
+          "widget",
+          {},
+          null,
+          null,
+          null,
+          {
+            "... on CreatePostResult": { hasReturnType: false },
+            "... on UpdatePostResult": { hasReturnType: false },
+          }
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "mutation upsertWidget {
+          upsertWidget {
+            success
+            errors {
+              message
+              code
+              ... on InvalidRecordError {
+                validationErrors {
+                  message
+                  apiIdentifier
+                }
+              }
+            }
+            ... on CreatePostResult {
+              __typename
+              widget {
+                __typename
+                id
+                name
+                eventAt
+              }
+            }
+            ... on UpdatePostResult {
+              __typename
+              widget {
+                __typename
+                id
+                name
+                eventAt
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("actionOperation should build a mutation query for an object hasReturnType with an inner return type", async () => {
+      expect(
+        actionOperation(
+          "upsertWidget",
+          { __typename: true, id: true, name: true, eventAt: true },
+          "widget",
+          "widget",
+          {},
+          null,
+          null,
+          null,
+          {
+            "... on CreatePostResult": { hasReturnType: false },
+            "... on UpdatePostResult": { hasReturnType: true },
+          }
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "mutation upsertWidget {
+          upsertWidget {
+            success
+            errors {
+              message
+              code
+              ... on InvalidRecordError {
+                validationErrors {
+                  message
+                  apiIdentifier
+                }
+              }
+            }
+            ... on CreatePostResult {
+              __typename
+              widget {
+                __typename
+                id
+                name
+                eventAt
+              }
+            }
+            ... on UpdatePostResult {
+              __typename
+              result
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
     test("actionOperation should build a mutation query for an action that has a return type", () => {
       expect(
         actionOperation(
@@ -706,13 +819,55 @@ describe("operation builders", () => {
       `);
     });
 
+    test("actionOperation should build a bulk mutation query", () => {
+      expect(
+        actionOperation(
+          "bulkCreateWidgets",
+          { __typename: true, id: true, state: true },
+          "widget",
+          "widgets",
+          {},
+          { select: { id: true } },
+          undefined,
+          true,
+          false
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "mutation bulkCreateWidgets {
+          bulkCreateWidgets {
+            success
+            errors {
+              message
+              code
+              ... on InvalidRecordError {
+                validationErrors {
+                  message
+                  apiIdentifier
+                }
+              }
+            }
+            widgets {
+              id
+              __typename
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
     test("actionOperation should build a bulk mutation query for an action that has a return type", () => {
       expect(
         actionOperation(
           "bulkCreateWidgets",
           { __typename: true, id: true, state: true },
           "widget",
-          "widget",
+          "widgets",
           {},
           { select: { id: true } },
           undefined,
@@ -734,7 +889,62 @@ describe("operation builders", () => {
                 }
               }
             }
-            result
+            results
+          }
+          gadgetMeta {
+            hydrations(modelName: "widget")
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("actionOperation should build a bulk mutation query for an action that has an object return type", () => {
+      expect(
+        actionOperation(
+          "bulkUpsertWidgets",
+          { __typename: true, id: true, state: true },
+          "widget",
+          "widgets",
+          {},
+          { select: { id: true } },
+          undefined,
+          true,
+          {
+            widgets: {
+              hasReturnType: {
+                "... on Widget": { select: true },
+                "... on UpsertWidgetReturnType": { hasReturnType: true },
+              },
+            },
+          }
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "mutation bulkUpsertWidgets {
+          bulkUpsertWidgets {
+            success
+            errors {
+              message
+              code
+              ... on InvalidRecordError {
+                validationErrors {
+                  message
+                  apiIdentifier
+                }
+              }
+            }
+            widgets {
+              ... on Widget {
+                id
+                __typename
+              }
+              ... on UpsertWidgetReturnType {
+                __typename
+                result
+              }
+            }
           }
           gadgetMeta {
             hydrations(modelName: "widget")

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -100,12 +100,15 @@ export interface BulkActionWithInputs<OptionsT, VariablesT> {
   <Options extends OptionsT>(inputs: VariablesT, options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;
 }
 
+export type HasReturnType = boolean | Record<string, { hasReturnType: HasReturnType } | { select: boolean }>;
+
 export interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, SchemaT, DefaultsT, IsBulk> {
   type: "action";
   operationName: string;
   operationReturnType?: string;
   namespace: string | string[] | null;
   modelApiIdentifier: string;
+  operatesWithRecordIdentity?: boolean;
   modelSelectionField: string;
   defaultSelection: DefaultsT;
   selectionType: SelectionT;
@@ -117,7 +120,7 @@ export interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, Schema
   hasAmbiguousIdentifier?: boolean;
   acceptsModelInput?: boolean;
   paramOnlyVariables?: readonly string[];
-  hasReturnType?: boolean;
+  hasReturnType?: HasReturnType;
   singleActionFunctionName?: string;
   /** @deprecated */
   hasCreateOrUpdateEffect?: boolean;

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -588,6 +588,9 @@ export const disambiguateActionVariables = (action: AnyActionFunction, variables
 
   let newVariables: Record<string, any>;
 
+  // for backwards compatibilty, actions without the operatesWithRecordIdentity metadata should extract the id from the variables
+  const shouldExtractId = action.operatesWithRecordIdentity ?? true;
+
   if (action.acceptsModelInput ?? action.hasCreateOrUpdateEffect) {
     if (
       action.modelApiIdentifier in variables &&
@@ -603,7 +606,7 @@ export const disambiguateActionVariables = (action: AnyActionFunction, variables
         if (action.paramOnlyVariables?.includes(key)) {
           newVariables[key] = value;
         } else {
-          if (key == "id") {
+          if (key == "id" && shouldExtractId) {
             newVariables.id = value;
           } else {
             newVariables[action.modelApiIdentifier][key] = value;


### PR DESCRIPTION
These changes will support introducing the upsert api to the js client. Mainly adds support for the case where an actions return type is a Union type.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
