### PR TITLE
adds new internal authentication method that can be used for session …

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.32",
+  "version": "0.15.33",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/src/ClientOptions.ts
+++ b/packages/api-client-core/src/ClientOptions.ts
@@ -92,9 +92,16 @@ export interface AuthenticationModeOptions {
   // Use no authentication at all, and get access only to the data that the Unauthenticated backend role has access to.
   anonymous?: true;
 
+  // @deprecated Use internal instead
+  internalAuthToken?: string;
+
   // @private Use an internal platform auth token for authentication
   // This is used to communicate within Gadget itself and shouldn't be used to connect to Gadget from other systems
-  internalAuthToken?: string;
+  internal?: {
+    authToken: string;
+    actAsSession?: boolean;
+    getSessionId?: () => Promise<string | undefined>;
+  };
 
   // @private Use a passed custom function for managing authentication. For some fancy integrations that the API client supports, like embedded Shopify apps, we use platform native features to authenticate with the Gadget backend.
   custom?: {


### PR DESCRIPTION
We want to add the ability for internal api clients in Gadget's app sandbox to be able to act either as the sys admin (the current state), or to act with the same identity as the session that is making the request. To do this I am changing the auth configuration for `internal` to take options to allow this functionality

This will be used in https://github.com/gadget-inc/gadget/pull/12813

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
