### PR TITLE
Refactor rows and columns

### DIFF
--- a/packages/react/cypress/component/auto/table/PolarisAutoTableCellRenderer.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableCellRenderer.cy.tsx
@@ -8,6 +8,9 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
+          header: "String",
+          field: "string",
+          sortable: true,
           type: FieldType.String,
         }}
         value="Hello, World!"
@@ -20,6 +23,9 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
+          header: "Date",
+          field: "date",
+          sortable: true,
           type: FieldType.DateTime,
         }}
         value={new Date("2024-07-01T01:00:00.000Z")}
@@ -32,6 +38,9 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
+          header: "Enum",
+          field: "enum",
+          sortable: true,
           type: FieldType.Enum,
         }}
         value={["foo", "bar"]}
@@ -47,6 +56,9 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
+          header: "String",
+          field: "string",
+          sortable: true,
           type: FieldType.String,
         }}
         value={null}

--- a/packages/react/cypress/component/auto/table/PolarisAutoTableCellRenderer.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableCellRenderer.cy.tsx
@@ -8,7 +8,7 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
-          fieldType: FieldType.String,
+          type: FieldType.String,
         }}
         value="Hello, World!"
       />,
@@ -20,7 +20,7 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
-          fieldType: FieldType.DateTime,
+          type: FieldType.DateTime,
         }}
         value={new Date("2024-07-01T01:00:00.000Z")}
       />,
@@ -32,7 +32,7 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
-          fieldType: FieldType.Enum,
+          type: FieldType.Enum,
         }}
         value={["foo", "bar"]}
       />,
@@ -47,7 +47,7 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
-          fieldType: FieldType.String,
+          type: FieldType.String,
         }}
         value={null}
       />,

--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -43,123 +43,104 @@ describe("useTable hook", () => {
         mustBeLongString: "hellllllllllllllllllllllllllllo",
       },
     ]);
-    expect(
-      result.current[0].columns?.map((column) => {
-        const { getValue: _getValue, ...rest } = column;
-        return rest;
-      })
-    ).toEqual([
+    expect( result.current[0].columns ).toEqual([
       {
         apiIdentifier: "id",
-        fieldType: "ID",
-        isCustomCell: false,
         name: "Id",
         relatedField: undefined,
         sortable: false,
+        type: "ID",
       },
       {
         apiIdentifier: "name",
-        fieldType: "String",
-        isCustomCell: false,
         name: "Name",
         relatedField: undefined,
         sortable: true,
+        type: "String",
       },
       {
         apiIdentifier: "inventoryCount",
-        fieldType: "Number",
-        isCustomCell: false,
         name: "Inventory count",
         relatedField: undefined,
         sortable: true,
+        type: "Number",
       },
       {
         apiIdentifier: "anything",
-        fieldType: "JSON",
-        isCustomCell: false,
         name: "Anything",
         relatedField: undefined,
         sortable: true,
+        type: "JSON",
       },
       {
         apiIdentifier: "description",
-        fieldType: "RichText",
-        isCustomCell: false,
         name: "Description",
         relatedField: undefined,
         sortable: true,
+        type: "RichText",
       },
       {
         apiIdentifier: "category",
-        fieldType: "Enum",
-        isCustomCell: false,
         name: "Category",
         relatedField: undefined,
         sortable: true,
+        type: "Enum",
       },
       {
         apiIdentifier: "startsAt",
-        fieldType: "DateTime",
-        isCustomCell: false,
         name: "Starts at",
         relatedField: undefined,
         sortable: true,
+        type: "DateTime",
       },
       {
         apiIdentifier: "isChecked",
-        fieldType: "Boolean",
-        isCustomCell: false,
         name: "Is checked",
         relatedField: undefined,
         sortable: true,
+        type: "Boolean",
       },
       {
         apiIdentifier: "metafields",
-        fieldType: "JSON",
-        isCustomCell: false,
         name: "Metafields",
         relatedField: undefined,
         sortable: true,
+        type: "JSON",
       },
       {
         apiIdentifier: "roles",
-        fieldType: "RoleAssignments",
-        isCustomCell: false,
         name: "Roles",
         relatedField: undefined,
         sortable: false,
+        type: "RoleAssignments",
       },
       {
         apiIdentifier: "birthday",
-        fieldType: "DateTime",
-        isCustomCell: false,
         name: "Birthday",
         relatedField: undefined,
         sortable: true,
+        type: "DateTime",
       },
       {
         apiIdentifier: "color",
-        fieldType: "Color",
-        isCustomCell: false,
         name: "Color",
         relatedField: undefined,
         sortable: true,
+        type: "Color",
       },
       {
         apiIdentifier: "secretKey",
-        fieldType: "EncryptedString",
-        isCustomCell: false,
         name: "Secret key",
         relatedField: undefined,
         sortable: false,
+        type: "EncryptedString",
       },
       {
         apiIdentifier: "mustBeLongString",
-        fieldType: "String",
-        isCustomCell: false,
         name: "Must be long string",
         relatedField: undefined,
         sortable: true,
+        type: "String",
       },
     ]);
   });
@@ -454,33 +435,23 @@ describe("useTable hook", () => {
       loadMockWidgetModelMetadataForRelationship();
       loadMockWidgetDataForRelationship();
 
-      expect(
-        result.current[0].columns?.map((column) => {
-          const { getValue: _getValue, ...rest } = column;
-          return rest;
-        })
-      ).toMatchInlineSnapshot(`
+      expect(result.current[0].columns).toMatchInlineSnapshot(`
         [
           {
             "apiIdentifier": "name",
-            "fieldType": "String",
-            "isCustomCell": false,
             "name": "Name",
             "relatedField": undefined,
             "sortable": true,
+            "type": "String",
           },
           {
             "apiIdentifier": "Custom column",
-            "isCustomCell": true,
             "name": "Custom column",
             "sortable": false,
+            "type": "CustomRenderer",
           },
         ]
       `);
-
-      const customColumnGetValueResult = result.current[0].columns![1].getValue({ name: "foo" });
-      // Expect the getValue result to be a valid React element
-      expect(isValidElement(customColumnGetValueResult)).toBe(true);
     });
   });
 

--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -45,99 +45,99 @@ describe("useTable hook", () => {
     ]);
     expect( result.current[0].columns ).toEqual([
       {
-        apiIdentifier: "id",
-        name: "Id",
+        field: "id",
+        header: "Id",
         relatedField: undefined,
         sortable: false,
         type: "ID",
       },
       {
-        apiIdentifier: "name",
-        name: "Name",
+        field: "name",
+        header: "Name",
         relatedField: undefined,
         sortable: true,
         type: "String",
       },
       {
-        apiIdentifier: "inventoryCount",
-        name: "Inventory count",
+        field: "inventoryCount",
+        header: "Inventory count",
         relatedField: undefined,
         sortable: true,
         type: "Number",
       },
       {
-        apiIdentifier: "anything",
-        name: "Anything",
+        field: "anything",
+        header: "Anything",
         relatedField: undefined,
         sortable: true,
         type: "JSON",
       },
       {
-        apiIdentifier: "description",
-        name: "Description",
+        field: "description",
+        header: "Description",
         relatedField: undefined,
         sortable: true,
         type: "RichText",
       },
       {
-        apiIdentifier: "category",
-        name: "Category",
+        field: "category",
+        header: "Category",
         relatedField: undefined,
         sortable: true,
         type: "Enum",
       },
       {
-        apiIdentifier: "startsAt",
-        name: "Starts at",
+        field: "startsAt",
+        header: "Starts at",
         relatedField: undefined,
         sortable: true,
         type: "DateTime",
       },
       {
-        apiIdentifier: "isChecked",
-        name: "Is checked",
+        field: "isChecked",
+        header: "Is checked",
         relatedField: undefined,
         sortable: true,
         type: "Boolean",
       },
       {
-        apiIdentifier: "metafields",
-        name: "Metafields",
+        field: "metafields",
+        header: "Metafields",
         relatedField: undefined,
         sortable: true,
         type: "JSON",
       },
       {
-        apiIdentifier: "roles",
-        name: "Roles",
+        field: "roles",
+        header: "Roles",
         relatedField: undefined,
         sortable: false,
         type: "RoleAssignments",
       },
       {
-        apiIdentifier: "birthday",
-        name: "Birthday",
+        field: "birthday",
+        header: "Birthday",
         relatedField: undefined,
         sortable: true,
         type: "DateTime",
       },
       {
-        apiIdentifier: "color",
-        name: "Color",
+        field: "color",
+        header: "Color",
         relatedField: undefined,
         sortable: true,
         type: "Color",
       },
       {
-        apiIdentifier: "secretKey",
-        name: "Secret key",
+        field: "secretKey",
+        header: "Secret key",
         relatedField: undefined,
         sortable: false,
         type: "EncryptedString",
       },
       {
-        apiIdentifier: "mustBeLongString",
-        name: "Must be long string",
+        field: "mustBeLongString",
+        header: "Must be long string",
         relatedField: undefined,
         sortable: true,
         type: "String",
@@ -179,7 +179,7 @@ describe("useTable hook", () => {
           }
         }"
       `);
-      expect(result.current[0].columns?.map((column) => column.apiIdentifier)).toEqual(["name", "inventoryCount"]);
+      expect(result.current[0].columns?.map((column) => column.field)).toEqual(["name", "inventoryCount"]);
       expect(result.current[0].rows).toMatchInlineSnapshot(`
               [
                 {
@@ -238,7 +238,7 @@ describe("useTable hook", () => {
           }
         }"
       `);
-      expect(result.current[0].columns?.map((column) => column.apiIdentifier)).toEqual(["name", "hasMany", "hasOne", "belongsTo"]);
+      expect(result.current[0].columns?.map((column) => column.field)).toEqual(["name", "hasMany", "hasOne", "belongsTo"]);
       expect(result.current[0].rows).toMatchInlineSnapshot(`
         [
           {
@@ -327,7 +327,7 @@ describe("useTable hook", () => {
           }
         }"
       `);
-      expect(result.current[0].columns?.map((column) => column.apiIdentifier)).toEqual(["name", "hasMany", "hasOne", "belongsTo"]);
+      expect(result.current[0].columns?.map((column) => column.field)).toEqual(["name", "hasMany", "hasOne", "belongsTo"]);
       expect(result.current[0].rows).toMatchInlineSnapshot(`
         [
           {
@@ -438,15 +438,15 @@ describe("useTable hook", () => {
       expect(result.current[0].columns).toMatchInlineSnapshot(`
         [
           {
-            "apiIdentifier": "name",
-            "name": "Name",
+            "field": "name",
+            "header": "Name",
             "relatedField": undefined,
             "sortable": true,
             "type": "String",
           },
           {
-            "apiIdentifier": "Custom column",
-            "name": "Custom column",
+            "field": "Custom column",
+            "header": "Custom column",
             "sortable": false,
             "type": "CustomRenderer",
           },
@@ -522,7 +522,7 @@ describe("useTable hook", () => {
       `);
 
       // The list should not contain "name" and "inventoryCount" because they are excluded
-      expect(result.current[0].columns?.map((column) => column.apiIdentifier)).toEqual([
+      expect(result.current[0].columns?.map((column) => column.field)).toEqual([
         "id",
         "anything",
         "description",

--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import React, { isValidElement } from "react";
+import React from "react";
 import { useTable } from "../../../src/useTable.js";
 import { testApi as api } from "../../apis.js";
 import { mockUrqlClient } from "../../testWrappers.js";
@@ -43,7 +43,7 @@ describe("useTable hook", () => {
         mustBeLongString: "hellllllllllllllllllllllllllllo",
       },
     ]);
-    expect( result.current[0].columns ).toEqual([
+    expect(result.current[0].columns).toEqual([
       {
         field: "id",
         header: "Id",
@@ -242,31 +242,13 @@ describe("useTable hook", () => {
       expect(result.current[0].rows).toMatchInlineSnapshot(`
         [
           {
-            "belongsTo": {
-              "str": "foo",
-            },
-            "hasMany": {
-              "edges": [
-                {
-                  "node": {
-                    "name": "gizmo 9",
-                  },
-                },
-                {
-                  "node": {
-                    "name": "gizmo 10",
-                  },
-                },
-                {
-                  "node": {
-                    "name": "gizmo 11",
-                  },
-                },
-              ],
-            },
-            "hasOne": {
-              "name": "gizmo 12",
-            },
+            "belongsTo": "foo",
+            "hasMany": [
+              "gizmo 9",
+              "gizmo 10",
+              "gizmo 11",
+            ],
+            "hasOne": "gizmo 12",
             "id": undefined,
             "name": "hello",
           },
@@ -331,31 +313,13 @@ describe("useTable hook", () => {
       expect(result.current[0].rows).toMatchInlineSnapshot(`
         [
           {
-            "belongsTo": {
-              "str": "foo",
-            },
-            "hasMany": {
-              "edges": [
-                {
-                  "node": {
-                    "name": "gizmo 9",
-                  },
-                },
-                {
-                  "node": {
-                    "name": "gizmo 10",
-                  },
-                },
-                {
-                  "node": {
-                    "name": "gizmo 11",
-                  },
-                },
-              ],
-            },
-            "hasOne": {
-              "name": "gizmo 12",
-            },
+            "belongsTo": "foo",
+            "hasMany": [
+              "gizmo 9",
+              "gizmo 10",
+              "gizmo 11",
+            ],
+            "hasOne": "gizmo 12",
             "id": undefined,
             "name": "hello",
           },
@@ -440,7 +404,6 @@ describe("useTable hook", () => {
           {
             "field": "name",
             "header": "Name",
-            "relatedField": undefined,
             "sortable": true,
             "type": "String",
           },
@@ -889,6 +852,12 @@ const loadMockWidgetModelMetadataForRelationship = () => {
                       fieldType: "String",
                       __typename: "GadgetModelField",
                     },
+                    {
+                      name: "Email",
+                      apiIdentifier: "email",
+                      fieldType: "Email",
+                      __typename: "GadgetModelField",
+                    },
                   ],
                   __typename: "GadgetModel",
                 },
@@ -939,6 +908,7 @@ const loadMockWidgetDataForRelationship = () => {
               },
               belongsTo: {
                 str: "foo",
+                email: "foo",
               },
               startsAt: "2024-07-01T01:00:00.000Z",
               updatedAt: "2023-09-21T17:19:11.197Z",

--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -41,14 +41,14 @@ const setMockUseTableResponse = (returns?: { newRows?: any[]; newColumns?: Table
   ];
   columns = returns?.newColumns ?? [
     {
-      apiIdentifier: "name",
-      name: "Name",
+      field: "name",
+      header: "Name",
       sortable: true,
       type: GadgetFieldType.String,
     },
     {
-      apiIdentifier: "inventoryCount",
-      name: "Inventory count",
+      field: "inventoryCount",
+      header: "Inventory count",
       sortable: true,
       type: GadgetFieldType.Number,
     },
@@ -221,38 +221,38 @@ describe("PolarisAutoTable", () => {
       ],
       newColumns: [
         {
-          apiIdentifier: "hasOne",
+          field: "hasOne",
           type: GadgetFieldType.HasOne,
-          name: "Has One",
+          header: "Has One",
           sortable: true,
           relatedField: {
             sortable: true,
-            name: "hasOneName",
-            apiIdentifier: "hasOneName",
+            header: "hasOneName",
+            field: "hasOneName",
             type: GadgetFieldType.String,
           },
         },
         {
-          apiIdentifier: "hasMany",
+          field: "hasMany",
           type: GadgetFieldType.HasMany,
-          name: "Has Many",
+          header: "Has Many",
           sortable: true,
           relatedField: {
-            name: "hasManyNumber",
+            header: "hasManyNumber",
             sortable: true,
-            apiIdentifier: "hasManyNumber",
+            field: "hasManyNumber",
             type: GadgetFieldType.Number,
           },
         },
         {
-          apiIdentifier: "belongsTo",
+          field: "belongsTo",
           type: GadgetFieldType.BelongsTo,
-          name: "Belongs To",
+          header: "Belongs To",
           sortable: true,
           relatedField: {
-            name: 'belongsToEnum',
+            header: 'belongsToEnum',
             sortable: true,
-            apiIdentifier: "belongsToEnum",
+            field: "belongsToEnum",
             type: GadgetFieldType.Enum,
           },
         },
@@ -310,14 +310,14 @@ describe("PolarisAutoTable", () => {
       ],
       newColumns: [
         {
-          apiIdentifier: "name",
+          field: "name",
           type: GadgetFieldType.String,
-          name: "Name",
+          header: "Name",
           sortable: true,
         },
         {
-          name: "Custom cell",
-          apiIdentifier: "Custom cell",
+          header: "Custom cell",
+          field: "Custom cell",
           type: "CustomRenderer",
           sortable: false,
         },
@@ -360,9 +360,9 @@ describe("PolarisAutoTable", () => {
         ],
         newColumns: [
           {
-            apiIdentifier: "tags",
+            field: "tags",
             type: GadgetFieldType.Enum,
-            name: "Tags",
+            header: "Tags",
             sortable: true,
           },
         ],
@@ -392,9 +392,9 @@ describe("PolarisAutoTable", () => {
         ],
         newColumns: [
           {
-            apiIdentifier: "tags",
+            field: "tags",
             type: GadgetFieldType.Enum,
-            name: "Tags",
+            header: "Tags",
             sortable: true,
           },
         ],

--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -5,6 +5,8 @@ import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { testApi as api } from "../../apis.js";
 import { PolarisMockedProviders } from "../inputs/PolarisMockedProviders.js";
+import type { TableColumn } from "../../../src/useTableUtils/types.js";
+import { GadgetFieldType } from "../../../src/internal/gql/graphql.js";
 
 const POLARIS_TABLE_CLASSES = {
   CONTAINER: "Polaris-IndexTable-ScrollContainer",
@@ -16,10 +18,10 @@ const POLARIS_TABLE_CLASSES = {
 const POLARIS_TAG_CLASS = "Polaris-Tag";
 
 let rows: any[] = [];
-let columns: any[] = [];
+let columns: TableColumn[] = [];
 let error: Error | undefined;
 
-const setMockUseTableResponse = (returns?: { newRows?: any[]; newColumns?: any[]; newError?: Error }) => {
+const setMockUseTableResponse = (returns?: { newRows?: any[]; newColumns?: TableColumn[]; newError?: Error }) => {
   rows = returns?.newRows ?? [
     {
       id: "1",
@@ -40,15 +42,15 @@ const setMockUseTableResponse = (returns?: { newRows?: any[]; newColumns?: any[]
   columns = returns?.newColumns ?? [
     {
       apiIdentifier: "name",
-      fieldType: "String",
       name: "Name",
       sortable: true,
+      type: GadgetFieldType.String,
     },
     {
       apiIdentifier: "inventoryCount",
-      fieldType: "Number",
       name: "Inventory count",
       sortable: true,
+      type: GadgetFieldType.Number,
     },
   ];
   error = returns?.newError ?? undefined;
@@ -220,32 +222,38 @@ describe("PolarisAutoTable", () => {
       newColumns: [
         {
           apiIdentifier: "hasOne",
-          fieldType: "HasOne",
+          type: GadgetFieldType.HasOne,
           name: "Has One",
           sortable: true,
           relatedField: {
+            sortable: true,
+            name: "hasOneName",
             apiIdentifier: "hasOneName",
-            fieldType: "String",
+            type: GadgetFieldType.String,
           },
         },
         {
           apiIdentifier: "hasMany",
-          fieldType: "HasMany",
+          type: GadgetFieldType.HasMany,
           name: "Has Many",
           sortable: true,
           relatedField: {
+            name: "hasManyNumber",
+            sortable: true,
             apiIdentifier: "hasManyNumber",
-            fieldType: "Number",
+            type: GadgetFieldType.Number,
           },
         },
         {
           apiIdentifier: "belongsTo",
-          fieldType: "BelongsTo",
+          type: GadgetFieldType.BelongsTo,
           name: "Belongs To",
           sortable: true,
           relatedField: {
+            name: 'belongsToEnum',
+            sortable: true,
             apiIdentifier: "belongsToEnum",
-            fieldType: "Enum",
+            type: GadgetFieldType.Enum,
           },
         },
       ],
@@ -303,16 +311,15 @@ describe("PolarisAutoTable", () => {
       newColumns: [
         {
           apiIdentifier: "name",
-          fieldType: "String",
+          type: GadgetFieldType.String,
           name: "Name",
           sortable: true,
         },
         {
           name: "Custom cell",
           apiIdentifier: "Custom cell",
-          isCustomCell: true,
+          type: "CustomRenderer",
           sortable: false,
-          getValue: customCellRenderer,
         },
       ],
     });
@@ -354,7 +361,7 @@ describe("PolarisAutoTable", () => {
         newColumns: [
           {
             apiIdentifier: "tags",
-            fieldType: "Enum",
+            type: GadgetFieldType.Enum,
             name: "Tags",
             sortable: true,
           },
@@ -386,7 +393,7 @@ describe("PolarisAutoTable", () => {
         newColumns: [
           {
             apiIdentifier: "tags",
-            fieldType: "Enum",
+            type: GadgetFieldType.Enum,
             name: "Tags",
             sortable: true,
           },

--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -3,10 +3,10 @@ import { act, render } from "@testing-library/react";
 import type { UserEvent } from "@testing-library/user-event";
 import { userEvent } from "@testing-library/user-event";
 import React from "react";
+import { GadgetFieldType } from "../../../src/internal/gql/graphql.js";
+import type { TableColumn } from "../../../src/useTableUtils/types.js";
 import { testApi as api } from "../../apis.js";
 import { PolarisMockedProviders } from "../inputs/PolarisMockedProviders.js";
-import type { TableColumn } from "../../../src/useTableUtils/types.js";
-import { GadgetFieldType } from "../../../src/internal/gql/graphql.js";
 
 const POLARIS_TABLE_CLASSES = {
   CONTAINER: "Polaris-IndexTable-ScrollContainer",
@@ -193,68 +193,32 @@ describe("PolarisAutoTable", () => {
       newRows: [
         {
           id: "1",
-          hasOne: {
-            id: "1",
-            hasOneName: "has one name value",
-          },
-          hasMany: {
-            edges: [
-              {
-                node: {
-                  id: "1",
-                  hasManyNumber: 1,
-                },
-              },
-              {
-                node: {
-                  id: "2",
-                  hasManyNumber: 2,
-                },
-              },
-            ],
-          },
-          belongsTo: {
-            id: "1",
-            belongsToEnum: ["belongs", "to", "enum", "value"],
-          },
+          hasOne: "has one name value",
+          hasMany: ["1", "2"],
+          belongsTo: ["belongs", "to", "enum", "value"],
         },
       ],
       newColumns: [
         {
           field: "hasOne",
-          type: GadgetFieldType.HasOne,
+          relationshipType: GadgetFieldType.HasOne,
+          type: GadgetFieldType.String,
           header: "Has One",
           sortable: true,
-          relatedField: {
-            sortable: true,
-            header: "hasOneName",
-            field: "hasOneName",
-            type: GadgetFieldType.String,
-          },
         },
         {
           field: "hasMany",
-          type: GadgetFieldType.HasMany,
+          relationshipType: GadgetFieldType.HasMany,
+          type: GadgetFieldType.String,
           header: "Has Many",
           sortable: true,
-          relatedField: {
-            header: "hasManyNumber",
-            sortable: true,
-            field: "hasManyNumber",
-            type: GadgetFieldType.Number,
-          },
         },
         {
           field: "belongsTo",
-          type: GadgetFieldType.BelongsTo,
+          relationshipType: GadgetFieldType.BelongsTo,
+          type: GadgetFieldType.Enum,
           header: "Belongs To",
           sortable: true,
-          relatedField: {
-            header: 'belongsToEnum',
-            sortable: true,
-            field: "belongsToEnum",
-            type: GadgetFieldType.Enum,
-          },
         },
       ],
     });

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -46,7 +46,7 @@ const gadgetToPolarisDirection = (direction?: SortOrder) => {
 };
 
 const getColumnIndex = (columns: TableColumn[], apiIdentifier: string | undefined) => {
-  return columns.findIndex((column) => column.apiIdentifier === apiIdentifier);
+  return columns.findIndex((column) => column.field === apiIdentifier);
 };
 
 /**
@@ -95,7 +95,7 @@ const PolarisAutoTableComponent = <
 
   const handleColumnSort = (headingIndex: number) => {
     if (columns) {
-      const columnApiIdentifier = columns[headingIndex].apiIdentifier;
+      const columnApiIdentifier = columns[headingIndex].field;
       sort.handleColumnSort(columnApiIdentifier);
     }
   };
@@ -115,7 +115,7 @@ const PolarisAutoTableComponent = <
 
     if (columns) {
       for (const column of columns) {
-        headings.push({ title: column.name });
+        headings.push({ title: column.header });
         sortable.push(column.sortable);
       }
     }
@@ -220,12 +220,12 @@ const PolarisAutoTableComponent = <
               selected={selection.recordIds.includes(row.id as string)}
             >
               {columns.map((column) => (
-                <IndexTable.Cell key={column.apiIdentifier}>
+                <IndexTable.Cell key={column.field}>
                   <div style={{ maxWidth: "200px" }}>
                     {column.type == "CustomRenderer" ? (
-                      (row[column.apiIdentifier] as ReactNode)
+                      (row[column.field] as ReactNode)
                     ) : (
-                      <PolarisAutoTableCellRenderer column={column} value={row[column.apiIdentifier] as ColumnValueType} />
+                      <PolarisAutoTableCellRenderer column={column} value={row[column.field] as ColumnValueType} />
                     )}
                   </div>
                 </IndexTable.Cell>

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -222,7 +222,7 @@ const PolarisAutoTableComponent = <
               {columns.map((column) => (
                 <IndexTable.Cell key={column.apiIdentifier}>
                   <div style={{ maxWidth: "200px" }}>
-                    {column.isCustomCell ? (
+                    {column.type == "CustomRenderer" ? (
                       (row[column.apiIdentifier] as ReactNode)
                     ) : (
                       <PolarisAutoTableCellRenderer column={column} value={row[column.apiIdentifier] as ColumnValueType} />

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { GadgetFieldType } from "../../../internal/gql/graphql.js";
 import { FieldType } from "../../../metadata.js";
 import type { ColumnValueType, HasManyValueType, ValueWithTypename } from "../../../utils.js";
 import { PolarisAutoTableBooleanCell } from "./PolarisAutoTableBooleanCell.js";
@@ -8,13 +7,14 @@ import { PolarisAutoTableEncryptedStringCell } from "./PolarisAutoTableEncrypted
 import { PolarisAutoTableFileCell } from "./PolarisAutoTableFileCell.js";
 import { PolarisAutoTableTagCell } from "./PolarisAutoTableTagCell.js";
 import { PolarisAutoTableTextCell } from "./PolarisAutoTableTextCell.js";
+import type { ColumnType } from "src/useTableUtils/types.js";
 
 export const PolarisAutoTableCellRenderer = (props: {
   column: {
-    fieldType: GadgetFieldType;
+    type: ColumnType;
     relatedField?: {
       apiIdentifier: string;
-      fieldType: GadgetFieldType;
+      type: ColumnType;
     };
   };
   value: ColumnValueType;
@@ -26,7 +26,7 @@ export const PolarisAutoTableCellRenderer = (props: {
     return null;
   }
 
-  switch (column.fieldType) {
+  switch (column.type) {
     case FieldType.Id:
     case FieldType.String:
     case FieldType.Number:

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
@@ -13,7 +13,7 @@ export const PolarisAutoTableCellRenderer = (props: {
   column: {
     type: ColumnType;
     relatedField?: {
-      apiIdentifier: string;
+      field: string;
       type: ColumnType;
     };
   };
@@ -64,7 +64,7 @@ export const PolarisAutoTableCellRenderer = (props: {
       return (
         <PolarisAutoTableCellRenderer
           column={column.relatedField}
-          value={(value as ValueWithTypename)[column.relatedField.apiIdentifier]}
+          value={(value as ValueWithTypename)[column.relatedField.field]}
         />
       );
     }
@@ -72,7 +72,7 @@ export const PolarisAutoTableCellRenderer = (props: {
     case FieldType.HasMany: {
       const { edges } = value as HasManyValueType;
       if (!column.relatedField) return null;
-      return <PolarisAutoTableTagCell value={edges.map((edge) => String(edge.node[column.relatedField!.apiIdentifier]))} />;
+      return <PolarisAutoTableTagCell value={edges.map((edge) => String(edge.node[column.relatedField!.field]))} />;
     }
 
     case FieldType.BelongsTo: {
@@ -80,7 +80,7 @@ export const PolarisAutoTableCellRenderer = (props: {
       return (
         <PolarisAutoTableCellRenderer
           column={column.relatedField}
-          value={(value as ValueWithTypename)[column.relatedField.apiIdentifier]}
+          value={(value as ValueWithTypename)[column.relatedField.field]}
         />
       );
     }

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableCellRenderer.tsx
@@ -1,29 +1,24 @@
 import React from "react";
+import type { TableColumn } from "src/useTableUtils/types.js";
 import { FieldType } from "../../../metadata.js";
-import type { ColumnValueType, HasManyValueType, ValueWithTypename } from "../../../utils.js";
+import type { ColumnValueType } from "../../../utils.js";
 import { PolarisAutoTableBooleanCell } from "./PolarisAutoTableBooleanCell.js";
 import { PolarisAutoTableDateTimeCell } from "./PolarisAutoTableDateTimeCell.js";
 import { PolarisAutoTableEncryptedStringCell } from "./PolarisAutoTableEncryptedStringCell.js";
 import { PolarisAutoTableFileCell } from "./PolarisAutoTableFileCell.js";
 import { PolarisAutoTableTagCell } from "./PolarisAutoTableTagCell.js";
 import { PolarisAutoTableTextCell } from "./PolarisAutoTableTextCell.js";
-import type { ColumnType } from "src/useTableUtils/types.js";
 
-export const PolarisAutoTableCellRenderer = (props: {
-  column: {
-    type: ColumnType;
-    relatedField?: {
-      field: string;
-      type: ColumnType;
-    };
-  };
-  value: ColumnValueType;
-}) => {
+export const PolarisAutoTableCellRenderer = (props: { column: TableColumn; value: ColumnValueType }) => {
   const { column, value } = props;
 
   if (value === null || value === undefined) {
     // Don't render anything for null values
     return null;
+  }
+
+  if (column.relationshipType === FieldType.HasMany) {
+    return <PolarisAutoTableTagCell value={value as any} />;
   }
 
   switch (column.type) {
@@ -57,32 +52,6 @@ export const PolarisAutoTableCellRenderer = (props: {
 
     case FieldType.File: {
       return <PolarisAutoTableFileCell value={value as any} />;
-    }
-
-    case FieldType.HasOne: {
-      if (!column.relatedField) return null;
-      return (
-        <PolarisAutoTableCellRenderer
-          column={column.relatedField}
-          value={(value as ValueWithTypename)[column.relatedField.field]}
-        />
-      );
-    }
-
-    case FieldType.HasMany: {
-      const { edges } = value as HasManyValueType;
-      if (!column.relatedField) return null;
-      return <PolarisAutoTableTagCell value={edges.map((edge) => String(edge.node[column.relatedField!.field]))} />;
-    }
-
-    case FieldType.BelongsTo: {
-      if (!column.relatedField) return null;
-      return (
-        <PolarisAutoTableCellRenderer
-          column={column.relatedField}
-          value={(value as ValueWithTypename)[column.relatedField.field]}
-        />
-      );
     }
 
     default:

--- a/packages/react/src/useTableUtils/helpers.ts
+++ b/packages/react/src/useTableUtils/helpers.ts
@@ -3,7 +3,7 @@ import type { FieldMetadataFragment } from "../internal/gql/graphql.js";
 import { GadgetFieldType } from "../internal/gql/graphql.js";
 import { acceptedAutoTableFieldTypes, filterAutoTableFieldList } from "../metadata.js";
 import { isCustomCellColumn, isRelatedFieldColumn } from "../utils.js";
-import type { TableColumn, TableOptions, TableRow } from "./types.js";
+import type { RelationshipType, TableColumn, TableOptions, TableRow } from "./types.js";
 
 type ColumnsOption = Exclude<TableOptions["columns"], undefined>;
 
@@ -145,36 +145,34 @@ export const getTableColumns = (spec: TableSpec) => {
         type: "CustomRenderer",
         sortable: false,
       });
-      continue;
-    }
+    } else {
+      const field = _getFieldMetadataByApiIdentifier(spec, isRelatedFieldColumn(targetColumn) ? targetColumn.field : targetColumn);
 
-    const field = _getFieldMetadataByApiIdentifier(spec, isRelatedFieldColumn(targetColumn) ? targetColumn.field : targetColumn);
+      const column: TableColumn = {
+        header: field.name,
+        field: field.apiIdentifier,
+        type: field.fieldType,
+        sortable: "sortable" in field && field.sortable,
+      };
 
-    const relatedModel = maybeGetRelatedModelFromRelationshipField(field);
-    const relatedField = isRelatedFieldColumn(targetColumn)
-      ? relatedModel?.fields?.find((field) => field.apiIdentifier === targetColumn.relatedField)
-      : relatedModel
-      ? {
-          name: relatedModel.defaultDisplayField.name,
-          apiIdentifier: relatedModel.defaultDisplayField.apiIdentifier,
-          fieldType: relatedModel.defaultDisplayField.fieldType,
+      const relatedModel = maybeGetRelatedModelFromRelationshipField(field);
+      if (relatedModel) {
+        const relatedField = isRelatedFieldColumn(targetColumn)
+          ? relatedModel.fields?.find((field) => field.apiIdentifier === targetColumn.relatedField)
+          : {
+              name: relatedModel.defaultDisplayField.name,
+              apiIdentifier: relatedModel.defaultDisplayField.apiIdentifier,
+              fieldType: relatedModel.defaultDisplayField.fieldType,
+            };
+
+        if (relatedField) {
+          column.type = relatedField.fieldType;
+          column.relationshipType = field.fieldType as RelationshipType;
         }
-      : undefined;
+      }
 
-    columns.push({
-      header: field.name,
-      field: field.apiIdentifier,
-      type: field.fieldType,
-      sortable: "sortable" in field && field.sortable,
-      relatedField: relatedField
-        ? {
-            header: relatedField.name,
-            field: relatedField.apiIdentifier,
-            type: relatedField.fieldType,
-            sortable: "sortable" in field && field.sortable,
-          }
-        : undefined,
-    });
+      columns.push(column);
+    }
   }
 
   return columns;
@@ -198,10 +196,30 @@ const _recordToRow = (spec: TableSpec, record: GadgetRecord<any>) => {
 
     if (isCustomCellColumn(targetColumn)) {
       row[columnApiIdentifier] = targetColumn.render(record);
-      continue;
-    }
+    } else {
+      const field = _getFieldMetadataByApiIdentifier(spec, isRelatedFieldColumn(targetColumn) ? targetColumn.field : targetColumn);
 
-    row[columnApiIdentifier] = record[columnApiIdentifier];
+      const relatedModel = maybeGetRelatedModelFromRelationshipField(field);
+      if (relatedModel) {
+        const relatedField = isRelatedFieldColumn(targetColumn)
+          ? relatedModel.fields?.find((field) => field.apiIdentifier === targetColumn.relatedField)
+          : {
+              name: relatedModel.defaultDisplayField.name,
+              apiIdentifier: relatedModel.defaultDisplayField.apiIdentifier,
+              fieldType: relatedModel.defaultDisplayField.fieldType,
+            };
+
+        if (relatedField) {
+          if (field.fieldType === GadgetFieldType.HasOne || field.fieldType === GadgetFieldType.BelongsTo) {
+            row[columnApiIdentifier] = record[columnApiIdentifier]?.[relatedField.apiIdentifier];
+          } else {
+            row[columnApiIdentifier] = record[columnApiIdentifier]?.edges.map((edge: any) => edge.node[relatedField.apiIdentifier]);
+          }
+        }
+      } else {
+        row[columnApiIdentifier] = record[columnApiIdentifier];
+      }
+    }
   }
 
   return row;

--- a/packages/react/src/useTableUtils/helpers.ts
+++ b/packages/react/src/useTableUtils/helpers.ts
@@ -140,8 +140,8 @@ export const getTableColumns = (spec: TableSpec) => {
   for (const targetColumn of spec.targetColumns) {
     if (isCustomCellColumn(targetColumn)) {
       columns.push({
-        name: targetColumn.name,
-        apiIdentifier: targetColumn.name,
+        header: targetColumn.name,
+        field: targetColumn.name,
         type: "CustomRenderer",
         sortable: false,
       });
@@ -162,14 +162,14 @@ export const getTableColumns = (spec: TableSpec) => {
       : undefined;
 
     columns.push({
-      name: field.name,
-      apiIdentifier: field.apiIdentifier,
+      header: field.name,
+      field: field.apiIdentifier,
       type: field.fieldType,
       sortable: "sortable" in field && field.sortable,
       relatedField: relatedField
         ? {
-            name: relatedField.name,
-            apiIdentifier: relatedField.apiIdentifier,
+            header: relatedField.name,
+            field: relatedField.apiIdentifier,
             type: relatedField.fieldType,
             sortable: "sortable" in field && field.sortable,
           }

--- a/packages/react/src/useTableUtils/helpers.ts
+++ b/packages/react/src/useTableUtils/helpers.ts
@@ -142,8 +142,7 @@ export const getTableColumns = (spec: TableSpec) => {
       columns.push({
         name: targetColumn.name,
         apiIdentifier: targetColumn.name,
-        getValue: (record) => targetColumn.render(record),
-        isCustomCell: true,
+        type: "CustomRenderer",
         sortable: false,
       });
       continue;
@@ -165,18 +164,14 @@ export const getTableColumns = (spec: TableSpec) => {
     columns.push({
       name: field.name,
       apiIdentifier: field.apiIdentifier,
-      fieldType: field.fieldType,
+      type: field.fieldType,
       sortable: "sortable" in field && field.sortable,
-      getValue: (record) => record[field.apiIdentifier],
-      isCustomCell: false,
       relatedField: relatedField
         ? {
             name: relatedField.name,
             apiIdentifier: relatedField.apiIdentifier,
-            fieldType: relatedField.fieldType,
+            type: relatedField.fieldType,
             sortable: "sortable" in field && field.sortable,
-            getValue: (record) => record[field.apiIdentifier],
-            isCustomCell: false,
           }
         : undefined,
     });

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -8,25 +8,17 @@ import type { PaginationResult } from "../useList.js";
 import type { RecordSelection } from "../useSelectedRecordsController.js";
 import type { ColumnValueType, CustomCellColumn, ErrorWrapper, RelatedFieldColumn } from "../utils.js";
 
-type BaseTableColumn = {
-  header: string;
-  field: string;
-};
-
 export type ColumnType = GadgetFieldType | "CustomRenderer";
 
-export type RecordTableColumnValue = BaseTableColumn & {
+export type RelationshipType = GadgetFieldType.HasMany | GadgetFieldType.HasOne | GadgetFieldType.BelongsTo;
+
+export type TableColumn = {
+  header: string;
+  field: string;
   type: ColumnType;
+  relationshipType?: RelationshipType;
   sortable: boolean;
-  relatedField?: RecordTableColumnValue;
 };
-
-export type CustomTableColumnValue = BaseTableColumn & {
-  type: ColumnType;
-  sortable: false;
-};
-
-export type TableColumn = RecordTableColumnValue | CustomTableColumnValue;
 
 export type TableRow = Record<string, ColumnValueType | ReactNode>;
 

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -13,17 +13,16 @@ type BaseTableColumn = {
   apiIdentifier: string;
 };
 
+export type ColumnType = GadgetFieldType | "CustomRenderer";
+
 export type RecordTableColumnValue = BaseTableColumn & {
-  fieldType: GadgetFieldType;
+  type: ColumnType;
   sortable: boolean;
   relatedField?: RecordTableColumnValue;
-  getValue: (record: GadgetRecord<any>) => ColumnValueType;
-  isCustomCell: false;
 };
 
 export type CustomTableColumnValue = BaseTableColumn & {
-  getValue: (record: GadgetRecord<any>) => ReactNode;
-  isCustomCell: true;
+  type: ColumnType;
   sortable: false;
 };
 

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -9,8 +9,8 @@ import type { RecordSelection } from "../useSelectedRecordsController.js";
 import type { ColumnValueType, CustomCellColumn, ErrorWrapper, RelatedFieldColumn } from "../utils.js";
 
 type BaseTableColumn = {
-  name: string;
-  apiIdentifier: string;
+  header: string;
+  field: string;
 };
 
 export type ColumnType = GadgetFieldType | "CustomRenderer";


### PR DESCRIPTION
In advance of switching over to a path notation for relationship fields, I think it makes sense to make some changes to the way the useTable rows and columns works. Right now, rows is mostly a representation of the record response, and the columns data structure hold a lot of information about i.e. the relationship and related model fields. 

Whatever is consuming the useTable has to implement some logic to i.e. extract the correct data from the edges/node type relationship gql response. 

After this change, that job is moved into the useTable hook, and `rows` now includes a more direct representation of what you would end up seeing in the final table (i.e. if a hasMany fields, the row entry would contain 'fieldName': ['first', 'second', 'third'] rather than a gql style edges/node data structure. 


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
