### PR TITLE
Updated useTable `select` property to override default selection instead of merging with it

### DIFF
--- a/packages/react/.changeset/kind-plants-rule.md
+++ b/packages/react/.changeset/kind-plants-rule.md
@@ -1,0 +1,6 @@
+---
+"@gadgetinc/react": patch
+---
+
+(Breaking change)
+Updated the `select` property in useTable and AutoTable to completely override the default selection instead of being combined with the default selection

--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -732,7 +732,7 @@ describe("useTable hook", () => {
   });
 
   describe("select property", () => {
-    it("should combine the selected fields from the `select` property and the `columns` property", () => {
+    it("should completely override the default selection on relationship fields", () => {
       const result = getUseTableResult({
         select: {
           gizmos: {
@@ -768,9 +768,79 @@ describe("useTable hook", () => {
                     }
                   }
                 }
-                id
-                name
-                inventoryCount
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: 
+        "widget")
+          }
+        }"
+      `);
+    });
+
+    it("should completely override the default selection on simple fields", () => {
+      const result = getUseTableResult({
+        select: {
+          gizmos: {
+            id: true,
+          },
+        },
+        columns: ["name", "inventoryCount"],
+      });
+      loadMockWidgetModelMetadata();
+      loadWidgetData();
+
+      // The "gizmos" field should be included in the query even though it's not in the columns
+      expect(mockUrqlClient.executeQuery.mock.calls[1][0].query.loc.source.body).toMatchInlineSnapshot(`
+        "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                gizmos {
+                  id
+                }
+                __typename
+              }
+            }
+          }
+          gadgetMeta {
+            hydrations(modelName: 
+        "widget")
+          }
+        }"
+      `);
+    });
+
+    it("should completely override the default selection to select nothing", () => {
+      const result = getUseTableResult({
+        select: {},
+        columns: ["name", "inventoryCount"],
+      });
+      loadMockWidgetModelMetadata();
+      loadWidgetData();
+
+      // The "gizmos" field should be included in the query even though it's not in the columns
+      expect(mockUrqlClient.executeQuery.mock.calls[1][0].query.loc.source.body).toMatchInlineSnapshot(`
+        "query widgets($after: String, $first: Int, $before: String, $last: Int) {
+          widgets(after: $after, first: $first, before: $before, last: $last) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
                 __typename
               }
             }

--- a/packages/react/src/useTable.tsx
+++ b/packages/react/src/useTable.tsx
@@ -11,7 +11,7 @@ import { useModelMetadata } from "./metadata.js";
 import { getTableColumns, getTableRows, getTableSelectionMap, getTableSpec } from "./use-table/helpers.js";
 import type { TableOptions, TableResult } from "./use-table/types.js";
 import { useList } from "./useList.js";
-import { deepMerge, type OptionsType, type ReadOperationOptions } from "./utils.js";
+import { type OptionsType, type ReadOperationOptions } from "./utils.js";
 
 const getNextDirection = (sortDirection: SortOrder | undefined) => {
   switch (sortDirection) {
@@ -87,13 +87,13 @@ export const useTable = <
     [manager.findMany.defaultSelection, metadata, options?.columns, options?.excludeColumns]
   );
 
-  const selectionMap = useMemo(() => tableSpec && getTableSelectionMap(tableSpec), [tableSpec]);
+  const selectionMap = useMemo(() => options?.select ?? (tableSpec && getTableSelectionMap(tableSpec)), [options?.select, tableSpec]);
 
   const [{ data, fetching: dataFetching, error: dataError, page, search, selection }, refresh] = useList(manager, {
     ...options,
     sort: sort,
     filter: options?.filter,
-    select: deepMerge(options?.select ?? {}, selectionMap),
+    select: selectionMap,
     pause: !metadata, // Don't fetch data until metadata is loaded
   } as any);
 


### PR DESCRIPTION
- UPDATE
  - Updated useTable `select` property to override default selection instead of merging with it
  - This is a breaking change for those who are using `select` property and are relying on the default values merged into it