### PR TITLE
Added error boundary to storybook

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -7,6 +7,7 @@ import { PolarisAutoForm } from "../../src/auto/polaris/PolarisAutoForm.tsx";
 import { PolarisAutoInput } from "../../src/auto/polaris/inputs/PolarisAutoInput.tsx";
 import { PolarisAutoSubmit } from "../../src/auto/polaris/submit/PolarisAutoSubmit.tsx";
 import { testApi as api } from "../apis.ts";
+import { StorybookErrorBoundary } from "./StorybookErrorBoundary.tsx";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
@@ -22,7 +23,9 @@ export default {
             <FormProvider {...useForm()}>
               <Page>
                 <Card>
-                  <Story />
+                  <StorybookErrorBoundary>
+                    <Story />
+                  </StorybookErrorBoundary>
                 </Card>
               </Page>
             </FormProvider>

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -6,6 +6,7 @@ import { Provider } from "../../src/GadgetProvider.tsx";
 import { PolarisAutoTable } from "../../src/auto/polaris/PolarisAutoTable.tsx";
 import { useAction } from "../../src/useAction.ts";
 import { testApi as api } from "../apis.ts";
+import { StorybookErrorBoundary } from "./StorybookErrorBoundary.tsx";
 
 const CustomEmptyStateMarkup = <p>This is a custom empty state. Bazinga.</p>;
 
@@ -13,10 +14,12 @@ const CustomEmptyStateMarkup = <p>This is a custom empty state. Bazinga.</p>;
 export default {
   title: "Polaris/AutoTable",
   component: PolarisAutoTable,
+
   decorators: [
     // 👇 Defining the decorator in the preview file applies it to all stories
     (Story) => {
       // 👇 Make it configurable by reading the theme value from parameters
+
       return (
         <Provider api={api}>
           <AppProvider i18n={translations}>
@@ -24,7 +27,9 @@ export default {
               <Box paddingBlockEnd="400">
                 <BlockStack gap="200">
                   <LegacyCard>
-                    <Story />
+                    <StorybookErrorBoundary>
+                      <Story />
+                    </StorybookErrorBoundary>
                   </LegacyCard>
                 </BlockStack>
               </Box>
@@ -299,7 +304,7 @@ export const CustomEmptyState = {
     filter: { AND: [{ bool: { equals: false } }, { bool: { equals: true } }] },
     model: api.autoTableTest,
     emptyState: CustomEmptyStateMarkup,
-  }
+  },
 };
 
 export const HideSearchAndPagination = {

--- a/packages/react/spec/auto/StorybookErrorBoundary.tsx
+++ b/packages/react/spec/auto/StorybookErrorBoundary.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
+export const StorybookErrorBoundary = (props: { children: React.ReactNode }) => {
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error }) => (
+        <>
+          <h1>AutoForm render error</h1>
+          <h1>{error && error.message}</h1>
+        </>
+      )}
+    >
+      {props.children}
+    </ErrorBoundary>
+  );
+};


### PR DESCRIPTION
Using the existing `"react-error-boundary"` library, an error boundary has been added to surround the storybook entries