### PR TITLE
Exported useList & useTable hooks

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -21,5 +21,7 @@ export { useGadgetMutation as useMutation } from "./useGadgetMutation.js";
 export { useGadgetQuery as useQuery } from "./useGadgetQuery.js";
 export * from "./useGet.js";
 export * from "./useGlobalAction.js";
+export * from "./useList.js";
 export * from "./useMaybeFindFirst.js";
 export * from "./useMaybeFindOne.js";
+export * from "./useTable.js";


### PR DESCRIPTION
The `useList` & `useTable` hooks were not exported by accident, this is a two-line change that exports these hooks so that users can use the headless versions of autocomponents. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
