### PR TITLE
Release @gadgetinc/react v0.17.0

### DIFF
--- a/packages/react-bigcommerce/package.json
+++ b/packages/react-bigcommerce/package.json
@@ -41,6 +41,6 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "@gadgetinc/react": "^0.16.0"
+    "@gadgetinc/react": "^0.17.0"
   }
 }

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@gadgetinc/react": "^0.16.0",
+    "@gadgetinc/react": "^0.17.0",
     "@shopify/app-bridge-react": "^4.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/react/.changeset/kind-plants-rule.md
+++ b/packages/react/.changeset/kind-plants-rule.md
@@ -1,6 +1,0 @@
----
-"@gadgetinc/react": patch
----
-
-(Breaking change)
-Updated the `select` property in useTable and AutoTable to completely override the default selection instead of being combined with the default selection

--- a/packages/react/.changeset/loud-balloons-cough.md
+++ b/packages/react/.changeset/loud-balloons-cough.md
@@ -1,5 +1,0 @@
----
-"@gadgetinc/react": minor
----
-
-Fixed a bug with AutoTable where custom cell renderers with duplicate headers would have duplicate columns content

--- a/packages/react/.changeset/moody-tips-do.md
+++ b/packages/react/.changeset/moody-tips-do.md
@@ -1,5 +1,0 @@
----
-"@gadgetinc/react": minor
----
-
-Updated AutoForm to throw an error when given an invalid action

--- a/packages/react/.changeset/nervous-bobcats-smoke.md
+++ b/packages/react/.changeset/nervous-bobcats-smoke.md
@@ -1,5 +1,0 @@
----
-"@gadgetinc/react": patch
----
-
-Fixed bug in Polaris AutoTable where the `createNewView` button would erroneously appear on certain parent element widths

--- a/packages/react/.changeset/perfect-cherries-grab.md
+++ b/packages/react/.changeset/perfect-cherries-grab.md
@@ -1,5 +1,0 @@
----
-"@gadgetinc/react": patch
----
-
-Updated AutoSubmit to have a loading state that is controlled by the useAutoFormMetadata hook.

--- a/packages/react/.changeset/red-wombats-share.md
+++ b/packages/react/.changeset/red-wombats-share.md
@@ -1,5 +1,0 @@
----
-"@gadgetinc/react": patch
----
-
-Fixed a bug in `<AutoForm/>` where the `defaultValues` prop values was not included in the submission request if the defaulted field was excluded with the `include` or `exclude` properties.

--- a/packages/react/.changeset/silent-lobsters-promise.md
+++ b/packages/react/.changeset/silent-lobsters-promise.md
@@ -1,5 +1,0 @@
----
-"@gadgetinc/react": patch
----
-
-Updated the `AutoTable` `onClick` callback prop to accept the full `GadgetRecord` corresponding to the row as well as the `TableRow` itself

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @gadgetinc/react
 
+## 0.17.0
+
+### Patch Changes
+
+- Updated the `select` property in useTable and AutoTable to completely override the default selection instead of being combined with the default selection (Breaking change)
+- Updated AutoForm to throw an error when given an invalid action
+- Updated AutoSubmit to have a loading state that is controlled by the useAutoFormMetadata hook
+- Updated the `AutoTable` `onClick` callback prop to accept the full `GadgetRecord` corresponding to the row as well as the `TableRow` itself
+- Bug: Fixed an issue with AutoTable where custom cell renderers with duplicate headers would have duplicate columns content
+- Bug: Fixed bug in Polaris AutoTable where the `createNewView` button would erroneously appear on certain parent element widths
+- Bug: Fixed a bug in `<AutoForm/>` where the `defaultValues` prop values was not included in the submission request if the defaulted field was excluded with the `include` or `exclude` properties.
+
 ## 0.16.4
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.16.7",
+  "version": "0.17.0",
   "files": [
     "README.md",
     "dist/**/*",

--- a/packages/shopify-extensions/package.json
+++ b/packages/shopify-extensions/package.json
@@ -47,6 +47,6 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "@gadgetinc/react": "^0.16.0"
+    "@gadgetinc/react": "^0.17.0"
   }
 }


### PR DESCRIPTION
Releasing the next version of @gadgetinc/react

Note that the version boost for the peer dependency on the other packages should not affect any of their behaviour. They don't have any references to AutoComponent stuff, thus they can't be affected by the breaking changes