### PR TITLE
Prevent showing time for dateTime fields with `includeTime:false`

### DIFF
--- a/packages/react/cypress/component/auto/table/PolarisAutoTableDateTimeCell.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableDateTimeCell.cy.tsx
@@ -2,8 +2,12 @@ import React from "react";
 import { PolarisAutoTableDateTimeCell } from "../../../../src/auto/polaris/tableCells/PolarisAutoTableDateTimeCell.js";
 
 describe("PolarisAutoTableDateTimeCell", () => {
-  it("renders the date as string", () => {
-    cy.mount(<PolarisAutoTableDateTimeCell value={new Date("2024-07-01T01:00:00.000Z")} />);
+  it("renders the date as string with the time", () => {
+    cy.mount(<PolarisAutoTableDateTimeCell value={new Date("2024-07-01T01:00:00.000Z")} includeTime={true} />);
     cy.get("span").should("have.text", "Jul 1, 2024 1:00 AM"); // Make sure the format defined in the component is correct
+  });
+  it("renders the date as string without the time", () => {
+    cy.mount(<PolarisAutoTableDateTimeCell value={new Date("2024-07-01T01:00:00.000Z")} includeTime={false} />);
+    cy.get("span").should("have.text", "Jul 1, 2024"); // Make sure the format defined in the component is correct
   });
 });

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
@@ -43,7 +43,7 @@ export const PolarisAutoTableCellRenderer = (props: { column: TableColumn; value
     }
 
     case FieldType.DateTime: {
-      return <PolarisAutoTableDateTimeCell value={value as any} />;
+      return <PolarisAutoTableDateTimeCell value={value as any} includeTime={column.includeTime ?? true} />;
     }
 
     case FieldType.Boolean: {

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableDateTimeCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableDateTimeCell.tsx
@@ -2,8 +2,10 @@ import { format } from "date-fns";
 import React from "react";
 import { PolarisAutoTableTextCell } from "./PolarisAutoTableTextCell.js";
 
-export const PolarisAutoTableDateTimeCell = (props: { value: Date }) => {
-  const { value } = props;
+export const PolarisAutoTableDateTimeCell = (props: { value: Date; includeTime: boolean }) => {
+  const { value, includeTime } = props;
 
-  return value instanceof Date ? <PolarisAutoTableTextCell value={format(value, "LLL d, y K:mm a")} /> : null;
+  const timeFormat = includeTime ? "LLL d, y K:mm a" : "LLL d, y";
+
+  return value instanceof Date ? <PolarisAutoTableTextCell value={format(value, timeFormat)} /> : null;
 };

--- a/packages/react/src/useTableUtils/helpers.ts
+++ b/packages/react/src/useTableUtils/helpers.ts
@@ -173,6 +173,10 @@ export const getTableColumns = (spec: Pick<TableSpec, "fieldMetadataTree" | "tar
       column.relationshipType = firstField.fieldType as RelationshipType;
     }
 
+    if (targetField.configuration?.__typename === "GadgetDateTimeConfig") {
+      column.includeTime = targetField.configuration.includeTime;
+    }
+
     columns.push(column);
   }
 

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -30,6 +30,8 @@ export type TableColumn = {
   /** parent relationship type if the parent field is a relationship */
   relationshipType?: RelationshipType;
   sortable: boolean;
+  /** For controlling if the time is shown on DateTime cell renderers   */
+  includeTime?: boolean;
 };
 
 export type TableRow = Record<string, ColumnValueType | ReactNode>;


### PR DESCRIPTION
- **UPDATE**
  - DateTime fields with `includeTime:false` will now only show the date
  - Showing the time requires that `includeTime:true` || `includeTime: undefined`
