### PR TITLE
Js client format errors

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.30",
+  "version": "0.15.31",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/InternalModelManager.spec.ts
+++ b/packages/api-client-core/spec/InternalModelManager.spec.ts
@@ -621,6 +621,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -651,6 +654,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -681,6 +687,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -711,6 +720,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -737,6 +749,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -775,6 +790,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -807,6 +825,9 @@ describe("InternalModelManager", () => {
                     message
                     code
                     ... on InvalidRecordError {
+                      model {
+                        apiIdentifier
+                      }
                       validationErrors {
                         message
                         apiIdentifier
@@ -840,6 +861,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -872,6 +896,9 @@ describe("InternalModelManager", () => {
                     message
                     code
                     ... on InvalidRecordError {
+                      model {
+                        apiIdentifier
+                      }
                       validationErrors {
                         message
                         apiIdentifier
@@ -905,6 +932,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -935,6 +965,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -969,6 +1002,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -1010,6 +1046,9 @@ describe("InternalModelManager", () => {
                     message
                     code
                     ... on InvalidRecordError {
+                      model {
+                        apiIdentifier
+                      }
                       validationErrors {
                         message
                         apiIdentifier
@@ -1043,6 +1082,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -1071,6 +1113,9 @@ describe("InternalModelManager", () => {
                     message
                     code
                     ... on InvalidRecordError {
+                      model {
+                        apiIdentifier
+                      }
                       validationErrors {
                         message
                         apiIdentifier
@@ -1099,6 +1144,9 @@ describe("InternalModelManager", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -1127,6 +1175,9 @@ describe("InternalModelManager", () => {
                     message
                     code
                     ... on InvalidRecordError {
+                      model {
+                        apiIdentifier
+                      }
                       validationErrors {
                         message
                         apiIdentifier

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -554,6 +554,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -586,6 +589,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -616,6 +622,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -645,6 +654,9 @@ describe("operation builders", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -692,6 +704,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -751,6 +766,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -802,6 +820,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -841,6 +862,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -883,6 +907,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -929,6 +956,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -967,6 +997,9 @@ describe("operation builders", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -1001,6 +1034,9 @@ describe("operation builders", () => {
                 message
                 code
                 ... on InvalidRecordError {
+                  model {
+                    apiIdentifier
+                  }
                   validationErrors {
                     message
                     apiIdentifier
@@ -1042,6 +1078,9 @@ describe("operation builders", () => {
                     message
                     code
                     ... on InvalidRecordError {
+                      model {
+                        apiIdentifier
+                      }
                       validationErrors {
                         message
                         apiIdentifier
@@ -1267,6 +1306,9 @@ describe("operation builders", () => {
                   message
                   code
                   ... on InvalidRecordError {
+                    model {
+                      apiIdentifier
+                    }
                     validationErrors {
                       message
                       apiIdentifier
@@ -1302,6 +1344,9 @@ describe("operation builders", () => {
                   message
                   code
                   ... on InvalidRecordError {
+                    model {
+                      apiIdentifier
+                    }
                     validationErrors {
                       message
                       apiIdentifier
@@ -1335,6 +1380,9 @@ describe("operation builders", () => {
                   message
                   code
                   ... on InvalidRecordError {
+                    model {
+                      apiIdentifier
+                    }
                     validationErrors {
                       message
                       apiIdentifier
@@ -1368,6 +1416,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier
@@ -1394,6 +1445,9 @@ describe("operation builders", () => {
                   message
                   code
                   ... on InvalidRecordError {
+                    model {
+                      apiIdentifier
+                    }
                     validationErrors {
                       message
                       apiIdentifier
@@ -1420,6 +1474,9 @@ describe("operation builders", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -697,6 +697,9 @@ export const ErrorsSelection: BuilderFieldSelection = {
     message: true,
     code: true,
     "... on InvalidRecordError": {
+      model: {
+        apiIdentifier: true,
+      },
       validationErrors: {
         message: true,
         apiIdentifier: true,

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship-with-support-for-Id-pre_1709343723/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship-with-support-for-Id-pre_1709343723/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
         },
         "response": {
-          "bodySize": 743,
+          "bodySize": 656,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 743,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twQpNlc0O0WlGpK7TQS1erarAnId1gW7aDiCr+fZU00IQmlFuU92Y87/l53gaEUAEOaETeBoQQQu1G6TQuFkaJnDt7AgihGhKcy1g1/hFCN2B/4d4tIEEakRgyi99a6MLgLlW57WFYB8bNcmOVoRGhWDzo59k8nL/eF4/Fww/aoKIU1xFfXlyhUcK2PJAujnPXhMORSVEkWEr8cyr9EEYI5dccRgiVSmDLlI4hli1fW/WE0FSUHM8fnwNrJYpqgD1sdYZkB1mOJFaGVMgZm6utBoNTtzApx98gK8dlnmXnRIPgUExd2dtn/vjG8288f+WFke9HfjBkzHs+774BKbKehvpd1wwcJsoUF0mrQvd1yddZajf1YJcIS676mtQJnnVJZN6KBRFjEWNDxtgniXXtkxan2q4THLjcdmMOkj4EtzoDh8s8jtN9Dyd1fQ7njZmuvrIdSlEluGzYgA6t/F5K6r1IkJ7Ih/rr7+kJXaqdKSmRu1TJ9w4=\",\"9ak0AZGge8TG3injVQgDJdm2F0zXfd6Bw1W6xeajb4enk8K/6tEyuYvQEZAP3qf90jbnZyV7qnWW8kpo5cDg6GtVRnHvUNqWCzRTVaboxjlto9EoSdwwS+W/UQmMvICFbDK65VzEHgtuw/UkDL77YwAMw9CboAgmEx7UKqgzwHFe7ZsvS8qpBof/AAAA//8DAJZZMBomBgAA\"]"
+            "size": 656,
+            "text": "[\"H4sIAAAAAAAAA4RSXW/iMBD8K2ifU3DCh6jfEK0qKvWEDu6lp1Nl7E3wXbAte4OIUP77yXw0wFXcmzM7u5mZ3T0oQQL4HsLaOp3Xc29VJSlEyIkCZya38b0W4RvuaC4KBJ6LMmASsbnHrbZVuMIDCU/TygfrgQPWr+59OhvNfj/Xb/XrIySARt0rf3xQ7dCIDQKH+VlEkwCqAgPwn3uQd9qNVRglX41ZXNmDBLQCDmnWhwRWVtVx1E5sXImdrSgr7OTWdw6FBKTdOOFxQnOvJX4XJno1VVkmID0KQjUh4JCxrP+QZg9ptkxHPMt4Nuwylr5DTMqo8rPJHUVMBWFhfX0DL2vXMqtVqcP6+IMbaCFtSzxtb/qFHJYu2ZAzxhnrMsainBP7h1Nn9mkKCarC+YtE0b5x40pBuKjyXO8+UU2tq6qddi+KLRoVNxebmuTekp5VgdD8usuZWmNQkrYm3kchVIH0hseLXtfKi1gKF/d9mdCTIFzqDcJN0JcF+TX/0uwF/G+wbfXW7MtB7MS5UsuDzIPuJp75jtCEs/DSxjXAmsgF3usVBXVLbf70It5Lh2zExj21GqdS9gdjteoP+uIxG+dyhblS6SgbII4hAfJC4iwe/X/JTfMXAAD//wMAGAqYkBcEAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:40 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:02 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "bf3efe781bed40f67af2a23326beace3"
+              "value": "58ef3bd4989ccf80ad1b72f8c1dcdbd3"
             },
             {
               "name": "x-trace-id",
-              "value": "4ccdf10546b865723aae66618ed588c5"
+              "value": "db81cc348db343a928fcbefdd1624ee8"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=4gP0lTjqtqaLqbV0aL2EUT0KItrS%2BSkfiGR6ocRlIWlAfsTUMOJ6SvjzwHN2P8mXYzDdZMSL%2BUJTbbMvEw8LhOkElHLzUEOWqsDXrlSvOyfdLKRoTYlZpEEHFr3inyHoS1naz1%2Bnn%2FF%2BWQur9dSkNrvB1MVpScbeuqKerA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874e22adcc32d-EWR"
+              "value": "8ba835033d3753ef-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:40.677Z",
-        "time": 261,
+        "startedDateTime": "2024-08-28T23:51:02.788Z",
+        "time": 130,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 261
+          "wait": 130
         }
       },
       {
-        "_id": "3490de2ca797e93bcc6d72993c8992df",
+        "_id": "bfe6b6207171d4656fa045c5fe154cc2",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 772,
+          "bodySize": 847,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "772"
+              "value": "847"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVFlmBcDNt0vTQQxtPvZh1d0RSBNwdEq3xvzcgpdKkscd9897MN7NnDwCNYoUpnD0AANSWFNNrk38OGgC6RmtyDlNg29DkWyZrK9uqZVMUg3oYhwFwveZTTaXaE6aAXfPJTzU3rRqEkbxVryBmyW1xLuZyKuR0Hq2COF3EqQxmoUzebwNMx87L5BgOv2Y0tflHt95/GVYZgz8Mt3kj1xR89fduzJTJiF/o5poAuDsZqzivSjc+yWi9R8W0yvf0J/FguEP41DEs67rIdTe1w7lien0M6chUuhESFlXWvnDHXLvU97OMZ0VefvhtwQ8WIhKJr2OhFlLHMoxiFUWbRKptkohAhma7CUTS4yNbpem5+9W7kZbKu3wBAAD//wMAh+IYWYkCAAA=\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQMW/CMBCF/0p1syFOnETBG2qlqkOHVkxdkGMfIcIkwT5LUJT/XjlQqrIw3um99927MxhFCuQZtENF+BHa7zj5oDV6D5JcQAboXO88yC5Yy+BwFa3XdBqwU3sECZOTQWtAQprzBbBrpFkSSMh4ls94NcuqVSZkkUou5pngX8CA8BgVhJ6eDpeUMJjHzpH9v+D51uATfbAUBY0yDdI7XjpuT8YpavvO/zW+QF4U4ard4x37tr5nvU65y2GwrZ4SJ8Q4MsAjYed/GbZvPEjYEg1eJknT0Ny23S6J+yQteMmrRBQqQ14alZZFnaIpVK6VWJha12KD1Sa+yCmNb/G1D8Xj+AMAAP//AwB5iPVT1AEAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:41 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:03 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "485e21606a17d4972408195a5f12121a"
+              "value": "d7298ae1a81637917feea6c110c93b33"
             },
             {
               "name": "x-trace-id",
-              "value": "c70a54c74367a66b84af880143dfb108"
+              "value": "35a2e06da165b1ed5a4ca39dbcb3fe8f"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=2Ogwfx69ik4K1APeG1Ejbr8pP3IUB%2BWkeeJXi1hF%2F7WibRRUavv60fqvIam6cIEXOZasP6TU15mt9clMzzUhovgZr92LA5pwovik2MIATIameVGU82gNgQFIHw92vJf8lxoEaQjDe8y6I4ZTqpzNmWEOKb%2BZs148vM9FSQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874e42aae8c18-EWR"
+              "value": "8ba83504280faaf8-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:40.998Z",
-        "time": 469,
+        "startedDateTime": "2024-08-28T23:51:02.946Z",
+        "time": 279,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 469
+          "wait": 279
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship_3235963512/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-BelongsTo-relationship_3235963512/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
         },
         "response": {
-          "bodySize": 747,
+          "bodySize": 656,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 747,
-            "text": "[\"H4sIAAAAAAAAA4xUXW+bMBR9z6+w/Lwmhiwf5S3KqimVOkVL9tJpqox9IWzEtuxLFFTlv09QQiGFNG+Ic+71PcfH93VACJUcOQ3I64AQQqjbaZNE+dpqmQl0NUAINTyGlYp04x8hdMfdDzjimsdAAxLx1MGXFrq2cEh05noYDrnFZWadtjQgFPJH87xcTVd/H/Kn/PGeNqig5G3ElxfMDSi+Lw6k6/PcFeF0ZlKQMRQSf9el78IIoeKWwwihSktomdIxxKbla6ueEJrIguP540sg1DIvBzjyvUmBHHiaAYm0JSVywRZ6b7iFBa5tIuAnV6XjKkvTS6IFjiAXWPT2mT++8/w7z99608D3A38yZMx7vuy+40qmPQ3Nm64lR4i1za+Strnp65KFaeJ21WDXCBuh+5pUCV52SWTelk0CxgLGhoyxDxKr2l9G1rVdJyDHzHVjyOM+BPYm5QibLIqSYw8nwT6Hs8ZMN1/ZAZQsE1w0bECnVn6vJfVBxkBr8qn6+lM/oQ==\",\"a7VLrRQITLR661CdSmMuY8AnaOydIl65tLwgu/aC6brPbxxhm+yh+ejb4emkiM96tEzuInQE5J33Yb+0zfleyl4YkyaiFFo6MDj7WpZROCIo13KBprrMFN0hGheMRnGMwzRR/0YFMPImbMrmIwEgxuDNwq+h7wEDmEkxvx+H83A+m0xCr1JB0XIBq3LffFpSTDU4/QcAAP//AwC+GBP1JgYAAA==\"]"
+            "size": 656,
+            "text": "[\"H4sIAAAAAAAAA4RT247aMBD9FTTPWXDC3W+IripW2goV+rJVtTLxOKQNtmVPEBHKv1fmsgl0Rd/sc86Mz1x8BClIAD+C3xqbq2rpjCxT8gGyIsOFViact8J/wwMtRYbAlSg8RgFbOtznpvQ3uCfhaF46bxxwwOrFvs0Xo8Xv5+q1eplCBKjlI/r9nSqLWuwQOCyvJuoIUGbogf88QvogXBuJwfJNmtVNeRBBLoFDnPQhgo2RVUh1EDtbYGcvihI7yrjOiYggNTsrHM5o6fIUvwsdatVlUUSQOhSEckbAIWFJ/ylOnuJkHY94kvBk2GUsfoPQKS2LjyB7NjEXhJlx1R28rmyjLDdF7rfnB+6gVWoa4WV680/ssHjNhpwxzliXMRbsXNQ/rLyqL1lIUOmvNxJZc8adLQThqlQqP3ygOTVVlU22R63Yo5ZhciGojh4N6VlmCPWvh5q50RpTyo0O+5EJmSG94nmjt5V0IlC+td/tDn0RhOt8h3DX6DaRfq5vF9uC/21sw94X+/VkdmZtkacnmyffdVjzA6H2V+OFCWOALZH1vNfLMuoWuf7TC3gvHrIRm/T6A7FRTLHpVI2n/Y2aiPFYTQbYV8lgwobhV5ATKS7C0v9XXNd/AQAA//8DAONYyYAXBAAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:39 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:02 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "b7ff3a731b585aae70ca9e356e7623cc"
+              "value": "4aedce1ca7089b16a1236be1446ab982"
             },
             {
               "name": "x-trace-id",
-              "value": "ceec3e17b4b21e0ee7dc893b8b8755b1"
+              "value": "34abf0f099f793bf8a77f84e3f248059"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=huuIYsKyV6uyuG8hpd3JjdI%2FeNofeFf%2FD%2B9oQ2EJ1CTJROC0uBZdzdEI7a4zfIBtnsExtWYpkM9XBah48B85%2B%2F4531%2BKMNU%2BMlmtqaiDrRWR2fwHtj2%2B2o11xGjDrfsJ67OgMTtERoeF0ddCm%2BzDW%2BRCHGr2AubtUrAFew%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874d7dd9641a6-EWR"
+              "value": "8ba834fd5edc3a04-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 959,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:39.034Z",
-        "time": 242,
+        "startedDateTime": "2024-08-28T23:51:01.847Z",
+        "time": 130,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 242
+          "wait": 130
         }
       },
       {
-        "_id": "3490de2ca797e93bcc6d72993c8992df",
+        "_id": "bfe6b6207171d4656fa045c5fe154cc2",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 772,
+          "bodySize": 847,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "772"
+              "value": "847"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVYHFBuJk2aXrooY2nXsy6OyApIrJDojX+9wakVJo09rhv3pv5ZvbsAKBRrDCBswMAgLomxfTa5J+DBoC20ZqsxQS4bmjyLVNd7+tWLZuiGNTDOAyA6zWfKirVjjAB7JpPfqq5aVU/CMWtegUxS26LwhPzqTefinDlR4mMkiCeRdJ/vw0wHTsvk2U4/JrRVOYf3Xr/ZVhlDP4w3OaNbFPw1d+7MVMmI36hm2sC4PZkasX5vrTjk4zWe1RMq3xHfxIPhjuETx3DsqqKXHdTO5wrptPHkI5MpR0hYbHP2hdumSubuG6W8azIyw+3Lbi+9EJv4QZyvlkIXxsR6yBNUxn4IpBhvNl4aSQi2eMj10rTc/erdyMtlXP5AgAA//8DADq/4VuJAgAA\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQMW+DMBCF/0p1sxOMwQS8Ra1UdejQKlOXyOCDoBAg9iEljfjvlSFN1SwZ7/Te++7dBYwmDeoChUVN+DHU335yQ1Ggc6DIDsgAre2sA9UOTcPgeBVtt3TusdUHBAWTk0FtQEEY8xWwa6RZEygQXMQLni5EuhGRkqHiYhmF0RcwIDx5BaGjp+OcMvTmsXNk/y94vjX4RDc05AWVNhXSO84dd2djNdVd6/4az5AXTbipD3jHvq3vWa9T7rrvm7qYEifEODLAE2HrfhlNVzlQsCPqnQqCqqJlU7f7wO+DUPKEp0GZpLiSOpYil2WZ8cxkXCarCE2eGx5L/yKrC3zzr30oHscfAAAA//8DAEI/vADUAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:40 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:02 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "ae747e1cdf3176ab4145d8a32fd6df1a"
+              "value": "2eecc5643ca185673d368c258aaf1a5b"
             },
             {
               "name": "x-trace-id",
-              "value": "354b821cd29c3fff53123569bb0f7275"
+              "value": "f68e75a452b5ff909d905673edbbd045"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=LY3W%2FzP8RPAAyll3EVVsVaSMUAL5%2BxrNE3npOUgJYRUY9an6LMauiCeB5R38npNP17y%2FK6gENrBNtIt4WZoahsvYcjheLS2MGZRxeOG84cvB7b3BiT9i3yTDoXJ%2FfC39amR4eMCO3Tl27LrjrwEllbmM6XTQTF6dRjKrTw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874d988ba43a4-EWR"
+              "value": "8ba834fe590ba241-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:39.302Z",
-        "time": 674,
+        "startedDateTime": "2024-08-28T23:51:02.004Z",
+        "time": 323,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 674
+          "wait": 323
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship-with-support-f_3501493881/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship-with-support-f_3501493881/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
         },
         "response": {
-          "bodySize": 743,
+          "bodySize": 656,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 743,
-            "text": "[\"H4sIAAAAAAAAA4xUwW7iMBC98xWWz1twQkkhN8RWKyp1hbb00tWqGuJJyG6wLXuCiCr+fZU0UEITyi3KezOe9/w8bz3GuAQCHrK3HmOMcbfWJo2LhdUyj8gdAca4gQTnKtYn/xjja3A/cUcLSJCHLIbM4bcGurC4TXXuOhiOwNIst05bHjKOxYN5mc2D+d/74rF4mPATKip5HfH1lQqDCjblgXxxmLsm7A9MjjLBUuLvY+mHMMZ4dM1hjHGlJTZMaRniqeFro54xnsqS4/nDc2ClZVENsIONyZBtIcuRxdqyCjljR3pjwOKUFjaN8BeoynGVZ9k50SIQyimVvX3hD288/8bzl14Q+n7oj/pCeC/n3degZNbR0LzrmgFhom1xkbQsTFeXfJWlbl0PdonwFOmuJnWCZ20ShbcUo1CIUIi+EOKTxLr22chjbdsJBJS7dowg6UJwYzIgfMrjON11cFLqcjg/menqK9uiklWCy4Yn0L6R30tJvZcJ8iN5X3/9OT6hS7UzrRRGlGr13qE+lScg\",\"E6RHPNk7ZbwKaaEku+aCabvP70C4TDd4+uib4WmlRF/1aJjcRmgJyAfv035pmvOjkj01JkujSmjlQO/ga1XGcUeoXMMFnukqU3xNZFw4GCQJ9bNU/RuUwMAbiUCMB/5oBfHKn8BkJCciCMYBTMaBdzuOhsHq7vauVsHJQoTzat98WVJO1dv/BwAA//8DAHDqQBEmBgAA\"]"
+            "size": 656,
+            "text": "[\"H4sIAAAAAAAAA4RSXY/aMBD8K2ifc+CEC238huip4qSrUKEvV1Unx96EtMG27A0iQvnvlfm4AD3RN2d2djMzu3tQggTwPfi1sVXRLpxRjSQfICtKnOvChPda+G+4o4UoEXghao9RwBYOt5Vp/BXuSTiaNc4bBxywfbavs/lk/vupfWmfM4gAtbpXfnuj1qIWGwQOi7OILgJUJXrgP/cg77RrozBIvhqzvLIHEVQKOMTJGCLIjWrDqJ3Y2BoHW1E3OCiMGxwKEUizscLhlBaukvhd6OBVN3UdgXQoCNWUgEPCkvFDnDzEySqe8CThSTpkLH6FkJRW9XuTPYqYCcLSuPYGXrW2ZzZ5Xfn18Qc30FKannja3uwDOSxesZQzxhkbMsaCnBP7h1Vn9mkKCWr8+YtE2b9xY2tBuGyKotq9oxX1rpp+2r0otqhV2Fxo6qJ7S3pSJUL36y5nZrRGSZXR4T5KoUqkFzxe9LpVToSSv7jvy4S+CMJVtUG4CfqyID/mX5q9gP8Ntq/emv16EDu1tq7kQeZBdxfOfEeo/Vl4bcIaYE1kPR+NypKGdaX/jAI+ilM2YZ9HLI9TJrPsMS0KwbJxnH96ZEzkKk9VlrEcIiAnJM7D0f+X3HV/AQAA//8DALXKzxEXBAAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:41 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:03 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "b5f6e022053de2ec2901de4a48ad1c55"
+              "value": "0887cb526cb288a9fa58dae5da8234d7"
             },
             {
               "name": "x-trace-id",
-              "value": "25bafb29a95d906686a986148c36b747"
+              "value": "0b150c9945ffa0931b7400abdb5d990b"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=EezjR13UCjLHGK3Lj5sdFC1Q4cam16F7ZbrF3EblMhBn0I8L7m5dUc8ETjz6fR8Z1F90rVyHS%2Bg2T3XAkvqzRLXK%2FQ0xY%2BYEhz0ca7k7DxMG0BlFP0DW51akx8D3r2d7u4db1Q68ruNUvbcprAVJqTRISnNpgV4LC5uEow%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874e738527288-EWR"
+              "value": "8ba835062e13ac00-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:41.497Z",
-        "time": 188,
+        "startedDateTime": "2024-08-28T23:51:03.254Z",
+        "time": 123,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 188
+          "wait": 123
         }
       },
       {
-        "_id": "f03e8f9e23189839d81b9bb20fdd9082",
+        "_id": "541535b4243c4d79a49cf452ee51288a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 815,
+          "bodySize": 890,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "815"
+              "value": "890"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"anotherProductSuggestion\":{\"_link\":\"123\"},\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"anotherProductSuggestion\":{\"_link\":\"123\"},\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sg7wSyQ61UddFFK1bdoGHGhKghCTOOBEX8e5UHKUGq6HKu7/Uc22cLAJVggQmcLQAAlJoE03udfQ8aAJpaSjIGE2Bd0+Qqk9albtSizvNBPYzDALhe86miQuwJE8C2+eS3mqlGdf0ovFU7ELXkpug5XjB1gqkXrdw4CeMkcGeL2Pu8DTAdWy+TYTjc/VFX6h/dev9lGGUM/jTs5oNMnXPn792YCpUSv9HNNgFwd1JacFYWZryS0XjPgmmV7elP4sHwgPClZVhWVZ7J9tcWp8O0+hjSkakwIyTMy7R54Y65MoltpynP8qz4spuC7YZO5MztwPc9QaF0N5uIYj+U5Afb2FPu1tnM/cX1fMhaSHptr/ow0lBZlx8AAAD//wMAxy0alokCAAA=\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQzW7CMBCEX6XasyHOnxN8Q61U9dBDK069IMfehqghCfZagqK8e+WEUpULx13NzLezZzCKFMgzaIuK8M0332FyXmt0DiRZjwzQ2t46kJ1vWwaHi2i7pdOAndojSJicDBoDEuIs5sAukWZNICHhSbbg5SIpN0kq81jydCmK9AMYEB6DgtDRw2FO8YO57xzZ/wserw3e0fmWgqBWpkZ6xbnj7mSsoqbv3F/jGfKkCDfNHm/Y1/Ut63nKXQ9D2+gpcUKMIwM8Enbul9H2tQMJO6LBySiqa1q2TfcVhX0U51zwMuK61HlRxVW2KlSBphTKCF4YIT55lalVeJFVGl/Ca++Kx/EHAAD//wMAf8a/mdQBAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:42 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:03 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "91c3792971933780a7c0e7ed93c20f6e"
+              "value": "c0dfcec95cddc5bb8d2a2703ea6e0970"
             },
             {
               "name": "x-trace-id",
-              "value": "4332ae5c1bb6e735ce34f72d1f0b8395"
+              "value": "0c8c57b1b497a7ed86ad607d66f0b4a9"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=9j7jHekc5IcWzjtYNHCo2VuXKmt38e5dU2GIVuoZsBqPRvRunEtVv2rvGaiZxomERXL6L%2BbxKZisvuEG0sCJCTp50kFiram2jve72YVMZrn0vRKKLDMSqRmBa34e8Z27JG84Bq1gY24nS1x2RGBTnCFR1Ag8puJeP11Alw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874e88e587c99-EWR"
+              "value": "8ba835074815ab8a-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 941,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:41.702Z",
-        "time": 306,
+        "startedDateTime": "2024-08-28T23:51:03.440Z",
+        "time": 234,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 306
+          "wait": 234
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship_1667904710/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-multiple-BelongsTo-relationship_1667904710/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=shopifyProducts"
         },
         "response": {
-          "bodySize": 743,
+          "bodySize": 656,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 743,
-            "text": "[\"H4sIAAAAAAAAA4xUwY7aMBC98xWWz11wgoA0N0RXFStthbr0slW1GuJJSBtsy54gohX/XiUb2IRNWG5R3pvnmefneR0wxiUQ8JC9DhhjjLutNmlcrKyWeUTuDDDGDSS4VLFu/GOMb8H9wAOtIEEeshgyh19a6MriPtW562E4AkuL3Dptecg4Fg/mebGcLv/eF4/Fw1feoKKStxFfXqgwqGBXHshXp75rwvHE5CgTLEf8fS59H4wxHt1yGGNcaYktUzqaeGr52qpnjKey5Hj++BLYaFlUDRxgZzJke8hyZLG2rEIu2JHeGbA4p5VNI/wJqnJc5Vl2SbQIhHJOpbYv/PGd5995/tqbhr4f+pOhEN7zpfoWlMx6BM3bXAsgTLQtrpLWhelTyTdZ6rZ1Y9cIT5HuE6kTvOgaUXhrMQmFCIUYCiE+jFjX/jLyXNt1AgHlrhsjSPoQ3JkMCJ/yOE4PPZyU+hzOGz3dfGV7VLJKcCnYgI6t/F5L6r1MkJ/Jx/rrz/kJXatdaKUwolSr\",\"N4X6VJ6ATJAesbF3yngV0kJJdu0F03Wf34Bwne6w+ejb4emkRJ9ptEzuInQE5J33Yb+0zflejT03JkujatDKgcHJ16qM44FQuZYLPNNVpviWyLhwNEoSGmap+jcqgZE3EVMRjHwZgAjQm+Es2GAwG8e48YQMosDzg4l32iycLES4rPbNpyVlV4PjfwAAAP//AwAKRkCaJgYAAA==\"]"
+            "size": 656,
+            "text": "[\"H4sIAAAAAAAAA4RT247aMBD9FTTPWXBCufkN0VXFSluhQl92Va289iS4DbZlTxARyr9X5rIBuqJv9jlnxmcu3oMSJIDvIayt03m98FZVkkKEnChwbnIbz2sRvuOOFqJA4LkoAyYRW3jcaluFKzyQ8DSrfLAeOGD95F5m8+H892P9XD9NIAE06h799ka1QyM2CBwWZxNNAqgKDMBf9yDvhBurMFq+SrO8Kg8S0Ao4pFkfEni3qo6pdmLjSuxsRVlhJ7e+cyASkHbjhMcpLbyW+EOYWKupyjIB6VEQqikBh4xl/Yc0e0izVTrkWcazQZex9AVip4wqP4Lc0cRMEBbW1zfwqnatsnovdVgfH7iBltK2wtP0Zp/YYemKDThjnLEuYyzaOal/OnVWn7KQoCqcbySK9owbVwrCZZXneveBamqrqtps91qxRaPi5GJQk9wb0qMqEJpfdzUzawxK0tbE/SiEKpCe8bjR61p5Ealwsd+XHfoqCFd6g3DT6EtCfq6/LPYC/rexLXtb7LeD2alzpZYHmwffTVzzHaEJZ+OljWOANZELvNcrCuqW2vzpRbyXDtiQjXujyUipDCfZezrCsRJiPBnjKB9M8i9Ssn78FeSFxHlc+v+Km+YvAAAA//8DAO76tf0XBAAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:40 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:02 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "aefd40ccd0ccc4fa11825cfa6ab26518"
+              "value": "76db1ca3e197e99b0ba0e7bd966c560a"
             },
             {
               "name": "x-trace-id",
-              "value": "2d8a08e17e78be873feb10d8c8128513"
+              "value": "797dd2e92b17e8daa898e7f59f4cc039"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=z3QQfK9mBBnig%2BdABKBvuczcz5rHP8oBQ9o1A03p71ELJlZQPGWomB1U16zuPVHAr1Mn7X16km7q%2Bhi8YgpK%2B3jJPz6qOXLXuPp4GLwHy6W40MPoUE%2Fw%2BsOlhLt0S6HLGABFFinm0nT1Qw%2B7PoQAOnsQAt0fTlIuO505Ng%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874ddeeda0dc7-EWR"
+              "value": "8ba835007cdb549d-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:40.007Z",
-        "time": 196,
+        "startedDateTime": "2024-08-28T23:51:02.339Z",
+        "time": 188,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 196
+          "wait": 188
         }
       },
       {
-        "_id": "f03e8f9e23189839d81b9bb20fdd9082",
+        "_id": "541535b4243c4d79a49cf452ee51288a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 815,
+          "bodySize": 890,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "815"
+              "value": "890"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"anotherProductSuggestion\":{\"_link\":\"123\"},\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"recommendedProduct\":{\"create\":{\"anotherProductSuggestion\":{\"_link\":\"123\"},\"productSuggestion\":{\"_link\":\"123\"}}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sgk3fIDrVS1UUXrVh1g4aMG6KGJMw4EhTx71UeTQlSRZdzfa997DlbAKgkS0zgbAEAYKpJMr02+deoAaBp0pSMwQRYNzT7kUnrSrdq2RTFqB6mYQDcbPhUUyn3hAlg13z2W81Vqzpe6F2rPYhacVt0hevPhT93w7UTJUGU+GIRLL336wDTsfMyGYbDzYymVv/oNvgv4ypT8IfxNm9kmoJ7/+DGTKqM+IWurgmAu5PSkvOqNNOTTNZ7lEzrfE9/Eo+GO4RPHcOqros87aZ2OD2mNcSQjkylmSBhUWXtC3fMtUlsO8t4UeTlp90WbCcQoYhtQWkQLx3/gxRtlQzkNvJUuA0jJWPPDcSAj6xlSs/dr96NtFTW5RsAAP//AwAu2YIKiQIAAA==\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQzW7CMBCEX6XasyHOH3F8Q61U9dBDK069INdegtWQBHstQVHevXKgVOXCcVcz8+3sCYwiBfIE2qEifAv2O04+aI3egyQXkAE61zsPsgtty2B/Ea3XdBywUzsECZOTgTUgIS24AHaJNEsCCRnPihkXs0ysslyWqeTZvKrSD2BAeIgKQk8P+3NKGMx958j+X/B4bfCOPrQUBY0yDdIrnjtuj8Ypsn3n/xqfIU+KcGV3eMO+rm9Zz1Puchhaq6fECTGODPBA2PlfRts3HiRsiQYvk6RpaN7a7iuJ+yQt+YKL5LPSm6qo86rAQtTCqDIXG611qUxe1OkivsgpjS/xtXfF4/gDAAD//wMAOhD5UtQBAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:40 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:02 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "80de093979f26282a1fca1f54eb03c51"
+              "value": "d37b257263d80663f293849e8d6657c5"
             },
             {
               "name": "x-trace-id",
-              "value": "0ec58914fedebda5ab73d6b67da83250"
+              "value": "b7cf749374e4898da538fccc5ad34916"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=uDAIOjk9IrMF2ryFmLc%2BvoBHX1tl899UnsMhClfBjB4aGtlM1d6goDehWP829FN1rigum30YqYUtRti%2FjDXO6q8OfSs%2BPUsYPgsYoklmbsQfa6%2BfFf9%2FKVlvCusP6gtltHdUh1ftlVYDiE%2B92JhEFEPewWyrmFTxoKrKvQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874df9977c463-EWR"
+              "value": "8ba83501b8eaac42-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:40.271Z",
-        "time": 378,
+        "startedDateTime": "2024-08-28T23:51:02.551Z",
+        "time": 220,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 378
+          "wait": 220
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-relationship_933332662/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-HasOne-relationship_933332662/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "78f065b3e1b9f63455a2454dd033b4ed",
+        "_id": "e9014bb962c8158501ba9656e95ffc60",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 745,
+          "bodySize": 820,
           "cookies": [],
           "headers": [
             {
@@ -33,7 +33,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "745"
+              "value": "820"
             },
             {
               "_fromType": "array",
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9A0/QPtDe0SdMOO2zitAsKiVWqlVISV4IhvvvU0nV00sSOeX7P/tk5ewBoFCvM4OwBAKC2pJhem+Jz0ADQNVqTc5gB24Ym3zJZu7etWjVlOaiHcRgA12s+1VSpHWEG2DWf/FQL06pBmIhb9QpiltwWpZDRVERTmayCeRbPs3Axk1H6fhtgOnZeJsdw+DWjqc0/uvX+y7DKGPxhuM0buabkq793Y65MTvxCN9cEwO3JWMXFvnLjk4zWe1RMq2JHfxIPhjuETx3Dsq7LQndTO5wrptfHkI5MlRshYbnP2xdumWuX+X6e86wsqg+/LfhBLBKx8KONEkaaRax1kOowlTJOpEiUisNApZt5j49slabn7lfvRloq7/IFAAD//wMAMtCvIokCAAA=\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQMW/CMBCF/0p1syFOSKjjDbVS1aFDK6Yu6IjPIWpIgn2WoCj/vUpCqcrCeKf33nfvzmCQEfQZCkfI9B6q72HyoSjIe9DsAgkg51rnQTehrgUcLqLNhk8dNbgn0DA6BVQGNMSpzEBcIs2KQUMik3Qm1SxR62Shs1hLOVdy8QkCmI6Dgsnzw2FKCZ257+zF/wuerg0+yIeaB0GJpiR+o6nj7mQcctU2/q/xBHlGpnW1pxv2dX3LehlzV11XV8WYOCL6XgAdmRr/y6jb0oOGHXPndRSVJc/rqvmKhn0UZ3IpVZRnuUW1tHa7jbdokjTHLKbUFmQfFdp8eJHDgl6H194V9/0PAAAA//8DAPPbmlzUAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:38 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:01 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "c4ca426cb2913e7765f80d3b9289ea6c"
+              "value": "1580e2bccb7d7b02d6bf7b16054677eb"
             },
             {
               "name": "x-trace-id",
-              "value": "4ba0d2d85cc19c392256206aa531a9b7"
+              "value": "959fa86ffbb1bad249a51e4fcef78af9"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=cWTGWdu2VuWlJIxtS09wK%2FDOXl0ZclbfJ%2F1L7mMTJDMX5pO1iWVAJSUQ1K%2BNrjoj9xN3nLuLsuKRFkNSdpptSN0KTnItzcoblI%2Bzh0Slg5A6TBM1m59KP4uiHdfEhKn%2BgqR3DUPpB43qadIqEhdWIY3lf6KlwK94Li19zw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874d0aee24252-EWR"
+              "value": "8ba834f4f873ac45-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:37.873Z",
-        "time": 600,
+        "startedDateTime": "2024-08-28T23:51:00.504Z",
+        "time": 1026,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 600
+          "wait": 1026
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-relationship_2952094097/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-HasMany-relationship_2952094097/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "dade2fdf1c439f174cda0faac8d85283",
+        "_id": "77d00634e25f0e7d11cf142a2f223db5",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 702,
+          "bodySize": 777,
           "cookies": [],
           "headers": [
             {
@@ -33,7 +33,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "702"
+              "value": "777"
             },
             {
               "_fromType": "array",
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRTW+CQBCG7/yKyZxVli/5uJk2aXrooY2nXszKDkiKgLtDojX+9wakVJo09rjvvO/MM7NnCwCVZIkJnC0AAEw1SabXtvgcNQA0bZqSMZgA65Zm3zJpXetOrdqyHNXDNAyAmw2fGqrknjAB7JvPfqqF6lTHC6Jb9QqiVtwVXeH6c+HP3eXaCZMgTLxw4Ybe+22A6dh7mQzD4deMtlH/6Db4L+MqU/CH8TZvZNqSr/7BjblUOfEL3VwTAHcnpSUXdWWmJ5ms9yiZ1sWe/iQeDXcIn3qGVdOURdpP7XGumNYQQzoyVWaChGWddy/cMTcmse0850VZVB92V7CdQCxFZMdbPxRxGscyy8Klt3VUHIjIi2QmpCMDMeAja5nSc/+rdyMdlXX5AgAA//8DALvJK8WJAgAA\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQMU/DMBCF/wq62W0cxyGRtwokxMAA6sRSOfY1jUiT1D5LLVX+O3JSiujS8U7vve/encFq0qDOYBxqwvfQfMfJB2PQe1DkAjJA53rnQXWhbRkcLqLNhk4DdnqPoGByMmgsKEglz4BdIu2KQIHgQi54uRDlWmQqTxXnS15kn8CA8BgVhJ4eDnNKGOx958j+X/B0bfCBPrQUBbW2NdIbzh13J+s0NX3n/xrPkGdNuG72eMO+rm9ZL1PuahjaxkyJE2IcGeCRsPO/jLavPSjYEQ1eJUld07Jtuq8k7pM054+8TGRlueQmq2RaVNvSoCyE4FmRG2EkT8v4IqcNvsbX3hWP4w8AAAD//wMAr4pjKNQBAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:37 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:00 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "7b27e474381eba9f7c0e2972401ae0a1"
+              "value": "96c73e601dcf134a2074783c934f366f"
             },
             {
               "name": "x-trace-id",
-              "value": "9b4709c99aff763b1d950838af0a1a50"
+              "value": "4bd040c3b417bf8ce47220375c2c4018"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=w3CpA4%2FHeAZBe3hiubd5aT2sWq2lI%2FEAoCmEgshTcyGiyPKhox%2FSnvHvnpP8Uhtnt7AyWZz3CvReTvPEUOckU1Kh3CaPUQArkZKNm%2Fc%2BAe1dhXUCEix5Uht9vzJIVH0m8SVBKRGX6zi9ElJ%2BKkS8R0WqNrL68Rx6Gqfv3A%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874ca182643cf-EWR"
+              "value": "8ba834f07f37aacd-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:36.838Z",
-        "time": 535,
+        "startedDateTime": "2024-08-28T23:50:59.763Z",
+        "time": 340,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 535
+          "wait": 340
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-relationship_3875503635/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-a-single-HasMany-relationship_3875503635/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "bc5e7d528fa0465c7aa8b8bd296bb5ff",
+        "_id": "9539f9f3e63d58de0a0a96810e20f1c5",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 648,
+          "bodySize": 723,
           "cookies": [],
           "headers": [
             {
@@ -33,7 +33,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "648"
+              "value": "723"
             },
             {
               "_fromType": "array",
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"text\":\"test question\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"text\":\"test question\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRy26DQAxF93yF5XUS3gNhF7VS1UUXrbLqJpqAIagEyIyRkkb594pHKVSq0uVc32sfe64GACaSJUZwNQAAMFYkmV6b/HPUAFA3cUxaYwSsGlp8y6RUpVq1bIpiVE/zMADudnypqZRHwgiwa774qeZJq9quL6ZqD5JsuC06luMtLW/piK0dRH4QuWLlOuJ9GmA6d14mzXD6NaOpk390G/y3cZU5+MN4mzfSTcG9f3BjJpOM+IUm1wTAwyVRkvOq1POTzNZ7lEzb/Eh/Eo+GO4RPHcOmros87qZ2OD2mMcSQzkylniFhUWXtCw/MtY5MM8t4VeTlh9kWTNu3hBWafii8tUeh2MdrP3VcIVIpPCml2Lsi9YMBH1nJmJ67X70baamM2xcAAAD//wMAsF+5QYkCAAA=\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQzW7CMBCEX6XasyHOL7FvqJWqHnpoxakX5NjbENUkwV5LUJR3r5JQqnLhuKuZ+Xb2DEaRAnkG7VARvoXme5x80Bq9B0kuIAN0rnMeZBusZXC4iLZbOvXYqj2ChMnJoDEgIc54DOwSadYEEhKeZAteLpJyk6Qy5zIXy7RIPoAB4XFUEHp6OMwpoTf3nQP7f8HjtcE7+mBpFNTK1EivOHfcnYxT1HSt/2s8Q54U4abZ4w37ur5lPU+56763jZ4SJ8QwMMAjYet/GbarPUjYEfVeRlFd09I27Vc07qM45wUvoyqreCGqQhtUojAaE/MpVumqTLkwIi/HFzml8WV87V3xMPwAAAD//wMATBoTYtQBAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:36 GMT"
+              "value": "Wed, 28 Aug 2024 23:50:59 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "7a8667da1bbfb7816ad1837d154fe9f5"
+              "value": "9e36dc34b4e2fd1c51f5896e8b9809d0"
             },
             {
               "name": "x-trace-id",
-              "value": "586494e86bc95f2366fa64aaa6b36f57"
+              "value": "b4b069b6cdea96dce2df97378309d958"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=KxRadUg2HvA%2FRvygaFIdjyslnKFlUXHZb1l8yW3NUZFKjTORap1UVpZdIHvS6tff2Eh1Di51APM1qf2CST7nATUcXQ9PYVYnY63ISKDihArp7bvX9zi84yexTpoIUM5Cp%2B3nZujHe5w1Ero6Wo1zUUwANGDDhtT4B3AaSQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874b6aef678d6-EWR"
+              "value": "8ba834de1f1139f4-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 943,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:33.630Z",
-        "time": 2747,
+        "startedDateTime": "2024-08-28T23:50:56.670Z",
+        "time": 2749,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2747
+          "wait": 2749
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-HasOne-relationships_2856696492/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-HasOne-relationships_2856696492/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "34d3a39de37e948de162dd46870fee96",
+        "_id": "97fef659a57a49d00419c5109e402b45",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 878,
+          "bodySize": 953,
           "cookies": [],
           "headers": [
             {
@@ -33,7 +33,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "878"
+              "value": "953"
             },
             {
               "_fromType": "array",
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}},{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}},{\"create\":{\"answers\":[{\"create\":{\"notification\":{\"create\":{\"enabled\":true}},\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRy27CQAxF9/kKy2sgk9ckZIdaqeqii1asukGjjBuihhBmHAmK+Pcqj6akEqLLub7XPvacHQDUihWmcHYAADAzpJhem+Jr1ADQNllG1mIKbBqa/chkzN60atWU5agepmEA3Gz4VFOldoQpYNd89lstdKt6gfSu1R5Er7gt+sIP5yKc+3LtxWkUp0GyWErxfh1gOnZeJstw+DOjqfU/ug3+y7jKFPxhvM0b2abk3j+4MVc6J36hq2sC4PakjeJiX9npSSbrPSqmdbGjm8Sj4Q7hU8ewquuyyLqpHU6P6QwxpCNTZSdIWO7z9oVb5tqmrpvnvCiL6tNtC64XCSkSV+hIhj6FQnp+lJAfyGgpKVZx+KFjmSwHfGSjMnrufvVupKVyLt8AAAD//wMAlxWUBokCAAA=\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQMU/DMBCF/wq62W0cN2mCtwokxMAA6sRSGftILdwktc9SS5X/jpyUIrp0vNN777t3JzCKFMgTaI+K8DXa7zSFqDWGAJJ8RAbofecDyDY6x2B/Fm02dOyxVTsECaOTgTUgIS/4Etg50qwIJAguihmvZ6Jei4Usc8nzeS3EOzAgPCQFYaC7/ZQSe3PbObD/FzxcGrxhiI6SoFGmQXrBqeP2aLwi27Xhr/EEeVSEa7vDK/Zlfc16GnNXfe+sHhNHxDAwwANhG34ZrmsCSNgS9UFmWdPQ3Nn2K0v7LC/5kteZElVZFcgrXpgyRy0KUd0vUCuDKD4+F+lFXml8Tq+9KR6GHwAAAP//AwCr0kXm1AEAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:39 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:01 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "0b52641f8626cdcddd4cbf5b3d0c8d56"
+              "value": "8a6769c9c522ed34c3a720dda9c8074d"
             },
             {
               "name": "x-trace-id",
-              "value": "0d5642e4061258e236596e7a74fd7689"
+              "value": "a27574e0704d51ec242793ecadee2bf3"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=LFj%2F6RzTEaB%2BR%2Bv25F9knsbWHtOC5tgdU6lXCiIHVfv34YprivUZWexj%2FIFIafQ0Jua0SscHe5Yj02SAAvU09zLA0Y0vpJtHYOOL8MSrpNC%2F64jnhEwTjF4K9VgfK%2BVQyZwDqW9xh9CtB9DB7WO%2FufWa2bjcSsXJC1qAFg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874d48d9d4379-EWR"
+              "value": "8ba834fb7f0cabe5-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 953,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:38.499Z",
-        "time": 510,
+        "startedDateTime": "2024-08-28T23:51:01.549Z",
+        "time": 282,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 510
+          "wait": 282
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-relationships_3250074585/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-HasMany-relationships_3250074585/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "6367b67a6d5d6c5684361f7ee7c00ee6",
+        "_id": "88fe68a8feb96dfc0655c94dcfce7454",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 792,
+          "bodySize": 867,
           "cookies": [],
           "headers": [
             {
@@ -33,7 +33,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "792"
+              "value": "867"
             },
             {
               "_fromType": "array",
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}},{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 2\"}}],\"text\":\"test question - 2\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 1\"}}],\"text\":\"test question - 1\"}},{\"create\":{\"answers\":[{\"create\":{\"text\":\"test answer - 2\"}}],\"text\":\"test question - 2\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRT2/CMAzF7/0Uls9A0/QvvaFNmnbYYROnXVCUWKVaKSVxJRjiu08tXUcnTeyY5/fsn52zB4BGscIczh4AAGpLium1LT9HDQBdqzU5hzmwbWn2LZO1e9updVtVo3qYhgFws+FTQ7XaEeaAffPZT7U0nRqE8fJWvYKYFXdFKWQ0F9FcJusgzeM0D9NFJoL32wDTsfcyOYbDrxltY/7RbfBfxlWm4A/jbd7ItRVf/YMbC2UK4he6uSYAbk/GKi73tZueZLLeo2Jalzv6k3g03CF86hlWTVOVup/a41wxvSGGdGSq3QQJq33RvXDL3Ljc94uCF1VZf/hdwQ9ikYjMz5JAiogyrUwQiSROk1CGKo2VWso4k3rAR7ZK03P/q3cjHZV3+QIAAP//AwDjmK8biQIAAA==\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQMW/CMBCF/0p1syFOYhLwhlqp6tChFVMX5DqXYNUkwT5LUJT/XjmhVGVhvNN777t3Z6gUKZBn0A4V4Vsw33HyQWv0HiS5gAzQuc55kG2wlsHhItpu6dRjq/YIEkYnA1OBhFRwAewSWa0JJGQ8EzO+nGXLTZbLRSo5n4uSfwADwmNUEHp6OEwpoa/uOwf2/4LHa4N39MFSFDSqapBeceq4O1VOkela/9d4gjwpwo3Z4w37ur5lPY+56763Ro+JI2IYGOCRsPW/DNs1HiTsiHovk6RpaG5N+5XEfZIueMGXiRZlqrnKV6h1ruqcZ0Up8DOtteZ1oXl8kVMaX+Jr74qH4QcAAP//AwDJFJ5v1AEAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:37 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:00 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "6034f50bc07b584d8812ceaf13c2a539"
+              "value": "f36ec9cf9cf852d106540a7c4e39a283"
             },
             {
               "name": "x-trace-id",
-              "value": "861204e8cad1406576323a75aa92582c"
+              "value": "c471c0a39ecc3af302674eb1fcc0f6c0"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=aA%2BYqjaUz7w6%2FIKbgaXqMc6ad4c42JS%2F0TvgDt6DVcKoXoHSvzGqQql2LTNN26aukMA1u8k4KjdawokVrsVH%2FrZB2QUX70rRbSs34%2FurOUJajO2U0z58AnXNWqHhc2cMtX8X2WJ1HLzpuhEpi%2FzVHCGQis4jlKbduiHlPg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874cd9d1643c8-EWR"
+              "value": "8ba834f2ea36ab1c-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:37.398Z",
-        "time": 447,
+        "startedDateTime": "2024-08-28T23:51:00.117Z",
+        "time": 357,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 447
+          "wait": 357
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-relationships_2510062961/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-create-multiple-HasMany-relationships_2510062961/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "f252f72a996d3cd7a8b6dc3e22b48f02",
+        "_id": "e8a9e9477f9b7e5d8d0da0b1136eeb19",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 692,
+          "bodySize": 767,
           "cookies": [],
           "headers": [
             {
@@ -33,7 +33,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "692"
+              "value": "767"
             },
             {
               "_fromType": "array",
@@ -56,7 +56,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"text\":\"test question - 1\"}},{\"create\":{\"text\":\"test question - 2\"}}],\"text\":\"test quiz\"}}}"
+            "text": "{\"operationName\":\"createQuiz\",\"query\":\"mutation createQuiz($quiz: CreateQuizInput) {\\n  createQuiz(quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      __typename\\n      id\\n      createdAt\\n      text\\n      updatedAt\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"quiz\":{\"questions\":[{\"create\":{\"text\":\"test question - 1\"}},{\"create\":{\"text\":\"test question - 2\"}}],\"text\":\"test quiz\"}}}"
           },
           "queryString": [
             {
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=createQuiz"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 384,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "[\"H4sIAAAAAAAAA4yRQW+CQBCF7/yKyZxVEFgRbqZNmh56aOOpF7PsjkiKgLtDojX+9wakVJo09rhv3pv5ZvbsAKCWLDGBswMAgMqQZHpt8s9BA0DbKEXWYgJsGpp8y2RMZVq1bIpiUA/jMABuNnyqqZR7wgSwaz75qea6VeeBiG7VK4hecVv0PT+ceuHUX6znUSKiJFjMlp73fhtgOnZeJstw+DWjqfU/uvX+y7DKGPxhuM0b2abgq793YyZ1RvxCN9cEwN1JG8l5VdrxSUbrPUqmdb6nP4kHwx3Cp45hVddFrrqpHc4V0+ljSEem0o6QsKiy9oU75tomrptlPCvy8sNtC+5ceAtv6aZhSulWUCBkrP2tpsiPQl+pWItUhPG2x0c2UtFz96t3Iy2Vc/kCAAD//wMAwmM/F4kCAAA=\"]"
+            "size": 384,
+            "text": "[\"H4sIAAAAAAAAA4SQT2+CQBDFv0oz51XWZRHYm2mTpoce2njqxeyfEYkIuDskWsN3bwBrUy8eZ/Le+82bCzhNGtQFrEdN+NGV38MUOmsxBFDkO2SA3jc+gKq7qmJwvIo2Gzq3WOsDgoLRyaB0oGAhuQB2jXQrAgWCCznj2UxkaxGrhKskn6dSfgEDwtOgIAz0dJxSutY9dvbs/wXPtwafGLqKBkGhXYH0jlPH3dl5TWVTh7/GE+RFE67LA96xb+t71uuYu2rbqrRj4ojoewZ4IqzDL6NqigAKdkRtUFFUFDSvynofDftokfAlzyKRpjyX1iRma1IhbWq4Nsi3LjZ5FuNyeJHXFt+G1z4U9/0PAAAA//8DAJjnIrzUAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 26 Apr 2024 17:57:36 GMT"
+              "value": "Wed, 28 Aug 2024 23:50:59 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "daeb6e78601b0bc0f3b44b171c474d3c"
+              "value": "f583f02e0c65ef25c65c5bfc2ab701be"
             },
             {
               "name": "x-trace-id",
-              "value": "b4bebf5e35a9d2fde72742cc9d5b549f"
+              "value": "277094cb5bfb724c7b0abe0fd3b983e6"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=cuS7IRzJdmuRpW%2F%2BU2DRXJT8X%2BYDO7IXHNeM4zQRYDbSOss8fz6Pgr6avAp%2F8RU%2FVF%2BmLOqkLBhYrN8N7TrNezzIloXQAHUR3rfhJGlR6fTwl3UpLtsMToKwE1EjC5ShCpHdz%2BYYRbrTAmeN9khAZplGojOquX6qUwt54g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a874c77bcb18c8-EWR"
+              "value": "8ba834ee5fcaabc7-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 953,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-26T17:57:36.411Z",
-        "time": 404,
+        "startedDateTime": "2024-08-28T23:50:59.448Z",
+        "time": 291,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,7 +160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 404
+          "wait": 291
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship-with-support-for-Id-prefix-test_2503398001/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship-with-support-for-Id-prefix-test_2503398001/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=answer"
         },
         "response": {
-          "bodySize": 360,
+          "bodySize": 320,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 360,
-            "text": "[\"H4sIAAAAAAAAA4SQzU7DQAyE73kKy2dEtpDm7xYJCXHgxr1yd91tRJouWVe0qvLuaLOhLUiIo2c8nk8+JwBoSAhrOCcAAEi9/+ThMgNga7AGXJQF3n1LwkcJorAXiAkPB2dI2Fy3Pg7spd33L/HAw+PVWq3k5LinHQeriZ2TOcYdtGQsyyvfsAHg9mQGCjf9jQqAeuDQ3UxUTyT81u74UgeAM9yvhdkf/+B6nhga57pWT60TTsRM5hjyUbj3P5Cw29sw4VbE+TpNrZX7ru3f02Cki6XKVZmqrFhrbTKz4WVWUsVlZZjzfF2oqtgoNeOjDKQ5/vDfSKBKxi8AAAD//wMAb09DFtcBAAA=\"]"
+            "size": 320,
+            "text": "[\"H4sIAAAAAAAAA4SPvU7DQBCEXyWa+oRj58fmOktIiIKOPlp7VxcL53L4NiJRdO+OzoYCGrrd0cx8mjuYlGDvIB8/ZcrXwLAomxoGKleFhUrU1WKIq0tgUmEYfFwk6nD2L3Og2sDgcNBbEE8ngUW7VCYDR+xEX2VBHW88UQ7G/PWT5L42g55I5W04CQy+Mb/l9IfwPPe2IYxDPzfOiJQM5Kri4w9jPLsIi6NqiLYonNOHcfDvRdaLcrfer5uCy77ZCnfdhrf9vquofqx23HQViXRS58E6US/z2n/NKX0BAAD//wMAt7mNf1sBAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:42:03 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:08 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "2a5d9ab3ed643135db3aa0912864287b"
+              "value": "d92dd6afb5f8b60bea14b126d9fedbc5"
             },
             {
               "name": "x-trace-id",
-              "value": "047bccd4dfe548a9e89dee66b7097f00"
+              "value": "d1c84edbb3d4c6b2a7925d8b2aeebe7d"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=1Eh0Z01ukZLxfk%2FE8fQpRNwabD1%2BYgN4wh7RpnrvUN%2F%2BqxbovJrRr7SxPe5LDdcW%2Fv6KCOVjuC%2B9gk5tmheVjofwFRtepBUE0ZZf0fM%2FglAzzNb3514o9wkzczqH2l6m2ajStmkMtNRwtqxYG%2FHPGw5uCNcRAsGbRi3YcQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d065184c436a-EWR"
+              "value": "8ba835253aa839c3-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 955,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:42:02.948Z",
-        "time": 232,
+        "startedDateTime": "2024-08-28T23:51:08.231Z",
+        "time": 127,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 232
+          "wait": 127
         }
       },
       {
-        "_id": "e983e56bd8087c1d032c760eeee592f6",
+        "_id": "02eaf720aecd293ca7218469cdfa2ac1",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 674,
+          "bodySize": 749,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "674"
+              "value": "749"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      questionId\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"question\":{\"_link\":123},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
+            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      questionId\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"question\":{\"_link\":123},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateAnswer"
         },
         "response": {
-          "bodySize": 404,
+          "bodySize": 364,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 404,
-            "text": "[\"H4sIAAAAAAAAA4SQTU+DQBCG7/yKyZwbAbVAuZGYGA9ejJ6bYZlQ4nbB3SG2afrfzQJF2kuPvB/L884pAMCKhDCHUwAAgH1XkXBh3C/bWQVA1yvFzmEOYnteXWS2trVeNb3Ws0q3dQBsKswB4yzF1b8ofBAvCzuBseVgRKiWuZ+enTSteRsfeXxamtutHDs2tGdvTuiTfZ6ZrlNfi5kf7HotY2PKY01VzfLOi9MA4O5YWfIc7nqbsuyJi2HLCwl/NnteIk6TbgJ3GF8HhqLrdKOGvw44I2Yw1ZAPwsZdIaFua/+FO5HO5WFY1/KgG/MdeiOM11ESZaEqn1WaxVmpVMq8KdMoiymJOF0TJWV6uTCKJcXj3e9WPFVw/gMAAP//AwBQyt28VgIAAA==\"]"
+            "size": 364,
+            "text": "[\"H4sIAAAAAAAAA4SQQU/DMAyF/8rkc0TbtV2z3CohIQ5cEJynkJiuIktL7IhNU/87SjsQ6oWjn57f9+wrWM0a1BXiaDVj6+kLQ5opGoNEoDhEFIAhDIFA+eicAP1r6y0oKGQDAhjPDAoYiTeLgTZLqgUBnxGJ+8E/zgvbEgQcDnwZ0esTgoIbeVrJr39qPSNFx8nSadshP+FS/XixQadsSpMJmJBt6nKvGV/6E4K43beS17SHObcdR9ebOXFGTJMAPDN6+mG4oSNQcGQeSWVZ1/Gd6/1HlvSsqPNdLrN3+1ZKrXe5kVg3TVHKfK/r/bZqKlk3lUkfC9rg/JB/zdP0DQAA//8DAA/HUaGrAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:42:03 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:08 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "4977450a3ea69bcb839cee0ea7b0145e"
+              "value": "dd997ea1b40eed6b3a3cfb066b17b362"
             },
             {
               "name": "x-trace-id",
-              "value": "cb4c7818bcc7ee9b7081a60e75aa6b73"
+              "value": "fdb38aa60c8e57713809a5924748574c"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ThY1GXcz%2BhIX%2BDb45cSvCtfmDiNxBCEkRzc9P%2BgkdsKXmfCEaGenqJa%2BpXftFvpfEc8N0X2DxhPxAxuiQ4JE8LRP2bga%2FRxtbMak9KDAYMaGyJNftRjf4QQ6wIc%2Bvxv0ttz8BkagBouMJeIoLgMDiertau%2Bpsf1uHuuayg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d066af9172b9-EWR"
+              "value": "8ba835264e50a23b-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 953,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:42:03.205Z",
-        "time": 214,
+        "startedDateTime": "2024-08-28T23:51:08.396Z",
+        "time": 221,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 214
+          "wait": 221
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-BelongsTo-relationship_3741776720/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=answer"
         },
         "response": {
-          "bodySize": 368,
+          "bodySize": 332,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 368,
-            "text": "[\"H4sIAAAAAAAAA4SRy26DQAxF93yF5XVVICG8dkiVoiy6qNR9ZBiXoBIyZRw1UZR/r4ZXoJssbd9759hzcwBQkRCmcHMAAJAa88vtVANgpTAF9OMIX8aW8EVsU9gI9A4DZ61IWD1UP2c2Up2aWdgjbrWehAC438tVc0NHtsOP0TgI7lPkUpf1rM5MgyWpkuWdZzsB4OGqWrKRZglTtGyZs26bNxL+rI48BxuW+id4wrXtGDKt66roXu1wekxnsCFfhBuzQML6VNoKDyLapK5blvJaV823aweuv/FCL3ajPPjaRBytKVSelxMlSZDkyqd4FcZBNH4TSksF77prP7VYKuf+BwAA//8DAGeMXGAPAgAA\"]"
+            "size": 332,
+            "text": "[\"H4sIAAAAAAAAA4SQS2vDMBCE/0qYs4gfqpVEN0Mh9NBDofcgrK1i4iiqtaEJQf+9yG4ozaW3fczuN8wN1rCBvsH4+EVjrnoLjWq9ggDThaHBFHkxC+LiHKxhshD4PFPk/uR/j2oJgd2Or4G8ORI03u6a9LBoZ14ScMY64leafeyvdjT5IuauGynD2uzi2TC990eCwI+Hv+NHwnb624Yw9N30cUKkJEAXJh/vjOHkIjT2zCHqonCOl0PvD0WeF1VTqnJd0JPd1I2VSlFVrahspG3kxsiaavVRSpWzGk1HLzmGf8UpfQMAAP//AwADQDKIeAEAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:42:02 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:08 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "90fcb42f5ba8b6985b641746804fc755"
+              "value": "3a0f1477542d35830d4befd1c0f0faeb"
             },
             {
               "name": "x-trace-id",
-              "value": "7b4f57e73a6d00baa9949bd1a8268477"
+              "value": "e4d925d366e117e053d539a32e26f036"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=eWKKg%2FKCBnFKmUSXPymUgxcZxoiVI%2FHvG7X%2B5Gce%2BTP3FFkbPDiOeCBDnGOW7JnHdiHb4pF%2FZvVum6DxJRaMziRkRXy3LERmO3IAbyA%2FIoWld5uwYMgy6kvF7e4NmJ8zOwkRMQY%2FcLKJ6CwWYvqNaJc2VSmVIWt%2Fdh8fmw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d05a8e32433a-EWR"
+              "value": "8ba83522ec95aaf8-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 955,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:42:01.269Z",
-        "time": 1185,
+        "startedDateTime": "2024-08-28T23:51:07.868Z",
+        "time": 112,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1185
+          "wait": 112
         }
       },
       {
-        "_id": "97b8775df5d78996afc33b4d54480992",
+        "_id": "b8c4be3d5b79ab343d34fd91acc0ff9b",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 715,
+          "bodySize": 790,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "715"
+              "value": "790"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      question {\\n        id\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"question\":{\"_link\":123},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
+            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      question {\\n        id\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"question\":{\"_link\":123},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateAnswer"
         },
         "response": {
-          "bodySize": 376,
+          "bodySize": 375,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 376,
-            "text": "[\"H4sIAAAAAAAAA4SQwU7DMBBEf6Xas0WaNmlS3yIhoR44gOBcGXuTRrhO6l2LVlX+HTlpAeXCccfPM7N7BaNYgbxC6I1irBx9oY8zBa2RCCT7gALQ+84TSBesFaB+sNaAhLQsQADjmUECI/FiAmgxuRoQcApI3Hbu99NqDQL2e7706NQRQcLLnRlmD7dac/n9T+dXpGA5Io0yDfIzTnsdLsaraEpx0h5jnyoWfVSMb+0RQdyWn8nztKfRt+p72+rRcYwYBgF4ZnR0z7BdQyDhwNyTTJKm4Qfbus8k6kmaLzfLMiny1bZe6zwrU5UWZZ1+ZFhsMl3nhdLbTMdzeqVxFy/1LzwM3wAAAP//AwD2sWQqyAEAAA==\"]"
+            "size": 375,
+            "text": "[\"H4sIAAAAAAAAA4SQQU/DMAyF/8rkc0RbaEeVWyUkxIEDCM6Tl7hdRZaW2BGbpv53lG4D1AtHv3x579knsCgI+gRxtCjUeP6ikGaOxhAzaAmRFFAIQ2DQPjqnAH+w3oKGor4HBUIHAQ1CLKszwKuzqwUFn5FY+sH/frq9AwWbjRxH8rgn0PByZabFw6XWUn7/0/mVODpJSIe2I3mm8167ow2YTDlNJlDq06SiDyj01u8J1GX5hbxMe5x9m3F0vZkd54hpUkAHIc/XDDd0DBp2IiPrLOs6uXG9/8iSnhVVvs7rrMhLrNpyjQZba2hbYt3mLZkCq3JbtHU6Z0BDT/Ol/oOn6RsAAP//\",\"AwCtxqLoyAEAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 11 Jul 2024 18:49:53 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:08 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "1cba612ed28ca81c81eb50b1fe05baf7"
+              "value": "b37a2991b5c84ca907a28464af156687"
             },
             {
               "name": "x-trace-id",
-              "value": "7529f3c5481a178f1b4e764cf57ac94c"
+              "value": "104a5f46acafdceb4a8f0fec1a54b1f8"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=CV6ujkpFXyMynbAy3YgYH0NIrSiMeX9D4JQqCwOW0sbq6ienCA5ZfYIqqGn7dF2KwEFxtgTgy79%2FS1E3N8aqOzqstqhm873jgZEiJQtkCP9bdnIvoEKLylimZFMtSG%2BmpM8wYSKKfDAES28pcTPe46ftTAFl7PBX2MTHxw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "8a1af9cd0e624388-EWR"
+              "value": "8ba83523fb267116-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 943,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-07-11T18:49:50.757Z",
-        "time": 2526,
+        "startedDateTime": "2024-08-28T23:51:08.022Z",
+        "time": 200,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2526
+          "wait": 200
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-Multiple-HasMany-relationship_4201319124/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 563,
+          "bodySize": 448,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 563,
-            "text": "[\"H4sIAAAAAAAAA9SUy07DMBBF9/mK0ayBPEjTtLsKEGLBAokdQpUVT9OI1kkTV/Sh/juy24Q8XKqWDSw9nnvneDz21gJAziTDIWwtAABcLJNNtQLAhOMQ0B14eFWGJK2kCkoqJKh8WGacSeLfKYslFTJJRVGzAkDiManQWxWC2rZOESmnhqjB4fm3VZFqq8Wzr1wywTW4XQkTxSflhaHQEUoz7SnqFr0bdlHMp9jz/XiGSjgey3VGgs0VAY60Eo3JO7OH0eGBx2RyMXr8sivepV3x/kxXOrH3rqvR8S4VgiI1sW3fDldL/3KY9KaupTqiaZ+joTrzRfrnv0jv0hf5z7pqGabhiLZLXNXsKJLNPueQgTHjMclnqv3jADhd85wZPuEoJ3UNI31D90zSazKn2oXg4Z5aCSeoHjXDKMtmSaSrahyrbIOWIa0kiaKBhLM0ViucSpkVQ9uOY3kzS8SHrTZst+cETmizwB/4HvOC0InI6feD0PEd7kf9QW8SOJNynlDmLKInPZgnJYrK2n0BAA==\",\"AP//AwCVxtz6AwcAAA==\"]"
+            "size": 448,
+            "text": "[\"H4sIAAAAAAAAA7SSTU/DMAyG/0rlc6FftN1yqwAhDhyQuKFpyhovi9jSrnHFtqr/HaXbQGzdKiFxSmTnfV7bcQOCEwfWwLpWO3sqAQyCcQguEG4IGBAacmzaqUvBCQW4sK7RkCq0sRIUEg2w9wZ0IfAHkqbJGWUvO5KcGycAF7g2n1hdZUVJfMLai05I0yltS9R8hcAg615A2xt+FBKhdc99kiGf8A8+k97cfaE15nYgZ+LXw6QuJi7Un6bp8MzD/pn/V5GTC9mrZLWzQcmFRHrB/Y4utqLi32uXV2j7yWynD5zwTa0QXDi0+Tt8yn/quFlZLlXeETuLtnUBN4TaHD2WhTTAYEFUGuZ5UtLtUukPz8a9IPYTf+T5QRQK9AOMYjELZ6N5Op4L317y6C6Oun2qeI7P9oMGH7ftFwAAAP//AwB5csBXlAMAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:59 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:07 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "ab1398b4dd2d25dc37fa1510651f624f"
+              "value": "ef7e967f5ee653241928ca3a0f7b9615"
             },
             {
               "name": "x-trace-id",
-              "value": "a64942a2680ce07768040d4c795f60f2"
+              "value": "0132de01e35db2b8f79fd02b8fc34536"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=ULJpTOBrxdh9q%2B9q2IrDYwMw64RrR5TLuY1TnJAVNS3dsQQQO5p4sjgQTQ30nUgzlUfFYwUMSkd83GHD1JYBJVFsA%2BKUrevsGt54glLM%2B%2BW2zTbYTMFgRBrC7U2cjTxw2qXqETTuWDyGO8oRwZYQsHc9Ws0x8zS1qK4qxw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d04f0bbf42b7-EWR"
+              "value": "8ba8351bbf8636db-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:59.400Z",
-        "time": 186,
+        "startedDateTime": "2024-08-28T23:51:06.687Z",
+        "time": 298,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 186
+          "wait": 298
         }
       },
       {
-        "_id": "75bbdb720234754eba2e5e8b4f75164e",
+        "_id": "804fae5fa1e38f5cec2ffd6f58fb89a3",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1317,
+          "bodySize": 1396,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "1317"
+              "value": "1396"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            answers {\\n              edges {\\n                node {\\n                  id\\n                  text\\n                  __typename\\n                }\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"192\",\"quiz\":{\"questions\":[{\"update\":{\"answers\":[{\"update\":{\"id\":\"181\",\"text\":\"test answer updated - 1\"}},{\"update\":{\"id\":\"182\",\"text\":\"test answer updated - 2\"}}],\"id\":\"243\",\"text\":\"test question updated - 1\"}},{\"update\":{\"answers\":[],\"id\":\"244\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            answers {\\n              edges {\\n                node {\\n                  id\\n                  text\\n                  __typename\\n                }\\n                __typename\\n              }\\n              __typename\\n            }\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"192\",\"quiz\":{\"questions\":[{\"update\":{\"answers\":[{\"update\":{\"id\":\"1365\",\"text\":\"test answer updated - 1\"}},{\"update\":{\"id\":\"1366\",\"text\":\"test answer updated - 2\"}}],\"id\":\"1776\",\"text\":\"test question updated - 1\"}},{\"update\":{\"answers\":[],\"id\":\"1777\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 488,
+          "bodySize": 492,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 488,
-            "text": "[\"H4sIAAAAAAAAA7STT2+CQBDFvwqZMy0uKsjeTNs0PfRg054aY1Z2RFJc6O6Q+id892ZBPQBq0qRHZt783u7b4QBSkAB+gLKQgnBWpnv7Zco4RmOAky7RBdQ61wa4KrPMhe+jKJXAgUU+uEC4JeBAaMixbafBSbBqNJTmytgRlAka4J8HULnEM8QfDTuQZuoEcu4cBi4IZX5QX0OxCWuhmpkWaLGgXYFKbBA4TGsFVL3lJ5kgVG7Hxr9l4//BZt7be8iVwtjG0RmeHXO62Og/vj8a3Q7c7w/8v844v9C9Sk73neLHeZPf0JQZWUEiZIL0is2ur3dSi/NOxhrthac2ikdB+J5uENzjD9Eqt72ea+60KLI0rom1RVW5gFtCZU4eWZ4Y4LAmKgz3vCSh+yxVX56te2w8CAYTT2IYBJMgGo4HIYYrjALGmFiJZSjkUPiRfTAtYnyxD3hTXFW/AAAA//8DAEz/bhPcAwAA\"]"
+            "size": 492,
+            "text": "[\"H4sIAAAAAAAAA7STTU+DQBCG/wqZMwqllKV7a9QYDx5q9GQas2WnlEgX3B1iP8J/NwttTaAfiYlHZt553t13hx1IQQL4DqpSCsJplW3tl6mSBI0BTrpCF1DrQhvgqspzF772okwCh8E4ABcI1wQcCA05tu20OAlWjYayQhk7gjJFA/x9B6qQ+AthLOpR2rEDyblxBuCCUOYb9UXWMBp1WO1Qh/TxQZsSlVghcJg0CqhPlh9kilC7fZ/omk/wB5/Zyd5doRQmNpDe8HSf1NnGmfMzxq5nHpzO/L8OOTvTvUjOtr3i23GbX9BUOVlBKmSK9Iztvi83UovjXiYa7YUnNop7QfiarRDc/U/RKXe9HhvupCzzLGmIjUVdu4BrQmUOHnmRGuCwJCoN97w0pds8U5+erXuDkR/5sSfmbCwWvh8tRBgGcYiSRX44Gso4wXk8D+2DaZHgk33Bq+K6/gEAAP//AwALHH8/4AMAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 09 Jul 2024 18:48:40 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:07 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "fa59a18c8ccd79edcb78b47da9db6af1"
+              "value": "78ba303af268aa8df582eabb3d6e9fad"
             },
             {
               "name": "x-trace-id",
-              "value": "de7668693507e7fe96111afab7ad3a29"
+              "value": "ab79af006fa44284ed760453d8ceb8b4"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=idQMorIDIoGAepTyQ1y52cKwhtfxeFJ1QX5NXt0A8Lkp2sqTjtrlirb7rD3GCBQOaLf28lNg6JYTckC4M8E8OBqORo%2Fe3yekvVg8TYHUCSpLRTwJeLwTSVQepQk8R%2B8ARyksuhz8sUnPb7jcLMqxwkngJw29g6aGHgSMtw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "8a0a7d4f6e030cac-EWR"
+              "value": "8ba8351d9ae736a6-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 943,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-07-09T18:48:39.521Z",
-        "time": 539,
+        "startedDateTime": "2024-08-28T23:51:07.013Z",
+        "time": 343,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 539
+          "wait": 343
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasMany-relationship_2440118782/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 436,
+          "bodySize": 368,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 436,
-            "text": "[\"H4sIAAAAAAAAA4SSzW6DMBCE7zzFas9VgZaQwi1qq6qHHir1VlWRY68cq4khYSPlR7x7ZSAOJI1yw7vfMKOxDwEAKsECczgEAAC42pi9PwGgUZgDxmmCd8cR05bdkKlicDxsSiWY1AlZbahiU9iq9ysAJKXJjb79CHrrBrGFooFokOMhSr2JX53laZ0vMnl8OuVdSVYsnQ9+djwOsHqouqJ5VZr6utp//5z0V7TPhbUk+87e80Jh9i3TEaiF0sQf1Ls3AJzv1Fr8U7pckyti0nT0Ipi+zJJ6tWDX1BlwI9Vbk2FSlgsjG9cmTnCsoZEhbZlsNYiEi0K7E86ZyyoPQ635fmHsb+gWYTyK0ugpjGOZUirjZJallIzGySiZZfRIFMlMjZXs4iOvhaT39onekrhUQf0HAAD//wMAckry5vMCAAA=\"]"
+            "size": 368,
+            "text": "[\"H4sIAAAAAAAAA4SQT2vDMAzFv0rROSxJl8Sdb2UbY4cdBruNUTxLc81SJ40VaBv83YfT7m8JOwnek3560gCoWIEcYNvbQ6wWQUJeFZAA045BApPnWbRnfYuKCSGBbU+ebeN8HCE05EE+D+AapG+IEJdnlOPYD9JqxfuWnNoQSHg8+RAmjFs0BOFlwr1unCM9AbCHKBqFhviBjkev99iprzt0RzHUMsa9UUxPdkOQwCnrb/kv/27kLtu2tnokjitCSIB2TM5/7qgb40HCmrn1Mk2N4Yvauvc06mleZlW2SLP5/O1KFVQWKLRYiIpy1ErkVZYVpXot41M7pek+fvnf5hA+AAAA//8DAPpJf+nlAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:57 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:05 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "131d3857ae8a7fc792914b11ee140b20"
+              "value": "c0038dc751b936c67a3314d631f633be"
             },
             {
               "name": "x-trace-id",
-              "value": "11c6e6c14b96e457454b9e3ee0c9d7dc"
+              "value": "022f9a4e54d7c7876e1dca7160045ab5"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=1HLS29hE9rFRxUXNqm5F%2BjOc5YH8%2BA0eugG0UX2AbYaBdngvQh%2By4D3S5ftgKLKIpVbJJbZqIMoqSpWwTOzxZcTRoYUBE14vJAeH1H357pa7wyzG4EYn6MK1FVfxd6dT4LqUXjUUD%2FrJ1RlpkD4UKKesFcEPifDYbLbsNQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d03e2e31435e-EWR"
+              "value": "8ba835127f62ab3c-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:56.722Z",
-        "time": 793,
+        "startedDateTime": "2024-08-28T23:51:05.213Z",
+        "time": 136,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 793
+          "wait": 136
         }
       },
       {
-        "_id": "7382de2c326ef389780d1eaae0d92d29",
+        "_id": "09b6dc4c997f2a35669ce0b799b50a4d",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 864,
+          "bodySize": 940,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "864"
+              "value": "940"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"164\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"206\",\"text\":\"test question updated\"}}],\"text\":\"test quiz updated\"}}}"
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"164\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"1773\",\"text\":\"test question updated\"}}],\"text\":\"test quiz updated\"}}}"
           },
           "queryString": [
             {
@@ -232,13 +228,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 412,
-            "text": "[\"H4sIAAAAAAAAA4SRT0/DMAzFv8rkc0X/sJY2twkQ4sBhCE4ITVniZhFdWhJX2lb1u6O0ZUKbKo7xe/45fu5AcuLAOmgbyQnXrT75l2uFQOeAkW0xALS2tg6YaasqgO/JpCUwiLMlBEB4IGBA6Gjh5cWIk+Dd6EjXxvkWlAodsI8OTC3xDEmi7Aoydv0BbTZ0bNDwPQKD9aRDPyM8SoXQf86o97UxKGYA+nRVfD+n84qurcgbFJcK6QXH/HZHafl5T2HR/3rl93nghG96jxBMIV+UL2c9DdxV01RaDMRhRN8HgAdC435nVLVywGBH1DgWhkrRTaXNV+jrYZxGWZSHRZIWvMyXyTYr0+IuSyMZR6W8xUKUeZkMp7Nc4LO/wr/mvv8BAAD//wMACv6fADACAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SRzU7DMBCEX6Xac0QS2rTEtwoQ4sChCE4IVcaeuhapE+yN1B/l3ZHbUFCriqN3Zr/dHe9IS5YkdtQ2WjJmrd3GV2iVQggk2LdICN7XPpBwbVUl9NWbrCZB+XhECTHWTIIYgQdRHhxwmqIbgW3tQmyBNggk3nbkao1fyGQyPKMc2v6Q5nPeNHByBRI063XqLgj32oC69wvqbe0c1AWA3Z4VX4/xPCO0FUeDkdqAn3AIcLnRXh4PVR5x62m8504yXuwKlPQpn5RPZz3sudOmqazaE/cjui4hrBku/MyoahNI0JK5CSJNjeGryrrPNNbTvMjG2U26kJNROc4WukCu5PBa5Sh1oVVRqkJl5UdM3UuFx/gN/5q77hsAAP//AwCXKkzMMQIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 09 Jul 2024 18:48:38 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:05 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "5e2a85639454117b5fdbd777d210522a"
+              "value": "19df13c852f69dc0eecb7ff60a9a2f2e"
             },
             {
               "name": "x-trace-id",
-              "value": "9259af842b6f597650d10fd3e9cf8f24"
+              "value": "fa74960fd5e1ca32c1e9d5dc59c5c09b"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=eaWZYTzkZrUmjv2EFjuoEG3Z6J0jw%2BfyDNXUMpPkurwupr4XqkjcIRpPvizmjABYLcBq8wtvcVV4jrVKzguxFQNL2coQexBKbHuYIAnyOxjRMNnNwIp5L%2BGzAfZIHwpt3S9oOjle2inX5O%2BNlL%2FxKSo8ZlTgvjAfk8k%2BZg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "8a0a7d3b196a4262-EWR"
+              "value": "8ba835138f2bac21-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-07-09T18:48:36.224Z",
-        "time": 2343,
+        "startedDateTime": "2024-08-28T23:51:05.379Z",
+        "time": 265,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2343
+          "wait": 265
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasOne-relationship_3220970997/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-a-single-HasOne-relationship_3220970997/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=answer"
         },
         "response": {
-          "bodySize": 384,
+          "bodySize": 344,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 384,
-            "text": "[\"H4sIAAAAAAAAA4SRzW6DQAyE7zyF5XNVoKjLzw2pUtVDe+o9Mqwhq5AFsa6aKMq7VwuUkl5ytD0z+432EgCgJiEs4BIAACBZ983jOgOg0VgAxlmKD78r4ZP4pbATmB0OvgZNwvpPZXsxjalJTG83gWukilYtALKlqmN/aKhzvLnsdnIe2NKRvetjm7qIruubt9pyLhNsNNiSblneeVMaAPdnPU6R7pa0HtmXKqe6LyT8aY68xV5a/xPc4XqdGMph6JYiE86MGSw25JOwdTdI2PWtn3AvMrgiDNtWHjtjD6E/hPFzpKIszPJEk8qanHTFTyrJM63SNFZVlTdKp8mCjzJSzW/TV9y1eKrg+gMAAP//AwCvSN2wMAIAAA==\"]"
+            "size": 344,
+            "text": "[\"H4sIAAAAAAAAA4SQzWrDMBCEXyXMWdQWiRVHN0Oh9NCeeg9ra+OYOrKxtjQh6N2L7LS0ufS2PzM7H3uFIyHYK8iHT55S1TlY6HILBeGzwEI4yGoRhNXH6EjYQcEP0h26hqQb/I/R5FBgT3XPDvZAfWCF/V4uI3s6MSxef9vi3bJaMKJCS65leeEF73hx0+wIqWsmTgxVgnsk4bfuxFC4of0d3yc8zXercexvDHNEjAp8FvbhO6Mf2gCLo8gYbJa1rTz0nX/P0jzTRW7yMqvNerfRtWnMwegt75qi0IU29VpvSJemSC+cqOHn9Jl/xTF+AQAA//8DAM3b3UuPAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:42:00 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:07 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "7d69e2e92a1ec813f512fcd462198a34"
+              "value": "8d2e57dbbeca0953e91dfd36547abd73"
             },
             {
               "name": "x-trace-id",
-              "value": "893da68f9adbe26398d67716bb9f6d73"
+              "value": "b63941b6c6f617e9c551516b314a1865"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=IkZX1Uij4UFJSsizdty3taGJNzh8b1bd2RpC21IPi074xDRDMpqeZzg9rEYHzw%2FKFrVhNKuB5%2Bi%2F9S4W1UCgJV8owalqaMA8padJTb1v8Fo%2BJJZwT0gcaOCVH7XJhzkpC7dkc%2Bcaa9uu0Mho4QhykFEfkN2I3Viof4Ao%2BA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d0523e9e43b9-EWR"
+              "value": "8ba8351fc8c9abb5-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:59.941Z",
-        "time": 212,
+        "startedDateTime": "2024-08-28T23:51:07.369Z",
+        "time": 160,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 212
+          "wait": 160
         }
       },
       {
-        "_id": "d2f261ad5b5c743ed461b115f53c49c5",
+        "_id": "7b04ea6984dc9dbeb9fe2d49f49dddc8",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 765,
+          "bodySize": 840,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "765"
+              "value": "840"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      notification {\\n        id\\n        enabled\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"notification\":{\"update\":{\"enabled\":false,\"id\":\"60\"}},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
+            "text": "{\"operationName\":\"updateAnswer\",\"query\":\"mutation updateAnswer($id: GadgetID!, $answer: UpdateAnswerInput) {\\n  updateAnswer(id: $id, answer: $answer) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    answer {\\n      id\\n      text\\n      notification {\\n        id\\n        enabled\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"answer\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"answer\":{\"notification\":{\"update\":{\"enabled\":false,\"id\":\"60\"}},\"text\":\"test answers updated\"},\"id\":\"187\"}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateAnswer"
         },
         "response": {
-          "bodySize": 440,
+          "bodySize": 388,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 440,
-            "text": "[\"H4sIAAAAAAAAA4SRzW6DMBCE7zzFas9RyS9xuCFVqnpoD1V7jgwsBNUxyF7URFHevTJQarjk6NmZ9efxLQDAXLLEGG4BAAC2TS6ZEm1/yIwqANo2y8hajIFNS4s/mYypjVN1q9SoynkcAKscY8CV2OPiX2S6sJOZLEOfstAj5L5P11wVVSa5qvVk7bg4Wnp+B6ZlqsiNCqksTWbHI18b0vJMLvnu7x5td+/2qX/oJpj5Zq4vr8cPsq3iPjH4sZR5SfxGXvcAeLrmpgOx0/IyQ66SpCvrWTJ9VmfyCxo6mxkeML50DEnTqOH5HU6PGQwxpAuTthMkVHXpTnhibmwchmXJT6rS36EbhKvdMlqKcLfPKF2n24PYbvIo3Yh1kRXiIEUaie1uvRnwkY3M6LX7xIcRRxXcfwEAAP//AwBrF/6AtwIAAA==\"]"
+            "size": 388,
+            "text": "[\"H4sIAAAAAAAAA4RQy26DQAz8lcjnVYFQHt0bUqWqh/ZQtefIYQ1B3SxobdREEf9eLaRRxKVHj8cz47mAQUHQFxgHg0KV4x/yYeaxrokZtPiRFJD3vWfQbrRWAd5onQENSVmAAqGTgAYhls1C4M2iakCB66Vruhql693tMI9BATncWzKgG7RMCnY7OQ/k8Eig4f3+bFotr2nX8NfdKx/Eo5VAadG0JG+0vHs4Gz+LcphqTyFmFfI/o9BndyRQ105W8NrtZdathsFeY84W06SATkKO/zxs3zJoOIgMrKOobeXBdu47CniUZHEel1FaPJV52uRlVqR7TOmxzAtKmiypG9qmmIaWPdb0Gsr7lzxNvwAAAP//AwDVa4+f3wEAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:42:01 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:07 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "100a53053a5b4e4bcdfc72f74608106f"
+              "value": "38362ae9d61e17ed4cb05ee6b43a8fef"
             },
             {
               "name": "x-trace-id",
-              "value": "57ceb2b49843d6b382fcf89a8b684523"
+              "value": "379863f68573ba3e4867e1f51cfe23a3"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=3pJ7Hvaes6aLBNFqXsS40J0oRwwjZ2GG%2Fl%2FeAAKxhqqRrgyRHcUv2%2FQB14l4XolqEH2Qn%2FfAoQuazM%2FMBi7GAoaFXzRV1%2BoQJnFjUXOEntNd0RvONdTOfu0usdRppypf3sAvHpNfZkTMFaYLxnah1IAznEMoyDvx8%2BM7BQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d053fc38c342-EWR"
+              "value": "8ba835211eec3981-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 953,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:42:00.210Z",
-        "time": 1033,
+        "startedDateTime": "2024-08-28T23:51:07.572Z",
+        "time": 280,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1033
+          "wait": 280
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 460,
+          "bodySize": 392,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 460,
-            "text": "[\"H4sIAAAAAAAAA7ySTW/CMAyG7/0Vls/b2sCgFTe0TdMOO0zabZpQaLwQraSFGokP8d+nhFJaPoS47NbY79P3teVNAIBKssQBbAIAAJwtzLp+AaBROAAU/QTv9iWmJbsiU8ng9LAolGRSB8lsQSWb3JaNXwEgKU2u9FWXoNH2EpsrakGtHB0R1SZ16yjPznmfCe5BnCKjEa8KsnLqvPCjYrAl27apC8yL0tTkWtSNs4nbZ+v862z19/eBv8A+5dZS2nSuPU8Is95pKgVqqTTxOzXuEgAnKzWXZ44qnZNbxtDv6VkyfZopNdaC1baOBFdSvfoMw6LITOpdfZxgvwaPIS2ZbNmKhFmu3QsnzEU5CEOt+SEz9jd0jVD0on6UhLHsPcqok6gkGfdj2Y2lUqo7jsRP0o1FPK7iI89lSm/+PK4iLlWw/QMAAP//AwCRPdCr0wMAAA==\"]"
+            "size": 392,
+            "text": "[\"H4sIAAAAAAAAA5yQT0vDQBDFv0qYczS7TfPHvRUV8eBB8CZS1t1xu5hu0uwE2oZ8d9m0VbSEgqeBNzO/93g9aEkSRA+bzu7DtBoE8LyEGAi3BAIIPUVhHXWNloQaYth06MnWzocX1AY9iNceXK3xB1IU8zPK4e1Eiq4iDjEsl7Rr0Mk1goDn4w0ME4t7bRCG+Nwtu+w2+6fb28T2tnYO1QTA7oNopDZIT3ioebXTrfxuTrUYgi1C5DtJ+GLXCDEc8/6W//IfRu6iaSqrRuJoMQwx4JbQ+ZNHVRsPAlZEjRdJYgxdV9Z9JkFPeMZyViapKmbyAzPJlZayYGnGdZlm/J0VOWPzm1BsKxU+hqYvHg/DFwAAAP//AwBdQ/TWVwIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:58 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:06 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "2e4efc885b81730acd27d53753897930"
+              "value": "9b834cbb9261484fea0e6fffcf7e0d28"
             },
             {
               "name": "x-trace-id",
-              "value": "7a54a028d88b67a37addd3b01f83717b"
+              "value": "3c72afe5a1cdaa70351d8351b0760049"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=YTTwZIRLmlJEGY7OVBwbWniFEoQ4efQeiBzQnhHka1vda0R0cFNVkTlNTXSTRkeY3LZnCjejLcVxS7i%2B%2BUXle5BPnQ%2BA0WOdxW6RgOIimAGRfb%2FfP03hnh%2FgbeovcXt9LWYJkHIiLt2zEno2jNgqKqiMmy%2BANMXr4XMNWg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d04af83a1a0b-EWR"
+              "value": "8ba835185b1fac99-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:58.776Z",
-        "time": 162,
+        "startedDateTime": "2024-08-28T23:51:06.144Z",
+        "time": 145,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 162
+          "wait": 145
         }
       },
       {
-        "_id": "8162bb2060b2c94a841df8f2b8ae4981",
+        "_id": "92f0993ea7a9aba2b2055384d7e2c25b",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 927,
+          "bodySize": 1004,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "927"
+              "value": "1004"
             },
             {
               "_fromType": "array",
@@ -210,13 +206,13 @@
               "value": "zxcv-deeply-nested--development.gadget.app"
             }
           ],
-          "headersSize": 461,
+          "headersSize": 462,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"210\",\"text\":\"test question updated - 1\"}},{\"update\":{\"id\":\"211\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"1774\",\"text\":\"test question updated - 1\"}},{\"update\":{\"id\":\"1775\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
           },
           "queryString": [
             {
@@ -232,13 +228,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 432,
-            "text": "[\"H4sIAAAAAAAAA5yRy2rDMBBFf8XMWq3t2Iod7UJbShddpLSrUoKQBkXUkV1pDHngfy/Ka5EQAllq5s65o7lb0JIkiC30nZaEs95u4iv0SmEIIMj3yAC9b30A4fqmYfB3EFkNAvJxDQwIVwQCCAMlsZ3scRqiGgPZ1oU4gtpgAPG9BddqPEFGeXYB2U8dQclDkgOD+ZzWHTq5RBAwO2hguNJ40QZhYBdm+W2z0Z1mP1e6T61zqK4A7Oai+HWK4wND31AUGKkN0jvuA1ustZenwyqPcfNp/NOzJPy0SwR2SPWsfO71uuNOu66xakfcWQwDA1wRunD0aFoTQMCCqAsiTY2hx8a63zTW05xn46xO64LXNedcqiofl5msJ0WZ8VJNFFYVr4p4eS8VvsUkboqH4R8AAP//AwDhgr6loQIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA5yRy2rDMBBFf8XMWq3t4FiJdqEtpYsuUtpVKUGRJoqoI7vSGPLA/16UVyEmBLrUzJ1zR3N3oCVJEDtoGy0Jp63dxldolcIQQJBvkQF6X/sAwrVVxeDnKLIaBOTlCBgQrgkEEAZKYjs54DRENQaytQtxBLXBAOJzB67W+AfhvOhRDmMnUnKX5MBgNqNNg06uEARMjxrorjSetEHoWN9teNtt8E+3ryvdh9o5VFcAdtsrfpwDecPQVhQFRmqD9IqHyJYb7eX5tMpj3HwS//QoCd/tCoEdc70oX3o977mTpqms2hP3Fl3HANeELpw8qtoEELAkaoJIU2PovrLuO431NB9mZTZK52qecZ4PcIyLsZRFKTmOJceyyDTP1SJe3kuFLzGKm+Ku+wUAAP//AwCwUnbFowIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 09 Jul 2024 18:48:39 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:06 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "01d8a5d123b645b39abb754bb1cd3198"
+              "value": "71e6f976bdf5819fc5352d25a97baf5e"
             },
             {
               "name": "x-trace-id",
-              "value": "83588555ac71640a8934054c9ce77573"
+              "value": "bcb07712e9ef9aa46a7e9a7e640d71cf"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=BDYsKww2wxdlQmJrfFv%2B49365lsiA44O6DbEl3jbz2JPxiHpk8wUfspG7UXJnjuBq2h1xjiQjVccGHrP1uXgbQ5Tbm0uUsVcW5voKLW%2BOcibZ2yhlGF5PlkXgFWQYwqhyBFTctVVefTq%2Fi7jDKhudJ800M6%2Ft5m6SeKKkg%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "8a0a7d4c5a877cf6-EWR"
+              "value": "8ba8351979ccac96-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 947,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-07-09T18:48:39.035Z",
-        "time": 412,
+        "startedDateTime": "2024-08-28T23:51:06.347Z",
+        "time": 328,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 412
+          "wait": 328
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships_1125172282/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 456,
+          "bodySize": 392,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 456,
-            "text": "[\"H4sIAAAAAAAAA7yST2vCQBDF7/kUw5zbJmtNNLlJW0oPPRR6K0WW3WFdqkk0I/gHv3vZNcZEK+Klt+zM++W9GWYbAKCWLDGDbQAAgPOl3TQvALQaM0CRDPHuUGJasSsyVQxOD8tSSyZ9lMyXVLEt8qr1KwAkbciVvpoStNpekheaOlAnR09EjUnTOsmzdz5kgnsQ58h4zOuScjlzXvhRM9iR7brUBeZFG2pzHerG2cTts/X+dbbm+/vIX2Cfijwn1XZuPM8Iu9lragUaqQ3xO7XuEgAna72QfxyVWpBbxsjv6VkyfdoZtdaC9bZOBFdSvfoMo7KcWuVdfZzgsAaPIa2Y8qoTCaeFcS+cMJdVFobG8MPU5j+ha4QijpJoGCaxUoKS3nCQiL5SIol1mjxGJNN+nPbTQR0feSEVvfnzuIq4VMHuFwAA//8DAPLuT6fTAwAA\"]"
+            "size": 392,
+            "text": "[\"H4sIAAAAAAAAA5yQS2vDMBCE/4rZs1o/44duoS2lhx4KvZUSFGujiDqyY60hifF/L3KSliaYQE8Ls7vfDNODFCSA97Dt9MFNLYFDmObAgHBHwIHQkufWXtdIQSiBwbZDS7o21r2gVGiBf/Rgaom/kCxLrijHtzPJu/NCYLBY0L5BIzYIHN5ONzBMLJ6kQhjYtdvstlv0T7fPie1DbQyWEwB9cKISUiG94rHm9V624qe5skUXbO4iPwrCd71BYHDK+1e+5D+P3HnTVLociaPFMDDAHaGxZ4+qVhY4rIkay31fKbqvtPnyne6HsyANcn+VxEEYRyKMMAmSLIjzKFgVS5kWy7zI89QV24oSX1zTN4+H4RsAAP//AwALD8LBVwIAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:58 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:05 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "6e40af077e7838c465c85f91ff94c55c"
+              "value": "86bc544fd85c3d841bdc2c1f2400db10"
             },
             {
               "name": "x-trace-id",
-              "value": "65cc1e6287614cc165d9630ea9459497"
+              "value": "f430132a12e404703820f9bd69b89886"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=8mrPgOF2YLz5oohF3gZ0ABWYmBBhuR0WoEfi0aEm70rzF2UMZHsNQU%2B81jVuRw%2Fgkp%2FeqOYIVlN2gg1o4I%2B2d9rFLB0ZVa3PqhJh%2BJeG1hXxviBS9U3XZllYiTxgcmLFbloXU81YwuwU5TESaQqeqRYXbcV%2B3%2BWyN8lF%2FQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d0461decc32c-EWR"
+              "value": "8ba835159ac3711b-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 955,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:57.996Z",
-        "time": 245,
+        "startedDateTime": "2024-08-28T23:51:05.700Z",
+        "time": 149,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 245
+          "wait": 149
         }
       },
       {
-        "_id": "8162bb2060b2c94a841df8f2b8ae4981",
+        "_id": "92f0993ea7a9aba2b2055384d7e2c25b",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 927,
+          "bodySize": 1004,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "927"
+              "value": "1004"
             },
             {
               "_fromType": "array",
@@ -210,13 +206,13 @@
               "value": "zxcv-deeply-nested--development.gadget.app"
             }
           ],
-          "headersSize": 461,
+          "headersSize": 462,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"210\",\"text\":\"test question updated - 1\"}},{\"update\":{\"id\":\"211\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"1774\",\"text\":\"test question updated - 1\"}},{\"update\":{\"id\":\"1775\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 432,
+          "bodySize": 428,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 432,
-            "text": "[\"H4sIAAAAAAAAA5yST08CMRDFv8pmztX9E1hKb0SN8eABoydjSGnH0rh013Y2ATb73U1h4QAhJB478+b3pn3tQEuSIDpoGy0J563dxVNolcIQQJBvkQF6X/sAwrVVxeB3EFkNAvKSAwPCDYEAwkBJbCcHnIaoxkC2diGOoDYYQHx24GqNJ0iRZxeQw9QRlNwlOTBYLGjboJNrBAHzQQP9lcaTNgg9uzDLb5sV/zT7utJ9qJ1DdQVgdxfFj1McbxjaiqLASG2QXvEQ2GqrvTw9rPIYN5/FOz1Kwne7RmBDqmflc6/nPXfWNJVVe+Leou8Z4IbQhaNHVZsAAlZETRBpagzdV9b9pLGe5uOszHg6zfh4OZ2U5VhN+IgXfDmd4OhbS67KcsTjhyAvFb7EJG6K+/4PAAD//wMA6/HxfKECAAA=\"]"
+            "size": 428,
+            "text": "[\"H4sIAAAAAAAAA5yRS0/DMBCE/0q050AayKu+VYAQBw5FcEIIGXvkWqROiDdSH8p/R+4LqVVViaN3Z79Z76xJS5Yk1tS3WjKmvV2Fl++VgvckuOsRE7qu6TwJ19d1TD87kdUkKC0qiomxYBLE8ByFdrTFaQpqeLaN82EE2sCTeF+TazT+IGWZnVC2Y3tSdBWlFNPnJy9bODkHCZruNDScaTxoAxriU7f8stvNP90+znTvGuegzgDs6qT4dgjkBb6vOQiM1Ab8jG1ks6Xu5OG0qkPYfBL+dC8Zr3YOine5HpWPvR433Enb1lZtiBuLYYgJC4bze4+6MZ4EzZhbL5LEGL6urftOQj1J81ExqhLklVSFvE3HKDNUlf4qxhoZqlLl46yS4fKdVHgKUVwUD8MvAAAA//8DAEWMC2CjAgAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 09 Jul 2024 18:48:38 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:06 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "cbb309e01864ddea724b8557106c5074"
+              "value": "831ea97554cde3ddae26266bb36d65bd"
             },
             {
               "name": "x-trace-id",
-              "value": "9085b97665c784828b97e4fda8c6648d"
+              "value": "e58ac6a319e74e88db69de4e87c5948a"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=3GKfAGTFV6YwwKvrWv6SJNGhRTa%2BFSBARoyg46jju9xATagFmGi%2BG8GZhqvpuKEwnpiBqYSV7AaPJrMDqjCH97ovgVcqvLRXEZlEeGWp2%2F6oNO%2FGdkW3E%2FLGQxdRDMPtpMMTETnGsMlbJTHwOm00mQwLW0%2Fm44zPw6TnPA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "8a0a7d49dd3e42e1-EWR"
+              "value": "8ba83516b9555401-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 951,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-07-09T18:48:38.638Z",
-        "time": 327,
+        "startedDateTime": "2024-08-28T23:51:05.908Z",
+        "time": 205,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 327
+          "wait": 205
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-even-if-nested_698860812/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-even-if-nested_698860812/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 344,
+          "bodySize": 308,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 344,
-            "text": "[\"H4sIAAAAAAAAA4SQQWvDMAyF7/kVQucxJ7TxstwKg9HDDoPdi2orrlmauokK7Ur++7Cbdd1g7Kj3nvQ+dM4A0JIQ1nDOAABwf/Af1wkAvcUasNAzvPuShI8SReFBIObhECwJ2+/IaiWnwB1tOQZf481kjZcEOrKO5YVvmgFwc7I9id91w40KgKbneH6RWp9I+M1v+VoGgFP/r8Dkj39QPSeGRQitN6k14Vwws2kN+SjcDT+QsN25OOFGJAy1Us7Jfeu7dxUNVZS5zivVPJqGH3Kb22rONCuqQttSM63X5dyQbiZ8lJ4ML9OT/12JVNn4CQAA//8DALtSioW1AQAA\"]"
+            "size": 308,
+            "text": "[\"H4sIAAAAAAAAA4SQMW8CMQyF/wryHJELgRzJhlQJdWCoxI7cixuiHkd6MRIU5b+jXNuhXTpZfvb7nuw7eGQEd4ePS/ysNXpwoIwGAUxXBgdMmWd1PLskj0weBBwOfEs04InAwUu1FgEBfSDe0RfwePMjcjwPuXbdSNW6qcAnZNrHE4GAb+JvufzhbyfuJqU+dhNxiihFAF2ZhvyT0Z9DBgdH5pSdlCHwvI/Du6y6VKvGNGtpSHe2VbZ9bdfG6tViYZVtzJtWGnHpVT17xI6e6xv+XS7lAQAA//8DAA1GqqVBAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:56 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:04 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "197d7e2b0981ed77f1f2e9ac63468966"
+              "value": "9ecc4cdc9a22550aa92fe2cdda0d29b5"
             },
             {
               "name": "x-trace-id",
-              "value": "f9cfe70d0d84ea31816d56eabb54ca6f"
+              "value": "6e3c97197b7869352291906f313aa4d1"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=decx%2BjKW4ucCYMoFipdOLdMn%2F0g2R4Ry2f0mVweoaF6tGp0WKXw0UK4ghvyZ6ih9rlVX3ON62bLsLTxCJJhavTeoZ8zCE5eqM6l89AGwUfYG7m%2BpJo1cq%2FU42aWYHxvbUmqk%2BP3MOXG4gHYrGoYd4IUWutOOwUUPwQGaNA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d039ceea6a4e-EWR"
+              "value": "8ba8350f7a68abd6-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:56.021Z",
-        "time": 235,
+        "startedDateTime": "2024-08-28T23:51:04.751Z",
+        "time": 128,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 235
+          "wait": 128
         }
       },
       {
-        "_id": "a1383329ee918866a6eddfeffb3fec50",
+        "_id": "0072a3e996ba5e231ddd9987300c7c92",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 608,
+          "bodySize": 683,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "608"
+              "value": "683"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"163\",\"quiz\":{\"text\":\"test quiz updated\"}}}"
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"163\",\"quiz\":{\"text\":\"test quiz updated\"}}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 388,
+          "bodySize": 348,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 388,
-            "text": "[\"H4sIAAAAAAAAA4SRPWvDMBCGd/+K4+ZQW/gD4y1QKB06tLRzUKSLI+rYrnSCpCH/vch2XbtLRr33vNxz6BoBoJYssYJrBACAvteS6dWb7zkDQOeVIuewAraeNr8xWdvZkLa+aeb0a10GQKOxAhRFipu/kOnMIWZyDKED4269hHY7vvTUyhMFdNCahrd535r5mA94I+cbHvmJxlrqmviFFicD4PGirWTTtW7trSwFoe3g+SiZ3s2JlnqT8T/gjuHT4LDt+8aoYeugM2pGUw3pzNS6lRI2XR1eeGTuXRXHdc0PjWk/4zCIRZ4USRlLEiJTiUgp1Qedi32WF0WSlWWusj2Jw6SPbKWi5+Fj7laCVXT7AQAA//8DAPKH9uAuAgAA\"]"
+            "size": 348,
+            "text": "[\"H4sIAAAAAAAAA4SQsU7DMBCGX6W62cJJmgTqrRISYugAgrkyvmtq1U1S+yy1VH535LQwZGG837++z3dXQM0a1BXiiJrpLdrvPIVoDIUAin0kAeT94AOoPjon4HQvWQQFZbsEAUxnBgVMgRf5eXHDIQjYbvkyUq+PBAomfpqFn3/qdwrRcS50GjviDd0+t7+g12yHPuTJeMrsdTY+a6YPeyQQ9w1m8dz1MnHX4+ismYiTIiUBdGbqw6/DDV0ABXvmMSgpu44fnO0PMueybIq2eJKruq6aall9mXJlil2NZDQ2hLsasX2sTL6L14Ze853+Laf0AwAA//8DACmozSaNAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:56 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:05 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "78edd6d9108885e17bdb84b35622f37c"
+              "value": "58021b128f7cd3c53bdfb4fea2b33969"
             },
             {
               "name": "x-trace-id",
-              "value": "ae114c013e3dfd51b456604885c4be1f"
+              "value": "94425232bc19c0f4decad5edf4dd672c"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=usbReQikaJptPbD1Rar77rl56tHpbUiOZncsiKHX4r9gRUWbN3bz6zNgndUTsAc2HOgx8Gw39EJXwQRGBAEW60bzmqS2vDu1TIw6HiQ%2FDyQ4GLZSLaEhnN358JarLjCx69rhHJbRq8p8rccV5BEgcOdb0LEsT8bpYsICSw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d03b7d964213-EWR"
+              "value": "8ba835108a27a1f3-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 941,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:56.293Z",
-        "time": 397,
+        "startedDateTime": "2024-08-28T23:51:04.916Z",
+        "time": 277,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 397
+          "wait": 277
         }
       }
     ],

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-object_3536142481/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-root-object_3536142481/recording.har
@@ -67,18 +67,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=quiz"
         },
         "response": {
-          "bodySize": 344,
+          "bodySize": 315,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 344,
-            "text": "[\"H4sIAAAAAAAAA4SQzWrDMBCE736KZc+hkmzqpL4FCqGHHAK9B9VaKaKOo9obSBr87kWK81coPe7M7M7HnjIANJo1VnDKAADwa++/rxMAeoMVoCoLnFwkpgNHkalniHnYB6OZzC2yXvMxUKu3FIOreDNZwzmBThtHvKS7ZgDcHE2n2e/a/k4FwLqjeH6eWl8107vf0rUMAMf+X4HRH/6gWiSGeQiNr1NrwjljZuMa0oGp7R+QsNm5OOGGOfSVEM7xU+PbTxENoZ5lKWeieLFFLqfS1lIVytDHzOaWrJ7m0qqyvPwKudM1vaUn/7sSqbLhBwAA//8DAJ+nW621AQAA\"]"
+            "size": 315,
+            "text": "[\"H4sIAAAAAAAAA4SQQWvDMAyF/0p5Z1PHS5o6vhUGZYcdBrsXEwnXLE29RIV2xf99ONsO22UnoSe97yHdQV483B3vl/hRaiQ4mLaGgvBV4CA8y6qMV5dEXpigcDjILfHoTwyHl2LNCsFTYHnmL+DxRpOXeB7n0vUTF+uuAB+98Gs8MRS+ib/l/Ie/X7i7lIbYL8QlImcFvgqP80/GcA4zHI4iaXZahyDrIY5vuujabKq2sroxRG1Fbd0Y7sh29WZrH3pr6o4a22xNOXvyPT+VN/y7nPMnAAAA//8=\",\"AwBA/6zXQQEAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:55 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:04 GMT"
             },
             {
               "name": "content-type",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "10a435ab917fa097f6aaa75b58bd4793"
+              "value": "7dc52fe09fc97842de091b78d449bde6"
             },
             {
               "name": "x-trace-id",
-              "value": "39f32070fc0131deb8f2fefa720f166d"
+              "value": "41dd60d6341e9d8935782c8139d48471"
             },
             {
               "name": "strict-transport-security",
@@ -129,34 +129,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=IPJ0Fa8xsikE0mSGEVbGkGCDcHovbLsm5LYto%2B6CoTGm7lNYeyM1F23ka5MUaLwESYJrA3RB8AZlc%2Fb9Qb3etJXTZHRM1yphmKtgaQ86Mh2D132v9HQFyFRVHgnG9OmjfRxM5pKVD0RX0A7OoQ%2F8lkzKAVTa1O7O2LXn5g%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d0323e977293-EWR"
+              "value": "8ba83508da29369e-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:54.817Z",
-        "time": 539,
+        "startedDateTime": "2024-08-28T23:51:03.691Z",
+        "time": 785,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -164,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 539
+          "wait": 785
         }
       },
       {
-        "_id": "a1383329ee918866a6eddfeffb3fec50",
+        "_id": "0072a3e996ba5e231ddd9987300c7c92",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 608,
+          "bodySize": 683,
           "cookies": [],
           "headers": [
             {
@@ -193,7 +189,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "608"
+              "value": "683"
             },
             {
               "_fromType": "array",
@@ -216,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"163\",\"quiz\":{\"text\":\"test quiz updated\"}}}"
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"163\",\"quiz\":{\"text\":\"test quiz updated\"}}}"
           },
           "queryString": [
             {
@@ -227,18 +223,18 @@
           "url": "https://zxcv-deeply-nested--development.gadget.app/api/graphql?operation=updateQuiz"
         },
         "response": {
-          "bodySize": 392,
+          "bodySize": 348,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 392,
-            "text": "[\"H4sIAAAAAAAAA4SRPWvDMBCGd/+K4+ZQW7Hjry1QKB06tLRzENbhiDq2K50hach/L5Jd1+6SUe89L/ccugYAqCRLLOEaAADg0CvJ9Dro7zkDQDtUFVmLJbAZaPMbkzGdcWk7NM2cfq3LAKgVloAijXHzFzKd2cVMlsF1YNytltDhwJeeWnkih3qtaXib962Zj/mAN7JDwyM/0VhLVRO/0OJkADxelJGsu9auvStDTmjvPR8l07s+0VJvMv4H3DF88g77vm905bd6nVEzmGpIZ6bWrpSw6Wr3wiNzb8swrGt+aHT7GbpBKHZRGuXhVsSp2Iok35GMkryQRZXFiZBFJLOkyIpJH9nIip79x9ytOKvg9gMAAP//AwA+rDU7LgIAAA==\"]"
+            "size": 348,
+            "text": "[\"H4sIAAAAAAAAA4SQMU/DMBCF/0r1ZoskLQnFWyUkxMAAgrk67Etq4SbBPkstVf47cloYujDe89P3+e4ES0LQJ6TRkvBLct95iskYjhFaQmIFDmEIEbpP3it8XUrOQqNqVlAQPgg0hKMs8vPijLNQ2G7lOHJPe4bGzJ+uwvc/9SvH5CUXOrIdyzOfP7c72kDihj7myQTO7E02PpDwm9sz1GWDq/ja9ThzN+PonZmJs2KaFPgg3Mdfhx+6CI2dyBh1UXSd3HjXfxY5L6q6bMp1saypqm/rsi1baombsiLTrOj+rq3X/FGZfJdAhp/ynf4tT9MPAAAA//8DAFufTMCNAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 25 Apr 2024 19:41:56 GMT"
+              "value": "Wed, 28 Aug 2024 23:51:04 GMT"
             },
             {
               "name": "content-type",
@@ -270,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "cff0012ff01112510dfdc1d92706981c"
+              "value": "71f32114f481ef9b54d82a9a80f2d540"
             },
             {
               "name": "x-trace-id",
-              "value": "2136121485ea0489a9c7341a90a74979"
+              "value": "25a15450f0fafae601ac63a97f58eb1c"
             },
             {
               "name": "strict-transport-security",
@@ -289,34 +285,30 @@
               "value": "DYNAMIC"
             },
             {
-              "name": "report-to",
-              "value": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=yAgwyUOSLmffJVVUzULzToVkXgqA%2Fg3wK%2BVSOzSQ5VXzn2A3lxOWWgNTb6mhNftY1Q6m1HORlLGhCK%2FVM3IBGLk0hEC8pKoJoHO62CwToDKQd4HBZVtmzAuz1bpZxZhfkmwBXGsSvzFHR7vMAiwtQYf%2BVSqRjhFG%2BRODnw%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
-              "name": "nel",
-              "value": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-            },
-            {
               "name": "server",
               "value": "cloudflare"
             },
             {
               "name": "cf-ray",
-              "value": "87a0d035b8fe4263-EWR"
+              "value": "8ba8350e1cc5a1ec-YYZ"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 949,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-04-25T19:41:55.382Z",
-        "time": 590,
+        "startedDateTime": "2024-08-28T23:51:04.520Z",
+        "time": 218,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -324,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 590
+          "wait": 218
         }
       }
     ],

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -171,6 +171,9 @@ describe("useAction", () => {
             message
             code
             ... on InvalidRecordError {
+              model {
+                apiIdentifier
+              }
               validationErrors {
                 message
                 apiIdentifier
@@ -356,6 +359,9 @@ describe("useAction", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier

--- a/packages/react/spec/useBulkAction.spec.ts
+++ b/packages/react/spec/useBulkAction.spec.ts
@@ -106,6 +106,9 @@ describe("useBulkAction", () => {
             message
             code
             ... on InvalidRecordError {
+              model {
+                apiIdentifier
+              }
               validationErrors {
                 message
                 apiIdentifier
@@ -189,6 +192,9 @@ describe("useBulkAction", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -74,6 +74,9 @@ describe("useGlobalAction", () => {
             message
             code
             ... on InvalidRecordError {
+              model {
+                apiIdentifier
+              }
               validationErrors {
                 message
                 apiIdentifier
@@ -181,6 +184,9 @@ describe("useGlobalAction", () => {
               message
               code
               ... on InvalidRecordError {
+                model {
+                  apiIdentifier
+                }
                 validationErrors {
                   message
                   apiIdentifier


### PR DESCRIPTION
I was working on formatting errors that come back from the imperative api and noticed that `InvalidRecordErrors` never had `modelApiIdentifier` set, even though it is on the type; turns out we just weren't selecting it in the operationRunners

This also adds a support function `formatErrorMessages` that takes GadgetErrors and turns them into nice structured objects for displaying error messages 

Forgive the large diff, it's snapshot changes now that we have changed the gql queries everywhere

~Also I've bumped all the other clients that depend on api-client-core so that if someone upgrades all gadget managed packages they will all ask for the same api client core version~

because of one of the react tests I need to release the new api-core-version first; I'll do that now and then follow up bumping all the other versions

then I'll get you guys to review the changes in userland deps

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
