### PR TITLE
Use default selection when `columns` property does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.498.0-development.1725",
+    "@gadget-client/js-clients-test": "1.498.0-development.1770",
     "@gadget-client/kitchen-sink": "1.5.0-development.200",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
@@ -72,31 +72,31 @@ describe("AutoTable - Sort", () => {
     cy.wait("@getWidgets").its("request.body.variables").should("deep.equal", { first: 50 });
 
     mockGetWidgetsWithDescendingSort();
-    cy.contains("Sortable Id").click({ force: true });
+    cy.contains("ID").click({ force: true });
     cy.wait("@getWidgetsWithDescendingSort");
     cy.get("@getWidgetsWithDescendingSort")
       .its("request.body.variables")
       .should("deep.equal", {
         first: 50,
         sort: {
-          sortableId: "Descending",
+          id: "Descending",
         },
       });
 
     mockGetWidgetsWithAscendingSort();
-    cy.contains("Sortable Id").click({ force: true });
+    cy.contains("ID").click({ force: true });
     cy.wait("@getWidgetsWithAscendingSort");
     cy.get("@getWidgetsWithAscendingSort")
       .its("request.body.variables")
       .should("deep.equal", {
         first: 50,
         sort: {
-          sortableId: "Ascending",
+          id: "Ascending",
         },
       });
 
     mockGetWidgets();
-    cy.contains("Sortable Id").click({ force: true });
+    cy.contains("ID").click({ force: true });
     cy.wait("@getWidgets");
     cy.get("@getWidgets").its("request.body.variables").should("deep.equal", {
       first: 50,
@@ -127,8 +127,8 @@ const sortTestWidgetModelMetadata = {
         name: "Sort Widget",
         fields: [
           {
-            name: "Sortable Id",
-            apiIdentifier: "sortableId",
+            name: "ID",
+            apiIdentifier: "id",
             fieldType: "ID",
             requiredArgumentForInput: true,
             sortable: true,
@@ -152,8 +152,8 @@ const sortTestWidgetModelMetadata = {
             },
           },
           {
-            name: "Sortable integer field",
-            apiIdentifier: "sortableIntegerField",
+            name: "Inventory count",
+            apiIdentifier: "inventoryCount",
             fieldType: "Number",
             requiredArgumentForInput: true,
             sortable: true,
@@ -199,8 +199,8 @@ const mockUnsortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "0",
-            sortableIntegerField: 17,
+            id: "0",
+            inventoryCount: 17,
           },
           __typename: "WidgetEdge",
         },
@@ -208,8 +208,8 @@ const mockUnsortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "2",
-            sortableIntegerField: 15,
+            id: "2",
+            inventoryCount: 15,
           },
           __typename: "WidgetEdge",
         },
@@ -217,8 +217,8 @@ const mockUnsortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "1",
-            sortableIntegerField: 16,
+            id: "1",
+            inventoryCount: 16,
           },
           __typename: "WidgetEdge",
         },
@@ -243,8 +243,8 @@ const mockDescendingSortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "2",
-            sortableIntegerField: 15,
+            id: "2",
+            inventoryCount: 15,
           },
           __typename: "WidgetEdge",
         },
@@ -252,8 +252,8 @@ const mockDescendingSortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "1",
-            sortableIntegerField: 16,
+            id: "1",
+            inventoryCount: 16,
           },
           __typename: "WidgetEdge",
         },
@@ -261,8 +261,8 @@ const mockDescendingSortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "0",
-            sortableIntegerField: 17,
+            id: "0",
+            inventoryCount: 17,
           },
           __typename: "WidgetEdge",
         },
@@ -287,8 +287,8 @@ const mockAscendingSortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "0",
-            sortableIntegerField: 17,
+            id: "0",
+            inventoryCount: 17,
           },
           __typename: "WidgetEdge",
         },
@@ -296,8 +296,8 @@ const mockAscendingSortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "1",
-            sortableIntegerField: 16,
+            id: "1",
+            inventoryCount: 16,
           },
           __typename: "WidgetEdge",
         },
@@ -305,8 +305,8 @@ const mockAscendingSortedIdContent = {
           cursor: "eyJpZCI6IjcifQ==",
           node: {
             __typename: "Widget",
-            sortableId: "2",
-            sortableIntegerField: 15,
+            id: "2",
+            inventoryCount: 15,
           },
           __typename: "WidgetEdge",
         },

--- a/packages/react/spec/apis.ts
+++ b/packages/react/spec/apis.ts
@@ -18,4 +18,13 @@ export const simpleExampleApi = new SimpleClient({ environment: "Development" })
 export const kitchenSinkApi = new KitchenSinkClient({ environment: "Development" });
 export const hasManyThroughApi = new ManyThroughClient({ environment: "Development" });
 export const fileFieldApi = new FileFieldClient({ environment: "Development" });
-export const testApi = new TestClient({ environment: "Development" });
+export const testApi = new TestClient({
+  environment: "Development",
+  authenticationMode:
+    "VITE_JS_CLIENTS_TEST_API_KEY" in (import.meta as any)
+      ? ({
+          apiKey: (import.meta as any).env.VITE_JS_CLIENTS_TEST_API_KEY,
+          dangerouslyAllowBrowserApiKey: true,
+        } as any)
+      : undefined,
+});

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -251,6 +251,12 @@ export const SelectProperty = {
   },
 };
 
+export const ShopifyShopModel = {
+  args: {
+    model: api.shopifyShop,
+  },
+};
+
 const CustomDeleteButtonCellRenderer = (props) => {
   const [{ error, fetching }, _delete] = useAction(api.autoTableTest.delete);
 

--- a/packages/react/src/useTableUtils/helpers.tsx
+++ b/packages/react/src/useTableUtils/helpers.tsx
@@ -40,7 +40,10 @@ export const getTableSpec = (
       .map((field) => field.apiIdentifier);
   } else {
     // Select all fields available for the table
-    spec.targetColumns = filterAutoTableFieldList(fieldMetadataArray).map((field) => field.apiIdentifier);
+    const defaultSelectionKeys = new Set(Object.keys(defaultSelection));
+    spec.targetColumns = filterAutoTableFieldList(fieldMetadataArray.filter((field) => defaultSelectionKeys.has(field.apiIdentifier))).map(
+      (field) => field.apiIdentifier
+    );
   }
 
   return spec;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.498.0-development.1725
-        version: 1.498.0-development.1725
+        specifier: 1.498.0-development.1770
+        version: 1.498.0-development.1770
       '@gadget-client/kitchen-sink':
         specifier: 1.5.0-development.200
         version: 1.5.0-development.200
@@ -3731,8 +3731,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.498.0-development.1725:
-    resolution: {integrity: sha1-9wcnpks0wmFUzO76ErsMB9q8ZjM=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8679}
+  /@gadget-client/js-clients-test@1.498.0-development.1770:
+    resolution: {integrity: sha1-ogZ0kfkNvCsqXULtKhcJ4cX/9Ec=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/8829}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
Some model fields are unavailable to query but are still included in the GadgetMeta response. This PR uses the `defaultSelection` instead to build the `targetColumns` array.

Fixes GGT-6903

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
