### PR TITLE
Switch how we call `render` function to a JSX style

### DIFF
--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -1,4 +1,4 @@
-import { AppProvider, BlockStack, Box, Button, LegacyCard } from "@shopify/polaris";
+import { AppProvider, BlockStack, Box, Button, Checkbox, LegacyCard } from "@shopify/polaris";
 import { DeleteIcon } from "@shopify/polaris-icons";
 import translations from "@shopify/polaris/locales/en.json";
 import React, { useEffect } from "react";
@@ -155,10 +155,38 @@ export const LiveData = {
   },
 };
 
-export const huh = {
+const CustomCheckboxCell = ({ record }) => {
+  const [_result, update] = useAction(api.autoTableTest.update);
+
+  return (
+    <Checkbox
+      checked={record.bool}
+      onChange={(value) => {
+        void update({
+          id: record.id,
+          bool: value,
+        });
+      }}
+    />
+  );
+};
+
+export const CustomCellWithUseAction = {
   args: {
     model: api.autoTableTest,
-    columns: [{ header: "custom", render: () => <p>hello</p> }],
+    columns: [
+      "bool",
+      {
+        header: "Pass the whole function",
+        render: CustomCheckboxCell,
+      },
+      {
+        header: "JSX style",
+        render: (props) => <CustomCheckboxCell {...props} />,
+      },
+    ],
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onClick: () => {},
   },
 };
 

--- a/packages/react/src/useTableUtils/helpers.tsx
+++ b/packages/react/src/useTableUtils/helpers.tsx
@@ -1,4 +1,5 @@
 import type { FieldSelection, GadgetRecord } from "@gadgetinc/api-client-core";
+import React from "react";
 import type { FieldMetadataFragment } from "../internal/gql/graphql.js";
 import { GadgetFieldType } from "../internal/gql/graphql.js";
 import { acceptedAutoTableFieldTypes, filterAutoTableFieldList } from "../metadata.js";
@@ -190,7 +191,8 @@ const recordToRow = (spec: Pick<TableSpec, "fieldMetadataTree" | "targetColumns"
 
   for (const targetColumn of spec.targetColumns) {
     if (isCustomCellColumn(targetColumn)) {
-      row[targetColumn.header] = targetColumn.render({ record });
+      const CellComponent = targetColumn.render;
+      row[targetColumn.header] = <CellComponent record={record} />;
       continue;
     }
 


### PR DESCRIPTION
Previously, passing the JSX element into the custom cell renderer's `render` function was impossible when a hook was inside. This PR fixes that by treating the `render` property as a JSX element and invoking it in a JSX style. 

Fixes GGT-6904

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
