### PR TITLE
fix(autotable): sorting after using pagination results in error due t…

### DIFF
--- a/packages/react/spec/useList.spec.ts
+++ b/packages/react/spec/useList.spec.ts
@@ -62,6 +62,22 @@ describe("useList", () => {
 
         expect(result.current[0].page.variables).toEqual({ first: 25, after: "endCursor" });
       });
+
+      test("changing the sort property will reset the cursor", async () => {
+        const { result, rerender } = renderHook((sort) => useList(manager, { pageSize: 25, sort }));
+
+        await act(async () => {
+          result.current[0].page.goToNextPage();
+        });
+
+        expect(result.current[0].page.variables).toEqual({ first: 25, after: "endCursor" });
+
+        //this is a weird api -- it takes a parameter that you pass to your original renderHook function
+        const sort = { name: "asc" };
+        rerender(sort);
+
+        expect(result.current[0].page.variables).toEqual({ after: undefined, first: 25 });
+      });
     });
 
     describe("when a data result has previous pages", () => {

--- a/packages/react/src/useList.ts
+++ b/packages/react/src/useList.ts
@@ -1,10 +1,11 @@
 import type { DefaultSelection, FindManyFunction, GadgetRecord, LimitToKnownKeys, Select } from "@gadgetinc/api-client-core";
 import type { OperationContext } from "@urql/core";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { SearchResult } from "./useDebouncedSearch.js";
 import { useDebouncedSearch } from "./useDebouncedSearch.js";
 import { useFindMany } from "./useFindMany.js";
-import { RecordSelection, useSelectedRecordsController } from "./useSelectedRecordsController.js";
+import type { RecordSelection } from "./useSelectedRecordsController.js";
+import { useSelectedRecordsController } from "./useSelectedRecordsController.js";
 import type { ErrorWrapper, OptionsType, ReadOperationOptions } from "./utils.js";
 import { omit } from "./utils.js";
 
@@ -55,6 +56,12 @@ export const useList = <
   const [cursor, setCursor] = useState<string | undefined>();
   const [direction, setDirection] = useState<"forward" | "backward">("forward");
   const clearCursor = useCallback(() => setCursor(undefined), []);
+
+  useMemo(() => {
+    clearCursor();
+    setDirection("forward");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options?.sort, clearCursor]);
 
   const { ...search } = useDebouncedSearch({
     onDebouncedSearchValueChange() {


### PR DESCRIPTION
If you paginate to a new page and then sort the column by a header, the query would throw an error because the cursor location wasn't necessarily valid anymore. 

I decided to fix this in useList, to make the logic: "if the sort option changes, reset the cursor tracking" so that we don't have to fix this bug again if we leverage useList in other places. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
