### PR TITLE
Added error for custom params colliding with model fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.498.0-development.1683",
+    "@gadget-client/js-clients-test": "1.498.0-development.1694",
     "@gadget-client/kitchen-sink": "1.5.0-development.200",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -124,3 +124,9 @@ export const onFailureCallback = {
     },
   },
 };
+export const FieldNameCustomParamCollisionError = {
+  args: {
+    findBy: "1",
+    action: api.autoTableTest.updateWithCustomParams,
+  },
+};

--- a/packages/react/spec/auto/hooks/useFormFields.spec.tsx
+++ b/packages/react/spec/auto/hooks/useFormFields.spec.tsx
@@ -71,6 +71,14 @@ describe("useFormFields hook", () => {
       })
     ).toThrowErrorMatchingInlineSnapshot(`"Cannot include and exclude the same field"`);
   });
+
+  test("Has an error when the metadata has duplicate input field api identifiers", () => {
+    expect(() => {
+      renderHook(() => useFormFields(autoFormMetadataWithDuplicateInputFields as any, {}), {
+        wrapper: MockForm({ submit: jest.fn<any>(), metadata }),
+      });
+    }).toThrowErrorMatchingInlineSnapshot(`"Input "str" is not unique for action "updateWithCustomParams""`);
+  });
 });
 
 const metadata: ActionMetadata = {
@@ -191,3 +199,72 @@ const metadata: ActionMetadata = {
   },
   __typename: "GadgetModel",
 } as ActionMetadata;
+
+const autoFormMetadataWithDuplicateInputFields = {
+  name: "Auto table test",
+  apiIdentifier: "autoTableTest",
+  defaultRecord: { str: "awd", __typename: "AutoTableTest" },
+  action: {
+    name: "Update with custom params",
+    apiIdentifier: "updateWithCustomParams",
+    operatesWithRecordIdentity: true,
+    isDeleteAction: false,
+    inputFields: [
+      {
+        name: "Auto table test",
+        apiIdentifier: "autoTableTest",
+        fieldType: "Object",
+        requiredArgumentForInput: false,
+        configuration: {
+          __typename: "GadgetObjectFieldConfig",
+          fieldType: "Object",
+          validations: [],
+          name: null,
+          fields: [
+            {
+              name: "Str",
+              apiIdentifier: "str",
+              fieldType: "String",
+              requiredArgumentForInput: false,
+              sortable: true,
+              filterable: true,
+              __typename: "GadgetModelField",
+              configuration: {
+                __typename: "GadgetGenericFieldConfig",
+                fieldType: "String",
+                validations: [],
+              },
+            },
+          ],
+        },
+        __typename: "GadgetObjectField",
+      },
+      {
+        name: "Str",
+        apiIdentifier: "str",
+        fieldType: "String",
+        requiredArgumentForInput: false,
+        configuration: {
+          __typename: "GadgetGenericFieldConfig",
+          fieldType: "String",
+          validations: [],
+        },
+        __typename: "GadgetObjectField",
+      },
+      {
+        name: "Id",
+        apiIdentifier: "id",
+        fieldType: "ID",
+        requiredArgumentForInput: true,
+        configuration: {
+          __typename: "GadgetGenericFieldConfig",
+          fieldType: "ID",
+          validations: [],
+        },
+        __typename: "GadgetObjectField",
+      },
+    ],
+    __typename: "GadgetAction",
+  },
+  __typename: "GadgetModel",
+};

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -69,6 +69,7 @@ export const useFormFields = (
   return useMemo(() => {
     if (!metadata) return [];
     const action = isActionMetadata(metadata) ? metadata.action : metadata;
+
     const isModelMetadata = metadata.__typename === "GadgetModel";
 
     const objectFields = isModelMetadata
@@ -96,8 +97,25 @@ export const useFormFields = (
       )
     );
 
-    return [...includedObjectFields, ...includedRootLevelFields];
+    const allFormFields = [...includedObjectFields, ...includedRootLevelFields];
+    validateFormFieldApiIdentifierUniqueness(
+      action.apiIdentifier,
+      allFormFields.map(({ metadata }) => metadata.apiIdentifier)
+    );
+
+    return allFormFields;
   }, [metadata, options]);
+};
+
+const validateFormFieldApiIdentifierUniqueness = (actionApiIdentifier: string, inputApiIdentifiers: string[]) => {
+  const seen = new Set<string>();
+
+  for (const apiId of inputApiIdentifiers) {
+    if (seen.has(apiId)) {
+      throw new Error(`Input "${apiId}" is not unique for action "${actionApiIdentifier}"`);
+    }
+    seen.add(apiId);
+  }
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.498.0-development.1683
-        version: 1.498.0-development.1683
+        specifier: 1.498.0-development.1694
+        version: 1.498.0-development.1694
       '@gadget-client/kitchen-sink':
         specifier: 1.5.0-development.200
         version: 1.5.0-development.200
@@ -3719,8 +3719,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.498.0-development.1683:
-    resolution: {integrity: sha1-frz+5P6w2nBj/fbSruCv+p47TS8=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8656}
+  /@gadget-client/js-clients-test@1.498.0-development.1694:
+    resolution: {integrity: sha1-MpptDSRppuGJwpehKLfN9oPkqp8=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8672}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
- **UPDATE**
  - Added an error for custom params with api IDs that collide with model fields
  - Why make an error? 
    - `<AutoInput field={"fieldApiId} />` does a contextual api Id based lookup to through the action metadata to find out which one it should correspond to. 
      - To discriminate between a model field and an action custom param, we would need...
        - A: Another component property to ALL auto inputs that can collide with modelFIelds
        - B: Force the user to use path like `modelA.field`. 
      - More complexity for EVERYONE when this is a really rare use case
    - The automatic labeling is based on API id and would result in duplicately named inputs. Confusing
    - `include`/`exclude` would need some changes in order to discriminate between modelFields vs customParams
    - The way that useActionForm combines the existing record data with the input values to make a GQL request will need to be updated since pathing the custom param to the root and the modelField to `modelApiId.fieldApiId` conflicts with this system
  - Overall, having those collisions will be very rare, and preventing feels more correct than all of the required technical complexity to support it