### PR TITLE
Added custom bulk action callback and render system

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -73,8 +73,7 @@ export const onClickCallback = {
   args: {
     model: api.autoTableTest,
     onClick: (row) => {
-      // eslint-disable-next-line no-undef
-      window.alert(`You clicked on row: ${JSON.stringify(row, null, 2)}`);
+      windowAlert(`You clicked on row: ${JSON.stringify(row, null, 2)}`);
     },
   },
 };
@@ -200,8 +199,7 @@ const CustomDeleteButtonCellRenderer = (props) => {
 
   useEffect(() => {
     if (error) {
-      // eslint-disable-next-line no-undef
-      window.alert(`Error deleting record: ${error.message}`);
+      windowAlert(`Error deleting record: ${error.message}`);
     }
   }, [error]);
 
@@ -238,4 +236,49 @@ export const ExcludeColumns = {
     model: api.autoTableTest,
     excludeColumns: ["str", "enum", "num"],
   },
+};
+
+export const IncludedActionParameters = {
+  args: {
+    model: api.autoTableTest,
+    actions: [
+      "customAction",
+      {
+        label: "Sum Nums callback",
+        callback: (ids, records) => windowAlert(`Sum of record "num" values: ${sumRecordNumValues(records)}`),
+      },
+      {
+        label: "Sum Nums rendered",
+        render: (ids, records) => {
+          return (
+            <div>
+              <p>
+                {sumRecordNumValues(records)}
+                {` is the sum of the num field in records with ids: `}
+                {ids.join(", ")}
+              </p>
+              <button onClick={() => windowAlert(ids)}>Alert the IDs</button>
+              <button onClick={() => windowAlert(JSON.stringify(records))}>Alert the full records</button>
+            </div>
+          );
+        },
+      },
+    ],
+  },
+};
+
+export const ExcludedActionParameters = {
+  args: {
+    model: api.autoTableTest,
+    excludeActions: ["delete"],
+  },
+};
+
+const windowAlert = (message) => {
+  // eslint-disable-next-line no-undef
+  window.alert(message);
+};
+
+const sumRecordNumValues = (records) => {
+  return records.reduce((total, record) => total + (record.num ?? 0), 0);
 };

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -22,4 +22,6 @@ export type AutoTableProps<
   onClick?: (row: TableRow) => void;
   initialSort?: Options["sort"];
   filter?: Options["filter"];
+  actions?: TableOptions["actions"];
+  excludeActions?: TableOptions["excludeActions"];
 };

--- a/packages/react/src/auto/hooks/useTableBulkActions.tsx
+++ b/packages/react/src/auto/hooks/useTableBulkActions.tsx
@@ -1,36 +1,90 @@
 import React, { useMemo } from "react";
 import deepEqual from "react-fast-compare";
+import { ActionCallback, TableOptions } from "../../useTableUtils/types.js";
 import { humanizeCamelCase } from "../../utils.js";
 
-export const useTableBulkActions = (props: { model: any }) => {
-  const [selectedModelActionDetails, setSelectedModelActionDetails] = React.useState<ModelActionDetails | undefined>(undefined);
-  const allModelActionsDetails = getModelActionsForTable({ model: props.model });
+export type ModelActionDetails =
+  | {
+      isGadgetAction: true;
+      apiIdentifier: string;
+      isDeleter: boolean;
+      isBulk: boolean;
+      acceptsModelInput: boolean;
+      variables?: any;
+    }
+  | {
+      isGadgetAction: false;
+      apiIdentifier: string;
+      render?: (recordIds: string[], records: any[]) => React.ReactNode;
+    };
 
-  const bulkActionOptions = useMemo(() => {
-    return allModelActionsDetails
-      .filter(
-        (actionDetails) =>
-          // Only bulk actions that accept only IDs are currently supported
-          actionDetails.isBulk &&
-          !actionDetails.acceptsModelInput && // Accepting modelInput guarantees that the action accepts more than just IDs
-          deepEqual(actionDetails.variables, OnlyIdsAcceptedInputVariables)
-      )
-      .map((actionDetails) => ({
-        humanizedName: humanizeCamelCase(actionDetails.apiIdentifier),
-        selectModelAction: () => setSelectedModelActionDetails(actionDetails), // To open the corresponding modal
-      }));
-  }, [allModelActionsDetails]);
+export type BulkActionOption = {
+  humanizedName: string;
+  selectModelAction: () => void;
+  apiIdentifier: string;
+  callback?: (recordIds: string[], records: any[]) => any;
+};
+
+export const useTableBulkActions = (props: {
+  model: any;
+  actions: TableOptions["actions"];
+  excludeActions: TableOptions["excludeActions"];
+}) => {
+  const { model, actions, excludeActions } = props;
+
+  if (actions && excludeActions) {
+    throw new Error("Cannot have both actions and excludeActions in the same table");
+  }
+
+  const [selectedModelActionDetails, setSelectedModelActionDetails] = React.useState<ModelActionDetails | undefined>(undefined);
+  const gadgetModelActionsAsBulkActionOptions = getModelActionsForTableAsBulkActionOptions({ model, setSelectedModelActionDetails });
+
+  const bulkActionOptions: BulkActionOption[] = useMemo(() => {
+    if (excludeActions) {
+      return getValidateActionsWithExclude(excludeActions, gadgetModelActionsAsBulkActionOptions);
+    }
+
+    if (actions) {
+      return getValidatedIncludedActions(actions, gadgetModelActionsAsBulkActionOptions, setSelectedModelActionDetails);
+    }
+
+    return gadgetModelActionsAsBulkActionOptions; // Default - No `actions` or `excludeActions` provided
+  }, [gadgetModelActionsAsBulkActionOptions, actions, excludeActions]);
 
   return { selectedModelActionDetails, bulkActionOptions };
 };
 
-export type ModelActionDetails = {
-  apiIdentifier: string;
-  operationName: string;
-  isDeleter: boolean;
-  isBulk: boolean;
-  acceptsModelInput: boolean;
-  variables: any;
+/**
+ * Returns a list of BulkActionOption objects for given model
+ */
+const getModelActionsForTableAsBulkActionOptions = (props: {
+  model: any;
+  setSelectedModelActionDetails: (value: ModelActionDetails) => void;
+}) => {
+  const { model, setSelectedModelActionDetails } = props;
+  const allModelActionsDetails = getModelActionsForTable({ model });
+
+  return allModelActionsDetails
+    .filter(isBulkActionThatOnlyTakesIds) // Only bulk actions that accept only IDs are currently supported
+    .map((actionDetails) => ({
+      humanizedName: humanizeCamelCase(removeBulkPrefix(actionDetails.apiIdentifier)),
+      selectModelAction: () => setSelectedModelActionDetails(actionDetails), // To open the corresponding modal
+      apiIdentifier: lowercaseFirstChar(removeBulkPrefix(actionDetails.apiIdentifier)), // `bulk` prefix removed
+    }));
+};
+
+const isBulkActionThatOnlyTakesIds = (actionDetails: ModelActionDetails) =>
+  actionDetails.isGadgetAction &&
+  actionDetails.isBulk &&
+  !actionDetails.acceptsModelInput && // Accepting modelInput guarantees that the action accepts more than just IDs
+  deepEqual(actionDetails.variables, OnlyIdsAcceptedInputVariables);
+
+// Expected variables for supported bulk actions
+const OnlyIdsAcceptedInputVariables = {
+  ids: {
+    required: true,
+    type: "[GadgetID!]",
+  },
 };
 
 /**
@@ -47,22 +101,77 @@ const getModelActionsForTable = (props: { model: any }) => {
     }
   }
 
-  const funcMapper = (func: any): ModelActionDetails => ({
-    apiIdentifier: func.functionName,
-    operationName: func.operationName,
-    isDeleter: func.isDeleter,
-    isBulk: func.isBulk,
-    acceptsModelInput: func.acceptsModelInput,
-    variables: func.variables,
-  });
-
-  return modelActions.map(funcMapper);
+  return modelActions.map(
+    (func: any): ModelActionDetails => ({
+      apiIdentifier: func.functionName,
+      isDeleter: func.isDeleter,
+      isBulk: func.isBulk,
+      acceptsModelInput: func.acceptsModelInput,
+      variables: func.variables,
+      isGadgetAction: true,
+    })
+  );
 };
 
-// Expected variables for supported bulk actions
-const OnlyIdsAcceptedInputVariables = {
-  ids: {
-    required: true,
-    type: "[GadgetID!]",
-  },
+function getValidateActionsWithExclude(excludeActions: string[], gadgetModelActionsAsBulkActionOptions: BulkActionOption[]) {
+  for (const excludedAction of excludeActions) {
+    if (!gadgetModelActionsAsBulkActionOptions.find((action) => action.apiIdentifier === excludedAction)) {
+      throw new Error(`Excluded action '${excludedAction}' not found in model`);
+    }
+  }
+  return gadgetModelActionsAsBulkActionOptions.filter((action) => !excludeActions.includes(action.apiIdentifier));
+}
+
+function getValidatedIncludedActions(
+  actions: (string | ActionCallback)[],
+  gadgetModelActionsAsBulkActionOptions: BulkActionOption[],
+  setSelectedModelActionDetails: React.Dispatch<React.SetStateAction<ModelActionDetails | undefined>>
+) {
+  const bulkActions = [];
+  for (const action of actions) {
+    if (typeof action === "string") {
+      // Ensure that this is a real action name
+      const modelAction = gadgetModelActionsAsBulkActionOptions.find((actionOption) => actionOption.apiIdentifier === action);
+      if (!modelAction) {
+        throw new Error(`Action '${action}' not found in model`);
+      }
+      bulkActions.push(modelAction);
+    } else {
+      // Custom callback/renderer
+      validateCallbackXorRender(action);
+      const customCallbackModelActionDetails = {
+        isGadgetAction: false,
+        apiIdentifier: action.label,
+        render: "render" in action ? action.render ?? undefined : undefined,
+      } as const;
+      bulkActions.push({
+        humanizedName: action.label,
+        selectModelAction: () => setSelectedModelActionDetails(customCallbackModelActionDetails),
+        callback: "callback" in action ? action.callback ?? undefined : undefined,
+        apiIdentifier: action.label,
+      });
+    }
+  }
+  return bulkActions;
+}
+
+/**
+ * Ensures that the action has either a callback or a render, but not both
+ */
+const validateCallbackXorRender = (action: ActionCallback) => {
+  const label = action.label;
+
+  if ("callback" in action && "render" in action) {
+    throw new Error(`Cannot have both callback and render in action with label: "${label}"`);
+  }
+
+  if (!("callback" in action) && !("render" in action)) {
+    throw new Error(`Missing required property "callback" | "render" in action with label: "${label}"`);
+  }
+};
+
+const removeBulkPrefix = (actionName: string) => (actionName.startsWith("bulk") ? actionName.slice(4) : actionName);
+
+const lowercaseFirstChar = (input: string) => {
+  return input.length === 0 ? "" : `${input.charAt(0).toLowerCase()}${input.slice(1)}`;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -143,7 +143,11 @@ const PolarisAutoTableComponent = <
     return { headings, sortable };
   }, [columns]);
 
-  const { bulkActionOptions, selectedModelActionDetails } = useTableBulkActions({ model: props.model });
+  const { bulkActionOptions, selectedModelActionDetails } = useTableBulkActions({
+    model: props.model,
+    actions: props.actions,
+    excludeActions: props.excludeActions,
+  });
 
   if (!error && ((fetching && !rows) || !columns)) {
     return <PolarisSkeletonTable columns={3} />;
@@ -154,9 +158,16 @@ const PolarisAutoTableComponent = <
     plural: metadata ? pluralize(metadata.name) : "",
   };
 
+  const selectedRows = (rows ?? []).filter((row) => selection.recordIds.includes(row.id as string));
+
   return (
     <BlockStack>
-      <PolarisAutoBulkActionModal model={props.model} modelActionDetails={selectedModelActionDetails} ids={selection.recordIds} />
+      <PolarisAutoBulkActionModal
+        model={props.model}
+        modelActionDetails={selectedModelActionDetails}
+        ids={selection.recordIds}
+        selectedRows={selectedRows}
+      />
       <IndexFilters
         mode={mode}
         setMode={setMode}
@@ -185,7 +196,10 @@ const PolarisAutoTableComponent = <
         {...disablePaginatedSelectAllButton}
         onSelectionChange={selection.onSelectionChange}
         {...polarisTableProps}
-        bulkActions={bulkActionOptions.map((option) => ({ content: option.humanizedName, onAction: option.selectModelAction }))}
+        bulkActions={bulkActionOptions.map((option) => ({
+          content: option.humanizedName,
+          onAction: option.callback ? () => option.callback?.(selection.recordIds, selectedRows) : option.selectModelAction,
+        }))}
         resourceName={resourceName}
         emptyState={<EmptySearchResult title={`No ${resourceName.plural} yet`} description={""} withIllustration />}
         loading={fetching}

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -37,7 +37,16 @@ export interface TableOptions {
   initialDirection?: "forward" | "backward";
   columns?: (string | RelatedFieldColumn | CustomCellColumn)[];
   excludeColumns?: string[];
+  actions?: (string | ActionCallback)[];
+  excludeActions?: string[];
 }
+
+export type ActionCallback = {
+  label: string;
+} & (
+  | { callback: (recordIds: string[], records: GadgetRecord<any>[]) => any }
+  | { render: (recordIds: string[], records: GadgetRecord<any>[]) => ReactNode }
+);
 
 export type TableData<Data> =
   | {


### PR DESCRIPTION
- **UPDATE**
  - The bulk action system has been updated to allow for custom callbacks and renderers
    - Custom renderers
      - Similar to the cell renderer, the user can now pass in a React component returning function that takes in record IDs and the full records.
      - POTENTIAL USE CASES
        - Using IDs to power a useBulkAction or other Gadget hooks 
        - Taking the records and doing an operation on their values. Ex: Showing the sum of all records on a particular field
    - Custom callbacks 
      - Similar to the custom renderer, runs the given callback with the selectedIds and selectedRecords and then shows the result of the callback in the modal 
      - This could be useful so that users don't need to make a whole react component, but debatable if this is redundant with the custom renderer. 
  - An `excludeActions` property has been added to the AutoTable
    - Error if excluding an action that does not exist on the model so that renaming a model won't accidentally expose it
  - `bulk` is now removed from the labels for bulk actions since it was contextually obvious