### PR TITLE
Added error message for passing bulk actions into the autoforms

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -652,6 +652,15 @@ describe("PolarisAutoForm", () => {
       });
     });
   });
+
+  describe("Bulk actions", () => {
+    it("throws an error when a bulk action is used", () => {
+      expect(() => {
+        render(<PolarisAutoForm action={api.widget.bulkUpdate as any} />, { wrapper: PolarisMockedProviders });
+        loadMockWidgetCreateMetadata();
+      }).toThrow("Bulk actions are not supported in AutoForms");
+    });
+  });
 });
 
 function loadMockGizmoCreateMetadata() {

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -110,6 +110,11 @@ export const useAutoForm = <
   props: AutoFormProps<GivenOptions, SchemaT, ActionFunc, any, any>
 ) => {
   const { action, record, onSuccess } = props;
+
+  if (action.isBulk) {
+    throw new Error("Bulk actions are not supported in AutoForms");
+  }
+
   const { metadata, fetching: fetchingMetadata, error: metadataError } = useActionMetadata(props.action);
 
   // filter down the fields to render only what we want to render for this form


### PR DESCRIPTION
- **UPDATE**
  - Previously, passing in a bulk action to the Autoform would result in a `can't find metadata error`
  - Now, we get `bulk actions are not supported` as an error message so the user can more easily identify where to fix the problem