### PR TITLE
test(cypress): disable testing in real chrome browser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cypress info
         run: pnpm exec cypress info
       - name: Run cypress tests
-        run: pnpm --filter=react exec cypress run --browser chrome --component --env JS_CLIENTS_TEST_API_KEY=${{secrets.CYPRESS_JS_CLIENTS_TEST_API_KEY}}
+        run: pnpm --filter=react exec cypress run --component --env JS_CLIENTS_TEST_API_KEY=${{secrets.CYPRESS_JS_CLIENTS_TEST_API_KEY}}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/packages/react/cypress.config.ts
+++ b/packages/react/cypress.config.ts
@@ -11,15 +11,6 @@ export default defineConfig({
         },
       },
     },
-    setupNodeEvents(on, config) {
-      on("before:browser:launch", (_browser, launchOptions) => {
-        if (process.env["CI"]) {
-          // try to fix https://github.com/cypress-io/cypress/issues/29860
-          launchOptions.args.push("--disable-gpu");
-        }
-        return launchOptions;
-      });
-    },
   },
   retries: process.env["CI"] ? 2 : 0,
 });


### PR DESCRIPTION
I think we've given chrome a good chance -- the flakiness isn't worth it. Disabling until we find a solution. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
