### PR TITLE
Introduce `onClick` callback in AutoTable

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -56,3 +56,14 @@ export const OnErrorState = {
     columns: ["somethingSuperWrong"],
   },
 };
+
+export const onClickCallback = {
+  name: "onClick callback",
+  args: {
+    model: api.widget,
+    onClick: (row) => {
+      // eslint-disable-next-line no-undef
+      window.alert(`You clicked on row: ${JSON.stringify(row, null, 2)}`);
+    },
+  },
+};

--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -1,5 +1,7 @@
 import { jest } from "@jest/globals";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
+import type { UserEvent } from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { testApi as api } from "../../apis.js";
 import { PolarisMockedProviders } from "../inputs/PolarisMockedProviders.js";
@@ -11,38 +13,44 @@ const POLARIS_TABLE_CLASSES = {
   CELL: "Polaris-IndexTable__TableCell",
 } as const;
 
-let rows: any[] = [
-  {
-    id: "1",
-    name: "hello",
-    inventoryCount: 1,
-  },
-  {
-    id: "2",
-    name: "cool",
-    inventoryCount: 2,
-  },
-  {
-    id: "3",
-    name: "world",
-    inventoryCount: null,
-  },
-];
-let columns: any[] = [
-  {
-    apiIdentifier: "name",
-    fieldType: "String",
-    name: "Name",
-    sortable: true,
-  },
-  {
-    apiIdentifier: "inventoryCount",
-    fieldType: "Number",
-    name: "Inventory count",
-    sortable: true,
-  },
-];
-let error: undefined | Error = undefined;
+let rows: any[] = [];
+let columns: any[] = [];
+let error: Error | undefined;
+
+const setMockUseTableResponse = (returns?: { newRows?: any[]; newColumns?: any[]; newError?: Error }) => {
+  rows = returns?.newRows ?? [
+    {
+      id: "1",
+      name: "hello",
+      inventoryCount: 1,
+    },
+    {
+      id: "2",
+      name: "cool",
+      inventoryCount: 2,
+    },
+    {
+      id: "3",
+      name: "world",
+      inventoryCount: null,
+    },
+  ];
+  columns = returns?.newColumns ?? [
+    {
+      apiIdentifier: "name",
+      fieldType: "String",
+      name: "Name",
+      sortable: true,
+    },
+    {
+      apiIdentifier: "inventoryCount",
+      fieldType: "Number",
+      name: "Inventory count",
+      sortable: true,
+    },
+  ];
+  error = returns?.newError ?? undefined;
+};
 
 // The path is relative to the file from the packages/react/spec/jest.setup.ts file, not from this test file
 jest.unstable_mockModule("../src/useTable", () => ({
@@ -75,7 +83,13 @@ jest.unstable_mockModule("../src/useTable", () => ({
 const { PolarisAutoTable } = await import("../../../src/auto/polaris/PolarisAutoTable.js");
 
 describe("PolarisAutoTable", () => {
+  let user: UserEvent;
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
   it("should render a table with records inside", () => {
+    setMockUseTableResponse();
     const { container } = render(<PolarisAutoTable model={api.widget} />, { wrapper: PolarisMockedProviders });
     const table = container.querySelector(`.${POLARIS_TABLE_CLASSES.CONTAINER}`)!;
 
@@ -110,9 +124,11 @@ describe("PolarisAutoTable", () => {
   });
 
   it("should show an error banner when there is a GraphQL error", () => {
-    rows = [];
-    columns = [];
-    error = new Error(`[GraphQL] Cannot query field "somethingSuperWrong" on type "Widget".`);
+    setMockUseTableResponse({
+      newRows: [],
+      newColumns: [],
+      newError: new Error(`[GraphQL] Cannot query field "somethingSuperWrong" on type "Widget".`),
+    });
 
     const { container } = render(<PolarisAutoTable model={api.widget} />, { wrapper: PolarisMockedProviders });
     const table = container.querySelector(`.${POLARIS_TABLE_CLASSES.CONTAINER}`)!;
@@ -128,5 +144,29 @@ describe("PolarisAutoTable", () => {
     // Zero rows should be rendered
     const tableRows = table.getElementsByClassName(POLARIS_TABLE_CLASSES.ROW);
     expect(tableRows.length).toBe(0);
+  });
+
+  it("should have the row record as a parameter when clicking on a table row if onClick callback is provided", async () => {
+    setMockUseTableResponse();
+
+    const onClickCallback = jest.fn();
+    const { container } = render(<PolarisAutoTable model={api.widget} onClick={onClickCallback} />, {
+      wrapper: PolarisMockedProviders,
+    });
+    const table = container.querySelector(`.${POLARIS_TABLE_CLASSES.CONTAINER}`)!;
+    const rows = table.getElementsByClassName(POLARIS_TABLE_CLASSES.ROW);
+
+    const firstRow = rows[0];
+    const firstRowCells = firstRow.getElementsByClassName(POLARIS_TABLE_CLASSES.CELL);
+
+    await act(async () => {
+      await user.click(firstRowCells[0]);
+    });
+
+    expect(onClickCallback).toHaveBeenCalledWith({
+      id: "1",
+      name: "hello",
+      inventoryCount: 1,
+    });
   });
 });

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -1,6 +1,6 @@
 import type { FindManyFunction } from "@gadgetinc/api-client-core";
 import type { TableOptions } from "../useTable.js";
-import type { OptionsType } from "../utils.js";
+import type { ColumnValueType, OptionsType } from "../utils.js";
 
 /**
  * The props to pass to an AutoTable. Includes both the Gadget-land props as well as the adapter specific props.
@@ -17,4 +17,5 @@ export type AutoTableProps<
   initialCursor?: string;
   initialDirection?: string;
   columns?: TableOptions["columns"];
+  onClick?: (row: Record<string, ColumnValueType>) => void;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -12,9 +12,9 @@ import {
   useSetIndexFiltersMode,
 } from "@shopify/polaris";
 import pluralize from "pluralize";
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useTable } from "../../useTable.js";
-import type { OptionsType } from "../../utils.js";
+import type { ColumnValueType, OptionsType } from "../../utils.js";
 import type { AutoTableProps } from "../AutoTable.js";
 import { PolarisAutoTableCellRenderer } from "./tableCells/PolarisAutoTableCellRenderer.js";
 
@@ -42,12 +42,21 @@ export const PolarisAutoTable = <
 >(
   props: AutoTableProps<GivenOptions, SchemaT, FinderFunction, Options>
 ) => {
+  const { onClick } = props;
+
   const [{ rows, columns, metadata, fetching, error, page, search }, refresh] = useTable<GivenOptions, SchemaT, FinderFunction, Options>(
     props.model,
     {
       select: props.select,
       columns: props.columns,
     } as any
+  );
+
+  const onClickCallback = useCallback(
+    (row: Record<string, ColumnValueType>) => {
+      return () => onClick?.(row);
+    },
+    [onClick]
   );
 
   const { mode, setMode } = useSetIndexFiltersMode();
@@ -124,7 +133,12 @@ export const PolarisAutoTable = <
         {rows &&
           columns &&
           rows.map((row, index) => (
-            <IndexTable.Row key={row.id as string} id={row.id as string} position={index}>
+            <IndexTable.Row
+              key={row.id as string}
+              id={row.id as string}
+              position={index}
+              onClick={onClick ? onClickCallback(row) : undefined}
+            >
               {columns.map((column) => (
                 <IndexTable.Cell key={column.apiIdentifier}>
                   <div style={{ maxWidth: "200px" }}>


### PR DESCRIPTION
This PR introduces an `onClick` callback in the AutoTable component for users to customise the operation when clicking on a table row. The callback will provide the row record in the parameter.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
