### PR TITLE
use consistent call signature for upsert between public and internal api

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.27",
+  "version": "0.15.28",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -1333,6 +1333,120 @@ describe("InternalModelManager", () => {
       expect(result.name).toBeTruthy();
     });
 
+    test("can execute an upsert against a model", async () => {
+      const promise = manager.upsert({ id: "123", name: "foo" });
+
+      expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toMatchInlineSnapshot(`
+        {
+          "widget": {
+            "id": "123",
+            "name": "foo",
+          },
+        }
+      `);
+
+      mockUrqlClient.executeMutation.pushResponse("InternalUpsertWidget", {
+        data: {
+          internal: {
+            upsertWidget: {
+              success: true,
+              errors: null,
+              widget: {
+                id: "123",
+                name: "foo",
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("can execute an upsert against a model with an on at the root level", async () => {
+      const promise = manager.upsert({ id: "123", name: "foo", on: ["name"] });
+
+      expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toMatchInlineSnapshot(`
+        {
+          "on": [
+            "name",
+          ],
+          "widget": {
+            "id": "123",
+            "name": "foo",
+          },
+        }
+      `);
+
+      mockUrqlClient.executeMutation.pushResponse("InternalUpsertWidget", {
+        data: {
+          internal: {
+            upsertWidget: {
+              success: true,
+              errors: null,
+              widget: {
+                id: "123",
+                name: "foo",
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("can execute an upsert against a model with an on at the fully qualified level", async () => {
+      const promise = manager.upsert({ widget: { id: "123", name: "bar" }, on: ["name"] });
+
+      expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toMatchInlineSnapshot(`
+        {
+          "on": [
+            "name",
+          ],
+          "widget": {
+            "id": "123",
+            "name": "bar",
+          },
+        }
+      `);
+
+      mockUrqlClient.executeMutation.pushResponse("InternalUpsertWidget", {
+        data: {
+          internal: {
+            upsertWidget: {
+              success: true,
+              errors: null,
+              widget: {
+                id: "123",
+                name: "bar",
+              },
+            },
+          },
+        },
+        stale: false,
+        hasNext: false,
+      });
+
+      const result = await promise;
+      expect(result.id).toBeTruthy();
+      expect(result.name).toBeTruthy();
+    });
+
+    test("throws an error if attempting to run an upsert with an empty on", async () => {
+      await expect(manager.upsert({ widget: { id: "123", name: "bar" }, on: [] })).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"assertion error: Must specify at least one field to upsert on"`
+      );
+    });
+
     test("can execute a delete operation against a model", async () => {
       const promise = manager.delete("123");
 

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -490,14 +490,15 @@ export class InternalModelManager<Shape extends RecordShape = RecordData> {
    * // upserts post with slug "new-post" in the database
    * // if a post with slug "new-post" exists, it will be updated
    * // if a post with slug "new-post" does not exist, it will be created
-   * const post = await api.internal.post.upsert({ slug: "new-post", title: "A new post title" }, ["slug"]);
+   * const post = await api.internal.post.upsert({ post: {slug: "new-post", title: "A new post title" }, on: ["slug"] });
    *
    * @param record The data for the record to update
    * @returns The upserted record
    */
-  async upsert(record: RecordData, on?: string[]): Promise<GadgetRecord<Shape>> {
+  async upsert(record: RecordData & { on?: string[] }): Promise<GadgetRecord<Shape>> {
+    const { on, ...recordData } = record;
     on && assert(on.length > 0, `Must specify at least one field to upsert on`);
-    const plan = internalUpsertMutation(this.apiIdentifier, this.namespace, on, this.getRecordFromData(record, "upsert"));
+    const plan = internalUpsertMutation(this.apiIdentifier, this.namespace, on, this.getRecordFromData(recordData, "upsert"));
     const response = await this.connection.currentClient.mutation(plan.query, plan.variables).toPromise();
     const result = assertMutationSuccess(response, this.dataPath(`upsert${this.capitalizedApiIdentifier}`));
 


### PR DESCRIPTION
In writing api tests for the internal upsert I realized I put an inconsistent call signature for the upsert between internal and public api. The fewer surprises the better so this moves the `on` param into the record payload of the internal call and pulls it out if its passed


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
