### PR TITLE
fix(react): handle when hasMany relationship has null value

### DIFF
--- a/packages/react/.changeset/kind-lies-draw.md
+++ b/packages/react/.changeset/kind-lies-draw.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Bug: Displaying HasMany relationship in AutoTable when some values are null throws an error

--- a/packages/react/cypress/component/auto/table/PolarisAutoTableTagCell.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableTagCell.cy.tsx
@@ -15,6 +15,12 @@ describe("PolarisAutoTableTextCell", () => {
     cy.get(".Polaris-Tag").eq(1).should("have.text", "bar");
   });
 
+  it("handles null values", () => {
+    cy.mountWithWrapper(<PolarisAutoTableTagCell value={["foo", null]} />, PolarisWrapper);
+    cy.get(".Polaris-Tag").should("have.length", 1);
+    cy.get(".Polaris-Tag").eq(0).should("have.text", "foo");
+  });
+
   it("renders an array of roles as multiple tags", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableTagCell

--- a/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTagCell.tsx
+++ b/packages/react/src/auto/polaris/tableCells/PolarisAutoTableTagCell.tsx
@@ -1,11 +1,11 @@
 import { InlineStack, Tag, Text } from "@shopify/polaris";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import type { RoleAssignmentsValueType } from "../../../utils.js";
+import type { Nullable, RoleAssignmentsValueType } from "../../../utils.js";
 import { isRoleAssignmentsArray } from "../../../utils.js";
 
 const MAX_TAGS_LENGTH = 5;
 
-export const PolarisAutoTableTagCell = (props: { value: string | string[] | RoleAssignmentsValueType[] }) => {
+export const PolarisAutoTableTagCell = (props: { value: Nullable<string> | Nullable<string>[] | RoleAssignmentsValueType[] }) => {
   const { value } = props;
   const [showMore, setShowMore] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -17,10 +17,13 @@ export const PolarisAutoTableTagCell = (props: { value: string | string[] | Role
       if (isRoleAssignmentsArray(value)) {
         formattedTags = value.map((role) => role.name);
       } else {
-        formattedTags = value.map((tag) => tag.toString());
+        const compactValues = value.filter((tag) => tag !== null && tag !== undefined) as string[];
+        formattedTags = compactValues.map((tag) => tag.toString());
       }
     } else {
-      formattedTags = [value];
+      if (value !== null && value !== undefined) {
+        formattedTags = [value];
+      }
     }
 
     return {

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -523,22 +523,25 @@ export type HasManyValueType = {
   }[];
 };
 
+export type Nullable<T> = T | null;
+
 export type ColumnValueType =
-  | string
-  | number
-  | boolean
-  | Date
+  | Nullable<string>
+  | Nullable<number>
+  | Nullable<boolean>
+  | Nullable<Date>
   | null
-  | string[]
+  | Nullable<string>[]
+  | Array<null>
   | RoleAssignmentsValueType[]
-  | FileValueType
-  | RichTextValueType
-  | ValueWithTypename
-  | HasManyValueType;
+  | Nullable<FileValueType>
+  | Nullable<RichTextValueType>
+  | Nullable<ValueWithTypename>
+  | Nullable<HasManyValueType>;
 
 export const isRoleAssignmentsArray = (value: ColumnValueType): value is RoleAssignmentsValueType[] => {
   if (!Array.isArray(value) || value.length === 0) return false;
-  if (!value.every((item) => typeof item === "object" && "__typename" in item && item.__typename === "Role")) return false;
+  if (!value.every((item) => item !== null && typeof item === "object" && "__typename" in item && item.__typename === "Role")) return false;
   return true;
 };
 


### PR DESCRIPTION
When checking to see if something was a RoleAssignment list when rendering tags, we didn't handle the case where not only could the value be `null`, but it could also be an array with `nulls` in the array, leading to a runtime error when that happened. 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
