### PR TITLE
Update AutoTable actions api signature and add promoted actions system

### DIFF
--- a/packages/react/cypress/component/auto/table/AutoTableBulkActions.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableBulkActions.cy.tsx
@@ -72,10 +72,8 @@ describe("AutoTable - Bulk actions", () => {
         model={api.widget}
         actions={[
           "delete",
-          { label: "Custom renderer action", promptComponent: SamplepromptComponent },
           { label: "Custom callback action", action: stubCallback },
           { label: "Relabeled model action", action: "delete" },
-          { promoted: true, label: "(Promoted)Custom renderer action", promptComponent: SamplepromptComponent },
           { promoted: true, label: "(Promoted)Custom callback action", action: stubCallback },
           { promoted: true, label: "(Promoted)Relabeled model action", action: "delete" },
         ]}
@@ -137,13 +135,6 @@ describe("AutoTable - Bulk actions", () => {
   describe.each([true, false])("Custom actions with promoted=%s", (promoted) => {
     beforeEach(() => {
       selectRecordIds(["10", "11", "12"]);
-    });
-
-    it("Can run custom actions with passed in renderers", () => {
-      openBulkAction(`${promoted ? `(Promoted)` : ""}Custom renderer action`, promoted);
-
-      cy.contains("Selected record ids: 10,11,12").should("exist");
-      cy.contains(`Selected record inventory count sum: 126`).should("exist");
     });
 
     it("Can run custom actions with passed in callbacks", () => {
@@ -224,14 +215,4 @@ const bulkDeleteFailureResponse = {
     logs: "https://ggt.link/logs/114412/3faf15ad42c60f33ea5f012e99137263",
     traceId: "3faf15ad42c60f33ea5f012e99137263",
   },
-};
-
-const SamplepromptComponent = (props: { records: any[] }) => {
-  const { records } = props;
-  return (
-    <div>
-      <p>Selected record ids: {records.map((record) => record.id).join(",")}</p>
-      <p>Selected record inventory count sum: {records.reduce((total, record) => total + (record.inventoryCount ?? 0), 0)}</p>
-    </div>
-  );
 };

--- a/packages/react/cypress/component/auto/table/AutoTableBulkActions.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableBulkActions.cy.tsx
@@ -45,9 +45,12 @@ describe("AutoTable - Bulk actions", () => {
     ).as(as);
   };
 
-  const openBulkAction = (label: string) => {
-    cy.get(`button[aria-label="Actions"]`).click();
-    return cy.contains(label).click();
+  const openBulkAction = (label: string, isPromoted = true) => {
+    if (isPromoted) {
+      return cy.contains(label).click({ force: true });
+    }
+    cy.get(`button[aria-label="More actions"]`).eq(1).click();
+    return cy.contains(label).click({ force: true });
   };
 
   const selectRecordIds = (ids: string[]) => {
@@ -69,21 +72,12 @@ describe("AutoTable - Bulk actions", () => {
         model={api.widget}
         actions={[
           "delete",
-          {
-            label: "Custom renderer action",
-            render: (recordIds, records) => {
-              return (
-                <div>
-                  <p>Selected record ids: {recordIds.join(",")}</p>
-                  <p>Selected record inventory count sum: {records.reduce((total, record) => total + (record.inventoryCount ?? 0), 0)}</p>
-                </div>
-              );
-            },
-          },
-          {
-            label: "Custom callback action",
-            callback: stubCallback,
-          },
+          { label: "Custom renderer action", promptComponent: SamplepromptComponent },
+          { label: "Custom callback action", action: stubCallback },
+          { label: "Relabeled model action", action: "delete" },
+          { promoted: true, label: "(Promoted)Custom renderer action", promptComponent: SamplepromptComponent },
+          { promoted: true, label: "(Promoted)Custom callback action", action: stubCallback },
+          { promoted: true, label: "(Promoted)Relabeled model action", action: "delete" },
         ]}
       />,
       PolarisWrapper
@@ -140,20 +134,38 @@ describe("AutoTable - Bulk actions", () => {
     cy.contains(bulkDeleteFailureMessage);
   });
 
-  describe("Custom actions", () => {
+  describe.each([true, false])("Custom actions with promoted=%s", (promoted) => {
     beforeEach(() => {
       selectRecordIds(["10", "11", "12"]);
     });
 
     it("Can run custom actions with passed in renderers", () => {
-      openBulkAction("Custom renderer action");
+      openBulkAction(`${promoted ? `(Promoted)` : ""}Custom renderer action`, promoted);
 
       cy.contains("Selected record ids: 10,11,12").should("exist");
       cy.contains(`Selected record inventory count sum: 126`).should("exist");
     });
 
     it("Can run custom actions with passed in callbacks", () => {
-      openBulkAction("Custom callback action").then(() => expect(stubCallback).to.be.called);
+      openBulkAction(`${promoted ? `(Promoted)` : ""}Custom callback action`, promoted).then(() => expect(stubCallback).to.be.called);
+    });
+
+    it("Can run relabeled Gadget actions", () => {
+      openBulkAction(`${promoted ? `(Promoted)` : ""}Relabeled model action`, promoted);
+
+      cy.contains("Are you sure you want to run this action on 3 records?").should("exist");
+
+      mockBulkDeleteWidgets(bulkDeleteSuccessResponse, "bulkDeleteWidgets");
+      mockGetWidgets();
+      cy.get("button").contains("Run").click();
+      cy.wait("@bulkDeleteWidgets")
+        .its("request.body.variables")
+        .should("deep.equal", { ids: ["10", "11", "12"] }); // selected IDs included
+
+      cy.wait("@getWidgets").its("request.body.variables").should("deep.equal", { first: 50 }); // No search value
+
+      cy.contains("Action completed successfully");
+      cy.get("button").contains("Close").click();
     });
   });
 });
@@ -212,4 +224,14 @@ const bulkDeleteFailureResponse = {
     logs: "https://ggt.link/logs/114412/3faf15ad42c60f33ea5f012e99137263",
     traceId: "3faf15ad42c60f33ea5f012e99137263",
   },
+};
+
+const SamplepromptComponent = (props: { records: any[] }) => {
+  const { records } = props;
+  return (
+    <div>
+      <p>Selected record ids: {records.map((record) => record.id).join(",")}</p>
+      <p>Selected record inventory count sum: {records.reduce((total, record) => total + (record.inventoryCount ?? 0), 0)}</p>
+    </div>
+  );
 };

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -245,42 +245,6 @@ export const ExcludeColumns = {
   },
 };
 
-export const IncludedActionParameters = {
-  args: {
-    model: api.autoTableTest,
-    actions: [
-      "customAction",
-      {
-        label: "Sum Nums callback",
-        callback: (ids, records) => windowAlert(`Sum of record "num" values: ${sumRecordNumValues(records)}`),
-      },
-      {
-        label: "Sum Nums rendered",
-        render: (ids, records) => {
-          return (
-            <div>
-              <p>
-                {sumRecordNumValues(records)}
-                {` is the sum of the num field in records with ids: `}
-                {ids.join(", ")}
-              </p>
-              <button onClick={() => windowAlert(ids)}>Alert the IDs</button>
-              <button onClick={() => windowAlert(JSON.stringify(records))}>Alert the full records</button>
-            </div>
-          );
-        },
-      },
-    ],
-  },
-};
-
-export const ExcludedActionParameters = {
-  args: {
-    model: api.autoTableTest,
-    excludeActions: ["delete"],
-  },
-};
-
 export const BuiltInPolarisTableProps = {
   args: {
     model: api.autoTableTest,
@@ -318,8 +282,4 @@ export const HideSearchAndPagination = {
 const windowAlert = (message) => {
   // eslint-disable-next-line no-undef
   window.alert(message);
-};
-
-const sumRecordNumValues = (records) => {
-  return records.reduce((total, record) => total + (record.num ?? 0), 0);
 };

--- a/packages/react/spec/auto/table/PolarisAutoTableActions.stories.jsx
+++ b/packages/react/spec/auto/table/PolarisAutoTableActions.stories.jsx
@@ -1,10 +1,10 @@
-import { AppProvider, BlockStack, Box, LegacyCard, Modal } from "@shopify/polaris";
+import { AppProvider, BlockStack, Box, LegacyCard } from "@shopify/polaris";
 import translations from "@shopify/polaris/locales/en.json";
 import React from "react";
 import { Provider } from "../../../src/GadgetProvider.tsx";
 import { PolarisAutoTable } from "../../../src/auto/polaris/PolarisAutoTable.tsx";
 import { testApi as api } from "../../apis.ts";
-
+import { StorybookErrorBoundary } from "../StorybookErrorBoundary.tsx";
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
   title: "Polaris/AutoTable/ActionParameters",
@@ -20,7 +20,9 @@ export default {
               <Box paddingBlockEnd="400">
                 <BlockStack gap="200">
                   <LegacyCard>
-                    <Story />
+                    <StorybookErrorBoundary>
+                      <Story />
+                    </StorybookErrorBoundary>
                   </LegacyCard>
                 </BlockStack>
               </Box>
@@ -31,22 +33,6 @@ export default {
     },
   ],
 };
-
-const CustomActionComponent = ({ records, close }) => (
-  <>
-    <Modal.Section>
-      <p>
-        {sumRecordNumValues(records)}
-        {` is the sum of the num field in records with ids: `}
-        {records.map((record) => record.id).join(", ")}
-      </p>
-    </Modal.Section>
-    <Modal.Section>
-      <button onClick={() => windowAlert(JSON.stringify(records))}>Alert the full records</button>
-      <button onClick={close}>Close</button>
-    </Modal.Section>
-  </>
-);
 
 export const IncludedActionParameters = {
   args: {
@@ -60,9 +46,9 @@ export const IncludedActionParameters = {
         action: (records) => windowAlert(`Sum of record "num" values: ${sumRecordNumValues(records)}`),
       },
       {
-        label: "Sum Nums rendered",
+        label: "Sum Nums promoted",
         promoted: true,
-        promptComponent: CustomActionComponent,
+        action: (records) => windowAlert(`Sum of record "num" values: ${sumRecordNumValues(records)}`),
       },
     ],
   },

--- a/packages/react/spec/auto/table/PolarisAutoTableActions.stories.jsx
+++ b/packages/react/spec/auto/table/PolarisAutoTableActions.stories.jsx
@@ -1,0 +1,85 @@
+import { AppProvider, BlockStack, Box, LegacyCard, Modal } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
+import React from "react";
+import { Provider } from "../../../src/GadgetProvider.tsx";
+import { PolarisAutoTable } from "../../../src/auto/polaris/PolarisAutoTable.tsx";
+import { testApi as api } from "../../apis.ts";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+export default {
+  title: "Polaris/AutoTable/ActionParameters",
+  component: PolarisAutoTable,
+  decorators: [
+    // 👇 Defining the decorator in the preview file applies it to all stories
+    (Story) => {
+      // 👇 Make it configurable by reading the theme value from parameters
+      return (
+        <Provider api={api}>
+          <AppProvider i18n={translations}>
+            <div style={{ width: "100%" }}>
+              <Box paddingBlockEnd="400">
+                <BlockStack gap="200">
+                  <LegacyCard>
+                    <Story />
+                  </LegacyCard>
+                </BlockStack>
+              </Box>
+            </div>
+          </AppProvider>
+        </Provider>
+      );
+    },
+  ],
+};
+
+const CustomActionComponent = ({ records, close }) => (
+  <>
+    <Modal.Section>
+      <p>
+        {sumRecordNumValues(records)}
+        {` is the sum of the num field in records with ids: `}
+        {records.map((record) => record.id).join(", ")}
+      </p>
+    </Modal.Section>
+    <Modal.Section>
+      <button onClick={() => windowAlert(JSON.stringify(records))}>Alert the full records</button>
+      <button onClick={close}>Close</button>
+    </Modal.Section>
+  </>
+);
+
+export const IncludedActionParameters = {
+  args: {
+    model: api.autoTableTest,
+    actions: [
+      "customAction",
+      { label: "Alternate action label", action: "customAction" },
+      {
+        label: "Sum Nums callback",
+        promoted: false,
+        action: (records) => windowAlert(`Sum of record "num" values: ${sumRecordNumValues(records)}`),
+      },
+      {
+        label: "Sum Nums rendered",
+        promoted: true,
+        promptComponent: CustomActionComponent,
+      },
+    ],
+  },
+};
+
+export const ExcludedActionParameters = {
+  args: {
+    model: api.autoTableTest,
+    excludeActions: ["delete"],
+  },
+};
+
+const windowAlert = (message) => {
+  // eslint-disable-next-line no-undef
+  window.alert(message);
+};
+
+const sumRecordNumValues = (records) => {
+  return records.reduce((total, record) => total + (record.num ?? 0), 0);
+};

--- a/packages/react/src/auto/polaris/PolarisAutoBulkActionModal.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoBulkActionModal.tsx
@@ -31,18 +31,14 @@ export const PolarisAutoBulkActionModal = (props: {
 
   const closeModal = useCallback(() => setShowModal(false), [setShowModal]);
 
-  if (!actionIsLoaded) {
+  if (!actionIsLoaded || !isBulkGadgetAction) {
     return null;
   }
 
   return (
     <>
       <Modal onClose={() => setShowModal(false)} title={modalTitle} open={showModal}>
-        {isBulkGadgetAction ? (
-          <GadgetBulkActionModalContent model={model} modelActionDetails={modelActionDetails} ids={ids} close={closeModal} />
-        ) : (
-          <CustomBulkActionModalContent modelActionDetails={modelActionDetails} close={closeModal} selectedRows={selectedRows} />
-        )}
+        <GadgetBulkActionModalContent model={model} modelActionDetails={modelActionDetails} ids={ids} close={closeModal} />
       </Modal>
     </>
   );
@@ -109,20 +105,6 @@ const CenteredSpinner = () => (
 
 const ActionCompletedMessage = `Action completed`;
 const ActionSuccessMessage = `${ActionCompletedMessage} successfully`;
-
-const CustomBulkActionModalContent = (props: { modelActionDetails: ModelActionDetails; close: () => void; selectedRows: TableRow[] }) => {
-  const { modelActionDetails, selectedRows, close } = props;
-
-  if (modelActionDetails.isGadgetAction) {
-    throw new Error(`Custom action "${modelActionDetails.apiIdentifier}" is invalid`);
-  }
-
-  if (!modelActionDetails.promptComponent) {
-    throw new Error(`Failed to render custom bulk action modal content. Property "promptComponent" must be provided`);
-  }
-
-  return modelActionDetails.promptComponent({ records: selectedRows, close });
-};
 
 const RunActionConfirmationText = (props: { count: number }) => {
   const { count } = props;

--- a/packages/react/src/auto/polaris/PolarisAutoBulkActionModal.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoBulkActionModal.tsx
@@ -41,7 +41,7 @@ export const PolarisAutoBulkActionModal = (props: {
         {isBulkGadgetAction ? (
           <GadgetBulkActionModalContent model={model} modelActionDetails={modelActionDetails} ids={ids} close={closeModal} />
         ) : (
-          <CustomBulkActionModalContent modelActionDetails={modelActionDetails} ids={ids} close={closeModal} selectedRows={selectedRows} />
+          <CustomBulkActionModalContent modelActionDetails={modelActionDetails} close={closeModal} selectedRows={selectedRows} />
         )}
       </Modal>
     </>
@@ -110,36 +110,18 @@ const CenteredSpinner = () => (
 const ActionCompletedMessage = `Action completed`;
 const ActionSuccessMessage = `${ActionCompletedMessage} successfully`;
 
-const CustomBulkActionModalContent = (props: {
-  modelActionDetails: ModelActionDetails;
-  ids: string[];
-  close: () => void;
-  selectedRows: TableRow[];
-}) => {
-  const { modelActionDetails, ids, selectedRows, close } = props;
+const CustomBulkActionModalContent = (props: { modelActionDetails: ModelActionDetails; close: () => void; selectedRows: TableRow[] }) => {
+  const { modelActionDetails, selectedRows, close } = props;
 
   if (modelActionDetails.isGadgetAction) {
-    throw new Error(`Custom callback "${modelActionDetails.apiIdentifier}" is invalid`);
+    throw new Error(`Custom action "${modelActionDetails.apiIdentifier}" is invalid`);
   }
 
-  if (!modelActionDetails.render) {
-    throw new Error(`Failed to render custom bulk action modal content. Property "render" must be provided`);
+  if (!modelActionDetails.promptComponent) {
+    throw new Error(`Failed to render custom bulk action modal content. Property "promptComponent" must be provided`);
   }
 
-  return (
-    <>
-      <Modal.Section>{modelActionDetails.render(ids, selectedRows)}</Modal.Section>
-      <Modal.Section>
-        <div style={{ float: "right", paddingBottom: "16px" }}>
-          <ButtonGroup>
-            <Button variant="secondary" onClick={close}>
-              Close
-            </Button>
-          </ButtonGroup>
-        </div>
-      </Modal.Section>
-    </>
-  );
+  return modelActionDetails.promptComponent({ records: selectedRows, close });
 };
 
 const RunActionConfirmationText = (props: { count: number }) => {

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -253,6 +253,6 @@ const bulkActionOptionMapper = (selectedRows: TableRow[]) => {
   return (option: BulkActionOption) => ({
     id: option.humanizedName,
     content: option.humanizedName,
-    onAction: option.action ? () => option.action?.(selectedRows) : option.selectModelAction,
+    onAction: option.action ? () => option.action?.(selectedRows) : option.selectModelAction ?? (() => undefined),
   });
 };

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -32,19 +32,12 @@ export interface TableOptions {
   actions?: (string | ActionCallback)[];
   excludeActions?: string[];
 }
+
 export type ActionCallback = {
   label: string;
   promoted?: boolean;
-} & (
-  | {
-      action: string | ((records: GadgetRecord<any>[]) => any);
-    }
-  | {
-      promptComponent: promptComponent;
-    }
-);
-
-export type promptComponent = (props: { records: GadgetRecord<any>[]; close?: () => void }) => ReactNode;
+  action: string | ((records: GadgetRecord<any>[]) => any);
+};
 
 export type TableData<Data> =
   | {

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -32,13 +32,19 @@ export interface TableOptions {
   actions?: (string | ActionCallback)[];
   excludeActions?: string[];
 }
-
 export type ActionCallback = {
   label: string;
+  promoted?: boolean;
 } & (
-  | { callback: (recordIds: string[], records: GadgetRecord<any>[]) => any }
-  | { render: (recordIds: string[], records: GadgetRecord<any>[]) => ReactNode }
+  | {
+      action: string | ((records: GadgetRecord<any>[]) => any);
+    }
+  | {
+      promptComponent: promptComponent;
+    }
 );
+
+export type promptComponent = (props: { records: GadgetRecord<any>[]; close?: () => void }) => ReactNode;
 
 export type TableData<Data> =
   | {


### PR DESCRIPTION
- **UPDATES TO ACTIONS PROP**
  - Added optional `promoted` property so that actions can be accessed without clicking on the `more actions` button
    - Custom actions are by default promoted to false where actions will be put into the dropdown menu
    - Gadget model actions are promoted by default
  - renamed `callback` to `action`
  - Added `action: function | string` so that it is now possible to relabel Gadget bulk actions