### PR TITLE
Add raw record as a second prop to the AutoTable onClick callback

### DIFF
--- a/packages/react/.changeset/silent-lobsters-promise.md
+++ b/packages/react/.changeset/silent-lobsters-promise.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated the `AutoTable` `onClick` callback prop to accept the full `GadgetRecord` corresponding to the row as well as the `TableRow` itself

--- a/packages/react/spec/auto/PolarisAutoTable.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoTable.stories.jsx
@@ -79,8 +79,11 @@ export const onClickCallback = {
   name: "onClick callback",
   args: {
     model: api.autoTableTest,
-    onClick: (row) => {
-      windowAlert(`You clicked on row: ${JSON.stringify(row, null, 2)}`);
+    onClick: (row, rawRecord) => {
+      windowAlert(`You clicked on a row with ID: ${row.id}`);
+      windowAlert(`row: ${JSON.stringify(row, null, 2)}`);
+      windowAlert(`rawRecord:\n ${JSON.stringify(rawRecord, null, 2)}
+`);
     },
   },
 };

--- a/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
+++ b/packages/react/spec/auto/table/PolarisAutoTable.spec.tsx
@@ -186,11 +186,14 @@ describe("PolarisAutoTable", () => {
       await user.click(firstRowCells[0]);
     });
 
-    expect(onClickCallback).toHaveBeenCalledWith({
-      id: "1",
-      name: "hello",
-      inventoryCount: 1,
-    });
+    expect(onClickCallback).toHaveBeenCalledWith(
+      {
+        id: "1",
+        name: "hello",
+        inventoryCount: 1,
+      },
+      undefined // Raw records are not mocked, thus are undefined in this callback
+    );
   });
 
   it("should render the columns using the correct cell renderer in related model fields", () => {

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -1,4 +1,4 @@
-import type { FindManyFunction } from "@gadgetinc/api-client-core";
+import type { FindManyFunction, GadgetRecord } from "@gadgetinc/api-client-core";
 import type { TableOptions, TableRow } from "../use-table/types.js";
 import type { OptionsType } from "../utils.js";
 
@@ -19,7 +19,7 @@ export type AutoTableProps<
   live?: boolean;
   columns?: TableOptions["columns"];
   excludeColumns?: string[];
-  onClick?: (row: TableRow) => void;
+  onClick?: (row: TableRow, record: GadgetRecord<any>) => void;
   initialSort?: Options["sort"];
   filter?: Options["filter"];
   actions?: TableOptions["actions"];

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -1,4 +1,4 @@
-import type { FindManyFunction, SortOrder } from "@gadgetinc/api-client-core";
+import type { FindManyFunction, GadgetRecord, SortOrder } from "@gadgetinc/api-client-core";
 import type { IndexTableProps } from "@shopify/polaris";
 import {
   Banner,
@@ -90,7 +90,7 @@ const PolarisAutoTableComponent = <
     filter: props.filter,
   } as any);
 
-  const { columns, rows, page, fetching, error, search, selection, sort, metadata } = methods;
+  const { columns, rows, page, fetching, error, search, selection, sort, metadata, data: rawRecords } = methods;
 
   const handleColumnSort = (headingIndex: number) => {
     if (columns) {
@@ -100,8 +100,8 @@ const PolarisAutoTableComponent = <
   };
 
   const onClickCallback = useCallback(
-    (row: TableRow) => {
-      return () => onClick?.(row);
+    (row: TableRow, rawRecord: GadgetRecord<any>) => {
+      return () => onClick?.(row, rawRecord);
     },
     [onClick]
   );
@@ -220,27 +220,30 @@ const PolarisAutoTableComponent = <
         >
           {rows &&
             columns &&
-            rows.map((row, index) => (
-              <IndexTable.Row
-                key={row.id as string}
-                id={row.id as string}
-                position={index}
-                onClick={onClick ? onClickCallback(row) : undefined}
-                selected={selection.recordIds.includes(row.id as string)}
-              >
-                {columns.map((column) => (
-                  <IndexTable.Cell key={column.identifier}>
-                    <div style={{ maxWidth: "200px" }}>
-                      {column.type == "CustomRenderer" ? (
-                        (row[column.identifier] as ReactNode)
-                      ) : (
-                        <PolarisAutoTableCellRenderer column={column} value={row[column.identifier] as ColumnValueType} />
-                      )}
-                    </div>
-                  </IndexTable.Cell>
-                ))}
-              </IndexTable.Row>
-            ))}
+            rows.map((row, index) => {
+              const rawRecord = rawRecords?.[index];
+              return (
+                <IndexTable.Row
+                  key={row.id as string}
+                  id={row.id as string}
+                  position={index}
+                  onClick={onClick ? onClickCallback(row, rawRecord) : undefined}
+                  selected={selection.recordIds.includes(row.id as string)}
+                >
+                  {columns.map((column) => (
+                    <IndexTable.Cell key={column.identifier}>
+                      <div style={{ maxWidth: "200px" }}>
+                        {column.type == "CustomRenderer" ? (
+                          (row[column.identifier] as ReactNode)
+                        ) : (
+                          <PolarisAutoTableCellRenderer column={column} value={row[column.identifier] as ColumnValueType} />
+                        )}
+                      </div>
+                    </IndexTable.Cell>
+                  ))}
+                </IndexTable.Row>
+              );
+            })}
         </IndexTable>
       </BlockStack>
     </AutoTableContext.Provider>


### PR DESCRIPTION
- **UPDATE**
  - AutoTable onClick prop now accepts 2 params
    - 1 - The row. Completely unchanged. May contains React components
    - 2 - The raw record without any processing on it