### PR TITLE
Introduce `onFailure` callback in AutoForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.498.0-development.1525",
+    "@gadget-client/js-clients-test": "1.498.0-development.1683",
     "@gadget-client/kitchen-sink": "1.5.0-development.200",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -64,6 +64,26 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
       });
   });
 
+  it("onFailure callback should return an error if the form submission fails", () => {
+    const onFailureSpy = cy.spy().as("onFailureSpy");
+    cy.mountWithWrapper(<AutoForm action={api.widget.alwaysThrowError} exclude={["gizmos"]} onFailure={onFailureSpy} />, wrapper);
+
+    cy.get(`input[name="widget.name"]`).type("test record");
+    cy.get(`input[name="widget.inventoryCount"]`).type("999");
+
+    cy.getSubmitButton().click();
+
+    cy.contains(`Saved Widget successfully`).should("not.exist");
+
+    // eslint-disable-next-line jest/valid-expect-in-promise
+    cy.get("@onFailureSpy")
+      .should("have.been.called")
+      .then(() => {
+        const error = onFailureSpy.getCalls()[0].args[0];
+        expect(error.message).to.equal("[GraphQL] GGT_UNKNOWN: something goes wrong");
+      });
+  });
+
   it("should show an error banner and not render a form when it fails to fetch metadata", () => {
     cy.intercept(
       {

--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -100,3 +100,27 @@ export const GlobalAction = {
     action: api.flipAll,
   },
 };
+
+export const onSuccessCallback = {
+  name: "onSuccess callback",
+  args: {
+    action: api.widget.create,
+    onSuccess: (record) => {
+      // eslint-disable-next-line no-undef
+      window.alert(`Record created: ${JSON.stringify(record, null, 2)}`);
+    },
+  },
+};
+
+export const onFailureCallback = {
+  name: "onFailure callback",
+  args: {
+    action: api.widget.alwaysThrowError,
+    onFailure: (error) => {
+      // eslint-disable-next-line no-undef
+      window.alert(`Error: ${error.message} (see console for details)`);
+      // eslint-disable-next-line no-undef
+      console.error(error);
+    },
+  },
+};

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -6,7 +6,7 @@ import type { AnyActionWithId, RecordIdentifier, UseActionFormHookStateData } fr
 import type { GadgetObjectFieldConfig } from "../internal/gql/graphql.js";
 import type { ActionMetadata, FieldMetadata, GlobalActionMetadata } from "../metadata.js";
 import { FieldType, filterAutoFormFieldList, isActionMetadata, useActionMetadata } from "../metadata.js";
-import type { FieldValues } from "../useActionForm.js";
+import type { FieldErrors, FieldValues } from "../useActionForm.js";
 import { useActionForm } from "../useActionForm.js";
 import { get, type OptionsType } from "../utils.js";
 import { validationSchema } from "../validationSchema.js";
@@ -35,6 +35,8 @@ export type AutoFormProps<
   successContent?: ReactNode;
   /** Called when the form submission completes successfully on the backend */
   onSuccess?: (record: UseActionFormHookStateData<ActionFunc>) => void;
+  /** Called when the form submission errors before sending, during the API call, or if the API call returns an error. */
+  onFailure?: (error: Error | FieldErrors<ActionFunc["variablesType"]>) => void;
 } & (ActionFunc extends AnyActionWithId<GivenOptions>
   ? {
       /**
@@ -109,7 +111,7 @@ export const useAutoForm = <
 >(
   props: AutoFormProps<GivenOptions, SchemaT, ActionFunc, any, any>
 ) => {
-  const { action, record, onSuccess } = props;
+  const { action, record, onSuccess, onFailure } = props;
 
   if (action.isBulk) {
     throw new Error("Bulk actions are not supported in AutoForms");
@@ -167,6 +169,7 @@ export const useAutoForm = <
       return fieldsToSend;
     },
     onSuccess,
+    onError: onFailure,
   });
 
   // we don't have synchronous access to the default values always -- sometimes we need to load them from the metadata. if we do that, then we need to forcibly set them into the form state once they have been loaded

--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -8,7 +8,7 @@ import { useAutoForm, type AutoFormProps } from "../AutoForm.js";
 import { AutoFormMetadataContext } from "../AutoFormContext.js";
 import { MUIAutoInput } from "./inputs/MUIAutoInput.js";
 import { MUIAutoSubmit } from "./submit/MUIAutoSubmit.js";
-import { MUISubmitErrorBanner, MUISubmitResultBanner } from "./submit/MUISubmitResultBanner.js";
+import { MUISubmitErrorBanner, MUISubmitSuccessfulBanner } from "./submit/MUISubmitResultBanner.js";
 
 export const MUIFormSkeleton = () => (
   <>
@@ -74,7 +74,8 @@ export const MUIAutoFormComponent = <
   const formContent = props.children ?? (
     <>
       <Typography variant="h5">{humanizedOperationName}</Typography>
-      {!props.onSuccess ? <MUISubmitResultBanner /> : <MUISubmitErrorBanner />}
+      {!props.onSuccess && <MUISubmitSuccessfulBanner />}
+      {!props.onFailure && <MUISubmitErrorBanner />}
       {fetchingMetadata && <MUIFormSkeleton />}
       {!metadataError && (
         <>

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -9,7 +9,7 @@ import { useAutoForm } from "../AutoForm.js";
 import { AutoFormMetadataContext } from "../AutoFormContext.js";
 import { PolarisAutoInput } from "./inputs/PolarisAutoInput.js";
 import { PolarisAutoSubmit } from "./submit/PolarisAutoSubmit.js";
-import { PolarisSubmitErrorBanner, PolarisSubmitResultBanner } from "./submit/PolarisSubmitResultBanner.js";
+import { PolarisSubmitErrorBanner, PolarisSubmitSuccessfulBanner } from "./submit/PolarisSubmitResultBanner.js";
 
 export const PolarisFormSkeleton = () => (
   <>
@@ -94,7 +94,8 @@ const PolarisAutoFormComponent = <
       <Text variant="headingLg" as="h5">
         {humanizedOperationName}
       </Text>
-      {!props.onSuccess ? <PolarisSubmitResultBanner /> : <PolarisSubmitErrorBanner />}
+      {!props.onSuccess && <PolarisSubmitSuccessfulBanner />}
+      {!props.onFailure && <PolarisSubmitErrorBanner />}
       {!metadataError && (
         <>
           {fields.map(({ metadata }) => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.498.0-development.1525
-        version: 1.498.0-development.1525
+        specifier: 1.498.0-development.1683
+        version: 1.498.0-development.1683
       '@gadget-client/kitchen-sink':
         specifier: 1.5.0-development.200
         version: 1.5.0-development.200
@@ -3719,8 +3719,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.498.0-development.1525:
-    resolution: {integrity: sha1-m2ceXE0cf87faLV4bJmr6ZwekAE=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8616}
+  /@gadget-client/js-clients-test@1.498.0-development.1683:
+    resolution: {integrity: sha1-frz+5P6w2nBj/fbSruCv+p47TS8=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8656}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
This PR introduces an `onFailure` callback in the `<AutoForm />` component. We already have a similar callback called `onError` in our `useActionForm` so we only need to expose it as part of the available property in the React component.

The default banner will not be shown when the `onFailure` callback exists, so people can override the behaviour.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
