### PR TITLE
Add customizable title control to AutoForm

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoFormTitles.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormTitles.cy.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable jest/valid-expect */
+import React from "react";
+import { api } from "../../../support/api.js";
+import { describeForEachAutoAdapter } from "../../../support/auto.js";
+
+describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }) => {
+  beforeEach(() => {
+    cy.viewport("macbook-13");
+    cy.intercept("POST", `${api.connection.options.endpoint}?operation=ModelActionMetadata`);
+  });
+
+  it("renders the default title without a specified title value", () => {
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} />, wrapper);
+    cy.contains("Create Widget").should("exist");
+  });
+
+  it("renders the default title when explicitly given undefined", () => {
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} title={undefined} />, wrapper);
+    cy.contains("Create Widget").should("exist");
+  });
+
+  it("renders the title as the specified value", () => {
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} title={"custom title here"} />, wrapper);
+    cy.contains("Create Widget").should("not.exist");
+    cy.contains("custom title here").should("exist");
+  });
+
+  it("does not render the title when given an empty string", () => {
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} title={""} />, wrapper);
+    cy.contains("Create Widget").should("not.exist");
+  });
+
+  it("does not render the title when given false", () => {
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} title={false} />, wrapper);
+    cy.contains("Create Widget").should("not.exist");
+  });
+
+  it("does not render the title when given null", () => {
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} title={null} />, wrapper);
+    cy.contains("Create Widget").should("not.exist");
+  });
+});

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -33,6 +33,8 @@ export type AutoFormProps<
   submitLabel?: ReactNode;
   /** What to show the user once the form has been submitted successfully */
   successContent?: ReactNode;
+  /** The title at the top of the form. False to omit */
+  title?: string | false;
   /** Called when the form submission completes successfully on the backend */
   onSuccess?: (record: UseActionFormHookStateData<ActionFunc>) => void;
   /** Called when the form submission errors before sending, during the API call, or if the API call returns an error. */

--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -1,7 +1,7 @@
 import type { ActionFunction } from "@gadgetinc/api-client-core";
 import type { GridProps } from "@mui/material";
 import { Grid, Skeleton, Typography } from "@mui/material";
-import React, { useMemo } from "react";
+import React from "react";
 import { FormProvider } from "react-hook-form";
 import { humanizeCamelCase, type OptionsType } from "../../utils.js";
 import { useAutoForm, type AutoFormProps } from "../AutoForm.js";
@@ -69,7 +69,7 @@ export const MUIAutoFormComponent = <
     },
   };
 
-  const humanizedOperationName = useMemo(() => humanizeCamelCase(action.operationName), [action.operationName]);
+  const formTitle = props.title === undefined ? humanizeCamelCase(action.operationName) : props.title;
 
   if (props.successContent && isSubmitSuccessful) {
     return props.successContent;
@@ -77,7 +77,7 @@ export const MUIAutoFormComponent = <
 
   const formContent = props.children ?? (
     <>
-      <Typography variant="h5">{humanizedOperationName}</Typography>
+      {formTitle && <Typography variant="h5">{formTitle}</Typography>}
       {!props.onSuccess && <MUISubmitSuccessfulBanner />}
       {!props.onFailure && <MUISubmitErrorBanner />}
       {fetchingMetadata && <MUIFormSkeleton />}

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -1,7 +1,7 @@
 import type { ActionFunction } from "@gadgetinc/api-client-core";
 import type { FormProps } from "@shopify/polaris";
 import { BlockStack, Form, FormLayout, SkeletonBodyText, SkeletonDisplayText, Text } from "@shopify/polaris";
-import React, { useMemo } from "react";
+import React from "react";
 import { FormProvider } from "react-hook-form";
 import { humanizeCamelCase, type OptionsType } from "../../utils.js";
 import type { AutoFormProps } from "../AutoForm.js";
@@ -77,7 +77,8 @@ const PolarisAutoFormComponent = <
       exclude: props.exclude,
     },
   };
-  const humanizedOperationName = useMemo(() => humanizeCamelCase(action.operationName), [action.operationName]);
+
+  const formTitle = props.title === undefined ? humanizeCamelCase(action.operationName) : props.title;
 
   if (props.successContent && isSubmitSuccessful) {
     return props.successContent;
@@ -95,9 +96,11 @@ const PolarisAutoFormComponent = <
 
   const formContent = props.children ?? (
     <>
-      <Text variant="headingLg" as="h5">
-        {humanizedOperationName}
-      </Text>
+      {formTitle && (
+        <Text variant="headingLg" as="h5">
+          {formTitle}
+        </Text>
+      )}
       {!props.onSuccess && <PolarisSubmitSuccessfulBanner />}
       {!props.onFailure && <PolarisSubmitErrorBanner />}
       {!metadataError && (


### PR DESCRIPTION
- **UPDATE**
  - Previously there was no way to control the title of the autoForm
  - This control has been added. If it is not given then the humanized operation name will be used as the default
  - Passing in an empty string will make it such that there is no title element rendered at all because the rendering it with an empty string will create some extra spacing