### PR TITLE
Added Upsert support in AutoForm

### DIFF
--- a/packages/react/.changeset/little-bikes-dress.md
+++ b/packages/react/.changeset/little-bikes-dress.md
@@ -1,0 +1,27 @@
+---
+"@gadgetinc/react": minor
+---
+
+# Added support for `upsert` actions in AutoForm.
+
+- Models that have `create` and `update` actions get the `upsert` meta-action
+  - Upsert actions update records with given ID, and create a new record if the record does not exist
+  - The ID field is optional and omitting it will run the create action
+- Upsert actions can be used in `AutoForm` components in the same way that other actions are used
+- Usage
+  - With a given `findBy` value, the `upsert` action will run on the given specified ID value
+    - ```jsx
+      <AutoForm action={api.someModel.upsert} findBy="1" />
+      ```
+  - Without a given `findBy` value, an ID input field will appear in the form
+    - ```jsx
+      <AutoForm action={api.someModel.upsert} />
+      ```
+  - Just like other actions, the content of the form can be customized
+    - ```jsx
+      <AutoForm action={api.someModel.upsert}>
+        <AutoInput field="id" />
+        <AutoInput field="name" />
+        <AutoSubmit />
+      </AutoForm>
+      ```

--- a/packages/react/cypress/component/auto/form/AutoFormUpsertAction.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormUpsertAction.cy.tsx
@@ -1,0 +1,308 @@
+import React from "react";
+import { apiTriggerOnly } from "../../../../spec/auto/support/Triggers.js";
+import { MUIAutoInput } from "../../../../src/auto/mui/inputs/MUIAutoInput.js";
+import { MUIAutoSubmit } from "../../../../src/auto/mui/submit/MUIAutoSubmit.js";
+import { PolarisAutoInput } from "../../../../src/auto/polaris/inputs/PolarisAutoInput.js";
+import { PolarisAutoSubmit } from "../../../../src/auto/polaris/submit/PolarisAutoSubmit.js";
+import { api } from "../../../support/api.js";
+import { describeForEachAutoAdapter } from "../../../support/auto.js";
+
+describeForEachAutoAdapter("AutoForm - ID field", ({ name, adapter: { AutoForm }, wrapper }) => {
+  it("does not render an input for ID when the action is not upsert", () => {
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} include={["name", "inventoryCount", "id"]} />, wrapper);
+
+    cy.contains("Name").should("exist");
+    cy.get(`input[name="widget.name"]`).should("exist");
+
+    cy.contains("Inventory count").should("exist");
+    cy.get(`input[name="widget.inventoryCount"]`).should("exist");
+
+    cy.contains("ID").should("not.exist");
+    cy.get(`input[name="widget.id"]`).should("not.exist");
+  });
+});
+
+describeForEachAutoAdapter("AutoForm - Upsert Action", ({ name, adapter: { AutoForm }, wrapper }) => {
+  let upsertHasBeenCalled: boolean;
+
+  const interceptModelUpsertActionMetadata = () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: `${api.connection.endpoint}?operation=ModelActionMetadata`,
+      },
+
+      upsertModelActionMetadataResponse
+    ).as("ModelCreateActionMetadata");
+  };
+
+  const mockSuccessfulUpsert = () => {
+    cy.intercept({ method: "POST", url: `${api.connection.endpoint}?operation=upsertWidget` }, (req) => {
+      upsertHasBeenCalled = true;
+
+      // The response content doesn't matter for the tests __typename: "UpdateWidgetResult",
+      req.reply({
+        data: {
+          upsertWidget: { success: true, errors: null, __typename: "UpdateWidgetResult", widget: {} },
+        },
+      });
+    }).as("upsertWidget");
+  };
+
+  const mockSuccessfulWidgetFindBy = () => {
+    cy.intercept({ method: "POST", url: `${api.connection.endpoint}?operation=widget` }, (req) => {
+      req.reply({
+        data: {
+          widget: {
+            __typename: "Widget",
+            id: "1",
+            createdAt: "2024-06-24T17:46:07.333Z",
+            inventoryCount: 1234,
+            name: "updated test record",
+            updatedAt: "2024-08-12T13:41:12.139Z",
+          },
+        },
+      });
+    }).as("widget");
+  };
+
+  const mockUnsuccessfulWidgetFindBy = () => {
+    cy.intercept({ method: "POST", url: `${api.connection.endpoint}?operation=widget` }, (req) => {
+      req.reply({
+        data: { widget: null },
+      });
+    }).as("widget");
+  };
+
+  const populateRequiredFields = () => {
+    cy.get(`input[name="widget.name"]`).clear().type("name");
+    cy.get(`input[name="widget.inventoryCount"]`).clear().type("123");
+  };
+
+  beforeEach(() => {
+    upsertHasBeenCalled = false;
+    cy.viewport("macbook-13");
+    interceptModelUpsertActionMetadata();
+  });
+
+  it("renders the ID input field when there is no given findBy value", () => {
+    cy.mountWithWrapper(<AutoForm action={api.widget.upsert} />, wrapper);
+
+    cy.contains("ID").should("exist");
+    cy.get(`input[name="widget.id"]`).should("exist");
+
+    mockSuccessfulUpsert();
+    populateRequiredFields();
+
+    // Does not allow submission when the ID input does not have a positive integer value
+    cy.get(`input[name="widget.id"]`).clear().type("-1{enter}");
+    if (upsertHasBeenCalled) throw new Error("Upsert was called when it shouldn't have been");
+
+    cy.get(`input[name="widget.id"]`).clear().type("1.1{enter}");
+    if (upsertHasBeenCalled) throw new Error("Upsert was called when it shouldn't have been");
+
+    cy.get(`input[name="widget.id"]`).clear().type("1{enter}");
+    cy.wait("@upsertWidget")
+      .its("request.body.variables")
+      .should("deep.equal", {
+        widget: {
+          id: "1",
+          name: "name",
+          inventoryCount: 123,
+        },
+      });
+  });
+
+  it("Does not render the ID input field when given a findBy value, and populates the form with the record data", () => {
+    mockSuccessfulWidgetFindBy();
+    cy.mountWithWrapper(<AutoForm action={api.widget.upsert} findBy="1" />, wrapper);
+
+    cy.contains("ID").should("not.exist");
+    cy.get(`input[name="widget.id"]`).should("not.exist");
+  });
+
+  it("Can exclude the ID field when there is no findBy and submit successfully", () => {
+    mockUnsuccessfulWidgetFindBy();
+    cy.mountWithWrapper(<AutoForm action={api.widget.upsert} exclude={["id"]} />, wrapper);
+
+    mockSuccessfulUpsert();
+    populateRequiredFields();
+    cy.contains("ID").should("not.exist");
+    cy.get(`input[name="widget.id"]`).should("not.exist");
+    cy.get(`button[type="submit"]`).eq(0).click({ force: true });
+
+    cy.wait("@upsertWidget")
+      .its("request.body.variables")
+      .should("deep.equal", {
+        widget: {
+          name: "name",
+          inventoryCount: 123,
+        },
+      });
+  });
+
+  it("Shows a message when given an ID that does not exist in findBy", () => {
+    mockUnsuccessfulWidgetFindBy();
+    cy.mountWithWrapper(<AutoForm action={api.widget.upsert} findBy="1" />, wrapper);
+    cy.contains("Record Not Found Error: Gadget API returned no data at widget").should("exist");
+  });
+
+  it("Can properly submit with custom form contents", () => {
+    mockSuccessfulWidgetFindBy();
+    mockSuccessfulUpsert();
+
+    cy.mountWithWrapper(
+      <AutoForm action={api.widget.upsert} findBy="1">
+        {name === "Polaris" ? (
+          <>
+            <PolarisAutoInput field="name" />
+            <PolarisAutoInput field="inventoryCount" />
+            <PolarisAutoSubmit />
+          </>
+        ) : (
+          <>
+            <MUIAutoInput field="name" />
+            <MUIAutoInput field="inventoryCount" />
+            <MUIAutoSubmit />
+          </>
+        )}
+      </AutoForm>,
+      wrapper
+    );
+
+    populateRequiredFields();
+
+    cy.get(`button[type="submit"]`).eq(0).click({ force: true });
+
+    cy.wait("@upsertWidget")
+      .its("request.body.variables")
+      .should("deep.equal", {
+        id: "1",
+        widget: {
+          id: "1",
+          name: "name",
+          inventoryCount: 123,
+        },
+      });
+  });
+});
+
+const upsertModelActionMetadataResponse = {
+  data: {
+    gadgetMeta: {
+      model: {
+        name: "Widget",
+        apiIdentifier: "widget",
+        defaultRecord: {
+          name: "",
+          description: {
+            markdown: "",
+          },
+          category: [],
+          __typename: "Widget",
+        },
+        action: {
+          name: "Upsert",
+          apiIdentifier: "upsert",
+          operatesWithRecordIdentity: false,
+          isDeleteAction: false,
+          inputFields: [
+            {
+              name: "On",
+              apiIdentifier: "on",
+              fieldType: "Array",
+              requiredArgumentForInput: false,
+              configuration: {
+                __typename: "GadgetGenericFieldConfig",
+                fieldType: "Array",
+                validations: [],
+              },
+              __typename: "GadgetObjectField",
+            },
+            {
+              name: "Widget",
+              apiIdentifier: "widget",
+              fieldType: "Object",
+              requiredArgumentForInput: false,
+              configuration: {
+                __typename: "GadgetObjectFieldConfig",
+                fieldType: "Object",
+                validations: [],
+                name: null,
+                fields: [
+                  {
+                    name: "Id",
+                    apiIdentifier: "id",
+                    fieldType: "ID",
+                    requiredArgumentForInput: false,
+                    sortable: true,
+                    filterable: true,
+                    __typename: "GadgetModelField",
+                    configuration: {
+                      __typename: "GadgetGenericFieldConfig",
+                      fieldType: "ID",
+                      validations: [],
+                    },
+                  },
+                  {
+                    name: "Name",
+                    apiIdentifier: "name",
+                    fieldType: "String",
+                    requiredArgumentForInput: true,
+                    sortable: true,
+                    filterable: true,
+                    __typename: "GadgetModelField",
+                    configuration: {
+                      __typename: "GadgetGenericFieldConfig",
+                      fieldType: "String",
+                      validations: [
+                        {
+                          __typename: "GadgetGenericFieldValidation",
+                          name: "Required",
+                          specID: "gadget/validation/required",
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    name: "Inventory count",
+                    apiIdentifier: "inventoryCount",
+                    fieldType: "Number",
+                    requiredArgumentForInput: true,
+                    sortable: true,
+                    filterable: true,
+                    __typename: "GadgetModelField",
+                    configuration: {
+                      __typename: "GadgetNumberConfig",
+                      fieldType: "Number",
+                      validations: [
+                        {
+                          __typename: "GadgetRangeFieldValidation",
+                          name: "Number range",
+                          specID: "gadget/validation/number-range",
+                          min: 0,
+                          max: null,
+                        },
+                        {
+                          __typename: "GadgetGenericFieldValidation",
+                          name: "Required",
+                          specID: "gadget/validation/required",
+                        },
+                      ],
+                      decimals: null,
+                    },
+                  },
+                ],
+              },
+              __typename: "GadgetObjectField",
+            },
+          ],
+          triggers: apiTriggerOnly,
+          __typename: "GadgetAction",
+        },
+        __typename: "GadgetModel",
+      },
+      __typename: "GadgetApplicationMeta",
+    },
+  },
+};

--- a/packages/react/cypress/component/auto/form/AutoRoleInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoRoleInput.cy.tsx
@@ -73,7 +73,6 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     cy.get(`span`).contains("test-api-key").should("exist"); // Chip to show the selected role
 
     expectCreateActionSubmissionVariables({
-      id: "0",
       widget: {
         roles: ["Role-abc123abc"], // Role key is sent. Not the role name
       },

--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -58,6 +58,19 @@ export const UpdateRecord = {
   },
 };
 
+export const UpsertRecordWithFindBy = {
+  args: {
+    action: api.widget.upsert,
+    findBy: "1",
+  },
+};
+
+export const UpsertRecordWithoutFindBy = {
+  args: {
+    action: api.widget.upsert,
+  },
+};
+
 export const Excluded = {
   args: {
     action: api.widget.create,

--- a/packages/react/src/auto/mui/inputs/MUIAutoIdInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoIdInput.tsx
@@ -1,0 +1,31 @@
+import { FieldType } from "../../../metadata.js";
+
+import type { TextFieldProps } from "@mui/material";
+import React from "react";
+import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { MUIAutoTextInput } from "./MUIAutoTextInput.js";
+
+export const MUIAutoIdInput = (
+  props: {
+    field: string;
+  } & Partial<TextFieldProps>
+) => {
+  const { field } = props;
+  const { name, metadata } = useStringInputController({ field });
+
+  if (metadata.fieldType !== FieldType.Id || field !== "id") {
+    throw new Error(`PolarisAutoIdInput: field ${field} is not of type Id`);
+  }
+
+  return (
+    <MUIAutoTextInput
+      field={field}
+      label="ID"
+      name={name}
+      InputProps={{
+        inputProps: { min: 1, step: 1 },
+      }}
+      type="number"
+    />
+  );
+};

--- a/packages/react/src/auto/mui/inputs/MUIAutoInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoInput.tsx
@@ -6,6 +6,7 @@ import MUIAutoDateTimePicker from "./MUIAutoDateTimePicker.js";
 import { MUIAutoEncryptedStringInput } from "./MUIAutoEncryptedStringInput.js";
 import { MUIAutoEnumInput } from "./MUIAutoEnumInput.js";
 import { MUIAutoFileInput } from "./MUIAutoFileInput.js";
+import { MUIAutoIdInput } from "./MUIAutoIdInput.js";
 import { MUIAutoJSONInput } from "./MUIAutoJSONInput.js";
 import { MUIAutoPasswordInput } from "./MUIAutoPasswordInput.js";
 import { MUIAutoRolesInput } from "./MUIAutoRolesInput.js";
@@ -21,6 +22,9 @@ export const MUIAutoInput = (props: { field: string }) => {
   const config = metadata.configuration;
 
   switch (config.fieldType) {
+    case FieldType.Id: {
+      return <MUIAutoIdInput field={props.field} />;
+    }
     case FieldType.String:
     case FieldType.Number:
     case FieldType.Email:

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoIdInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoIdInput.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { FieldType } from "../../../metadata.js";
+import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
+
+export const PolarisAutoIdInput = (props: {
+  field: string; // The field API identifier
+}) => {
+  const { field } = props;
+  const { name, metadata } = useStringInputController({ field });
+
+  if (metadata.fieldType !== FieldType.Id || field !== "id") {
+    throw new Error(`PolarisAutoIdInput: field ${field} is not of type Id`);
+  }
+
+  return <PolarisAutoTextInput step={1} field={field} min={1} type="number" label="ID" name={name} />;
+};

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
@@ -6,6 +6,7 @@ import { PolarisAutoDateTimePicker } from "./PolarisAutoDateTimePicker.js";
 import { PolarisAutoEncryptedStringInput } from "./PolarisAutoEncryptedStringInput.js";
 import { PolarisAutoEnumInput } from "./PolarisAutoEnumInput.js";
 import { PolarisAutoFileInput } from "./PolarisAutoFileInput.js";
+import { PolarisAutoIdInput } from "./PolarisAutoIdInput.js";
 import { PolarisAutoJSONInput } from "./PolarisAutoJSONInput.js";
 import { PolarisAutoNumberInput } from "./PolarisAutoNumberInput.js";
 import { PolarisAutoPasswordInput } from "./PolarisAutoPasswordInput.js";
@@ -22,6 +23,9 @@ export const PolarisAutoInput = (props: { field: string }) => {
   const config = metadata.configuration;
 
   switch (config.fieldType) {
+    case FieldType.Id: {
+      return <PolarisAutoIdInput field={props.field} />;
+    }
     case FieldType.String:
     case FieldType.Email:
     case FieldType.Color:

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -353,7 +353,7 @@ export const useActionMetadata = (actionFunction: ActionFunction<any, any, any, 
  */
 export const filterAutoFormFieldList = (
   fields: FieldMetadata[] | undefined,
-  options?: { include?: string[]; exclude?: string[] }
+  options?: { include?: string[]; exclude?: string[]; isUpsertAction?: boolean }
 ): FieldMetadata[] => {
   if (!fields) {
     return [];
@@ -384,7 +384,7 @@ export const filterAutoFormFieldList = (
   }
 
   // Filter out fields that are not supported by the form
-  const validFieldTypeSubset = subset.filter(isAcceptedFieldTypeFilter);
+  const validFieldTypeSubset = subset.filter(options?.isUpsertAction ? isAcceptedUpsertFieldType : isAcceptedFieldType);
 
   return options?.include
     ? validFieldTypeSubset // Everything explicitly included is valid
@@ -405,7 +405,9 @@ const isNotRelatedToSpecialModelFilter = (field: FieldMetadata) => {
 
 const specialModelKeys = new Set(["DataModel-Shopify-Shop"]);
 
-const isAcceptedFieldTypeFilter = (field: FieldMetadata) => acceptedAutoFormFieldTypes.has(field.fieldType);
+const isAcceptedFieldType = (field: FieldMetadata) => acceptedAutoFormFieldTypes.has(field.fieldType);
+const isAcceptedUpsertFieldType = (field: FieldMetadata) => field.fieldType === FieldType.Id || isAcceptedFieldType(field);
+
 const acceptedAutoFormFieldTypes = new Set([
   FieldType.Boolean,
   FieldType.Color,


### PR DESCRIPTION
- **UPDATE**
  - Added upsert support to AutoForm
    - When findBy is passed in 
      - Is effectively an update action, but will create a record if given the ID that does not exist
      - Does not clear inputs upon submission
    - Without findBy
      - An ID field input will be rendered allowing users to set the ID
      - Clears all inputs upon submit
- **OTHER CONSIDERATIONS**
  - Consider if/how the `on` field in upsert actions should work in fields. Currently unsupported

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
