### PR TITLE
Make skeleton table header wider in AutoTable

### DIFF
--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -24,7 +24,9 @@ const PolarisSkeletonTable = (props: { columns: number }) => {
     <DataTable
       columnContentTypes={count.map(() => "text")}
       headings={count.map((i) => (
-        <SkeletonBodyText key={i} lines={1} />
+        <Box width="100px" key={i}>
+          <SkeletonBodyText lines={1} />
+        </Box>
       ))}
       rows={Array.from(Array(3)).map((_) => count.map((i) => <SkeletonBodyText key={i} lines={1} />))}
     />
@@ -78,7 +80,7 @@ export const PolarisAutoTable = <
   }, [columns]);
 
   if (!error && ((fetching && !rows) || !columns)) {
-    return <PolarisSkeletonTable columns={polarisTableProps.headings.length} />;
+    return <PolarisSkeletonTable columns={3} />;
   }
 
   const resourceName = {


### PR DESCRIPTION
We already have a skeleton table, but because the header is too small, it doesn't show the skeleton properly.

This PR fixes that by setting a width to the headers.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
