### PR TITLE
fix(autoform): fix testing flake waiting for lazy load suspense

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -1,7 +1,7 @@
 import { AppProvider } from "@shopify/polaris";
 import translations from "@shopify/polaris/locales/en.json";
 import type { RenderResult } from "@testing-library/react";
-import { act, render } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import type { UserEvent } from "@testing-library/user-event";
 import { userEvent } from "@testing-library/user-event";
 import type { ReactNode } from "react";
@@ -26,9 +26,9 @@ describe("PolarisAutoForm", () => {
   describe("when used as a one liner", () => {
     describe("for widget create", () => {
       test("it renders the name input", async () => {
-        const { findByLabelText } = render(<PolarisAutoForm action={api.widget.create} />, { wrapper: PolarisMockedProviders });
+        render(<PolarisAutoForm action={api.widget.create} />, { wrapper: PolarisMockedProviders });
         loadMockWidgetCreateMetadata();
-        expect(await findByLabelText("Name")).toBeInTheDocument();
+        expect(await screen.findByLabelText("Name")).toBeInTheDocument();
       });
 
       test("it throws an error if a create action is mixed with a findBy prop", async () => {


### PR DESCRIPTION
The AutoForm component under test here is doing a React.lazy suspense,
and for some reason, it seems that possibly using the `screen` findBy
api results in a more reliable test result.
![CleanShot 2024-07-31 at 12 49 11@2x](https://github.com/user-attachments/assets/cef8f41e-9b0a-42c7-9c14-a67d061d7cbb)


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
