### PR TITLE
Removed color input

### DIFF
--- a/packages/react/src/auto/mui/test-index.ts
+++ b/packages/react/src/auto/mui/test-index.ts
@@ -11,7 +11,6 @@ export { MUIAutoInput as AutoInput } from "./inputs/MUIAutoInput.js";
 export { MUIAutoJSONInput as AutoJSONInput } from "./inputs/MUIAutoJSONInput.js";
 export { MUIAutoRolesInput as AutoRolesInput } from "./inputs/MUIAutoRolesInput.js";
 export {
-  MUIAutoTextInput as AutoColorInput,
   MUIAutoTextInput as AutoEmailInput,
   MUIAutoTextInput as AutoNumberInput,
   MUIAutoTextInput as AutoStringInput,

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -14,7 +14,6 @@ export { PolarisAutoNumberInput as AutoNumberInput } from "./inputs/PolarisAutoN
 export { PolarisAutoPasswordInput as AutoPasswordInput } from "./inputs/PolarisAutoPasswordInput.js";
 export { PolarisAutoRolesInput as AutoRolesInput } from "./inputs/PolarisAutoRolesInput.js";
 export {
-  PolarisAutoTextInput as AutoColorInput,
   PolarisAutoTextInput as AutoEmailInput,
   PolarisAutoTextInput as AutoStringInput,
   PolarisAutoTextInput as AutoTextInput,


### PR DESCRIPTION
The color input does not correspond with a Gadget field type, so it is being removed from the Polaris and MUI autocomponents. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
