### PR TITLE
feat(autotable): Add a useTableContext hook for custom cell rendering

### DIFF
--- a/packages/react/cypress/component/auto/table/AutoTableContext.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableContext.cy.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useAutoTableContext } from "../../../../src/auto/AutoTableContext.js";
+import { PolarisAutoTable } from "../../../../src/auto/polaris/PolarisAutoTable.js";
+import { api } from "../../../support/api.js";
+import { PolarisWrapper } from "../../../support/auto.js";
+import { mockGetWidgets, mockModelMetadata } from "./helpers.js";
+
+const CustomComponent = (props: { record: any; index: number }) => {
+  const [{ data }, refresh] = useAutoTableContext();
+  return (
+    <>
+      <p>
+        index: {props.index}, props.record.id: {props.record.id}, data[index].id: {data[props.index].id}
+      </p>
+      <button onClick={refresh}>refresh</button>
+    </>
+  );
+};
+
+describe("AutoTable - TableContext", () => {
+  it("can be accessed from inside a custom cell renderer", () => {
+    mockModelMetadata();
+    mockGetWidgets();
+
+    cy.mountWithWrapper(
+      <PolarisAutoTable model={api.widget} select={{ name: true }} columns={[{ header: "custom", render: CustomComponent }]} />,
+      PolarisWrapper
+    );
+
+    cy.wait("@getModelMetadata");
+    cy.wait("@getWidgets");
+
+    cy.contains("index: 0, props.record.id: 7, data[index].id: 7");
+
+    cy.contains("refresh").first().click();
+    cy.wait("@getWidgets");
+    cy.get("@getWidgets");
+  });
+});

--- a/packages/react/cypress/component/auto/table/helpers.ts
+++ b/packages/react/cypress/component/auto/table/helpers.ts
@@ -1,0 +1,41 @@
+import { api } from "../../../support/api.js";
+import { first50WidgetRecords, mockSearchResultWidget, widgetModelMetadata } from "./metadata/widgetMetadata.js";
+
+export const mockModelMetadata = () => {
+  cy.intercept(
+    {
+      method: "POST",
+      url: `${api.connection.options.endpoint}?operation=GetModelMetadata`,
+      times: 1,
+    },
+    (req) => {
+      req.reply(widgetModelMetadata);
+    }
+  ).as("getModelMetadata");
+};
+
+export const mockGetWidgets = () => {
+  cy.intercept(
+    {
+      method: "POST",
+      url: `${api.connection.options.endpoint}?operation=widgets`,
+      times: 2,
+    },
+    (req) => {
+      req.reply(first50WidgetRecords);
+    }
+  ).as("getWidgets");
+};
+
+export const mockGetWidgetsWithSearch = (searchedForWidgetName: string) => {
+  cy.intercept(
+    {
+      method: "POST",
+      url: `${api.connection.options.endpoint}?operation=widgets`,
+      times: 1,
+    },
+    (req) => {
+      req.reply(mockSearchResultWidget(searchedForWidgetName));
+    }
+  ).as("getWidgetsWithSearch");
+};

--- a/packages/react/cypress/component/auto/table/metadata/widgetMetadata.ts
+++ b/packages/react/cypress/component/auto/table/metadata/widgetMetadata.ts
@@ -1677,3 +1677,59 @@ export const first50WidgetRecords = {
     traceId: "62efa3ded4eaed65c4309ee48de15d3a",
   },
 };
+
+export const mockSearchResultWidget = (searchedForWidgetName: string) => ({
+  data: {
+    widgets: {
+      pageInfo: {
+        hasNextPage: true,
+        hasPreviousPage: false,
+        startCursor: "eyJpZCI6IjcifQ==",
+        endCursor: "eyJpZCI6IjU2In0=",
+        __typename: "PageInfo",
+      },
+      edges: [
+        {
+          cursor: "eyJpZCI6IjcifQ==",
+          node: {
+            __typename: "Widget",
+            id: "777",
+            anything: null,
+            birthday: "2002-02-02",
+            category: [],
+            color: null,
+            createdAt: "2023-09-07T19:18:50.262Z",
+            description: null,
+            embedding: null,
+            inStock: true,
+            inventoryCount: 1,
+            isChecked: false,
+            metafields: null,
+            mustBeLongString: null,
+            name: searchedForWidgetName,
+            roles: [],
+            secretKey: "skey",
+            startsAt: null,
+            updatedAt: "2024-07-17T20:55:36.191Z",
+          },
+          __typename: "WidgetEdge",
+        },
+      ],
+
+      __typename: "WidgetConnection",
+    },
+    gadgetMeta: {
+      hydrations: {
+        updatedAt: "DateTime",
+        startsAt: "DateTime",
+        birthday: "DateTime",
+        createdAt: "DateTime",
+      },
+      __typename: "GadgetApplicationMeta",
+    },
+  },
+  extensions: {
+    logs: "https://ggt.link/logs/114412/62efa3ded4eaed65c4309ee48de15d3a",
+    traceId: "62efa3ded4eaed65c4309ee48de15d3a",
+  },
+});

--- a/packages/react/src/auto/AutoTableContext.ts
+++ b/packages/react/src/auto/AutoTableContext.ts
@@ -1,0 +1,30 @@
+import { GadgetRecord } from "@gadgetinc/api-client-core";
+import React, { useContext } from "react";
+import type { TableResult } from "src/useTableUtils/types.js";
+
+export type AutoTableContext = TableResult<GadgetRecord<any>>;
+
+/**
+ * React context that stores an instance of the metadata loaded for a particular form action
+ */
+
+export const AutoTableContext = React.createContext<AutoTableContext | undefined>(undefined);
+
+/**
+ * Get the current `metadata` object and `submit` function from React context
+ * Must be called within a component wrapped by the `<AutoForm>` component.
+ **/
+export const useAutoTableContext = () => {
+  const autoTableContext = useContext(AutoTableContext);
+  if (!autoTableContext) {
+    throw new Error(
+      `useAutoTableContext hook called in context where no AutoTableContext is available. Please ensure you are wrapping this hook with the <AutoTable/> component from @gadgetinc/react.
+
+    Possible remedies:
+      - ensuring you have the <AutoTable/> component wrapped around your hook invocation
+      - ensuring your @gadget-client/<your-app> package and your @gadgetinc/react package are up to date`
+    );
+  }
+
+  return autoTableContext;
+};

--- a/packages/react/src/useTableUtils/helpers.tsx
+++ b/packages/react/src/useTableUtils/helpers.tsx
@@ -139,7 +139,7 @@ export const getTableSelectionMap = (spec: TableSpec) => {
 };
 
 export const getTableRows = (spec: Pick<TableSpec, "fieldMetadataTree" | "targetColumns">, records: GadgetRecord<any>[]) => {
-  return records.map((record) => recordToRow(spec, record));
+  return records.map((record, index) => recordToRow(spec, record, index));
 };
 
 export const getTableColumns = (spec: Pick<TableSpec, "fieldMetadataTree" | "targetColumns">) => {
@@ -187,7 +187,7 @@ export const getTableColumns = (spec: Pick<TableSpec, "fieldMetadataTree" | "tar
   return columns;
 };
 
-const recordToRow = (spec: Pick<TableSpec, "fieldMetadataTree" | "targetColumns">, record: GadgetRecord<any>) => {
+const recordToRow = (spec: Pick<TableSpec, "fieldMetadataTree" | "targetColumns">, record: GadgetRecord<any>, index: number) => {
   const row: TableRow = {
     id: record.id,
   };
@@ -195,7 +195,7 @@ const recordToRow = (spec: Pick<TableSpec, "fieldMetadataTree" | "targetColumns"
   for (const targetColumn of spec.targetColumns) {
     if (isCustomCellColumn(targetColumn)) {
       const CellComponent = targetColumn.render;
-      row[targetColumn.header] = <CellComponent record={record} />;
+      row[targetColumn.header] = <CellComponent record={record} index={index} />;
       continue;
     }
 

--- a/packages/react/src/useTableUtils/types.ts
+++ b/packages/react/src/useTableUtils/types.ts
@@ -67,7 +67,7 @@ export type TableData<Data> =
       metadata: null;
     };
 
-type SortState = {
+export type SortState = {
   column: string;
   direction: SortOrder;
   handleColumnSort: (column: string) => void;
@@ -96,7 +96,7 @@ export type RelatedFieldColumn = {
 
 export type CustomCellColumn = {
   header: string;
-  render: (props: { record: GadgetRecord<any> }) => ReactNode;
+  render: (props: { record: GadgetRecord<any>; index: number }) => ReactNode;
 };
 
 export type CellDetailColumn = {


### PR DESCRIPTION
In order to enable maximum flexibility for custom cell renderers, there is now a AutoTableContext and useAutoTableContext hook which basically returns everything that useTable() returns. 

You can access this in your component to trigger search actions, get pagination information, or access the raw data across records/rows. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
