### PR TITLE
Bump react-shopify-app-bridge version to v0.16.1

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "files": [
     "README.md",
     "dist/**/*"


### PR DESCRIPTION
This PR bumps the `@gadgetinc/react-shopify-app-bridge` package to v0.16.1, which includes better SSR support.
- https://github.com/gadget-inc/js-clients/pull/606

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
