### PR TITLE
bulk actions should return null when there is no selection

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.29",
+  "version": "0.15.30",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -1061,7 +1061,7 @@ describe("operationRunners", () => {
           connection,
         },
         "bulkDeleteWidgets",
-        { id: true, name: true },
+        null,
         "widget",
         "widgets",
         true,

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -261,7 +261,7 @@ export interface ActionRunner {
   ): Promise<Shape extends void ? void : GadgetRecord<Shape>[]>;
 }
 
-export const actionRunner: ActionRunner = async <Shape extends RecordShape = any>(
+export const actionRunner: ActionRunner = async (
   modelManager: { connection: GadgetConnection },
   operation: string,
   defaultSelection: FieldSelection | null,
@@ -314,7 +314,7 @@ const processBulkActionResponse = <Shape extends RecordShape = any>(
   modelSelectionField: string,
   hasReturnType?: HasReturnType | null
 ) => {
-  if (defaultSelection == null) return [];
+  if (defaultSelection == null) return;
   if (!hasReturnType) {
     return hydrateRecordArray<Shape>(response, records[modelSelectionField]);
   } else if (typeof hasReturnType == "boolean") {


### PR DESCRIPTION
https://github.com/gadget-inc/js-clients/pull/536 introduced a regression for delete actions where we started returning an empty array instead of undefined. Unfortunately the test that was meant to catch that passed a default selection so we weren't actually covered; this fixes that regression and changes the test to actually test what we want


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
