### PR TITLE
fix(autotable): enable tooltip on hover for string cells with truncat…

### DIFF
--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTextCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTextCell.tsx
@@ -1,13 +1,34 @@
-import { Text } from "@shopify/polaris";
-import React from "react";
+import { Tooltip } from "@shopify/polaris";
+import React, { useEffect, useRef, useState } from "react";
 
 export const PolarisAutoTableTextCell = (props: { value: any }) => {
   const { value } = props;
   const stringifiedValue = typeof value === "object" ? ("markdown" in value ? value.markdown : JSON.stringify(value)) : value;
 
-  return (
-    <Text as="span" truncate>
+  const [isOverflowed, setIsOverflow] = useState(false);
+  const textElementRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    setIsOverflow(!!textElementRef.current && textElementRef.current.scrollWidth > textElementRef.current.clientWidth);
+  }, []);
+
+  const polarisTextWithRef = (
+    <span className="Polaris-Text--root Polaris-Text--block Polaris-Text--truncate" ref={textElementRef}>
       {stringifiedValue}
-    </Text>
+    </span>
+  );
+
+  if (!isOverflowed) {
+    return polarisTextWithRef;
+  }
+
+  return (
+    <Tooltip
+      width="wide"
+      persistOnClick
+      content={<div style={{ maxHeight: "200px", overflow: "auto", pointerEvents: "auto" }}>{stringifiedValue}</div>}
+    >
+      {polarisTextWithRef}
+    </Tooltip>
   );
 };


### PR DESCRIPTION
Due to a few unfortunate limitations in polaris, it's quite hard to figure out if a <Text> element with `truncate` is displaying with an ellipsis or not. 

This method works but requires a ref on the element to detect if it has overflowed, so I essentially vendored the polaris classes into the text cell markup. 

I think the only other solution would be to take over truncation in js land, which raises some performance concerns for me. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
