### PR TITLE
Add a pre-render with mocked GQL responses to test to try to prevent the test stuck-in-suspense test flake

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -25,6 +25,12 @@ const PolarisMockedProviders = (props: { children: ReactNode }) => {
 describe("PolarisAutoForm", () => {
   describe("when used as a one liner", () => {
     describe("for widget create", () => {
+      test("it renders", async () => {
+        //  Render without expects because the first time using the mockUrqlClient can occasionally get stuck in a suspense, which will fail DOM checks
+        render(<PolarisAutoForm action={api.widget.create} />, { wrapper: PolarisMockedProviders });
+        loadMockWidgetCreateMetadata();
+      });
+
       test("it renders the name input", async () => {
         const { findByLabelText } = render(<PolarisAutoForm action={api.widget.create} />, { wrapper: PolarisMockedProviders });
         loadMockWidgetCreateMetadata();


### PR DESCRIPTION
- **UPDATE**
  - The test flake in `packages/react/spec/auto/PolarisAutoForm.spec.tsx` was is caused by getting stuck in a suspense's fallback
    - This only happens on the first test in the whole test suite that mocks a GQL response.
    - A simple render test has been added to absorb the the stuck-in-suspense situation, allowing us to proceed normally though all other tests

Otherwise...
![CleanShot 2024-07-29 at 17 38 56@2x](https://github.com/user-attachments/assets/d37233d0-aa8a-43a7-81bc-f44a42ba99c8)
