### PR TITLE
Expose button props on Polaris auto submit

### DIFF
--- a/packages/react/.changeset/chilled-drinks-mate.md
+++ b/packages/react/.changeset/chilled-drinks-mate.md
@@ -1,0 +1,19 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated PolarisAutoSubmit to expose Polaris button props
+
+Example - Using props from `https://polaris.shopify.com/components/actions/button#props`
+
+```jsx
+import { AutoForm, AutoSubmit } from "@gadgetinc/react/auto/polaris";
+
+const Component = () => {
+  return (
+    <AutoForm>
+      <AutoSubmit size="micro" textAlign="left" tone="critical" variant="plain" />
+    </AutoForm>
+  );
+};
+```

--- a/packages/react/src/auto/polaris/submit/PolarisAutoSubmit.tsx
+++ b/packages/react/src/auto/polaris/submit/PolarisAutoSubmit.tsx
@@ -1,6 +1,5 @@
-import { Button } from "@shopify/polaris";
-import type { ReactNode } from "react";
-import React from "react";
+import { Button, ButtonProps } from "@shopify/polaris";
+import React, { ReactNode } from "react";
 
 /**
  * Button for submitting the AutoForm values
@@ -11,7 +10,12 @@ import React from "react";
  * const { submit } = useAutoFormMetadata();
  *
  */
-export const PolarisAutoSubmit = (props: { children?: ReactNode; isSubmitting?: boolean }) => {
+export const PolarisAutoSubmit = (
+  props: {
+    children?: ReactNode;
+    isSubmitting?: boolean;
+  } & Omit<ButtonProps, "children">
+) => {
   return (
     <Button submit loading={props.isSubmitting}>
       {(props.children as any) ?? "Submit"}


### PR DESCRIPTION
- **UPDATE**
  - Previously, we did not expose the Polaris button props on the PolarisAutoSubmitButton component. Now we can