### PR TITLE
Add mock response wait statements to autoform cypress test metadata requests

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoFormDynamicFormInputChanges.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormDynamicFormInputChanges.cy.tsx
@@ -55,6 +55,8 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     interceptFindByValue();
     cy.mountWithWrapper(<AutoFormWithInputControls />, wrapper);
 
+    cy.wait("@ModelCreateActionMetadata");
+
     cy.get(`input[name="widget.name"]`).should("have.value", "test record 1");
     cy.get(`input[name="widget.inventoryCount"]`).should("have.value", "1");
     cy.get(`input[name="widget.name"]`).type("Dirty the value");

--- a/packages/react/cypress/component/auto/form/PolarisAutoBelongsToInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoBelongsToInput.cy.tsx
@@ -117,6 +117,7 @@ describe("PolarisAutoBelongsToInput", () => {
   });
   it("can deselect a related record and submit it", () => {
     cy.mountWithWrapper(<PolarisAutoForm action={api.widget.update} findBy="42" />, PolarisWrapper);
+    cy.wait("@ModelCreateActionMetadata");
 
     cy.get(`[id="1_Section 1"]`); // Section 1 is already selected
     cy.get(`button[aria-label="Remove "]`).click(); // Deselect
@@ -128,6 +129,7 @@ describe("PolarisAutoBelongsToInput", () => {
 
   it("can select a related record and submit it", () => {
     cy.mountWithWrapper(<PolarisAutoForm action={api.widget.update} findBy="42" />, PolarisWrapper);
+    cy.wait("@ModelCreateActionMetadata");
 
     cy.get(`input[name="widget.section"]`).click();
     cy.contains(`Section 3`).click();
@@ -148,6 +150,7 @@ describe("PolarisAutoBelongsToInput", () => {
         </PolarisAutoForm>,
         PolarisWrapper
       );
+      cy.wait("@ModelCreateActionMetadata");
       cy.get(`input[name="widget.section"]`).click();
       cy.contains(`Section 3 other field`).click();
 
@@ -165,6 +168,7 @@ describe("PolarisAutoBelongsToInput", () => {
         </PolarisAutoForm>,
         PolarisWrapper
       );
+      cy.wait("@ModelCreateActionMetadata");
       cy.get(`input[name="widget.section"]`).click();
       cy.contains(`Custom label for 3`).click();
 

--- a/packages/react/cypress/component/auto/form/PolarisAutoDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoDateTimePicker.cy.tsx
@@ -153,6 +153,7 @@ describe("PolarisDateTimePicker", () => {
         </PolarisAutoForm>,
         PolarisWrapper
       );
+      cy.wait("@ModelCreateActionMetadata");
 
       cy.get("#test-date").should("have.value", "2024-07-10");
       cy.get("#test-time").should("have.value", "4:00 AM");

--- a/packages/react/cypress/component/auto/form/PolarisAutoEnumInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoEnumInput.cy.tsx
@@ -59,6 +59,7 @@ describe("PolarisEnumInput", () => {
     cy.mockModelActionMetadata(api, baseModelActionMetadata);
 
     cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+    cy.wait("@ModelCreateActionMetadata");
     cy.get("#type-combobox-textfield").click();
     cy.contains("football").should("exist");
     cy.contains("basketball").should("exist");
@@ -76,6 +77,7 @@ describe("PolarisEnumInput", () => {
       cy.mockModelActionMetadata(api, baseModelActionMetadata);
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
       cy.get("#type-combobox-textfield").click();
       cy.contains("football").click();
       cy.get(".Polaris-InlineStack").should("contain", "football");
@@ -100,6 +102,7 @@ describe("PolarisEnumInput", () => {
       cy.mockModelActionMetadata(api, baseModelActionMetadata);
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
       // For single select enums
       cy.get("#type-combobox-textfield").type("foot");
 
@@ -156,6 +159,7 @@ describe("PolarisEnumInput", () => {
       });
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
       cy.get("#type-combobox-textfield").type("extra");
       cy.contains(`Add "extra"`).click();
       cy.get(".Polaris-InlineStack").should("contain", "extra");
@@ -197,6 +201,7 @@ describe("PolarisEnumInput", () => {
       });
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
       cy.get("#type-combobox-textfield").type("hello");
       cy.contains(`Add "hello"`).should("not.exist");
       cy.contains(`No options found matching "hello"`).should("exist");
@@ -235,6 +240,7 @@ describe("PolarisEnumInput", () => {
       });
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.update} findBy="42" />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
       cy.get(".Polaris-InlineStack").should("contain", "football");
       cy.get(".Polaris-InlineStack").should("contain", "hello");
       cy.get(".Polaris-InlineStack").should("contain", "world");
@@ -250,6 +256,7 @@ describe("PolarisEnumInput", () => {
       });
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.update} findBy="42" />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
       cy.get("#type-combobox-textfield").click();
       cy.get('[aria-label="Remove football"]').click();
 

--- a/packages/react/cypress/component/auto/form/PolarisAutoFileInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoFileInput.cy.tsx
@@ -97,6 +97,7 @@ describe("PolarisFileInput", () => {
       interceptModelUpdateActionMetadata([]);
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.update} findBy="42" />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
 
       cy.get("#clear-file-photo").should("exist");
 
@@ -120,6 +121,7 @@ describe("PolarisFileInput", () => {
       </PolarisAutoForm>,
       PolarisWrapper
     );
+    cy.wait("@ModelCreateActionMetadata");
 
     cy.get(".Polaris-DropZone-FileUpload").selectFile("./cypress/support/assets/ottawa-stadium.jpg", {
       action: "drag-drop",
@@ -149,6 +151,7 @@ describe("PolarisFileInput", () => {
       ).as("uploadFile");
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
 
       cy.get(".Polaris-DropZone-FileUpload").selectFile("./cypress/support/assets/ottawa-stadium.jpg", {
         action: "drag-drop",
@@ -176,6 +179,7 @@ describe("PolarisFileInput", () => {
         ]);
 
         cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+        cy.wait("@ModelCreateActionMetadata");
 
         cy.get(".Polaris-DropZone-FileUpload").should("contain", "Accepts .jpg, .webp, .svg, and .png");
 
@@ -225,6 +229,7 @@ describe("PolarisFileInput", () => {
         ]);
 
         cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+        cy.wait("@ModelCreateActionMetadata");
 
         cy.get(".Polaris-DropZone-FileUpload").selectFile("./cypress/support/assets/ottawa-stadium.jpg", {
           action: "drag-drop",
@@ -248,6 +253,7 @@ describe("PolarisFileInput", () => {
         ]);
 
         cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+        cy.wait("@ModelCreateActionMetadata");
 
         cy.get(".Polaris-DropZone-FileUpload").should("contain", "Accepts larger than 10 MB");
 
@@ -273,6 +279,7 @@ describe("PolarisFileInput", () => {
         ]);
 
         cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.create} />, PolarisWrapper);
+        cy.wait("@ModelCreateActionMetadata");
 
         cy.get(".Polaris-DropZone-FileUpload").should("contain", "Accepts smaller than 100 B");
 
@@ -306,6 +313,7 @@ describe("PolarisFileInput", () => {
       interceptModelUpdateActionMetadata([]);
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.update} findBy="42" />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
 
       cy.get(".Polaris-InlineStack > div").contains("icon.svg");
       cy.get(".Polaris-Thumbnail").find("img").should("have.attr", "src").should("contain", "https://assets.gadget.dev/assets/icon.svg");
@@ -321,6 +329,7 @@ describe("PolarisFileInput", () => {
       ]);
 
       cy.mountWithWrapper(<PolarisAutoForm action={api.game.stadium.update} findBy="42" />, PolarisWrapper);
+      cy.wait("@ModelCreateActionMetadata");
 
       cy.get(".Polaris-InlineStack > div").contains("icon.svg");
       cy.get(".Polaris-Thumbnail").find("img").should("have.attr", "src").should("contain", "https://assets.gadget.dev/assets/icon.svg");

--- a/packages/react/cypress/component/auto/form/PolarisAutoHasManyInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoHasManyInput.cy.tsx
@@ -108,6 +108,7 @@ describe("PolarisAutoHasManyInput", () => {
 
   it("can deselect exiting related records and select new records and submit it", () => {
     cy.mountWithWrapper(<PolarisAutoForm action={api.widget.update} findBy="42" />, PolarisWrapper);
+    cy.wait("@ModelCreateActionMetadata");
 
     cy.get(`span[title="Gizmo 1"]`);
     cy.get(`span[title="Gizmo 2"]`);


### PR DESCRIPTION
- UPDATE
  - It seems that there are some cases where the AutoForm metadata response is not awaited which leads to tests failing their assertions without failing CI
    - packages/react/cypress/component/auto/form/PolarisAutoDateTimePicker.cy.tsx was an example of this
  - Now those metadata requests are awaited so that failed assertions are properly noted in CI