### PR TITLE
Fix autoform banner closability

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -45,6 +45,10 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     // Ensure that the form is cleared after submitting the create action
     cy.get(`input[name="widget.name"]`).should("have.value", "");
     cy.get(`input[name="widget.inventoryCount"]`).should("have.value", "");
+
+    // Ensure that the success banner can be closed
+    cy.get(`button[aria-label="Dismiss notification"]`).click();
+    cy.contains(`Saved Widget successfully`).should("not.exist");
   });
 
   it("onSuccess callback should return a record result after the form submission", () => {

--- a/packages/react/src/auto/mui/submit/MUISubmitResultBanner.tsx
+++ b/packages/react/src/auto/mui/submit/MUISubmitResultBanner.tsx
@@ -3,17 +3,6 @@ import { Alert, Button } from "@mui/material";
 import React from "react";
 import { useResultBannerController } from "../../hooks/useResultBannerController.js";
 
-const MUIBaseSubmitResultBanner = (props: AlertProps) => {
-  const { hide, successful, title } = useResultBannerController();
-
-  return (
-    <Alert severity={successful ? "success" : "error"} {...props}>
-      {title}
-      <Button onClick={hide}>X</Button>
-    </Alert>
-  );
-};
-
 export const MUISubmitResultBanner = (props: { successBannerProps?: AlertProps; errorBannerProps?: AlertProps }) => {
   return (
     <>
@@ -24,11 +13,37 @@ export const MUISubmitResultBanner = (props: { successBannerProps?: AlertProps; 
 };
 
 export const MUISubmitSuccessfulBanner = (props: AlertProps) => {
-  const { show, successful } = useResultBannerController();
-  return show && successful ? <MUIBaseSubmitResultBanner {...props} /> : null;
+  const { show, successful, title, hide } = useResultBannerController();
+  if (!show || !successful) {
+    return null;
+  }
+
+  return (
+    <Alert severity={"success"} {...props}>
+      {title}
+      <CloseBannerButton onClick={hide} />
+    </Alert>
+  );
 };
 
 export const MUISubmitErrorBanner = (props: AlertProps) => {
-  const { show, successful } = useResultBannerController();
-  return show && !successful ? <MUIBaseSubmitResultBanner {...props} /> : null;
+  const { show, successful, title, hide } = useResultBannerController();
+  if (!show || successful) {
+    return null;
+  }
+
+  return (
+    <Alert severity={"error"} {...props}>
+      {title}
+      <CloseBannerButton onClick={hide} />
+    </Alert>
+  );
+};
+
+const CloseBannerButton = (props: { onClick: () => void }) => {
+  return (
+    <Button onClick={props.onClick} aria-label="Dismiss notification">
+      X
+    </Button>
+  );
 };

--- a/packages/react/src/auto/polaris/submit/PolarisSubmitResultBanner.tsx
+++ b/packages/react/src/auto/polaris/submit/PolarisSubmitResultBanner.tsx
@@ -3,22 +3,6 @@ import { Banner } from "@shopify/polaris";
 import React from "react";
 import { useResultBannerController } from "../../hooks/useResultBannerController.js";
 
-const PolarisBaseSubmitResultBanner = (props: BannerProps) => {
-  const { hide, successful, title } = useResultBannerController();
-
-  return (
-    <Banner
-      title={title}
-      tone={successful ? "success" : "critical"}
-      {...props}
-      onDismiss={() => {
-        hide();
-        props?.onDismiss?.();
-      }}
-    />
-  );
-};
-
 export const PolarisSubmitResultBanner = (props: { successBannerProps?: BannerProps; errorBannerProps?: BannerProps }) => {
   return (
     <>
@@ -29,11 +13,17 @@ export const PolarisSubmitResultBanner = (props: { successBannerProps?: BannerPr
 };
 
 export const PolarisSubmitSuccessfulBanner = (props: BannerProps) => {
-  const { show, successful } = useResultBannerController();
-  return show && successful ? <PolarisBaseSubmitResultBanner {...props} /> : null;
+  const { show, hide, successful, ...rest } = useResultBannerController();
+  if (!show || !successful) {
+    return null;
+  }
+  return <Banner tone="success" onDismiss={hide} {...rest} {...props} />;
 };
 
 export const PolarisSubmitErrorBanner = (props: BannerProps) => {
-  const { show, successful } = useResultBannerController();
-  return show && !successful ? <PolarisBaseSubmitResultBanner {...props} /> : null;
+  const { show, hide, successful, ...rest } = useResultBannerController();
+  if (!show || successful) {
+    return null;
+  }
+  return <Banner tone="critical" onDismiss={hide} {...rest} {...props} />;
 };


### PR DESCRIPTION
- **UPDATE**
  - It was previously impossible to close submission result banners for autoforms
  - This was because of different instances of the same hook being used in the base banner component
  - Updated to ensure that each banner only uses one hook
  - Added test to ensure that the banners are closable