### PR TITLE
fix(use-action-form): relationships that have only readonly fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "lint": "pnpm lint:prettier && pnpm lint:eslint",
     "lint:prettier": "NODE_OPTIONS=\"--max-old-space-size=4096\" prettier --check \"(packages|scripts)/**/*.{js,ts,tsx}\"",
+    "lint:prettier:fix": "NODE_OPTIONS=\"--max-old-space-size=4096\" prettier --write --check \"(packages|scripts)/**/*.{js,ts,tsx}\"",
     "lint:eslint": "NODE_OPTIONS=\"--max-old-space-size=4096\" eslint --quiet --ext ts,tsx packages scripts",
     "lint:fix": "NODE_OPTIONS=\"--max-old-space-size=4096\" prettier --write --check \"(packages|scripts)/**/*.{js,ts,tsx}\" && eslint --ext ts,tsx --fix packages scripts",
     "typecheck": "pnpm -r --no-bail run --if-present typecheck",

--- a/packages/react/.changeset/rich-melons-decide.md
+++ b/packages/react/.changeset/rich-melons-decide.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+fix(useActionForm): fixes issue where relationship fields with readonly children were sometimes updated

--- a/packages/react/spec/useActionForm.spec.tsx
+++ b/packages/react/spec/useActionForm.spec.tsx
@@ -3144,6 +3144,114 @@ describe("utils", () => {
     `);
   });
 
+  test("it removes relationship fields that are entirely read-only", async () => {
+    const result = applyDataMask({
+      modelApiIdentifier: "answer",
+      data: {
+        answer: {
+          text: "Answer create",
+          question: {
+            text: "question text",
+          },
+        },
+      },
+      select: {
+        id: true,
+        text: true,
+        question: {
+          text: "ReadOnly",
+        },
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "answer": {
+          "text": "Answer create",
+        },
+      }
+    `);
+  });
+
+  test("it does not remove relationship fields that are not entirely read-only", async () => {
+    const result = applyDataMask({
+      modelApiIdentifier: "answer",
+      data: {
+        answer: {
+          text: "Answer create",
+          question: {
+            foo: "bar",
+            text: "question text",
+          },
+        },
+      },
+      select: {
+        id: true,
+        text: true,
+        question: {
+          foo: true,
+          text: "ReadOnly",
+        },
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "answer": {
+          "question": {
+            "foo": "bar",
+          },
+          "text": "Answer create",
+        },
+      }
+    `);
+  });
+
+  test("it does not remove relationship fields when only some of their fields are read-only", async () => {
+    const result = applyDataMask({
+      modelApiIdentifier: "answer",
+      data: {
+        answer: {
+          text: "Answer create",
+          question: {
+            text: "question text",
+            a: {
+              b: {
+                c: "NICE",
+                d: "abc",
+              },
+              e: "xyz",
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        text: true,
+        question: {
+          text: true,
+          a: { b: { c: true, d: "ReadOnly" }, e: "ReadOnly" },
+        },
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "answer": {
+          "question": {
+            "a": {
+              "b": {
+                "c": "NICE",
+              },
+            },
+            "text": "question text",
+          },
+          "text": "Answer create",
+        },
+      }
+    `);
+  });
+
   test("can apply data mask with send", async () => {
     const result = applyDataMask({
       modelApiIdentifier: "answer",


### PR DESCRIPTION
If you use useActionForm and select some fields from a relationship field and tag them as ReadOnly, it will still try to submit an empty value to the relationship field.

If your relationship field contains only ReadOnly values, it will consider the relationship field ReadOnly as well.


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
