### PR TITLE
Context based loading spinner on AutoSubmit in AutoForm

### DIFF
--- a/packages/react/.changeset/perfect-cherries-grab.md
+++ b/packages/react/.changeset/perfect-cherries-grab.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated AutoSubmit to have a loading state that is controlled by the useAutoFormMetadata hook.

--- a/packages/react/src/auto/AutoFormContext.ts
+++ b/packages/react/src/auto/AutoFormContext.ts
@@ -5,6 +5,7 @@ import type { ActionMetadata, GlobalActionMetadata } from "../metadata.js";
 export interface AutoFormSubmitResult {
   isSuccessful?: boolean;
   error?: Error;
+  isSubmitting?: boolean;
 }
 
 export interface AutoFormMetadataContext {

--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -53,7 +53,7 @@ export const MUIAutoFormComponent = <
   props: MUIAutoFormProps<GivenOptions, SchemaT, ActionFunc>
 ) => {
   const { record: _record, action, findBy, ...rest } = props as MUIAutoFormProps<GivenOptions, SchemaT, ActionFunc> & { findBy: any };
-  const { metadata, fetchingMetadata, metadataError, fields, submit, formError, isSubmitSuccessful, isLoading, originalFormMethods } =
+  const { metadata, fetchingMetadata, metadataError, fields, submit, formError, isSubmitting, isSubmitSuccessful, originalFormMethods } =
     useAutoForm(props);
 
   const autoFormMetadataContext: AutoFormMetadataContext = {
@@ -63,6 +63,7 @@ export const MUIAutoFormComponent = <
     submitResult: {
       isSuccessful: isSubmitSuccessful,
       error: formError ?? metadataError,
+      isSubmitting,
     },
     model: {
       apiIdentifier: action.modelApiIdentifier,
@@ -94,7 +95,7 @@ export const MUIAutoFormComponent = <
             </Grid>
           ))}
           <Grid item xs={12}>
-            <MUIAutoSubmit loading={isLoading}>{props.submitLabel ?? "Submit"}</MUIAutoSubmit>
+            <MUIAutoSubmit>{props.submitLabel ?? "Submit"}</MUIAutoSubmit>
           </Grid>
         </>
       )}

--- a/packages/react/src/auto/mui/submit/MUIAutoSubmit.tsx
+++ b/packages/react/src/auto/mui/submit/MUIAutoSubmit.tsx
@@ -1,6 +1,7 @@
 import type { LoadingButtonProps } from "@mui/lab";
 import { LoadingButton } from "@mui/lab";
 import React from "react";
+import { useAutoFormMetadata } from "../../AutoFormContext.js";
 
 /**
  * Button for submitting the AutoForm values
@@ -12,8 +13,11 @@ import React from "react";
  *
  */
 export const MUIAutoSubmit = (props: LoadingButtonProps) => {
+  const { submitResult } = useAutoFormMetadata();
+  const isSubmitting = submitResult?.isSubmitting;
+
   return (
-    <LoadingButton type="submit" {...props}>
+    <LoadingButton type="submit" loading={isSubmitting} {...props}>
       {props.children ?? "Submit"}
     </LoadingButton>
   );

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -72,6 +72,7 @@ const PolarisAutoFormComponent = <
     submitResult: {
       isSuccessful: isSubmitSuccessful,
       error: formError ?? metadataError,
+      isSubmitting,
     },
     model: {
       apiIdentifier: action.modelApiIdentifier,
@@ -114,7 +115,7 @@ const PolarisAutoFormComponent = <
             <PolarisAutoInput field={metadata.apiIdentifier} key={metadata.apiIdentifier} />
           ))}
           <div>
-            <PolarisAutoSubmit isSubmitting={isSubmitting}>{props.submitLabel ?? "Submit"}</PolarisAutoSubmit>
+            <PolarisAutoSubmit>{props.submitLabel ?? "Submit"} </PolarisAutoSubmit>
           </div>
         </>
       )}

--- a/packages/react/src/auto/polaris/submit/PolarisAutoSubmit.tsx
+++ b/packages/react/src/auto/polaris/submit/PolarisAutoSubmit.tsx
@@ -2,6 +2,7 @@ import type { ButtonProps } from "@shopify/polaris";
 import { Button } from "@shopify/polaris";
 import type { ReactNode } from "react";
 import React from "react";
+import { useAutoFormMetadata } from "../../AutoFormContext.js";
 
 /**
  * Button for submitting the AutoForm values
@@ -18,8 +19,11 @@ export const PolarisAutoSubmit = (
     isSubmitting?: boolean;
   } & Omit<ButtonProps, "children">
 ) => {
+  const { submitResult } = useAutoFormMetadata();
+  const isSubmitting = submitResult?.isSubmitting;
+
   return (
-    <Button submit loading={props.isSubmitting}>
+    <Button submit loading={props.isSubmitting ?? isSubmitting} {...props}>
       {(props.children as any) ?? "Submit"}
     </Button>
   );


### PR DESCRIPTION
- **UPDATE**
  - Previously
    - Having `AutoSubmit` as a child of an AutoForm would not show the spinner while the form was submitting
    - This was because that functionality was controlled by a prop in the one-liner approach
  - NOW
    - `AutoSubmit` has its loading state controlled by a hook thus it will properly show the spinner while it is submitting
    - The state can be overridden if desired