### PR TITLE
Fixed AutoForm number input spinner button usage

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -65,8 +65,7 @@ export const Excluded = {
 export const Included = {
   args: {
     action: api.widget.create,
-    findBy: "999",
-    include: ["startsAt", "roles"],
+    include: ["name", "inventoryCount"],
   },
 };
 

--- a/packages/react/spec/auto/inputs/PolarisAutoTextInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoTextInput.spec.tsx
@@ -189,7 +189,7 @@ describe("PolarisAutoTextInput", () => {
     test("it renders number inputs with any step value when no decimals are set", async () => {
       result = render(<PolarisAutoNumberInput field="inventoryCount" />, getCreateWrapper());
       const field = result.container.querySelector(`input[name="widget.inventoryCount"]`);
-      expect(field).toHaveAttribute("step", "any");
+      expect(field).toHaveAttribute("step", "1");
     });
 
     test("it renders number inputs with a step value when decimals are set", async () => {

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoNumberInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoNumberInput.tsx
@@ -11,25 +11,30 @@ export const PolarisAutoNumberInput = (
   } & Partial<TextFieldProps>
 ) => {
   const { field, control } = props;
-  const { type, metadata } = useStringInputController({ field, control });
+  const { type, metadata, value } = useStringInputController({ field, control });
   const fieldType = type as TextFieldProps["type"];
 
-  let step;
-  if (
+  const step =
     fieldType === "number" &&
     metadata.configuration.__typename === "GadgetNumberConfig" &&
     metadata.configuration.decimals &&
     metadata.configuration.decimals > 0
-  ) {
-    step = Number(`0.${"0".repeat(metadata.configuration.decimals - 1)}1`);
-  } else {
-    step = "any";
-  }
+      ? getStepFromNumberOfDecimals(metadata.configuration.decimals)
+      : value
+      ? getStepFromNumberOfDecimals(countNumberOfDecimals(`${value}`))
+      : 1;
 
-  return (
-    <PolarisAutoTextInput
-      step={step as any} // HTML input allow "any" as a step value, but the TS type from Polaris does not allow it, so we cast it to any type here.
-      {...props}
-    />
-  );
+  return <PolarisAutoTextInput step={step} {...props} />;
+};
+
+const getStepFromNumberOfDecimals = (numberOfDecimals: number) =>
+  numberOfDecimals === 0 ? 1 : Number(`0.${"0".repeat(numberOfDecimals - 1)}1`);
+
+const countNumberOfDecimals = (value: string) => {
+  if (value.includes("e")) {
+    // +e scientific notation for large numbers does not get decimal steps
+    return 0;
+  }
+  const [, decimals] = value.split(".");
+  return decimals?.length ?? 0;
 };


### PR DESCRIPTION
- **Previously**
  - The up/down spinner buttons in number field inputs did not work when number fields did not have a defined `decimals` value
  - This was because we defaulted their step to "any". We did this to avoid the default `step={1}` which would sometimes erroneously cause a `must be an integer` error when the field would accept decimals 
- **Now**
  - The step is set dynamically to match the current value in the input if there is no decimal count from the field configuration 
- **Things to test**
  - UpDown spinner buttons on number inputs work
  - Using decimals and the UpDown spinner buttons will change the highest precision decimal 
  - UpDown arrow keys will be similar to clicking the UpDown spinner buttons, but they will not add trailing zeros
    - This basically incrementally increases the steps as you hold the key, but that feels ok. Basically, an accelerating number changer