### PR TITLE
Accept location object when initialising GadgetProvider for SSR support

### DIFF
--- a/packages/react-shopify-app-bridge/spec/Provider-windowless.spec.tsx
+++ b/packages/react-shopify-app-bridge/spec/Provider-windowless.spec.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+import type { AnyClient } from "@gadgetinc/api-client-core";
+import { GadgetConnection } from "@gadgetinc/api-client-core";
+import "@testing-library/jest-dom";
+import type { ReactNode } from "react";
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { AppType, Provider } from "../src/Provider.js";
+
+describe("GadgetProvider in windowless environment", () => {
+  let mockApiClient: AnyClient;
+  const mockApiKey = "some-api-key";
+
+  beforeEach(() => {
+    mockApiClient = {
+      connection: new GadgetConnection({
+        endpoint: "https://test-app.gadget.app/endpoint",
+      }),
+    } as any;
+  });
+
+  const render = (element: ReactNode) => {
+    return ReactDOMServer.renderToString(element);
+  };
+
+  // To make sure the test setup is running in a windowless environment
+  it("should not include window object", () => {
+    const result = render(<div>{typeof window}</div>);
+
+    expect(result).toMatchInlineSnapshot(`"<div>undefined</div>"`);
+  });
+
+  it("should render a standalone app type without throwing an error", () => {
+    const result = render(
+      <Provider
+        api={mockApiClient}
+        shopifyApiKey={mockApiKey}
+        type={AppType.Standalone}
+        location={{
+          pathname: "/",
+          search: "",
+        }}
+      >
+        <span>hello world</span>
+      </Provider>
+    );
+
+    expect(result).toMatchInlineSnapshot(`"<span>hello world</span>"`);
+  });
+
+  it("should render an embedded app type without throwing an error", () => {
+    const result = render(
+      <Provider
+        api={mockApiClient}
+        shopifyApiKey={mockApiKey}
+        type={AppType.Embedded}
+        location={{
+          pathname: "/",
+          search: "",
+        }}
+      >
+        <span>hello world</span>
+      </Provider>
+    );
+
+    expect(result).toMatchInlineSnapshot(`"<span>hello world</span>"`);
+  });
+});

--- a/packages/react/spec/GadgetProvider-windowless.spec.tsx
+++ b/packages/react/spec/GadgetProvider-windowless.spec.tsx
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment node
+ */
+import type { AnyClient } from "@gadgetinc/api-client-core";
+import { GadgetConnection } from "@gadgetinc/api-client-core";
+import "@testing-library/jest-dom";
+import type { ReactNode } from "react";
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { Provider } from "../src/GadgetProvider.js";
+
+describe("GadgetProvider in windowless environment", () => {
+  let mockApiClient: AnyClient;
+  beforeEach(() => {
+    mockApiClient = {
+      connection: new GadgetConnection({
+        endpoint: "https://whatever.gadget.app/endpoint",
+      }),
+    } as any;
+  });
+
+  const render = (element: ReactNode) => {
+    return ReactDOMServer.renderToString(element);
+  };
+
+  // To make sure the test setup is running in a windowless environment
+  it("should not include window object", () => {
+    const result = render(<div>{typeof window}</div>);
+
+    expect(result).toMatchInlineSnapshot(`"<div>undefined</div>"`);
+  });
+
+  it("should render a gadget app type without throwing an error", () => {
+    const result = render(
+      <Provider api={mockApiClient}>
+        <span>hello world</span>
+      </Provider>
+    );
+
+    expect(result).toMatchInlineSnapshot(`"<span>hello world</span>"`);
+  });
+});


### PR DESCRIPTION
Currently, we use the `window.location` object to determine if the connection and set-up are ready. However, in some SSR frameworks like Remix.js, the `window` object is undefined, and instead, the `useLocation` hook is needed to access the location object.

This PR accepts passing the location object to our Shopify app provider and other fixes related to using the `window` object to enhance SSR support.

Example use case for a Remix.js app:
```jsx
// In root.jsx file
export default function App() {
  const location = useLocation();  // <-- create a location object

  return (
    <html lang="en">
      <body>
        <AppProvider i18n={enTranslations}>
          <GadgetProvider
            type={AppType.Embedded}
            shopifyApiKey={shopifyApiKey}
            api={new Client({ environment: "development" })}
            location={location}  // <-- then pass that to the provider
          >
            <Outlet />
          </GadgetProvider>
        </AppProvider>
      </body>
    </html>
  );
}
```

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
