### PR TITLE
makes formatErrorMessages more portable across different js contexts

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.31",
+  "version": "0.15.32",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -733,11 +733,12 @@ export const ErrorsSelection: BuilderFieldSelection = {
 export const formatErrorMessages = (error: Error) => {
   const result: Record<string, any> = {};
 
-  if (error instanceof InvalidRecordError) {
-    for (const validationError of error.validationErrors) {
-      if (error.modelApiIdentifier) {
-        result[error.modelApiIdentifier] ??= {};
-        result[error.modelApiIdentifier][validationError.apiIdentifier] = { message: validationError.message };
+  if ("validationErrors" in error) {
+    const invalidRecordError = error as InvalidRecordError;
+    for (const validationError of invalidRecordError.validationErrors) {
+      if (invalidRecordError.modelApiIdentifier) {
+        result[invalidRecordError.modelApiIdentifier] ??= {};
+        result[invalidRecordError.modelApiIdentifier][validationError.apiIdentifier] = { message: validationError.message };
       } else {
         result[validationError.apiIdentifier] = { message: validationError.message };
       }


### PR DESCRIPTION
`instanceOf` is not working well when importing this function in the sandbox; this makes `formatErrorMessages` more portable across different js contexts

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
