### PR TITLE
Truncate tags when overflow in AutoTable

### DIFF
--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -13,6 +13,8 @@ const POLARIS_TABLE_CLASSES = {
   CELL: "Polaris-IndexTable__TableCell",
 } as const;
 
+const POLARIS_TAG_CLASS = "Polaris-Tag";
+
 let rows: any[] = [];
 let columns: any[] = [];
 let error: Error | undefined;
@@ -267,12 +269,12 @@ describe("PolarisAutoTable", () => {
     expect(firstRowCells[1].textContent).toBe("has one name value");
 
     // "hasMany" column
-    const tagsInHasManyCell = firstRowCells[2].getElementsByClassName("Polaris-Tag");
+    const tagsInHasManyCell = firstRowCells[2].getElementsByClassName(POLARIS_TAG_CLASS);
     expect(tagsInHasManyCell.length).toBe(2);
     expect(Array.from(tagsInHasManyCell).map((t) => t.textContent)).toEqual(["1", "2"]);
 
     // "belongsTo" column
-    const tagsInBelongsToCell = firstRowCells[3].getElementsByClassName("Polaris-Tag");
+    const tagsInBelongsToCell = firstRowCells[3].getElementsByClassName(POLARIS_TAG_CLASS);
     expect(tagsInBelongsToCell.length).toBe(4);
     expect(Array.from(tagsInBelongsToCell).map((t) => t.textContent)).toEqual(["belongs", "to", "enum", "value"]);
   });
@@ -331,5 +333,71 @@ describe("PolarisAutoTable", () => {
     const firstRowCells = firstRow.getElementsByClassName(POLARIS_TABLE_CLASSES.CELL);
     expect(firstRowCells[1].textContent).toBe("hello");
     expect(firstRowCells[2].textContent).toBe("this is a custom cell: 1-hello");
+  });
+
+  describe("show more indicator in tag cell renderer", () => {
+    it("should appear in the cell when there are more than 5 tags", () => {
+      setMockUseTableResponse({
+        newRows: [
+          {
+            id: "1",
+            tags: ["1", "2", "3", "4", "5", "6"],
+          },
+        ],
+        newColumns: [
+          {
+            apiIdentifier: "tags",
+            fieldType: "Enum",
+            name: "Tags",
+            sortable: true,
+          },
+        ],
+      });
+
+      const { container } = render(<PolarisAutoTable model={api.widget} />, {
+        wrapper: PolarisMockedProviders,
+      });
+
+      const table = container.querySelector(`.${POLARIS_TABLE_CLASSES.CONTAINER}`)!;
+      const rows = table.getElementsByClassName(POLARIS_TABLE_CLASSES.ROW);
+
+      const firstRow = rows[0];
+      const firstRowCells = firstRow.getElementsByClassName(POLARIS_TABLE_CLASSES.CELL);
+
+      expect(firstRowCells[1].getElementsByClassName(POLARIS_TAG_CLASS).length).toBe(5);
+      expect(firstRowCells[1].innerHTML).toContain("...");
+    });
+
+    it("should not appear in the cell when there are less than 5 tags", () => {
+      setMockUseTableResponse({
+        newRows: [
+          {
+            id: "1",
+            tags: ["1", "2", "3", "4"],
+          },
+        ],
+        newColumns: [
+          {
+            apiIdentifier: "tags",
+            fieldType: "Enum",
+            name: "Tags",
+            sortable: true,
+          },
+        ],
+      });
+
+      const { container } = render(<PolarisAutoTable model={api.widget} />, {
+        wrapper: PolarisMockedProviders,
+      });
+
+      const table = container.querySelector(`.${POLARIS_TABLE_CLASSES.CONTAINER}`)!;
+      const rows = table.getElementsByClassName(POLARIS_TABLE_CLASSES.ROW);
+
+      const firstRow = rows[0];
+      const firstRowCells = firstRow.getElementsByClassName(POLARIS_TABLE_CLASSES.CELL);
+
+      expect(firstRowCells[1].getElementsByClassName(POLARIS_TAG_CLASS).length).toBe(4);
+      expect(firstRowCells[1].innerHTML).not.toContain("...");
+    });
   });
 });

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTagCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTagCell.tsx
@@ -1,32 +1,59 @@
-import { InlineStack, Tag } from "@shopify/polaris";
-import React, { useMemo } from "react";
+import { InlineStack, Tag, Text } from "@shopify/polaris";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { RoleAssignmentsValueType } from "../../../utils.js";
 import { isRoleAssignmentsArray } from "../../../utils.js";
 
+const MAX_TAGS_LENGTH = 5;
+
 export const PolarisAutoTableTagCell = (props: { value: string | string[] | RoleAssignmentsValueType[] }) => {
   const { value } = props;
+  const [showMore, setShowMore] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
-  const tags = useMemo(() => {
+  const { tags, originalLength } = useMemo(() => {
+    let formattedTags: string[] = [];
+
     if (Array.isArray(value)) {
       if (isRoleAssignmentsArray(value)) {
-        return value.map((role) => role.name);
+        formattedTags = value.map((role) => role.name);
       } else if (typeof value[0] === "string") {
-        return value;
-      } else {
-        return [];
+        formattedTags = value;
       }
     } else {
-      return [value];
+      formattedTags = [value];
     }
+
+    return {
+      tags: formattedTags.slice(0, MAX_TAGS_LENGTH),
+      originalLength: formattedTags.length,
+    };
   }, [value]);
+
+  useEffect(() => {
+    if (ref.current) {
+      setShowMore(ref.current.scrollWidth > ref.current.clientWidth);
+    }
+  }, [tags]);
+
+  const showMoreComponent = <Text as="span">...</Text>;
 
   return (
     <InlineStack gap="100" wrap={false}>
-      {tags.map((tag) => (
-        <Tag key={tag} accessibilityLabel={`tag-${tag}`}>
-          {tag}
-        </Tag>
-      ))}
+      <div
+        style={{
+          width: showMore ? "calc(100% - 20px)" : "auto",
+          overflowX: "hidden",
+        }}
+        ref={ref}
+      >
+        <InlineStack gap="100" wrap={false}>
+          {tags.map((tag) => (
+            <Tag key={tag}>{tag}</Tag>
+          ))}
+          {originalLength > MAX_TAGS_LENGTH && showMoreComponent}
+        </InlineStack>
+      </div>
+      {showMore && showMoreComponent}
     </InlineStack>
   );
 };


### PR DESCRIPTION
As the title suggests, this PR truncates the tags when they overflow in the UI or there are more than five tags.
<img width="238" alt="CleanShot 2024-07-22 at 10 16 08@2x" src="https://github.com/user-attachments/assets/dda1576b-b25a-4dcd-9cb7-8de525b5c8f5">



## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
