### PR TITLE
Fixed a bug with AutoTable where custom cell renderers with duplicate headers would have duplicate columns content

### DIFF
--- a/packages/react/.changeset/loud-balloons-cough.md
+++ b/packages/react/.changeset/loud-balloons-cough.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": minor
+---
+
+Fixed a bug with AutoTable where custom cell renderers with duplicate headers would have duplicate columns content

--- a/packages/react/cypress/component/auto/table/PolarisAutoTableCellRenderer.cy.tsx
+++ b/packages/react/cypress/component/auto/table/PolarisAutoTableCellRenderer.cy.tsx
@@ -8,6 +8,7 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
+          identifier: "String",
           header: "String",
           field: "string",
           sortable: true,
@@ -23,6 +24,7 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
+          identifier: "Date",
           header: "Date",
           field: "date",
           sortable: true,
@@ -38,6 +40,7 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
+          identifier: "Enum",
           header: "Enum",
           field: "enum",
           sortable: true,
@@ -56,6 +59,7 @@ describe("PolarisAutoTableCellRenderer", () => {
     cy.mountWithWrapper(
       <PolarisAutoTableCellRenderer
         column={{
+          identifier: "String",
           header: "String",
           field: "string",
           sortable: true,

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -284,12 +284,8 @@ export const CustomCellWithDeleteButton = {
     model: api.autoTableTest,
     columns: [
       "str",
-      {
-        header: "Actions",
-        render: ({ record }) => {
-          return <CustomDeleteButtonCellRenderer record={record} />;
-        },
-      },
+      { header: "Delete", render: ({ record }) => <CustomDeleteButtonCellRenderer record={record} /> },
+      { header: "Delete", render: ({ record }) => <p>ID:{record.id} | Different renderer, same header</p> },
     ],
   },
 };

--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -10,6 +10,26 @@ import { recordIdInputField } from "../support/shared.js";
 import { widgetModelInputFields } from "../support/widgetModel.js";
 
 describe("useTable hook", () => {
+  let timesUsedCryptoRandomUUID = 0;
+  const uuids: string[] = [];
+
+  const shimCryptoRandomUUID = () => {
+    Object.defineProperty(globalThis, "crypto", {
+      value: {
+        randomUUID: () => {
+          timesUsedCryptoRandomUUID++;
+          const mostRecentCryptoRandomUUID = `000-000-000-000-${timesUsedCryptoRandomUUID}`;
+          uuids.push(mostRecentCryptoRandomUUID);
+          return mostRecentCryptoRandomUUID;
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    shimCryptoRandomUUID();
+  });
+
   const getUseTableResult = (options?: Parameters<typeof useTable>["1"], customDefaultSelection?: Record<string, any>) => {
     const { result } = renderHook(
       () => {
@@ -99,106 +119,110 @@ describe("useTable hook", () => {
         mustBeLongString: "hellllllllllllllllllllllllllllo",
       },
     ]);
-    expect(result.current[0].columns).toEqual([
-      {
-        field: "id",
-        header: "Id",
-        relatedField: undefined,
-        sortable: false,
-        type: "ID",
-      },
-      {
-        field: "name",
-        header: "Name",
-        relatedField: undefined,
-        sortable: true,
-        type: "String",
-      },
-      {
-        field: "inventoryCount",
-        header: "Inventory count",
-        relatedField: undefined,
-        sortable: true,
-        type: "Number",
-      },
-      {
-        field: "anything",
-        header: "Anything",
-        relatedField: undefined,
-        sortable: true,
-        type: "JSON",
-      },
-      {
-        field: "description",
-        header: "Description",
-        relatedField: undefined,
-        sortable: true,
-        type: "RichText",
-      },
-      {
-        field: "category",
-        header: "Category",
-        relatedField: undefined,
-        sortable: true,
-        type: "Enum",
-      },
-      {
-        field: "startsAt",
-        header: "Starts at",
-        relatedField: undefined,
-        sortable: true,
-        type: "DateTime",
-      },
-      {
-        field: "isChecked",
-        header: "Is checked",
-        relatedField: undefined,
-        sortable: true,
-        type: "Boolean",
-      },
-      {
-        field: "metafields",
-        header: "Metafields",
-        relatedField: undefined,
-        sortable: true,
-        type: "JSON",
-      },
-      {
-        field: "roles",
-        header: "Roles",
-        relatedField: undefined,
-        sortable: false,
-        type: "RoleAssignments",
-      },
-      {
-        field: "birthday",
-        header: "Birthday",
-        relatedField: undefined,
-        sortable: true,
-        type: "DateTime",
-      },
-      {
-        field: "color",
-        header: "Color",
-        relatedField: undefined,
-        sortable: true,
-        type: "Color",
-      },
-      {
-        field: "secretKey",
-        header: "Secret key",
-        relatedField: undefined,
-        sortable: false,
-        type: "EncryptedString",
-      },
-      {
-        field: "mustBeLongString",
-        header: "Must be long string",
-        relatedField: undefined,
-        sortable: true,
-        type: "String",
-      },
-    ]);
+    expect(result.current[0].columns).toMatchInlineSnapshot(`
+      [
+        {
+          "field": "id",
+          "header": "Id",
+          "identifier": "id",
+          "sortable": false,
+          "type": "ID",
+        },
+        {
+          "field": "name",
+          "header": "Name",
+          "identifier": "name",
+          "sortable": true,
+          "type": "String",
+        },
+        {
+          "field": "inventoryCount",
+          "header": "Inventory count",
+          "identifier": "inventoryCount",
+          "sortable": true,
+          "type": "Number",
+        },
+        {
+          "field": "anything",
+          "header": "Anything",
+          "identifier": "anything",
+          "sortable": true,
+          "type": "JSON",
+        },
+        {
+          "field": "description",
+          "header": "Description",
+          "identifier": "description",
+          "sortable": true,
+          "type": "RichText",
+        },
+        {
+          "field": "category",
+          "header": "Category",
+          "identifier": "category",
+          "sortable": true,
+          "type": "Enum",
+        },
+        {
+          "field": "startsAt",
+          "header": "Starts at",
+          "identifier": "startsAt",
+          "includeTime": undefined,
+          "sortable": true,
+          "type": "DateTime",
+        },
+        {
+          "field": "isChecked",
+          "header": "Is checked",
+          "identifier": "isChecked",
+          "sortable": true,
+          "type": "Boolean",
+        },
+        {
+          "field": "metafields",
+          "header": "Metafields",
+          "identifier": "metafields",
+          "sortable": true,
+          "type": "JSON",
+        },
+        {
+          "field": "roles",
+          "header": "Roles",
+          "identifier": "roles",
+          "sortable": false,
+          "type": "RoleAssignments",
+        },
+        {
+          "field": "birthday",
+          "header": "Birthday",
+          "identifier": "birthday",
+          "includeTime": undefined,
+          "sortable": true,
+          "type": "DateTime",
+        },
+        {
+          "field": "color",
+          "header": "Color",
+          "identifier": "color",
+          "sortable": true,
+          "type": "Color",
+        },
+        {
+          "field": "secretKey",
+          "header": "Secret key",
+          "identifier": "secretKey",
+          "sortable": false,
+          "type": "EncryptedString",
+        },
+        {
+          "field": "mustBeLongString",
+          "header": "Must be long string",
+          "identifier": "mustBeLongString",
+          "sortable": true,
+          "type": "String",
+        },
+      ]
+    `);
   });
 
   describe("no columns property", () => {
@@ -500,12 +524,15 @@ describe("useTable hook", () => {
           {
             "field": "name",
             "header": "Name",
+            "identifier": "name",
             "sortable": true,
             "type": "String",
           },
           {
             "field": "Custom column",
             "header": "Custom column",
+            "identifier": "000-000-000-000-1",
+            "render": [Function],
             "sortable": false,
             "type": "CustomRenderer",
           },
@@ -675,7 +702,9 @@ describe("useTable hook", () => {
       loadWidgetData();
 
       // Trigger a render to get the record
-      render(<>{result.current[0].rows?.[0]?.["Custom column"]}</>);
+      const customCellRenderColumnResultKey = Object.keys(result.current[0].rows?.[0] ?? {}).find((key) => uuids.includes(key))!;
+      expect(customCellRenderColumnResultKey).toBeDefined();
+      render(<>{result.current[0].rows?.[0]?.[customCellRenderColumnResultKey]}</>);
 
       // It should include all model fields in the query
       expect(mockUrqlClient.executeQuery.mock.calls[1][0].query.loc.source.body).toMatchInlineSnapshot(`
@@ -728,6 +757,49 @@ describe("useTable hook", () => {
       expect(recordFromRender.name).toBe("foo");
       // "inventoryCount" should be included in the record even though it's not in the columns
       expect(recordFromRender.inventoryCount).toBe(1);
+    });
+
+    it("should be able to access all fields of a table with duplicate custom cell headers", () => {
+      let recordFromRender: any;
+
+      const result = getUseTableResult({
+        columns: [
+          "name",
+          {
+            header: "Custom column",
+            render: ({ record }) => {
+              recordFromRender = record;
+              return <div>some custom stuff</div>;
+            },
+          },
+          {
+            header: "Custom column",
+            render: ({ record }) => {
+              recordFromRender = record;
+              return <div>some different stuff</div>;
+            },
+          },
+        ],
+      });
+      loadMockWidgetModelMetadata();
+      loadWidgetData();
+
+      const columns = result.current[0].rows?.[0] ?? {};
+      const columnKeys = Object.keys(columns);
+      expect(columnKeys).toMatchInlineSnapshot(`
+        [
+          "id",
+          "000-000-000-000-8",
+          "000-000-000-000-9",
+          "name",
+        ]
+      `);
+
+      const customColumn1Result = render(<>{result.current[0].rows?.[0]?.[columnKeys[1]]}</>);
+      expect(customColumn1Result.container.textContent).toBe("some custom stuff");
+
+      const customColumn2Result = render(<>{result.current[0].rows?.[0]?.[columnKeys[2]]}</>);
+      expect(customColumn2Result.container.textContent).toBe("some different stuff");
     });
   });
 

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -229,12 +229,12 @@ const PolarisAutoTableComponent = <
                 selected={selection.recordIds.includes(row.id as string)}
               >
                 {columns.map((column) => (
-                  <IndexTable.Cell key={column.field}>
+                  <IndexTable.Cell key={column.identifier}>
                     <div style={{ maxWidth: "200px" }}>
                       {column.type == "CustomRenderer" ? (
-                        (row[column.field] as ReactNode)
+                        (row[column.identifier] as ReactNode)
                       ) : (
-                        <PolarisAutoTableCellRenderer column={column} value={row[column.field] as ColumnValueType} />
+                        <PolarisAutoTableCellRenderer column={column} value={row[column.identifier] as ColumnValueType} />
                       )}
                     </div>
                   </IndexTable.Cell>

--- a/packages/react/src/use-table/types.ts
+++ b/packages/react/src/use-table/types.ts
@@ -10,7 +10,7 @@ import type { ColumnValueType, ErrorWrapper } from "../utils.js";
 
 export type ColumnType = GadgetFieldType | "CustomRenderer";
 
-type ColumnsOption = Exclude<TableOptions["columns"], undefined>;
+export type ColumnsOption = Exclude<TableOptions["columns"], undefined>;
 
 export type TableSpec = {
   targetColumns: ColumnsOption;
@@ -22,6 +22,8 @@ export type TableSpec = {
 export type RelationshipType = GadgetFieldType.HasMany | GadgetFieldType.HasOne | GadgetFieldType.BelongsTo;
 
 export type TableColumn = {
+  /** Identifier for the column */
+  identifier: string;
   /** Human-readable header value for the column */
   header: string;
   /** Dot-separated path to the field in the record */
@@ -32,6 +34,8 @@ export type TableColumn = {
   sortable: boolean;
   /** For controlling if the time is shown on DateTime cell renderers   */
   includeTime?: boolean;
+  /** Custom render function */
+  render?: CustomCellRenderer;
 };
 
 export type TableRow = Record<string, ColumnValueType | ReactNode>;
@@ -96,8 +100,10 @@ export type RelatedFieldColumn = {
 
 export type CustomCellColumn = {
   header: string;
-  render: (props: { record: GadgetRecord<any>; index: number }) => ReactNode;
+  render: CustomCellRenderer;
 };
+
+export type CustomCellRenderer = (props: { record: GadgetRecord<any>; index: number }) => ReactNode;
 
 export type CellDetailColumn = {
   header?: string;

--- a/packages/react/src/useTable.tsx
+++ b/packages/react/src/useTable.tsx
@@ -98,19 +98,23 @@ export const useTable = <
   } as any);
 
   const tableData = useMemo(() => {
-    return tableSpec && data && metadata
-      ? {
-          rows: getTableRows(tableSpec, data),
-          columns: getTableColumns(tableSpec),
-          data,
-          metadata,
-        }
-      : {
-          rows: null,
-          columns: null,
-          data: null,
-          metadata: null,
-        };
+    if (tableSpec && data && metadata) {
+      const columns = getTableColumns(tableSpec);
+      const rows = getTableRows(tableSpec, columns, data);
+      return {
+        rows,
+        columns,
+        data,
+        metadata,
+      };
+    } else {
+      return {
+        rows: null,
+        columns: null,
+        data: null,
+        metadata: null,
+      };
+    }
   }, [data, metadata, tableSpec]);
 
   const isAwaitingDebouncedSearchValue = search.value != search.debouncedValue;


### PR DESCRIPTION
- **UPDATE**
  - Columns with custom cell renderers were previously added to a record with the header as the key
    - If duplicate custom cell headers were used, the earliest custom cell renderers would be overwritten due to the duplicate header used as a record key
  - Now, the custom cell renderer index is incorporated into the record key, thus duplicate header named custom cell renderers no longer overwrite each other 
