### PR TITLE
Cypress test to ensure explicit sort is handled correctly

### DIFF
--- a/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
@@ -106,7 +106,7 @@ describe("AutoTable - Sort", () => {
   it("displays the default sorting direction when it is set explicitly", () => {
     mockModelMetadata();
     mockGetWidgetsWithAscendingSort();
-    cy.mountWithWrapper(<PolarisAutoTable model={api.widget} defaultSort={{ id: "Ascending" }} />, PolarisWrapper);
+    cy.mountWithWrapper(<PolarisAutoTable model={api.widget} initialSort={{ id: "Ascending" }} />, PolarisWrapper);
     cy.get("@getWidgetsWithAscendingSort")
       .its("request.body.variables")
       .should("deep.equal", {

--- a/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
@@ -64,7 +64,7 @@ describe("AutoTable - Sort", () => {
     ).as("getWidgetsWithAscendingSort");
   };
 
-  it("sorts ID in descending order", () => {
+  it("cycles through sorting directions when the column is selected", () => {
     mockModelMetadata();
     mockGetWidgets();
     cy.mountWithWrapper(<PolarisAutoTable model={api.widget} />, PolarisWrapper);
@@ -101,6 +101,20 @@ describe("AutoTable - Sort", () => {
     cy.get("@getWidgets").its("request.body.variables").should("deep.equal", {
       first: 50,
     });
+  });
+
+  it("displays the default sorting direction when it is set explicitly", () => {
+    mockModelMetadata();
+    mockGetWidgetsWithAscendingSort();
+    cy.mountWithWrapper(<PolarisAutoTable model={api.widget} sort={{ id: "Ascending" }} />, PolarisWrapper);
+    cy.get("@getWidgetsWithAscendingSort")
+      .its("request.body.variables")
+      .should("deep.equal", {
+        first: 50,
+        sort: {
+          id: "Ascending",
+        },
+      });
   });
 });
 

--- a/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
@@ -106,7 +106,7 @@ describe("AutoTable - Sort", () => {
   it("displays the default sorting direction when it is set explicitly", () => {
     mockModelMetadata();
     mockGetWidgetsWithAscendingSort();
-    cy.mountWithWrapper(<PolarisAutoTable model={api.widget} sort={{ id: "Ascending" }} />, PolarisWrapper);
+    cy.mountWithWrapper(<PolarisAutoTable model={api.widget} defaultSort={{ id: "Ascending" }} />, PolarisWrapper);
     cy.get("@getWidgetsWithAscendingSort")
       .its("request.body.variables")
       .should("deep.equal", {

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -46,7 +46,6 @@ export default {
 export const Primary = {
   args: {
     model: api.autoTableTest,
-    initialSort: { id: "Descending" },
   },
 };
 

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -46,6 +46,7 @@ export default {
 export const Primary = {
   args: {
     model: api.autoTableTest,
+    initialSort: { id: "Descending" },
   },
 };
 

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -19,6 +19,6 @@ export type AutoTableProps<
   live?: boolean;
   columns?: TableOptions["columns"];
   onClick?: (row: TableRow) => void;
-  defaultSort?: Options["sort"];
+  initialSort?: Options["sort"];
   filter?: Options["filter"];
 };

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -19,6 +19,6 @@ export type AutoTableProps<
   live?: boolean;
   columns?: TableOptions["columns"];
   onClick?: (row: TableRow) => void;
-  sort?: Options["sort"];
+  defaultSort?: Options["sort"];
   filter?: Options["filter"];
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -83,14 +83,16 @@ export const PolarisAutoTable = <
     columns: props.columns,
     pageSize: props.pageSize,
     live: props.live,
-    sort: props.sort,
+    sort: props.defaultSort,
     filter: props.filter,
   } as any);
 
   const [sortColumnApiIdentifier, setSortColumnApiIdentifier] = useState<string | undefined>(
-    props.sort ? Object.keys(props.sort)[0] : undefined
+    props.defaultSort ? Object.keys(props.defaultSort)[0] : undefined
   );
-  const [sortDirection, setSortDirection] = useState<SortOrder | undefined>(props.sort ? Object.values(props.sort)[0] : undefined);
+  const [sortDirection, setSortDirection] = useState<SortOrder | undefined>(
+    props.defaultSort ? Object.values(props.defaultSort)[0] : undefined
+  );
 
   const handleColumnSort = (headingIndex: number) => {
     if (columns) {

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -83,15 +83,15 @@ export const PolarisAutoTable = <
     columns: props.columns,
     pageSize: props.pageSize,
     live: props.live,
-    sort: props.defaultSort,
+    sort: props.initialSort,
     filter: props.filter,
   } as any);
 
   const [sortColumnApiIdentifier, setSortColumnApiIdentifier] = useState<string | undefined>(
-    props.defaultSort ? Object.keys(props.defaultSort)[0] : undefined
+    props.initialSort ? Object.keys(props.initialSort)[0] : undefined
   );
   const [sortDirection, setSortDirection] = useState<SortOrder | undefined>(
-    props.defaultSort ? Object.values(props.defaultSort)[0] : undefined
+    props.initialSort ? Object.values(props.initialSort)[0] : undefined
   );
 
   const handleColumnSort = (headingIndex: number) => {


### PR DESCRIPTION
A test is missing from #534. It is added in this PR.

It ensures that when a sort prop is included in AutoTable, the correct column is sorted. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
