### PR TITLE
Added humanized action names to forms

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -94,3 +94,9 @@ export const Namespaced = {
     findBy: "1",
   },
 };
+
+export const GlobalAction = {
+  args: {
+    action: api.flipAll,
+  },
+};

--- a/packages/react/spec/humanizeCamelCase.spec.ts
+++ b/packages/react/spec/humanizeCamelCase.spec.ts
@@ -1,0 +1,13 @@
+import { humanizeCamelCase } from "../src/utils.js";
+
+describe("humanizeCamelCase", () => {
+  it("Properly humanizes camelCasedStrings", async () => {
+    expect(humanizeCamelCase("camelCasedString")).toEqual("Camel Cased String");
+    expect(humanizeCamelCase("lowercase")).toEqual("Lowercase");
+    expect(humanizeCamelCase("createModelA")).toEqual("Create Model A");
+    expect(humanizeCamelCase("ABCDE")).toEqual("ABCDE");
+
+    expect(humanizeCamelCase("do99Things")).toEqual("Do 99 Things");
+    expect(humanizeCamelCase("123456789A")).toEqual("123456789 A");
+  });
+});

--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -1,9 +1,9 @@
 import type { ActionFunction } from "@gadgetinc/api-client-core";
 import type { GridProps } from "@mui/material";
-import { Grid, Skeleton } from "@mui/material";
-import React from "react";
+import { Grid, Skeleton, Typography } from "@mui/material";
+import React, { useMemo } from "react";
 import { FormProvider } from "react-hook-form";
-import type { OptionsType } from "../../utils.js";
+import { humanizeCamelCase, type OptionsType } from "../../utils.js";
 import { useAutoForm, type AutoFormProps } from "../AutoForm.js";
 import { AutoFormMetadataContext } from "../AutoFormContext.js";
 import { MUIAutoInput } from "./inputs/MUIAutoInput.js";
@@ -65,12 +65,15 @@ export const MUIAutoFormComponent = <
     },
   };
 
+  const humanizedOperationName = useMemo(() => humanizeCamelCase(action.operationName), [action.operationName]);
+
   if (props.successContent && isSubmitSuccessful) {
     return props.successContent;
   }
 
   const formContent = props.children ?? (
     <>
+      <Typography variant="h5">{humanizedOperationName}</Typography>
       {!props.onSuccess ? <MUISubmitResultBanner /> : <MUISubmitErrorBanner />}
       {fetchingMetadata && <MUIFormSkeleton />}
       {!metadataError && (

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -1,9 +1,9 @@
 import type { ActionFunction } from "@gadgetinc/api-client-core";
 import type { FormProps } from "@shopify/polaris";
-import { BlockStack, Form, FormLayout, SkeletonBodyText, SkeletonDisplayText } from "@shopify/polaris";
-import React from "react";
+import { BlockStack, Form, FormLayout, SkeletonBodyText, SkeletonDisplayText, Text } from "@shopify/polaris";
+import React, { useMemo } from "react";
 import { FormProvider } from "react-hook-form";
-import type { OptionsType } from "../../utils.js";
+import { humanizeCamelCase, type OptionsType } from "../../utils.js";
 import type { AutoFormProps } from "../AutoForm.js";
 import { useAutoForm } from "../AutoForm.js";
 import { AutoFormMetadataContext } from "../AutoFormContext.js";
@@ -73,6 +73,7 @@ const PolarisAutoFormComponent = <
       namespace: action.namespace,
     },
   };
+  const humanizedOperationName = useMemo(() => humanizeCamelCase(action.operationName), [action.operationName]);
 
   if (props.successContent && isSubmitSuccessful) {
     return props.successContent;
@@ -90,6 +91,9 @@ const PolarisAutoFormComponent = <
 
   const formContent = props.children ?? (
     <>
+      <Text variant="headingLg" as="h5">
+        {humanizedOperationName}
+      </Text>
       {!props.onSuccess ? <PolarisSubmitResultBanner /> : <PolarisSubmitErrorBanner />}
       {!metadataError && (
         <>

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -539,3 +539,24 @@ export type RelatedFieldColumn = {
 export const isRelatedFieldColumn = (value: any): value is RelatedFieldColumn => {
   return typeof value === "object" && value !== null && "field" in value && "relatedField" in value;
 };
+
+/**
+ * Humanizes a camelCase string by adding spaces between words and capitalizing the first letter
+ * Examples
+ *    humanizeCamelCase("createNewWidget") => "Create New Widget"
+ *    humanizeCamelCase("do99Things") => "Do 99 Things"
+ */
+export const humanizeCamelCase = (camelCaseString: string): string => {
+  // Regular expression to find sequences of lowercase letters or digits followed by uppercase letters
+  const uppercaseAfterLowercaseRegex = /([a-z\d])([A-Z])/g;
+
+  // Add a space between the lowercase letter or digit and the uppercase letter
+  let humanized = camelCaseString.replace(uppercaseAfterLowercaseRegex, "$1 $2");
+
+  // Adjust to keep sequential numbers together with spaces around them
+  humanized = humanized.replace(/([a-zA-Z])(\d)/g, "$1 $2");
+  humanized = humanized.replace(/(\d)([a-zA-Z])/g, "$1 $2");
+
+  // Capitalize the first letter
+  return humanized.replace(/^./, (str) => str.toUpperCase());
+};


### PR DESCRIPTION
- **UPDATE**
  - Added humanized action names to forms 
    - They are based on the GQL operation name, which is based on the API ID and the model
    - Global actions get titles as well
    - Action operation names containing numbers will keep the numbers beside each other 
      - Ex: `Do99Things` -> `Do 99 Things`
    - This only appears in one-liner AutoForms