### PR TITLE
refactor(autotable): move sort state into useTable hook

### DIFF
--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -75,6 +75,12 @@ jest.unstable_mockModule("../src/useTable", () => ({
         set: jest.fn(),
         clear: jest.fn(),
       },
+      sort: {
+        column: "",
+        direction: "Ascending",
+        handleColumnSort: jest.fn(),
+        setSort: jest.fn(),
+      },
       error,
       selection: {
         recordIds: [],

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -13,7 +13,7 @@ import {
 } from "@shopify/polaris";
 import pluralize from "pluralize";
 import type { ReactNode } from "react";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useTable } from "../../useTable.js";
 import type { TableColumn, TableRow } from "../../useTableUtils/types.js";
 import type { ColumnValueType, OptionsType } from "../../utils.js";
@@ -47,18 +47,6 @@ const gadgetToPolarisDirection = (direction?: SortOrder) => {
 
 const getColumnIndex = (columns: TableColumn[], apiIdentifier: string | undefined) => {
   return columns.findIndex((column) => column.apiIdentifier === apiIdentifier);
-};
-
-const getNextDirection = (sortDirection: SortOrder | undefined) => {
-  switch (sortDirection) {
-    case "Descending":
-      return "Ascending";
-    case "Ascending":
-      return undefined;
-    case undefined:
-    default:
-      return "Descending";
-  }
 };
 
 /**
@@ -101,24 +89,14 @@ const PolarisAutoTableComponent = <
     excludeColumns: props.excludeColumns,
     pageSize: props.pageSize,
     live: props.live,
-    sort: props.initialSort,
+    initialSort: props.initialSort,
     filter: props.filter,
   } as any);
-
-  const [sortColumnApiIdentifier, setSortColumnApiIdentifier] = useState<string | undefined>(
-    props.initialSort ? Object.keys(props.initialSort)[0] : undefined
-  );
-  const [sortDirection, setSortDirection] = useState<SortOrder | undefined>(
-    props.initialSort ? Object.values(props.initialSort)[0] : undefined
-  );
 
   const handleColumnSort = (headingIndex: number) => {
     if (columns) {
       const columnApiIdentifier = columns[headingIndex].apiIdentifier;
-      const nextDirection = columnApiIdentifier !== sortColumnApiIdentifier ? "Descending" : getNextDirection(sortDirection);
-      setSortDirection(nextDirection);
-      setSortColumnApiIdentifier(nextDirection ? columnApiIdentifier : undefined);
-      sort(columnApiIdentifier, nextDirection);
+      sort.handleColumnSort(columnApiIdentifier);
     }
   };
 
@@ -223,8 +201,8 @@ const PolarisAutoTableComponent = <
               }
             : undefined
         }
-        sortDirection={gadgetToPolarisDirection(sortDirection)}
-        sortColumnIndex={columns ? getColumnIndex(columns, sortColumnApiIdentifier) : undefined}
+        sortDirection={gadgetToPolarisDirection(sort.direction)}
+        sortColumnIndex={columns ? getColumnIndex(columns, sort.column) : undefined}
         onSort={(headingIndex) => handleColumnSort(headingIndex)}
       >
         {rows &&

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -35,6 +35,7 @@ export interface TableOptions {
   pageSize?: number;
   initialCursor?: string;
   initialDirection?: "forward" | "backward";
+  initialSort?: { [column: string]: SortOrder };
   columns?: (string | RelatedFieldColumn | CustomCellColumn)[];
   excludeColumns?: string[];
   actions?: (string | ActionCallback)[];
@@ -62,6 +63,13 @@ export type TableData<Data> =
       metadata: null;
     };
 
+type SortState = {
+  column: string;
+  direction: SortOrder;
+  handleColumnSort: (column: string) => void;
+  setSort: (column: string, direction: SortOrder) => void;
+};
+
 export type TableResult<Data> = [
   TableData<Data> & {
     page: PaginationResult;
@@ -69,7 +77,7 @@ export type TableResult<Data> = [
     error?: ErrorWrapper;
     search: SearchResult;
     selection: RecordSelection;
-    sort: (colName: string, direction?: SortOrder) => void;
+    sort: SortState;
   },
   refresh: (opts?: Partial<OperationContext>) => void
 ];


### PR DESCRIPTION
In order to pass around all the sort callbacks to the TableContext, it would be easier if the sort state was in the useTable hook. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
