### PR TITLE
Show banner inside the table when there is a GraphQL error

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -49,3 +49,10 @@ export const SelectFields = {
     columns: ["name", "inventoryCount"],
   },
 };
+
+export const OnErrorState = {
+  args: {
+    model: api.widget,
+    columns: ["somethingSuperWrong"],
+  },
+};

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -1,7 +1,9 @@
 import type { FindManyFunction } from "@gadgetinc/api-client-core";
 import type { IndexTableProps } from "@shopify/polaris";
 import {
+  Banner,
   BlockStack,
+  Box,
   DataTable,
   EmptySearchResult,
   IndexFilters,
@@ -64,7 +66,7 @@ export const PolarisAutoTable = <
     return { headings, sortable };
   }, [columns]);
 
-  if ((fetching && !rows) || !columns) {
+  if (!error && ((fetching && !rows) || !columns)) {
     return <PolarisSkeletonTable columns={polarisTableProps.headings.length} />;
   }
 
@@ -92,14 +94,26 @@ export const PolarisAutoTable = <
         queryValue={search.value}
         onQueryChange={search.set}
         onQueryClear={search.clear}
+        disabled={!!error}
       />
+
+      {error && (
+        <Box paddingBlockStart="200" paddingBlockEnd="1000">
+          <Banner title={error.message} tone="critical" />
+        </Box>
+      )}
+
       <IndexTable
         {...polarisTableProps}
         resourceName={resourceName}
         emptyState={<EmptySearchResult title={`No ${resourceName.plural} yet`} description={""} withIllustration />}
         loading={fetching}
         hasMoreItems={page.hasNextPage}
-        itemCount={rows?.length ?? 0}
+        itemCount={
+          error
+            ? 1 // Don't show the empty state if there's an error
+            : rows?.length ?? 0
+        }
         pagination={{
           hasNext: page.hasNextPage,
           hasPrevious: page.hasPreviousPage,


### PR DESCRIPTION
This PR shows a banner when there's a GraphQL error. It will look like this:
<img width="630" alt="CleanShot 2024-07-18 at 17 24 31@2x" src="https://github.com/user-attachments/assets/ba819343-26e6-4b2f-8cda-0b76da14c128">


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
