### PR TITLE
Allow setting custom page size in AutoTable

### DIFF
--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -49,6 +49,7 @@ export const PolarisAutoTable = <
     {
       select: props.select,
       columns: props.columns,
+      pageSize: props.pageSize,
     } as any
   );
 


### PR DESCRIPTION
This feature is available in `AutoTable` but hasn't passed the value into the `useTable` hook. This PR fixes that.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
