### PR TITLE
ensure that legacy clients still typecheck correctly

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.28",
+  "version": "0.15.29",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/TestSchema.ts
+++ b/packages/api-client-core/spec/TestSchema.ts
@@ -1,4 +1,5 @@
-import type { AvailableSelection } from "../src/types.js";
+import type { GadgetRecord } from "src/index.js";
+import type { AvailableSelection, DeepFilterNever, DefaultSelection, Select, Selectable } from "../src/types.js";
 
 export type NestedThing = {
   bool: boolean;
@@ -48,3 +49,36 @@ export type TestSchema = {
 };
 
 export type AvailableTestSchemaSelection = AvailableSelection<TestSchema>;
+
+export const DefaultPostSelection = {
+  __typename: true,
+  createdAt: true,
+  id: true,
+  updatedAt: true,
+} as const;
+
+export type Post = {
+  __typename: "Post";
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type AvailablePostSelection = {
+  __typename?: boolean | null | undefined;
+  id?: boolean | null | undefined;
+  createdAt?: boolean | null | undefined;
+  updatedAt?: boolean | null | undefined;
+};
+
+export type SelectedPostOrDefault<Options extends Selectable<AvailablePostSelection>> = DeepFilterNever<
+  Select<Post, DefaultSelection<AvailablePostSelection, Options, typeof DefaultPostSelection>>
+>;
+
+export interface CreatePostOptions {
+  select?: AvailablePostSelection;
+}
+
+export type CreatePostResult<Options extends CreatePostOptions> = SelectedPostOrDefault<Options> extends void
+  ? void
+  : GadgetRecord<SelectedPostOrDefault<Options>>;

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -184,7 +184,7 @@ export const findManyRunner = <Shape extends RecordShape = any, Options extends 
 };
 
 export interface ActionRunner {
-  <Shape extends RecordShape = any>(
+  (
     modelManager: { connection: GadgetConnection },
     operation: string,
     defaultSelection: FieldSelection | null,
@@ -195,7 +195,7 @@ export interface ActionRunner {
     options?: BaseFindOptions | null,
     namespace?: string | string[] | null,
     hasReturnType?: HasReturnType
-  ): Promise<Shape>;
+  ): Promise<any>;
 
   <Shape extends RecordShape = any>(
     modelManager: { connection: GadgetConnection },
@@ -234,7 +234,7 @@ export interface ActionRunner {
     namespace?: string | string[] | null
   ): Promise<Shape extends void ? void : GadgetRecord<Shape>[]>;
 
-  <Shape extends RecordShape = any>(
+  (
     modelManager: { connection: GadgetConnection },
     operation: string,
     defaultSelection: FieldSelection | null,
@@ -245,7 +245,7 @@ export interface ActionRunner {
     options?: BaseFindOptions | null,
     namespace?: string | string[] | null,
     hasReturnType?: HasReturnType
-  ): Promise<Shape[]>;
+  ): Promise<any[]>;
 
   <Shape extends RecordShape = any>(
     modelManager: { connection: GadgetConnection },


### PR DESCRIPTION
I made a type change to `ActionRunner` that seemed like it made sense in the context of the metadata client generation, but ended up breaking typechecking for the previous client generation strategy. This PR rolls back that type change and adds a test to make prevent this regression in the future

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
