### PR TITLE
fix(auto-table): remove accidental polaris import from useTable hooks

### DIFF
--- a/packages/react/spec/imports/example-vite-base-react-project/index.html
+++ b/packages/react/spec/imports/example-vite-base-react-project/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/packages/react/spec/imports/example-vite-base-react-project/main.js
+++ b/packages/react/spec/imports/example-vite-base-react-project/main.js
@@ -1,0 +1,7 @@
+import * as GadgetReact from "@gadgetinc/react";
+
+document.querySelector("#app").innerHTML = `
+  <div>
+    <h1>Hello Vite!</h1> ${typeof GadgetReact}
+  </div>
+`;

--- a/packages/react/spec/imports/example-vite-base-react-project/package.json
+++ b/packages/react/spec/imports/example-vite-base-react-project/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "example-vite-project",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "4.4.9"
+  }
+}
+

--- a/packages/react/src/useSelectedRecordsController.tsx
+++ b/packages/react/src/useSelectedRecordsController.tsx
@@ -1,6 +1,13 @@
-import { IndexTableSelectionType } from "@shopify/polaris";
 import { useEffect, useState } from "react";
 import { uniq } from "./utils.js";
+
+export enum SelectionType {
+  All = "all",
+  Page = "page",
+  Multi = "multi",
+  Single = "single",
+  Range = "range",
+}
 
 export type RecordSelection = {
   recordIds: string[];
@@ -8,12 +15,7 @@ export type RecordSelection = {
   selectCurrentPage: () => void;
   selectIds: (ids: string[]) => void;
   deselectIds: (ids: string[]) => void;
-  onSelectionChange: (
-    selectionType: IndexTableSelectionType,
-    toggleType: boolean,
-    selection?: string | [number, number],
-    position?: number
-  ) => void;
+  onSelectionChange: (selectionType: SelectionType, toggleType: boolean, selection?: string | [number, number], position?: number) => void;
 };
 
 export const useSelectedRecordsController = (props: { currentPageIds: string[] }) => {
@@ -33,22 +35,22 @@ export const useSelectedRecordsController = (props: { currentPageIds: string[] }
   }, [currentPageIds.join(",")]);
 
   const onSelectionChange = (
-    selectionType: IndexTableSelectionType,
+    selectionType: SelectionType,
     toggleType: boolean,
     selection?: string | [number, number],
     position?: number
   ) => {
     switch (selectionType) {
-      case IndexTableSelectionType.Single: {
+      case SelectionType.Single: {
         const selectedId = [`${selection}`];
         toggleType ? selected.selectIds(selectedId) : selected.deselectIds(selectedId);
         break;
       }
-      case IndexTableSelectionType.Page: {
+      case SelectionType.Page: {
         toggleType ? selected.selectCurrentPage() : selected.clearAll();
         break;
       }
-      case IndexTableSelectionType.Multi: {
+      case SelectionType.Multi: {
         // During a multiselect, the row indexes are returned instead of the record ids
         if (!Array.isArray(selection)) {
           throw new Error("Expected an array of indexes for multi-select");
@@ -60,8 +62,8 @@ export const useSelectedRecordsController = (props: { currentPageIds: string[] }
         toggleType ? selected.selectIds(selectedIds) : selected.deselectIds(selectedIds);
         break;
       }
-      case IndexTableSelectionType.All: // Do not allow selection outside of the current page
-      case IndexTableSelectionType.Range: // Do not allow selection outside of the current page
+      case SelectionType.All: // Do not allow selection outside of the current page
+      case SelectionType.Range: // Do not allow selection outside of the current page
       default:
         break;
     }


### PR DESCRIPTION
We accidentally relied on a Polaris type import when building one of the base hooks, which results in an error when consuming from a project that doesn't have Polaris installed. 

Also added a new test to confirm that importing the base @gadgetinc/react components works without Polaris installed. 
## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
