### PR TITLE
refactor(api-client-core): add operation builder plans to types

### DIFF
--- a/packages/api-client-core/src/AnyClient.ts
+++ b/packages/api-client-core/src/AnyClient.ts
@@ -15,6 +15,7 @@ export interface AnyClient {
   mutate(graphQL: string, variables?: Record<string, any>): Promise<any>;
   transaction<T>(callback: (transaction: GadgetTransaction) => Promise<T>): Promise<T>;
   internal: InternalModelManagerNamespace;
+  apiClientCoreVersion?: string;
   [$modelRelationships]?: { [modelName: string]: { [apiIdentifier: string]: { type: string; model: string } } };
 }
 

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -23,7 +23,7 @@ export interface FindOneFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
-  plan: <Options extends OptionsT>(fieldValue: string, options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
+  plan?: <Options extends OptionsT>(fieldValue: string, options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface MaybeFindOneFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
@@ -38,7 +38,7 @@ export interface MaybeFindOneFunction<OptionsT, SelectionT, SchemaT, DefaultsT> 
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
-  plan: <Options extends OptionsT>(fieldValue: string, options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
+  plan?: <Options extends OptionsT>(fieldValue: string, options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface FindManyFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
@@ -52,7 +52,7 @@ export interface FindManyFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
-  plan: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
+  plan?: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface FindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
@@ -66,7 +66,7 @@ export interface FindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
-  plan: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>)  => GQLBuilderResult;
+  plan?: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface MaybeFindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
@@ -80,7 +80,7 @@ export interface MaybeFindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
-  plan: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>)  => GQLBuilderResult;
+  plan?: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface ActionWithIdAndVariables<OptionsT, VariablesT> {
@@ -131,7 +131,7 @@ export interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, Schema
   paramOnlyVariables?: readonly string[];
   hasReturnType?: HasReturnType;
   singleActionFunctionName?: string;
-  plan:<Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>)  => GQLBuilderResult;
+  plan?: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
   /** @deprecated */
   hasCreateOrUpdateEffect?: boolean;
 }
@@ -172,7 +172,7 @@ export interface GetFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
-  plan: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>)  => GQLBuilderResult;
+  plan?: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface GlobalActionFunction<VariablesT> {
@@ -185,6 +185,7 @@ export interface GlobalActionFunction<VariablesT> {
   variables: VariablesOptions;
   variablesType: VariablesT;
   isBulk?: undefined;
+  plan?: (variables?: VariablesOptions) => GQLBuilderResult;
 }
 
 export type AnyActionFunction = ActionFunctionMetadata<any, any, any, any, any, any> | GlobalActionFunction<any>;

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -7,9 +7,13 @@ export type AsyncRecord<T extends RecordShape> = PromiseOrLiveIterator<GadgetRec
 export type AsyncNullableRecord<T extends RecordShape> = PromiseOrLiveIterator<GadgetRecord<T> | null>;
 export type AsyncRecordList<T extends RecordShape> = PromiseOrLiveIterator<GadgetRecordList<T>>;
 
+export interface GQLBuilderResult {
+  query: string;
+  variables: Record<string, any>;
+}
+
 export interface FindOneFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   <Options extends OptionsT>(fieldValue: string, options?: LimitToKnownKeys<Options, OptionsT>): AsyncRecord<any>;
-
   type: "findOne";
   findByVariableName: string;
   operationName: string;
@@ -19,6 +23,7 @@ export interface FindOneFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
+  plan: <Options extends OptionsT>(fieldValue: string, options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface MaybeFindOneFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
@@ -33,6 +38,7 @@ export interface MaybeFindOneFunction<OptionsT, SelectionT, SchemaT, DefaultsT> 
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
+  plan: <Options extends OptionsT>(fieldValue: string, options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface FindManyFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
@@ -46,6 +52,7 @@ export interface FindManyFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
+  plan: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
 export interface FindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
@@ -59,6 +66,7 @@ export interface FindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
+  plan: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>)  => GQLBuilderResult;
 }
 
 export interface MaybeFindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
@@ -72,6 +80,7 @@ export interface MaybeFindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
+  plan: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>)  => GQLBuilderResult;
 }
 
 export interface ActionWithIdAndVariables<OptionsT, VariablesT> {
@@ -122,6 +131,7 @@ export interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, Schema
   paramOnlyVariables?: readonly string[];
   hasReturnType?: HasReturnType;
   singleActionFunctionName?: string;
+  plan:<Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>)  => GQLBuilderResult;
   /** @deprecated */
   hasCreateOrUpdateEffect?: boolean;
 }
@@ -162,6 +172,7 @@ export interface GetFunction<OptionsT, SelectionT, SchemaT, DefaultsT> {
   selectionType: SelectionT;
   optionsType: OptionsT;
   schemaType: SchemaT | null;
+  plan: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>)  => GQLBuilderResult;
 }
 
 export interface GlobalActionFunction<VariablesT> {


### PR DESCRIPTION
We want to remove the dependency from @gadgetinc/react -> api-client-core, because it's really easy to end up with multiple incompatible versions of api client core installed.

A main reason for the dependency is that @gadgetinc/react needs to access the operationBuilder functions in order to create query plans to pass to urql in hooks.

This PR attaches the plan builder functions as part of the action function prototype, alongside the other metadata about the action that is already present in the prototype.

This PR is a chain, currently consisting of:

1. This change to js-clients to introduce the plan to the types
2. This change to add the plan functions to the client instance when building it: https://github.com/gadget-inc/gadget/pull/12843
3. [in progress] having the react hooks consume these plans rather than import them from the api-client-core lib

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
