### PR TITLE
Added live option to AutoTable props

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -111,3 +111,11 @@ export const SelectRelatedFieldsBelongsTo = {
     ],
   },
 };
+
+export const LiveData = {
+  name: "Live data",
+  args: {
+    model: api.widget,
+    live: true,
+  },
+};

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -16,6 +16,7 @@ export type AutoTableProps<
   pageSize?: number;
   initialCursor?: string;
   initialDirection?: string;
+  live?: boolean;
   columns?: TableOptions["columns"];
   onClick?: (row: Record<string, ColumnValueType>) => void;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -50,6 +50,7 @@ export const PolarisAutoTable = <
       select: props.select,
       columns: props.columns,
       pageSize: props.pageSize,
+      live: props.live,
     } as any
   );
 


### PR DESCRIPTION
![CleanShot 2024-07-22 at 09 59 44](https://github.com/user-attachments/assets/c2bc1b56-c996-4774-9471-fc3b65b63b6e)

- **UPDATE**
  - Exposed the `live` option from `useTable.useList.useFindMany` as a property in the `PolarisAutoTable` component so that the table can stay up to date with the real DB without refreshing the page