### PR TITLE
Fix dynamic model changes in autoTables

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -48,6 +48,11 @@ export const Primary = {
     model: api.autoTableTest,
   },
 };
+export const Namespaced = {
+  args: {
+    model: api.game.city,
+  },
+};
 
 export const SelectFields = {
   args: {

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -71,6 +71,20 @@ export const PolarisAutoTable = <
 >(
   props: AutoTableProps<GivenOptions, SchemaT, FinderFunction, Options>
 ) => {
+  const { model } = props;
+  const componentKey = `${[model.findMany.namespace, model.findMany.modelApiIdentifier].join("_")}AutoTable`;
+
+  return <PolarisAutoTableComponent key={componentKey} {...props} />;
+};
+
+const PolarisAutoTableComponent = <
+  GivenOptions extends OptionsType,
+  SchemaT,
+  FinderFunction extends FindManyFunction<GivenOptions, any, SchemaT, any>,
+  Options extends FinderFunction["optionsType"]
+>(
+  props: AutoTableProps<GivenOptions, SchemaT, FinderFunction, Options>
+) => {
   const { onClick } = props;
 
   const [{ rows, columns, metadata, fetching, error, page, search, sort, selection }, refresh] = useTable<


### PR DESCRIPTION
- **UPDATE**
  - Similar to the AutoForm, dynamically changing the input model would cause errors since some of the memoized stuff would still be associated with the old model
  - Updated such that dynamically changing the model will completely re-render the whole table 👍 
  - This was done in the same way as the form where a wrapper passing in a key surrounds the whole component content