### PR TITLE
AutoForm `defaultValues` included in request if not included in include/exclude

### DIFF
--- a/packages/react/.changeset/red-wombats-share.md
+++ b/packages/react/.changeset/red-wombats-share.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Fixed a bug in `<AutoForm/>` where the `defaultValues` prop values was not included in the submission request if the defaulted field was excluded with the `include` or `exclude` properties.

--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -75,7 +75,14 @@ export const Excluded = {
   args: {
     action: api.widget.create,
     exclude: ["birthday", "roles"],
-    include: ["name", "inventoryCount"],
+  },
+};
+
+export const ExcludedWithDefaultValues = {
+  args: {
+    action: api.widget.create,
+    exclude: ["name"],
+    defaultValues: { widget: { name: "Name from default when there is no field input component" } },
   },
 };
 
@@ -83,6 +90,14 @@ export const Included = {
   args: {
     action: api.widget.create,
     include: ["name", "inventoryCount"],
+  },
+};
+
+export const IncludedWithDefaultValues = {
+  args: {
+    action: api.widget.create,
+    include: ["inventoryCount"],
+    defaultValues: { widget: { name: "Name from default when there is no field input component" } },
   },
 };
 

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -8,7 +8,7 @@ import type { ActionMetadata, FieldMetadata, GlobalActionMetadata } from "../met
 import { FieldType, filterAutoFormFieldList, isActionMetadata, useActionMetadata } from "../metadata.js";
 import type { FieldErrors, FieldValues } from "../useActionForm.js";
 import { useActionForm } from "../useActionForm.js";
-import { get, type OptionsType } from "../utils.js";
+import { get, getFlattenedObjectKeys, type OptionsType } from "../utils.js";
 import { validationSchema } from "../validationSchema.js";
 import { validateNonBulkAction, validateTriggersFromApiClient, validateTriggersFromMetadata } from "./AutoFormActionValidators.js";
 
@@ -203,6 +203,17 @@ export const useAutoForm = <
       if (operatesWithRecordId) {
         fieldsToSend.push("id");
       }
+
+      if (props.defaultValues && modelApiIdentifier) {
+        // Add any explicitly set default values to the fields to send in the event that they are not included
+        const explicityDefaultedPaths = getFlattenedObjectKeys(props.defaultValues);
+        explicityDefaultedPaths.forEach((path) => {
+          if (!fieldsToSend.includes(path)) {
+            fieldsToSend.push(path);
+          }
+        });
+      }
+
       return fieldsToSend;
     },
     onError: onFailure,
@@ -232,7 +243,7 @@ export const useAutoForm = <
 
   useEffect(() => {
     if (isUpsertWithFindBy) {
-      setValue(`${modelApiIdentifier!}.id`, findBy); // Upsert actions use mode.id instead of use root level api value
+      setValue(`${modelApiIdentifier!}.id`, findBy); // Upsert actions use model.id instead of use root level api value
     }
   }, [getValues(`${modelApiIdentifier!}.id`), isUpsertWithFindBy]);
 

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -578,3 +578,41 @@ export const deepMerge = (obj1: any, obj2: any) => {
   }
   return obj1;
 };
+
+/**
+ * Deep flattens an object by converting all nested objects into a single level of keys.
+ * Example:
+ *    deepFlattenObject( { a: { b: { c: 1, d: 2, }, e: 3, }, f: 4, }} ) => {
+ *      "a.b.c": 1, "a.b.d": 2, "a.e": 3, "f": 4
+ *    }
+ * @param obj - The object to flatten.
+ * @param parentKey - The current key path in the object.
+ * @param separator - The separator to use between keys.
+ * @returns A flattened object with keys separated by the specified separator.
+ */
+export const deepFlattenObject = (obj: any, parentKey = "", separator = "."): Record<string, any> => {
+  const result: Record<string, any> = {};
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const newKey = parentKey ? `${parentKey}${separator}${key}` : key;
+
+      if (typeof obj[key] === "object" && obj[key] !== null && !Array.isArray(obj[key])) {
+        Object.assign(result, deepFlattenObject(obj[key], newKey, separator));
+      } else {
+        result[newKey] = obj[key];
+      }
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Get a list of all the keys in a flattened object
+ * @param obj - The object to flatten
+ * @returns A list of all the keys in the flattened object
+ */
+export const getFlattenedObjectKeys = (obj: any) => {
+  return Object.keys(deepFlattenObject(obj));
+};


### PR DESCRIPTION
- PREVIOUSLY
  - AutoForm `include/exclude` props would filter out what would be sent in the submission request. This filtering would apply to explicit passed in default values, making it impossible to set a non-editable default value
- NOW
  - The `defaultValues` property will be used in the request regardless of the `include` / `exclude` properties 