### PR TITLE
fix(autoform): dynamically import mdx module to prevent vite bundling…

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -291,7 +291,7 @@ describe("PolarisAutoForm", () => {
         category: [],
         color: null,
         description: {
-          markdown: "example *rich* **text**",
+          markdown: "example _rich_ **text**",
         },
         embedding: null,
         inventoryCount: 1234,

--- a/packages/react/spec/imports/example-vite-project/package.json
+++ b/packages/react/spec/imports/example-vite-project/package.json
@@ -9,10 +9,9 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^5.3.4",
+    "vite": "4.4.9",
     "@shopify/polaris": "^13.8.0",
-    "@shopify/polaris-icons": "^9.3.0",
-    "@mdxeditor/editor": "^3.10.0"
+    "@shopify/polaris-icons": "^9.3.0"
   }
 }
 

--- a/packages/react/src/auto/shared/AutoRichTextInput.tsx
+++ b/packages/react/src/auto/shared/AutoRichTextInput.tsx
@@ -1,49 +1,73 @@
-import {
-  BlockTypeSelect,
-  BoldItalicUnderlineToggles,
-  CodeToggle,
-  CreateLink,
-  DiffSourceToggleWrapper,
-  ListsToggle,
-  MDXEditor,
-  Separator,
-  UndoRedo,
-  diffSourcePlugin,
-  headingsPlugin,
-  linkDialogPlugin,
-  listsPlugin,
-  markdownShortcutPlugin,
-  quotePlugin,
-  thematicBreakPlugin,
-  toolbarPlugin,
-  type MDXEditorMethods,
-  type MDXEditorProps,
-} from "@mdxeditor/editor";
-import "@mdxeditor/editor/style.css";
 import type { ForwardedRef } from "react";
-import React, { useEffect, useRef } from "react";
-import { useFormContext, type Control } from "react-hook-form";
+import React, { useEffect, useRef, useState } from "react";
+import type { Control } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import { get } from "../../utils.js";
 import { useStringInputController } from "../hooks/useStringInputController.js";
 import { multiref } from "../hooks/utils.js";
 
-export default function AutoRichTextInput(
-  props: {
-    field: string;
-    control?: Control<any>;
-    editorRef?: ForwardedRef<MDXEditorMethods> | null;
-  } & Omit<MDXEditorProps, "markdown" | "onChange">
-) {
+interface MDXEditorMethods {
+  setMarkdown: (markdown: string) => void;
+}
+
+interface AutoRichTextInputProps {
+  field: string;
+  control?: Control<any>;
+  editorRef?: ForwardedRef<MDXEditorMethods> | null;
+}
+
+const AutoRichTextInput: React.FC<AutoRichTextInputProps> = (props) => {
   const { formState } = useFormContext();
   const { field, control, editorRef, ...rest } = props;
   const controller = useStringInputController({ field, control });
   const innerRef = useRef<MDXEditorMethods>(null);
+  const [isEditorLoaded, setIsEditorLoaded] = useState(false);
+  const [mdxModule, setMdxModule] = useState<any>(null);
 
   useEffect(() => {
-    if (innerRef.current) {
+    const loadEditor = async () => {
+      try {
+        const module = await import("@mdxeditor/editor");
+        await import("@mdxeditor/editor/style.css");
+        setMdxModule(module);
+        setIsEditorLoaded(true);
+      } catch (error) {
+        console.warn("Optional dependency not found, some features may not be available.");
+      }
+    };
+
+    void loadEditor();
+  }, []);
+
+  useEffect(() => {
+    if (innerRef.current && isEditorLoaded) {
       innerRef.current.setMarkdown(controller.value?.markdown ?? "");
     }
-  }, [controller.value]);
+  }, [controller.value, isEditorLoaded]);
+
+  if (!isEditorLoaded || !mdxModule) {
+    return <div>Loading editor...</div>;
+  }
+
+  const {
+    MDXEditor,
+    BoldItalicUnderlineToggles,
+    ListsToggle,
+    CodeToggle,
+    CreateLink,
+    headingsPlugin,
+    listsPlugin,
+    quotePlugin,
+    thematicBreakPlugin,
+    markdownShortcutPlugin,
+    linkDialogPlugin,
+    diffSourcePlugin,
+    toolbarPlugin,
+    DiffSourceToggleWrapper,
+    UndoRedo,
+    BlockTypeSelect,
+    Separator,
+  } = mdxModule;
 
   return (
     <MDXEditor
@@ -75,9 +99,11 @@ export default function AutoRichTextInput(
       ]}
       contentEditableClassName="autoform-prose"
       markdown={controller.value?.markdown ?? ""}
-      onChange={(markdown) => controller.onChange({ markdown })}
+      onChange={(markdown: any) => controller.onChange({ markdown })}
       ref={multiref(innerRef, editorRef)}
       {...rest}
     />
   );
-}
+};
+
+export default AutoRichTextInput;

--- a/packages/react/src/type-extensions/css.d.ts
+++ b/packages/react/src/type-extensions/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";


### PR DESCRIPTION
In order to keep @mdxeditor/editor a true optional dependency, we need to dynamically import the module inside the react component. 

I don't think Vite was seeing the React.lazy load as a dynamic import, and was trying to bundle the dependency at build time. 

I also had to vendor the style.css from @mdxeditor/editor as I couldn't figure out a way to dynamically import the .css file

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
