### PR TITLE
Add ID field in AutoTable

### DIFF
--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -49,6 +49,12 @@ describe("useTable hook", () => {
       })
     ).toEqual([
       {
+        apiIdentifier: "id",
+        fieldType: "ID",
+        name: "Id",
+        sortable: false,
+      },
+      {
         apiIdentifier: "name",
         fieldType: "String",
         name: "Name",
@@ -152,30 +158,30 @@ describe("useTable hook", () => {
 
       // The fields inside the `node` should only contain the fields that are specified in the columns property + the id field
       expect(mockUrqlClient.executeQuery.mock.calls[1][0].query.loc.source.body).toMatchInlineSnapshot(`
-              "query widgets($after: String, $first: Int, $before: String, $last: Int) {
-                widgets(after: $after, first: $first, before: $before, last: $last) {
-                  pageInfo {
-                    hasNextPage
-                    hasPreviousPage
-                    startCursor
-                    endCursor
-                  }
-                  edges {
-                    cursor
-                    node {
-                      name
-                      inventoryCount
-                      id
-                      __typename
-                    }
-                  }
-                }
-                gadgetMeta {
-                  hydrations(modelName: 
-              "widget")
-                }
-              }"
-          `);
+        "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                name
+                inventoryCount
+                id
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: 
+        "widget")
+          }
+        }"
+      `);
       expect(result.current[0].columns?.map((column) => column.apiIdentifier)).toEqual(["name", "inventoryCount"]);
       expect(result.current[0].rows).toMatchInlineSnapshot(`
               [

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
@@ -27,6 +27,7 @@ export const PolarisAutoTableCellRenderer = (props: {
   }
 
   switch (column.fieldType) {
+    case FieldType.Id:
     case FieldType.String:
     case FieldType.Number:
     case FieldType.Email:

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -447,6 +447,7 @@ export const filterAutoTableFieldList = (fields: FieldMetadata[] | undefined, op
 };
 
 const acceptedAutoTableFieldTypes = new Set([
+  FieldType.Id,
   FieldType.Boolean,
   FieldType.Color,
   FieldType.Computed,

--- a/packages/react/src/useTable.tsx
+++ b/packages/react/src/useTable.tsx
@@ -158,10 +158,7 @@ export const useTable = <
       }
     }
 
-    return {
-      ...selectionMap,
-      id: true,
-    };
+    return selectionMap;
   }, [metadata, options?.columns, options?.select]);
 
   let variables;
@@ -181,7 +178,7 @@ export const useTable = <
     ...options,
     ...(variables as any),
     ...(debouncedSearchValue && { search: debouncedSearchValue }),
-    select: fieldSelectionMap,
+    select: fieldSelectionMap ? { ...fieldSelectionMap, id: true } : undefined,
     pause: !metadata, // Don't fetch data until metadata is loaded
   });
 


### PR DESCRIPTION
This PR adds the missing ID field to the AutoTable:
<img width="324" alt="CleanShot 2024-07-19 at 15 55 51@2x" src="https://github.com/user-attachments/assets/8d0f075d-c823-4f5f-b000-a426637da44c">


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
