### PR TITLE
Introduce custom cell renderer in AutoTable

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -123,3 +123,22 @@ export const LiveData = {
     live: true,
   },
 };
+
+export const CustomCell = {
+  args: {
+    model: api.autoTableTest,
+    columns: [
+      "str",
+      {
+        field: "hasOne",
+        relatedField: "name",
+      },
+      {
+        name: "Custom cell",
+        render: (record) => {
+          return <div>Custom cell: {record.str}</div>;
+        },
+      },
+    ],
+  },
+};

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -1,8 +1,10 @@
-import { AppProvider, Box, BlockStack, LegacyCard } from "@shopify/polaris";
+import { AppProvider, BlockStack, Box, Button, LegacyCard } from "@shopify/polaris";
+import { DeleteIcon } from "@shopify/polaris-icons";
 import translations from "@shopify/polaris/locales/en.json";
-import React from "react";
+import React, { useEffect } from "react";
 import { Provider } from "../../src/GadgetProvider.tsx";
 import { PolarisAutoTable } from "../../src/auto/polaris/PolarisAutoTable.tsx";
+import { useAction } from "../../src/useAction.ts";
 import { testApi as api } from "../apis.ts";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
@@ -16,7 +18,7 @@ export default {
       return (
         <Provider api={api}>
           <AppProvider i18n={translations}>
-            <div style={{ width: '100%'}}>
+            <div style={{ width: "100%" }}>
               <Box paddingBlockEnd="400">
                 <BlockStack gap="200">
                   <LegacyCard>
@@ -137,6 +139,44 @@ export const CustomCell = {
         name: "Custom cell",
         render: (record) => {
           return <div>Custom cell: {record.str}</div>;
+        },
+      },
+    ],
+  },
+};
+
+const CustomDeleteButtonCellRenderer = (props) => {
+  const [{ error, fetching }, _delete] = useAction(api.autoTableTest.delete);
+
+  useEffect(() => {
+    if (error) {
+      // eslint-disable-next-line no-undef
+      window.alert(`Error deleting record: ${error.message}`);
+    }
+  }, [error]);
+
+  return (
+    <Button
+      icon={DeleteIcon}
+      onClick={() => {
+        void _delete({
+          id: props.record.id,
+        });
+      }}
+      loading={fetching}
+    />
+  );
+};
+
+export const CustomCellWithDeleteButton = {
+  args: {
+    model: api.autoTableTest,
+    columns: [
+      "str",
+      {
+        name: "Actions",
+        render: (record) => {
+          return <CustomDeleteButtonCellRenderer record={record} />;
         },
       },
     ],

--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from "@testing-library/react";
+import React, { isValidElement } from "react";
 import { useTable } from "../../../src/useTable.js";
 import { testApi as api } from "../../apis.js";
 import { mockUrqlClient } from "../../testWrappers.js";
@@ -51,12 +52,15 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "id",
         fieldType: "ID",
+        isCustomCell: false,
         name: "Id",
+        relatedField: undefined,
         sortable: false,
       },
       {
         apiIdentifier: "name",
         fieldType: "String",
+        isCustomCell: false,
         name: "Name",
         relatedField: undefined,
         sortable: true,
@@ -64,6 +68,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "inventoryCount",
         fieldType: "Number",
+        isCustomCell: false,
         name: "Inventory count",
         relatedField: undefined,
         sortable: true,
@@ -71,6 +76,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "anything",
         fieldType: "JSON",
+        isCustomCell: false,
         name: "Anything",
         relatedField: undefined,
         sortable: true,
@@ -78,6 +84,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "description",
         fieldType: "RichText",
+        isCustomCell: false,
         name: "Description",
         relatedField: undefined,
         sortable: true,
@@ -85,6 +92,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "category",
         fieldType: "Enum",
+        isCustomCell: false,
         name: "Category",
         relatedField: undefined,
         sortable: true,
@@ -92,6 +100,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "startsAt",
         fieldType: "DateTime",
+        isCustomCell: false,
         name: "Starts at",
         relatedField: undefined,
         sortable: true,
@@ -99,6 +108,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "isChecked",
         fieldType: "Boolean",
+        isCustomCell: false,
         name: "Is checked",
         relatedField: undefined,
         sortable: true,
@@ -106,6 +116,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "metafields",
         fieldType: "JSON",
+        isCustomCell: false,
         name: "Metafields",
         relatedField: undefined,
         sortable: true,
@@ -113,6 +124,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "roles",
         fieldType: "RoleAssignments",
+        isCustomCell: false,
         name: "Roles",
         relatedField: undefined,
         sortable: false,
@@ -120,6 +132,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "birthday",
         fieldType: "DateTime",
+        isCustomCell: false,
         name: "Birthday",
         relatedField: undefined,
         sortable: true,
@@ -127,6 +140,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "color",
         fieldType: "Color",
+        isCustomCell: false,
         name: "Color",
         relatedField: undefined,
         sortable: true,
@@ -134,6 +148,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "secretKey",
         fieldType: "EncryptedString",
+        isCustomCell: false,
         name: "Secret key",
         relatedField: undefined,
         sortable: false,
@@ -141,6 +156,7 @@ describe("useTable hook", () => {
       {
         apiIdentifier: "mustBeLongString",
         fieldType: "String",
+        isCustomCell: false,
         name: "Must be long string",
         relatedField: undefined,
         sortable: true,
@@ -323,6 +339,48 @@ describe("useTable hook", () => {
       }
 
       expect(error!.message).toBe("Field 'notExist' not found in metadata");
+    });
+
+    it("should include custom cell columns if specified", async () => {
+      const result = getUseTableResult({
+        columns: [
+          "name",
+          {
+            name: "Custom column",
+            render: (record) => <div>hello {record.name}</div>,
+          },
+        ],
+      });
+      loadMockWidgetModelMetadataForRelationship();
+      loadMockWidgetDataForRelationship();
+
+      expect(
+        result.current[0].columns?.map((column) => {
+          const { getValue: _getValue, ...rest } = column;
+          return rest;
+        })
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "apiIdentifier": "name",
+            "fieldType": "String",
+            "isCustomCell": false,
+            "name": "Name",
+            "relatedField": undefined,
+            "sortable": true,
+          },
+          {
+            "apiIdentifier": "Custom column",
+            "isCustomCell": true,
+            "name": "Custom column",
+            "sortable": false,
+          },
+        ]
+      `);
+
+      const customColumnGetValueResult = result.current[0].columns![1].getValue({ name: "foo" });
+      // Expect the getValue result to be a valid React element
+      expect(isValidElement(customColumnGetValueResult)).toBe(true);
     });
   });
 });

--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -170,7 +170,7 @@ describe("PolarisAutoTable", () => {
     });
   });
 
-  it("should render the columns using the correct cell renderer in related model fields", async () => {
+  it("should render the columns using the correct cell renderer in related model fields", () => {
     setMockUseTableResponse({
       newRows: [
         {
@@ -267,5 +267,61 @@ describe("PolarisAutoTable", () => {
     const tagsInBelongsToCell = firstRowCells[3].getElementsByClassName("Polaris-Tag");
     expect(tagsInBelongsToCell.length).toBe(4);
     expect(Array.from(tagsInBelongsToCell).map((t) => t.textContent)).toEqual(["belongs", "to", "enum", "value"]);
+  });
+
+  it("should render the custom columns", () => {
+    const customCellRenderer = (record: any) => (
+      <div data-testid="custom-cell-div">
+        this is a custom cell: {record.id}-{record.name}
+      </div>
+    );
+    setMockUseTableResponse({
+      newRows: [
+        {
+          id: "1",
+          name: "hello",
+          customCell: customCellRenderer({ name: "hello" }),
+        },
+      ],
+      newColumns: [
+        {
+          apiIdentifier: "name",
+          fieldType: "String",
+          name: "Name",
+          sortable: true,
+        },
+        {
+          name: "Custom cell",
+          apiIdentifier: "Custom cell",
+          isCustomCell: true,
+          sortable: false,
+          getValue: customCellRenderer,
+        },
+      ],
+    });
+
+    const { container } = render(
+      <PolarisAutoTable
+        model={api.widget}
+        columns={[
+          "name",
+          {
+            name: "Custom cell",
+            render: customCellRenderer,
+          },
+        ]}
+      />,
+      {
+        wrapper: PolarisMockedProviders,
+      }
+    );
+
+    const table = container.querySelector(`.${POLARIS_TABLE_CLASSES.CONTAINER}`)!;
+    const rows = table.getElementsByClassName(POLARIS_TABLE_CLASSES.ROW);
+
+    const firstRow = rows[0];
+    const firstRowCells = firstRow.getElementsByClassName(POLARIS_TABLE_CLASSES.CELL);
+    expect(firstRowCells[1].textContent).toBe("hello");
+    expect(firstRowCells[2].textContent).toBe("this is a custom cell: 1-hello");
   });
 });

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -1,5 +1,5 @@
 import type { FindManyFunction } from "@gadgetinc/api-client-core";
-import type { TableOptions, TableRow } from "../useTable.js";
+import type { TableOptions, TableRow } from "../useTableUtils/types.js";
 import type { OptionsType } from "../utils.js";
 
 /**

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -1,6 +1,6 @@
 import type { FindManyFunction } from "@gadgetinc/api-client-core";
-import type { TableOptions } from "../useTable.js";
-import type { ColumnValueType, OptionsType } from "../utils.js";
+import type { TableOptions, TableRow } from "../useTable.js";
+import type { OptionsType } from "../utils.js";
 
 /**
  * The props to pass to an AutoTable. Includes both the Gadget-land props as well as the adapter specific props.
@@ -18,5 +18,5 @@ export type AutoTableProps<
   initialDirection?: string;
   live?: boolean;
   columns?: TableOptions["columns"];
-  onClick?: (row: Record<string, ColumnValueType>) => void;
+  onClick?: (row: TableRow) => void;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -13,8 +13,8 @@ import {
 } from "@shopify/polaris";
 import pluralize from "pluralize";
 import React, { useCallback, useMemo } from "react";
-import type { TableRow } from "../../useTable.js";
 import { useTable } from "../../useTable.js";
+import type { TableRow } from "../../useTableUtils/types.js";
 import type { ColumnValueType, OptionsType } from "../../utils.js";
 import type { AutoTableProps } from "../AutoTable.js";
 import { PolarisAutoTableCellRenderer } from "./tableCells/PolarisAutoTableCellRenderer.js";

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -13,6 +13,7 @@ import {
 } from "@shopify/polaris";
 import pluralize from "pluralize";
 import React, { useCallback, useMemo } from "react";
+import type { TableRow } from "../../useTable.js";
 import { useTable } from "../../useTable.js";
 import type { ColumnValueType, OptionsType } from "../../utils.js";
 import type { AutoTableProps } from "../AutoTable.js";
@@ -57,7 +58,7 @@ export const PolarisAutoTable = <
   );
 
   const onClickCallback = useCallback(
-    (row: Record<string, ColumnValueType>) => {
+    (row: TableRow) => {
       return () => onClick?.(row);
     },
     [onClick]
@@ -146,7 +147,11 @@ export const PolarisAutoTable = <
               {columns.map((column) => (
                 <IndexTable.Cell key={column.apiIdentifier}>
                   <div style={{ maxWidth: "200px" }}>
-                    <PolarisAutoTableCellRenderer column={column} value={row[column.apiIdentifier]} />
+                    {column.isCustomCell ? (
+                      column.getValue(row)
+                    ) : (
+                      <PolarisAutoTableCellRenderer column={column} value={row[column.apiIdentifier] as ColumnValueType} />
+                    )}
                   </div>
                 </IndexTable.Cell>
               ))}

--- a/packages/react/src/useTable.tsx
+++ b/packages/react/src/useTable.tsx
@@ -6,78 +6,12 @@ import {
   type LimitToKnownKeys,
   type Select,
 } from "@gadgetinc/api-client-core";
-import type { OperationContext } from "@urql/core";
-import type { ReactNode } from "react";
 import { useMemo } from "react";
-import { GadgetFieldType } from "./internal/gql/graphql.js";
-import type { ModelMetadata } from "./metadata.js";
 import { filterAutoTableFieldList, useModelMetadata } from "./metadata.js";
-import type { SearchResult } from "./useDebouncedSearch.js";
-import type { PaginationResult } from "./useList.js";
 import { useList } from "./useList.js";
-import type { CustomCellColumn, RelatedFieldColumn } from "./utils.js";
-import {
-  isCustomCellColumn,
-  isRelatedFieldColumn,
-  type ColumnValueType,
-  type ErrorWrapper,
-  type OptionsType,
-  type ReadOperationOptions,
-} from "./utils.js";
-
-type BaseTableColumn = {
-  name: string;
-  apiIdentifier: string;
-};
-
-type RecordTableColumnValue = BaseTableColumn & {
-  fieldType: GadgetFieldType;
-  sortable: boolean;
-  relatedField?: RecordTableColumnValue;
-  getValue: (record: GadgetRecord<any>) => ColumnValueType;
-  isCustomCell: false;
-};
-
-type CustomTableColumnValue = BaseTableColumn & {
-  getValue: (record: GadgetRecord<any>) => ReactNode;
-  isCustomCell: true;
-  sortable: false;
-};
-
-export type TableColumn = RecordTableColumnValue | CustomTableColumnValue;
-
-export type TableRow = Record<string, ColumnValueType | ReactNode>;
-
-export interface TableOptions {
-  pageSize?: number;
-  initialCursor?: string;
-  initialDirection?: "forward" | "backward";
-  columns?: (string | RelatedFieldColumn | CustomCellColumn)[];
-}
-
-export type TableData<Data> =
-  | {
-      columns: TableColumn[];
-      rows: TableRow[];
-      data: Data;
-      metadata: ModelMetadata;
-    }
-  | {
-      columns: null;
-      rows: null;
-      data: null;
-      metadata: null;
-    };
-
-export type TableResult<Data> = [
-  TableData<Data> & {
-    page: PaginationResult;
-    fetching: boolean;
-    error?: ErrorWrapper;
-    search: SearchResult;
-  },
-  refresh: (opts?: Partial<OperationContext>) => void
-];
+import { getTableColumns, getTableData } from "./useTableUtils/helpers.js";
+import type { TableOptions, TableResult } from "./useTableUtils/types.js";
+import { isRelatedFieldColumn, type OptionsType, type ReadOperationOptions } from "./utils.js";
 
 /**
  * Headless React hook for powering a table showing a page of Gadget records from the backend, optionally sorted, filtered, searched, and selected from. Returns a standard hook result set with a tuple of the result object with `data`, `fetching`, and `error` keys, and a `refetch` function. `data` will be a `GadgetRecordList` object holding the list of returned records and pagination info.
@@ -170,92 +104,19 @@ export const useTable = <
     [fieldSelectionMap, metadata?.fields, options]
   );
 
-  const columns: TableColumn[] = useMemo(() => {
-    const columnsMap =
-      options?.columns &&
-      new Map(
-        options.columns.map((column) => {
-          if (isRelatedFieldColumn(column)) {
-            return [column.field, column.relatedField];
-          } else {
-            return [column, undefined];
-          }
-        })
-      );
-
-    const result: TableColumn[] = fields.map((field) => {
-      let relatedField: RecordTableColumnValue | undefined;
-      const relatedFieldColumn = columnsMap?.get(field.apiIdentifier);
-
-      if (relatedFieldColumn) {
-        if (
-          field.fieldType !== GadgetFieldType.HasOne &&
-          field.fieldType !== GadgetFieldType.BelongsTo &&
-          field.fieldType !== GadgetFieldType.HasMany
-        ) {
-          throw new Error(`Field '${field.apiIdentifier}' is not a relationship field`);
-        }
-
-        const relatedFieldMetadata =
-          field.configuration.__typename === "GadgetHasOneConfig" ||
-          field.configuration.__typename === "GadgetBelongsToConfig" ||
-          field.configuration.__typename === "GadgetHasManyConfig"
-            ? field.configuration.relatedModel?.fields?.find((relatedField) => relatedField.apiIdentifier === relatedFieldColumn)
-            : undefined;
-
-        if (!relatedFieldMetadata) {
-          throw new Error(`Related field '${relatedFieldColumn}' not found in metadata`);
-        }
-
-        relatedField = {
-          name: relatedFieldMetadata.name,
-          apiIdentifier: relatedFieldMetadata.apiIdentifier,
-          fieldType: relatedFieldMetadata.fieldType,
-          getValue: (record: GadgetRecord<any>) => {
-            return record[field.apiIdentifier]?.[relatedFieldMetadata.apiIdentifier];
-          },
-          isCustomCell: false,
-          sortable: false,
-        } satisfies RecordTableColumnValue;
-      }
-
-      return {
-        name: field.name,
-        apiIdentifier: field.apiIdentifier,
-        fieldType: field.fieldType,
-        getValue: (record: GadgetRecord<any>) => {
-          return record[field.apiIdentifier];
-        },
-        sortable: "sortable" in field && field.sortable,
-        relatedField,
-        isCustomCell: false,
-      } satisfies RecordTableColumnValue;
-    });
-
-    if (options?.columns) {
-      // Add custom cell columns
-      for (const custom of options.columns) {
-        if (!isCustomCellColumn(custom)) continue;
-        result.push({
-          name: custom.name,
-          apiIdentifier: custom.name,
-          isCustomCell: true,
-          getValue: (record: GadgetRecord<any>) => custom.render(record),
-          sortable: false,
-        });
-      }
-    }
-
-    return result;
+  const columns = useMemo(() => {
+    return getTableColumns(fields, options?.columns);
   }, [fields, options?.columns]);
 
   const isAwaitingDebouncedSearchValue = search.value != search.debouncedValue;
   const fetching = dataFetching || fetchingMetadata || isAwaitingDebouncedSearchValue;
   const error = dataError || metadataError;
 
+  const tableData = useMemo(() => getTableData({ metadata, data, columns }), [metadata, data, columns]);
+
   return [
     {
-      ...getTableData({ metadata, data, columns }),
+      ...tableData,
       page,
       fetching,
       error,
@@ -263,35 +124,4 @@ export const useTable = <
     },
     refresh,
   ];
-};
-
-const getTableData = (props: { columns?: TableColumn[]; data?: GadgetRecord<any>[]; metadata?: ModelMetadata }) => {
-  const { columns, data, metadata } = props;
-
-  return metadata && data && columns
-    ? {
-        rows: getRows({ data, columns }),
-        columns,
-        data,
-        metadata,
-      }
-    : {
-        rows: null,
-        columns: null,
-
-        data: null,
-        metadata: null,
-      };
-};
-
-const getRows = (props: { data: GadgetRecord<any>[]; columns: TableColumn[] }) => {
-  const { columns, data } = props;
-
-  return data.map((record) => {
-    const row: TableRow = { id: record.id };
-    for (const { apiIdentifier, getValue } of columns) {
-      row[apiIdentifier] = getValue(record);
-    }
-    return row;
-  });
 };

--- a/packages/react/src/useTableUtils/helpers.ts
+++ b/packages/react/src/useTableUtils/helpers.ts
@@ -1,0 +1,138 @@
+import type { GadgetRecord } from "@gadgetinc/api-client-core";
+import type { FieldMetadataFragment } from "../internal/gql/graphql.js";
+import { GadgetFieldType } from "../internal/gql/graphql.js";
+import type { ModelMetadata } from "../metadata.js";
+import { isCustomCellColumn, isRelatedFieldColumn } from "../utils.js";
+import type { RecordTableColumnValue, TableColumn, TableOptions, TableRow } from "./types.js";
+
+export const getTableData = (props: { columns?: TableColumn[]; data?: GadgetRecord<any>[]; metadata?: ModelMetadata }) => {
+  const { columns, data, metadata } = props;
+
+  return metadata && data && columns
+    ? {
+        rows: getTableRows({ data, columns }),
+        columns,
+        data,
+        metadata,
+      }
+    : {
+        rows: null,
+        columns: null,
+
+        data: null,
+        metadata: null,
+      };
+};
+
+export const getTableRows = (props: { data: GadgetRecord<any>[]; columns: TableColumn[] }) => {
+  const { columns, data } = props;
+
+  return data.map((record) => {
+    const row: TableRow = { id: record.id };
+    for (const { apiIdentifier, getValue } of columns) {
+      row[apiIdentifier] = getValue(record);
+    }
+    return row;
+  });
+};
+
+export const getTableColumns = (fields: FieldMetadataFragment[], columns: TableOptions["columns"]) => {
+  const columnsMap = columns && getColumnsMap(columns);
+
+  const result: TableColumn[] = fields.map((field) => {
+    let relatedField: RecordTableColumnValue | undefined;
+    const relatedFieldColumn = columnsMap?.get(field.apiIdentifier);
+
+    if (relatedFieldColumn) {
+      relatedField = getRelatedFieldTableColumn(field, relatedFieldColumn);
+    }
+
+    return {
+      name: field.name,
+      apiIdentifier: field.apiIdentifier,
+      fieldType: field.fieldType,
+      getValue: (record: GadgetRecord<any>) => {
+        return record[field.apiIdentifier];
+      },
+      sortable: "sortable" in field && field.sortable,
+      relatedField,
+      isCustomCell: false,
+    } satisfies RecordTableColumnValue;
+  });
+
+  if (columns) {
+    // Add custom cell columns
+    for (const column of columns) {
+      if (!isCustomCellColumn(column)) continue;
+      result.push({
+        name: column.name,
+        apiIdentifier: column.name,
+        isCustomCell: true,
+        getValue: (record: GadgetRecord<any>) => column.render(record),
+        sortable: false,
+      });
+    }
+
+    // Sort columns based on the order in the options
+    const sortingColumnList = columns.map((column) => {
+      if (isRelatedFieldColumn(column)) {
+        return column.field;
+      }
+
+      if (isCustomCellColumn(column)) {
+        return column.name;
+      }
+
+      return column;
+    });
+    result.sort((a, b) => {
+      return sortingColumnList.indexOf(a.apiIdentifier) - sortingColumnList.indexOf(b.apiIdentifier);
+    });
+  }
+
+  return result;
+};
+
+const getColumnsMap = (columns: Exclude<TableOptions["columns"], undefined>) => {
+  return new Map(
+    columns.map((column) => {
+      if (isRelatedFieldColumn(column)) {
+        return [column.field, column.relatedField];
+      } else {
+        return [column, undefined];
+      }
+    })
+  );
+};
+
+const getRelatedFieldTableColumn = (field: FieldMetadataFragment, relatedFieldColumn: string): RecordTableColumnValue => {
+  if (
+    field.fieldType !== GadgetFieldType.HasOne &&
+    field.fieldType !== GadgetFieldType.BelongsTo &&
+    field.fieldType !== GadgetFieldType.HasMany
+  ) {
+    throw new Error(`Field '${field.apiIdentifier}' is not a relationship field`);
+  }
+
+  const relatedFieldMetadata =
+    field.configuration.__typename === "GadgetHasOneConfig" ||
+    field.configuration.__typename === "GadgetBelongsToConfig" ||
+    field.configuration.__typename === "GadgetHasManyConfig"
+      ? field.configuration.relatedModel?.fields?.find((relatedField) => relatedField.apiIdentifier === relatedFieldColumn)
+      : undefined;
+
+  if (!relatedFieldMetadata) {
+    throw new Error(`Related field '${relatedFieldColumn}' not found in metadata`);
+  }
+
+  return {
+    name: relatedFieldMetadata.name,
+    apiIdentifier: relatedFieldMetadata.apiIdentifier,
+    fieldType: relatedFieldMetadata.fieldType,
+    getValue: (record: GadgetRecord<any>) => {
+      return record[field.apiIdentifier]?.[relatedFieldMetadata.apiIdentifier];
+    },
+    isCustomCell: false,
+    sortable: false,
+  };
+};

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -1,0 +1,62 @@
+import type { GadgetRecord } from "@gadgetinc/api-client-core";
+import type { OperationContext } from "@urql/core";
+import type { ReactNode } from "react";
+import type { GadgetFieldType } from "../internal/gql/graphql.js";
+import type { ModelMetadata } from "../metadata.js";
+import type { SearchResult } from "../useDebouncedSearch.js";
+import type { PaginationResult } from "../useList.js";
+import type { ColumnValueType, CustomCellColumn, ErrorWrapper, RelatedFieldColumn } from "../utils.js";
+
+type BaseTableColumn = {
+  name: string;
+  apiIdentifier: string;
+};
+
+export type RecordTableColumnValue = BaseTableColumn & {
+  fieldType: GadgetFieldType;
+  sortable: boolean;
+  relatedField?: RecordTableColumnValue;
+  getValue: (record: GadgetRecord<any>) => ColumnValueType;
+  isCustomCell: false;
+};
+
+export type CustomTableColumnValue = BaseTableColumn & {
+  getValue: (record: GadgetRecord<any>) => ReactNode;
+  isCustomCell: true;
+  sortable: false;
+};
+
+export type TableColumn = RecordTableColumnValue | CustomTableColumnValue;
+
+export type TableRow = Record<string, ColumnValueType | ReactNode>;
+
+export interface TableOptions {
+  pageSize?: number;
+  initialCursor?: string;
+  initialDirection?: "forward" | "backward";
+  columns?: (string | RelatedFieldColumn | CustomCellColumn)[];
+}
+
+export type TableData<Data> =
+  | {
+      columns: TableColumn[];
+      rows: TableRow[];
+      data: Data;
+      metadata: ModelMetadata;
+    }
+  | {
+      columns: null;
+      rows: null;
+      data: null;
+      metadata: null;
+    };
+
+export type TableResult<Data> = [
+  TableData<Data> & {
+    page: PaginationResult;
+    fetching: boolean;
+    error?: ErrorWrapper;
+    search: SearchResult;
+  },
+  refresh: (opts?: Partial<OperationContext>) => void
+];

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -8,12 +8,14 @@ import type {
   EnqueueBackgroundActionOptions,
   FieldSelection,
   GadgetError,
+  GadgetRecord,
   InvalidFieldError,
   InvalidRecordError,
 } from "@gadgetinc/api-client-core";
 import { gadgetErrorFor, getNonNullableError, namespaceDataPath } from "@gadgetinc/api-client-core";
 import type { CombinedError, RequestPolicy } from "@urql/core";
-import { RefCallback, RefObject, useMemo } from "react";
+import type { ReactNode, RefCallback, RefObject } from "react";
+import { useMemo } from "react";
 import type { AnyVariables, Operation, OperationContext, UseQueryArgs, UseQueryState } from "urql";
 
 /**
@@ -548,6 +550,15 @@ export type RelatedFieldColumn = {
 
 export const isRelatedFieldColumn = (value: any): value is RelatedFieldColumn => {
   return typeof value === "object" && value !== null && "field" in value && "relatedField" in value;
+};
+
+export type CustomCellColumn = {
+  name: string;
+  render: (record: GadgetRecord<any>) => ReactNode;
+};
+
+export const isCustomCellColumn = (value: any): value is CustomCellColumn => {
+  return typeof value === "object" && value !== null && "name" in value && "render" in value;
 };
 
 /**


### PR DESCRIPTION
This PR adds support for having custom cell renderers in the `columns` property. By passing in an object like this:
```jsx
{
  name: "some custom stuff",
  render: (record) => <div>{record.name}</div>
}
```
it will render the column using the `render` function included in the object instead of using the default cell renderers.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
