### PR TITLE
fix issue with signed in or redirect redirect

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "files": [
     "README.md",
     "dist/**/*",

--- a/packages/react/src/auth/SignedInOrRedirect.tsx
+++ b/packages/react/src/auth/SignedInOrRedirect.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import { GadgetConfigurationContext } from "../GadgetProvider.js";
 import { useAuth } from "./useAuth.js";
 import { windowNavigate } from "./utils.js";
@@ -8,15 +8,15 @@ import { windowNavigate } from "./utils.js";
  * Renders its `children` if the current `Session` is signed in, otherwise redirects the browser to the `signInPath` configured in the `Provider`. Uses `window.location.assign` to perform the redirect.
  */
 export const SignedInOrRedirect = (props: { path?: string; children: ReactNode }) => {
-  const [redirected, setRedirected] = useState(false);
+  const redirected = useRef(false);
 
   const { user, isSignedIn } = useAuth();
   const context = useContext(GadgetConfigurationContext);
   const { auth } = context ?? {};
 
   useEffect(() => {
-    if (auth && !redirected && (!isSignedIn || !user)) {
-      setRedirected(true);
+    if (auth && !redirected.current && (!isSignedIn || !user)) {
+      redirected.current = true;
       const redirectPath = props.path ?? auth.signInPath;
       const redirectUrl = new URL(redirectPath, window.location.origin);
       redirectUrl.searchParams.set("redirectTo", window.location.pathname);
@@ -24,7 +24,7 @@ export const SignedInOrRedirect = (props: { path?: string; children: ReactNode }
       const navigate = context?.navigate ?? windowNavigate;
       navigate(`${redirectUrl.pathname}${redirectUrl.search}`);
     }
-  }, [props.path, redirected, isSignedIn, auth, user]);
+  }, [props.path, isSignedIn, auth, user, context?.navigate]);
 
   if (user && isSignedIn) {
     return <>{props.children}</>;


### PR DESCRIPTION
blerg React.StrictMode doesn't like when you useState to change how the flow of double invoked useEffects :(

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
