### PR TITLE
Export PolarisAutoTable component to index.ts file

### DIFF
--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -1,6 +1,7 @@
 export { PolarisAutoButton as AutoButton } from "./PolarisAutoButton.js";
 export * from "./PolarisAutoForm.js";
 export { PolarisAutoForm as AutoForm } from "./PolarisAutoForm.js";
+export { PolarisAutoTable as AutoTable } from "./PolarisAutoTable.js";
 export { PolarisAutoBooleanInput as AutoBooleanInput } from "./inputs/PolarisAutoBooleanInput.js";
 export { PolarisAutoDateTimePicker as DateTimePicker } from "./inputs/PolarisAutoDateTimePicker.js";
 export { PolarisAutoEncryptedStringInput as AutoEncryptedStringInput } from "./inputs/PolarisAutoEncryptedStringInput.js";


### PR DESCRIPTION
As the title suggested, this PR exports the `PolarisAutoTable` component as `AutoTable` in `polaris/index.ts`.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
