### PR TITLE
Fixed bug in Polaris AutoTable where the `createNewView` button would erroneously appear on certain parent element widths

### DIFF
--- a/packages/react/.changeset/nervous-bobcats-smoke.md
+++ b/packages/react/.changeset/nervous-bobcats-smoke.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Fixed bug in Polaris AutoTable where the `createNewView` button would erroneously appear on certain parent element widths

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -165,6 +165,7 @@ const PolarisAutoTableComponent = <
             filters={[]}
             onClearAll={() => undefined}
             tabs={[]}
+            canCreateNewView={false}
             selected={1}
             loading={fetching}
             cancelAction={{ onAction: () => search.clear() }}


### PR DESCRIPTION
- **UPDATE**
  - This button would erroneously appear on slender parent component widths. Disabled with the boolean flag on `<IndexFilter>`
  - ![CleanShot 2024-08-26 at 14 40 59](https://github.com/user-attachments/assets/dc257edb-0d85-43d8-8c17-284d0534776b)
