### PR TITLE
Update AutoForm error messages for bad actions

### DIFF
--- a/packages/react/.changeset/moody-tips-do.md
+++ b/packages/react/.changeset/moody-tips-do.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": minor
+---
+
+Updated AutoForm to throw an error when given an invalid action

--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -6,6 +6,7 @@ import type { UserEvent } from "@testing-library/user-event";
 import { userEvent } from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import React from "react";
+import { TriggerableActionRequiredErrorMessage } from "../../src/auto/AutoFormActionValidators.js";
 import { PolarisAutoForm } from "../../src/auto/polaris/PolarisAutoForm.js";
 import { PolarisAutoInput } from "../../src/auto/polaris/inputs/PolarisAutoInput.js";
 import { PolarisAutoSubmit } from "../../src/auto/polaris/submit/PolarisAutoSubmit.js";
@@ -675,13 +676,13 @@ describe("PolarisAutoForm", () => {
       it("throws an error when a model action without triggers", () => {
         expect(() => {
           render(<PolarisAutoForm action={api.autoTableTest.noTriggerAction as any} />, { wrapper: PolarisMockedProviders });
-        }).toThrow("Actions must have API triggers to be used in AutoForms");
+        }).toThrow(TriggerableActionRequiredErrorMessage);
       });
 
       it("throws an error when a global action without triggers", () => {
         expect(() => {
           render(<PolarisAutoForm action={api.noTriggerGlobalAction as any} />, { wrapper: PolarisMockedProviders });
-        }).toThrow("Actions must have API triggers to be used in AutoForms");
+        }).toThrow(TriggerableActionRequiredErrorMessage);
       });
     });
     describe("Has triggers in api client but no triggers in action metadata", () => {
@@ -689,14 +690,14 @@ describe("PolarisAutoForm", () => {
         expect(() => {
           render(<PolarisAutoForm action={api.widget.create as any} />, { wrapper: PolarisMockedProviders });
           loadMockWidgetCreateMetadata({ triggers: [{ specID: "non/api/trigger", __typename: "GadgetTrigger" }] });
-        }).toThrow("Actions must have API triggers to be used in AutoForms");
+        }).toThrow(TriggerableActionRequiredErrorMessage);
       });
 
       it("throws an error when a global action without triggers", () => {
         expect(() => {
           render(<PolarisAutoForm action={api.flipAll as any} />, { wrapper: PolarisMockedProviders });
           loadMockFlipAllMetadata({ triggers: [{ specID: "non/api/trigger", __typename: "GadgetTrigger" }] });
-        }).toThrow("Actions must have API triggers to be used in AutoForms");
+        }).toThrow(TriggerableActionRequiredErrorMessage);
       });
     });
   });

--- a/packages/react/src/auto/AutoFormActionValidators.ts
+++ b/packages/react/src/auto/AutoFormActionValidators.ts
@@ -8,14 +8,14 @@ export const validateNonBulkAction = (action: ActionFunction<any, any, any, any,
 };
 
 const GadgetApiTriggerSpecId = "gadget/trigger/graphql_api";
-const ApiTriggerRequiredError = `Actions must have API triggers to be used in AutoForms`;
+export const TriggerableActionRequiredErrorMessage = `"action" must be a valid Gadget action with an API trigger to be used in AutoForms`;
 const validActionTypes = ["globalAction", "action"];
 
 export const validateTriggersFromApiClient = (action: ActionFunction<any, any, any, any, any> | GlobalActionFunction<any>) => {
   if (!validActionTypes.includes(action.type)) {
     // When the API client is built with an action without the API trigger, the type will be "stubbedAction"
     // action.type === "globalAction" | "action" // Only when the action has the API trigger when the api client is built
-    throw new Error(ApiTriggerRequiredError);
+    throw new Error(TriggerableActionRequiredErrorMessage);
   }
 };
 
@@ -32,7 +32,7 @@ export const validateTriggersFromMetadata = (metadata?: ActionMetadata | GlobalA
 
     const hasApiTrigger = triggersAsArray.some((trigger) => trigger.specID === GadgetApiTriggerSpecId);
     if (!hasApiTrigger) {
-      throw new Error(ApiTriggerRequiredError);
+      throw new Error(TriggerableActionRequiredErrorMessage);
     }
   }
 };

--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { FormProvider } from "react-hook-form";
 import { humanizeCamelCase, type OptionsType } from "../../utils.js";
 import { useAutoForm, type AutoFormProps } from "../AutoForm.js";
+import { TriggerableActionRequiredErrorMessage } from "../AutoFormActionValidators.js";
 import { AutoFormMetadataContext } from "../AutoFormContext.js";
 import { MUIAutoInput } from "./inputs/MUIAutoInput.js";
 import { MUIAutoSubmit } from "./submit/MUIAutoSubmit.js";
@@ -35,8 +36,12 @@ export const MUIAutoForm = <
 ) => {
   const { action, findBy } = props as MUIAutoFormProps<GivenOptions, SchemaT, ActionFunc> & { findBy: any };
 
+  if (!action) {
+    throw new Error(TriggerableActionRequiredErrorMessage);
+  }
+
   // Component key to force re-render when the action or findBy changes
-  const componentKey = `${action.modelApiIdentifier}.${action.operationName}.${findBy}`;
+  const componentKey = `${action.modelApiIdentifier ?? ""}.${action.operationName}.${findBy}`;
 
   return <MUIAutoFormComponent key={componentKey} {...props} />;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -6,6 +6,7 @@ import { FormProvider } from "react-hook-form";
 import { humanizeCamelCase, type OptionsType } from "../../utils.js";
 import type { AutoFormProps } from "../AutoForm.js";
 import { useAutoForm } from "../AutoForm.js";
+import { TriggerableActionRequiredErrorMessage } from "../AutoFormActionValidators.js";
 import { AutoFormMetadataContext } from "../AutoFormContext.js";
 import { PolarisAutoInput } from "./inputs/PolarisAutoInput.js";
 import { PolarisAutoSubmit } from "./submit/PolarisAutoSubmit.js";
@@ -32,8 +33,12 @@ export const PolarisAutoForm = <
   const { action, findBy } = props as AutoFormProps<GivenOptions, SchemaT, ActionFunc> &
     Omit<Partial<FormProps>, "action"> & { findBy: any };
 
+  if (!action) {
+    throw new Error(TriggerableActionRequiredErrorMessage);
+  }
+
   // Component key to force re-render when the action or findBy changes
-  const componentKey = `${action.modelApiIdentifier}.${action.operationName}.${findBy}`;
+  const componentKey = `${action.modelApiIdentifier ?? ""}.${action.operationName}.${findBy}`;
 
   return (
     <PolarisAutoFormComponent


### PR DESCRIPTION
- **UPDATE**
  - Updated the error message for passing in non-actions to be more explicit in describing that AutoForm needs valid Gadget actions with API triggers

AGMD-48