### PR TITLE
Updated AutoForm such that required fields can be excluded

### DIFF
--- a/packages/react/.changeset/moody-bees-hide.md
+++ b/packages/react/.changeset/moody-bees-hide.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated AutoForm such that required fields can be excluded

--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -54,22 +54,15 @@ describe("PolarisAutoForm", () => {
           }).toThrow("The 'findBy' prop is required for actions that operate with a record identity.");
         });
       });
+    });
 
-      describe("for a required field", () => {
-        test("it throw an error if you exclude the field", async () => {
-          expect(() => {
-            render(<PolarisAutoForm action={api.widget.create} exclude={["inventoryCount"]} />, { wrapper: PolarisMockedProviders });
-            loadMockWidgetCreateMetadata();
-          }).toThrow("The field inventoryCount is required and cannot be excluded.");
+    test("it throws an error if you use include and exclude at the same time", async () => {
+      expect(() => {
+        render(<PolarisAutoForm action={api.widget.create} exclude={["inventoryCount"]} include={["name"]} />, {
+          wrapper: PolarisMockedProviders,
         });
-
-        test("if you include fields, you must include the required fields", async () => {
-          expect(() => {
-            render(<PolarisAutoForm action={api.widget.create} include={["name"]} />, { wrapper: PolarisMockedProviders });
-            loadMockWidgetCreateMetadata();
-          }).toThrow("The following required fields are missing from the include list: inventoryCount");
-        });
-      });
+        loadMockWidgetCreateMetadata();
+      }).toThrow("Cannot use both 'include' and 'exclude' options at the same time");
     });
 
     test("it includes the record ID when submitting a form that updates a record", async () => {

--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -62,6 +62,7 @@ export const Excluded = {
   args: {
     action: api.widget.create,
     exclude: ["birthday", "roles"],
+    include: ["name", "inventoryCount"],
   },
 };
 

--- a/packages/react/spec/auto/hooks/useFormFields.spec.tsx
+++ b/packages/react/spec/auto/hooks/useFormFields.spec.tsx
@@ -78,13 +78,13 @@ describe("useFormFields hook", () => {
     });
   });
 
-  test("Has an error when including and excluding the same fields", () => {
+  test("Has an error when using include and exclude at the same time", () => {
     expect(() =>
       getUseFormFieldsResult({
         include: ["stringField2", "stringField1", "stringField3"],
         exclude: ["stringField2", "stringField3"],
       })
-    ).toThrowErrorMatchingInlineSnapshot(`"Cannot include and exclude the same field"`);
+    ).toThrowErrorMatchingInlineSnapshot(`"Cannot use both 'include' and 'exclude' options at the same time"`);
   });
 
   test("Has an error when the metadata has duplicate input field api identifiers", () => {

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -360,7 +360,10 @@ export const filterAutoFormFieldList = (
   }
 
   let subset = fields;
-  const requiredFields = fields.filter((field) => field.requiredArgumentForInput && field.apiIdentifier !== "id");
+
+  if (options?.include && options?.exclude) {
+    throw new Error("Cannot use both 'include' and 'exclude' options at the same time");
+  }
 
   if (options?.include) {
     // When including fields, the order will match the order of the `include` array
@@ -373,30 +376,10 @@ export const filterAutoFormFieldList = (
         subset.push(metadataField);
       }
     }
-
-    //if any of the required fields are not included, throw an error as they must be included
-    const missingRequiredFields = requiredFields.filter((field) => !includes.has(field.apiIdentifier));
-    if (missingRequiredFields.length) {
-      throw new Error(
-        `The following required fields are missing from the include list: ${missingRequiredFields
-          .map((field) => field.apiIdentifier)
-          .join(", ")}`
-      );
-    }
   }
 
   if (options?.exclude) {
     const excludes = new Set(options.exclude);
-    if (options?.include && options.include.some((fieldApiId) => excludes.has(fieldApiId))) {
-      throw new Error("Cannot include and exclude the same field");
-    }
-
-    options.exclude.forEach((excludedField) => {
-      if (requiredFields.some((field) => field.apiIdentifier === excludedField)) {
-        throw new Error(`The field ${excludedField} is required and cannot be excluded.`);
-      }
-    });
-
     subset = subset.filter((field) => !excludes.has(field.apiIdentifier));
   }
 


### PR DESCRIPTION
- **UPDATE**
  - Previously, when a create action did not have required model fields due to `include` / `exclude` options, there would be an error that prevents the usage of the AutoForm
    - This did not account for the possibility of action files setting the field values in the code instead of directly using the form value
  - Updated such that required fields can be excluded from the autoform 
  - Added an error to AutoForm when using `include` and `exclude` at the same time which aligns with the similar error in AutoTable