### PR TITLE
Added system to clear form fields upon successful action submission for create and update actions

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -41,6 +41,10 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
 
     submit("Widget");
     ensureFieldInputLabelsExist();
+
+    // Ensure that the form is cleared after submitting the create action
+    cy.get(`input[name="widget.name"]`).should("have.value", "");
+    cy.get(`input[name="widget.inventoryCount"]`).should("have.value", "");
   });
 
   it("onSuccess callback should return a record result after the form submission", () => {
@@ -176,6 +180,10 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     cy.get(`[id="1_Section Foo"]`);
 
     submit("Widget");
+
+    // Ensure that the form values remain after submitting the update action
+    cy.get(`input[name="widget.name"]`).should("have.value", "updated test record");
+    cy.get(`input[name="widget.inventoryCount"]`).should("have.value", "1234");
   });
 
   it("can render a form to create namespaced model", () => {

--- a/packages/react/cypress/component/auto/form/AutoFormGlobalActions.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormGlobalActions.cy.tsx
@@ -33,6 +33,10 @@ describeForEachAutoAdapter("AutoForm - Global actions", ({ name, adapter: { Auto
     cy.wait("@globalActionCall");
 
     cy.contains("Flip all succeeded.");
+
+    // Inputs are cleared after submission on global actions
+    cy.get(`input[name="title"]`).should("have.value", "");
+    cy.get(`input[name="inventoryCount"]`).should("have.value", "");
   });
 
   it("builds forms for global actions and submits, showing any errors and allowing resubmission", () => {

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -122,6 +122,8 @@ export const useAutoForm = <
   // filter down the fields to render only what we want to render for this form
   const fields = useFormFields(metadata, props);
   const operatesWithRecordId = !!(metadata && isActionMetadata(metadata) && metadata.action.operatesWithRecordIdentity);
+  const isDeleteAction = metadata && isActionMetadata(metadata) && metadata.action.isDeleteAction;
+  const isGlobalAction = action.type === "globalAction";
   const modelApiIdentifier = action.type == "action" ? action.modelApiIdentifier : undefined;
   const defaultValues: Record<string, unknown> = useMemo(
     () =>
@@ -139,6 +141,7 @@ export const useAutoForm = <
   const {
     submit,
     error: formError,
+    reset,
     formState: { isSubmitSuccessful, isLoading, isReady, isSubmitting, touchedFields },
     originalFormMethods,
   } = useActionForm(action, {
@@ -168,8 +171,15 @@ export const useAutoForm = <
       }
       return fieldsToSend;
     },
-    onSuccess,
     onError: onFailure,
+    onSuccess:
+      onSuccess ??
+      function clearInputValues() {
+        const isCreateAction = !operatesWithRecordId && !isDeleteAction && !isGlobalAction;
+        if (isCreateAction || isGlobalAction) {
+          reset();
+        }
+      },
   });
 
   // we don't have synchronous access to the default values always -- sometimes we need to load them from the metadata. if we do that, then we need to forcibly set them into the form state once they have been loaded

--- a/packages/react/src/auto/hooks/useJSONInputController.tsx
+++ b/packages/react/src/auto/hooks/useJSONInputController.tsx
@@ -29,6 +29,13 @@ export const useJSONInputController = (
     }
   }, [jsonValue, isParseError]);
 
+  // Setting the value to an empty string when the value gets undefined through resets
+  useEffect(() => {
+    if (stringInputController.value === undefined) {
+      setString("");
+    }
+  }, [stringInputController.value]);
+
   const onChange = useCallback(
     (newString: string) => {
       setString(newString);


### PR DESCRIPTION
- **UPDATE**
  - Added a field value resetting system that runs upon successful completion of create and global actions
    - Some state based inputs had to get updates such that their input values would stay in sync with the overall hook context
  - Inputs shall be untouched on errors
  - Passing in an `onSuccess` property will avoid this behaviour 