### PR TITLE
Allow hiding searching and/or pagination in AutoTable

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -274,6 +274,14 @@ export const ExcludedActionParameters = {
   },
 };
 
+export const HideSearchAndPagination = {
+  args: {
+    model: api.autoTableTest,
+    searchable: false,
+    paginate: false,
+  },
+};
+
 const windowAlert = (message) => {
   // eslint-disable-next-line no-undef
   window.alert(message);

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -24,4 +24,6 @@ export type AutoTableProps<
   filter?: Options["filter"];
   actions?: TableOptions["actions"];
   excludeActions?: TableOptions["excludeActions"];
+  searchable?: boolean;
+  paginate?: boolean;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -87,6 +87,8 @@ const PolarisAutoTableComponent = <
   props: AutoTableProps<GivenOptions, SchemaT, FinderFunction, Options>
 ) => {
   const { onClick } = props;
+  const searchable = props.searchable ?? true;
+  const paginate = props.paginate ?? true;
 
   const [{ rows, columns, metadata, fetching, error, page, search, sort, selection }, refresh] = useTable<
     GivenOptions,
@@ -168,22 +170,24 @@ const PolarisAutoTableComponent = <
         ids={selection.recordIds}
         selectedRows={selectedRows}
       />
-      <IndexFilters
-        mode={mode}
-        setMode={setMode}
-        appliedFilters={[]}
-        filters={[]}
-        onClearAll={() => undefined}
-        tabs={[]}
-        selected={1}
-        loading={fetching}
-        cancelAction={{ onAction: () => search.clear() }}
-        disabled={!!error}
-        // Search
-        queryValue={search.value}
-        onQueryChange={search.set}
-        onQueryClear={search.clear}
-      />
+      {searchable && (
+        <IndexFilters
+          mode={mode}
+          setMode={setMode}
+          appliedFilters={[]}
+          filters={[]}
+          onClearAll={() => undefined}
+          tabs={[]}
+          selected={1}
+          loading={fetching}
+          cancelAction={{ onAction: () => search.clear() }}
+          disabled={!!error}
+          // Search
+          queryValue={search.value}
+          onQueryChange={search.set}
+          onQueryClear={search.clear}
+        />
+      )}
 
       {error && (
         <Box paddingBlockStart="200" paddingBlockEnd="1000">
@@ -209,12 +213,16 @@ const PolarisAutoTableComponent = <
             ? 1 // Don't show the empty state if there's an error
             : rows?.length ?? 0
         }
-        pagination={{
-          hasNext: page.hasNextPage,
-          hasPrevious: page.hasPreviousPage,
-          onNext: page.goToNextPage,
-          onPrevious: page.goToPreviousPage,
-        }}
+        pagination={
+          paginate
+            ? {
+                hasNext: page.hasNextPage,
+                hasPrevious: page.hasPreviousPage,
+                onNext: page.goToNextPage,
+                onPrevious: page.goToPreviousPage,
+              }
+            : undefined
+        }
         sortDirection={gadgetToPolarisDirection(sortDirection)}
         sortColumnIndex={columns ? getColumnIndex(columns, sortColumnApiIdentifier) : undefined}
         onSort={(headingIndex) => handleColumnSort(headingIndex)}


### PR DESCRIPTION
This PR introduces two new parameters in AutoTable, `search` and `paginate`, which allow you to hide the search bar and pagination buttons by setting them as `false`.

Fixes GGT-6881, GGT-6882

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
