### PR TITLE
Updated `AutoTable` to automatically deselect records and close after running Gadget bulk actions

### DIFF
--- a/packages/react/.changeset/blue-bears-float.md
+++ b/packages/react/.changeset/blue-bears-float.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated `AutoTable` to automatically deselect records and close after running Gadget bulk actions

--- a/packages/react/cypress/component/auto/table/AutoTableBulkActions.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableBulkActions.cy.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jest/valid-expect */
 import React from "react";
+import { ActionErrorMessage, ActionSuccessMessage } from "../../../../src/auto/polaris/PolarisAutoBulkActionModal.js";
 import { PolarisAutoTable } from "../../../../src/auto/polaris/PolarisAutoTable.js";
 import { api } from "../../../support/api.js";
 import { PolarisWrapper } from "../../../support/auto.js";
@@ -113,15 +114,10 @@ describe("AutoTable - Bulk actions", () => {
 
     cy.wait("@getWidgets").its("request.body.variables").should("deep.equal", { first: 50 }); // No search value
 
-    cy.contains("Action completed successfully");
-    cy.get("button").contains("Close").click();
+    cy.contains(ActionSuccessMessage);
 
     // Now ensure that error response appears in the modal
     selectRecordIds(["20", "21", "22"]);
-
-    cy.get(`input[id="Select-20"]`).eq(0).click();
-    cy.get(`input[id="Select-21"]`).eq(0).click();
-    cy.get(`input[id="Select-22"]`).eq(0).click();
     openBulkAction("Delete");
 
     mockBulkDeleteWidgets(bulkDeleteFailureResponse, "bulkDeleteWidgets2");
@@ -129,7 +125,7 @@ describe("AutoTable - Bulk actions", () => {
     cy.get("button").contains("Run").click();
     cy.wait("@bulkDeleteWidgets2");
 
-    cy.contains(bulkDeleteFailureMessage);
+    cy.contains(ActionErrorMessage);
   });
 
   describe.each([true, false])("Custom actions with promoted=%s", (promoted) => {
@@ -155,8 +151,7 @@ describe("AutoTable - Bulk actions", () => {
 
       cy.wait("@getWidgets").its("request.body.variables").should("deep.equal", { first: 50 }); // No search value
 
-      cy.contains("Action completed successfully");
-      cy.get("button").contains("Close").click();
+      cy.contains(ActionSuccessMessage);
     });
   });
 });

--- a/packages/react/spec/auto/table/PolarisAutoTableActions.stories.jsx
+++ b/packages/react/spec/auto/table/PolarisAutoTableActions.stories.jsx
@@ -38,6 +38,7 @@ export const IncludedActionParameters = {
   args: {
     model: api.autoTableTest,
     actions: [
+      "delete",
       "customAction",
       { label: "Alternate action label", action: "customAction" },
       {

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -6,11 +6,13 @@ import {
   Box,
   DataTable,
   EmptySearchResult,
+  Frame,
   IndexFilters,
   IndexTable,
   SkeletonBodyText,
   useSetIndexFiltersMode,
 } from "@shopify/polaris";
+
 import pluralize from "pluralize";
 import type { ReactNode } from "react";
 import React, { useCallback, useMemo } from "react";
@@ -151,101 +153,105 @@ const PolarisAutoTableComponent = <
 
   return (
     <AutoTableContext.Provider value={[methods, refresh]}>
-      <BlockStack>
-        <PolarisAutoBulkActionModal
-          model={props.model}
-          modelActionDetails={selectedModelActionDetails}
-          ids={selection.recordIds}
-          selectedRows={selectedRows}
-        />
-        {searchable && (
-          <IndexFilters
-            mode={mode}
-            setMode={setMode}
-            appliedFilters={[]}
-            filters={[]}
-            onClearAll={() => undefined}
-            tabs={[]}
-            canCreateNewView={false}
-            selected={1}
-            loading={fetching}
-            cancelAction={{ onAction: () => search.clear() }}
-            disabled={!!error}
-            // Search
-            queryValue={search.value}
-            onQueryChange={search.set}
-            onQueryClear={search.clear}
+      <Frame>
+        <BlockStack>
+          <PolarisAutoBulkActionModal
+            model={props.model}
+            modelActionDetails={selectedModelActionDetails}
+            ids={selection.recordIds}
+            selectedRows={selectedRows}
+            clearSelection={selection.clearAll}
           />
-        )}
 
-        {error && (
-          <Box paddingBlockStart="200" paddingBlockEnd="1000">
-            <Banner title={error.message} tone="critical" />
-          </Box>
-        )}
+          {searchable && (
+            <IndexFilters
+              mode={mode}
+              setMode={setMode}
+              appliedFilters={[]}
+              filters={[]}
+              onClearAll={() => undefined}
+              tabs={[]}
+              canCreateNewView={false}
+              selected={1}
+              loading={fetching}
+              cancelAction={{ onAction: () => search.clear() }}
+              disabled={!!error}
+              // Search
+              queryValue={search.value}
+              onQueryChange={search.set}
+              onQueryClear={search.clear}
+            />
+          )}
 
-        <IndexTable
-          selectedItemsCount={selection.recordIds.length}
-          {...disablePaginatedSelectAllButton}
-          onSelectionChange={selection.onSelectionChange}
-          {...polarisTableProps}
-          promotedBulkActions={promotedBulkActions.length ? promotedBulkActions : undefined}
-          bulkActions={bulkActions.length ? bulkActions : undefined}
-          resourceName={resourceName}
-          emptyState={props.emptyState ?? <EmptySearchResult title={`No ${resourceName.plural} yet`} description={""} withIllustration />}
-          loading={fetching}
-          hasMoreItems={page.hasNextPage}
-          itemCount={
-            error
-              ? 1 // Don't show the empty state if there's an error
-              : rows?.length ?? 0
-          }
-          pagination={
-            paginate
-              ? {
-                  hasNext: page.hasNextPage,
-                  hasPrevious: page.hasPreviousPage,
-                  onNext: page.goToNextPage,
-                  onPrevious: page.goToPreviousPage,
-                }
-              : undefined
-          }
-          sortDirection={gadgetToPolarisDirection(sort.direction)}
-          sortColumnIndex={columns ? getColumnIndex(columns, sort.column) : undefined}
-          onSort={(headingIndex) => handleColumnSort(headingIndex)}
-          selectable={props.selectable === undefined ? bulkActionOptions.length !== 0 : props.selectable}
-          lastColumnSticky={props.lastColumnSticky}
-          hasZebraStriping={props.hasZebraStriping}
-          condensed={props.condensed}
-        >
-          {rows &&
-            columns &&
-            rows.map((row, index) => {
-              const rawRecord = rawRecords?.[index];
-              return (
-                <IndexTable.Row
-                  key={row.id as string}
-                  id={row.id as string}
-                  position={index}
-                  onClick={onClick ? onClickCallback(row, rawRecord) : undefined}
-                  selected={selection.recordIds.includes(row.id as string)}
-                >
-                  {columns.map((column) => (
-                    <IndexTable.Cell key={column.identifier}>
-                      <div style={{ maxWidth: "200px" }}>
-                        {column.type == "CustomRenderer" ? (
-                          (row[column.identifier] as ReactNode)
-                        ) : (
-                          <PolarisAutoTableCellRenderer column={column} value={row[column.identifier] as ColumnValueType} />
-                        )}
-                      </div>
-                    </IndexTable.Cell>
-                  ))}
-                </IndexTable.Row>
-              );
-            })}
-        </IndexTable>
-      </BlockStack>
+          {error && (
+            <Box paddingBlockStart="200" paddingBlockEnd="1000">
+              <Banner title={error.message} tone="critical" />
+            </Box>
+          )}
+
+          <IndexTable
+            selectedItemsCount={selection.recordIds.length}
+            {...disablePaginatedSelectAllButton}
+            onSelectionChange={selection.onSelectionChange}
+            {...polarisTableProps}
+            promotedBulkActions={promotedBulkActions.length ? promotedBulkActions : undefined}
+            bulkActions={bulkActions.length ? bulkActions : undefined}
+            resourceName={resourceName}
+            emptyState={props.emptyState ?? <EmptySearchResult title={`No ${resourceName.plural} yet`} description={""} withIllustration />}
+            loading={fetching}
+            hasMoreItems={page.hasNextPage}
+            itemCount={
+              error
+                ? 1 // Don't show the empty state if there's an error
+                : rows?.length ?? 0
+            }
+            pagination={
+              paginate
+                ? {
+                    hasNext: page.hasNextPage,
+                    hasPrevious: page.hasPreviousPage,
+                    onNext: page.goToNextPage,
+                    onPrevious: page.goToPreviousPage,
+                  }
+                : undefined
+            }
+            sortDirection={gadgetToPolarisDirection(sort.direction)}
+            sortColumnIndex={columns ? getColumnIndex(columns, sort.column) : undefined}
+            onSort={(headingIndex) => handleColumnSort(headingIndex)}
+            selectable={props.selectable === undefined ? bulkActionOptions.length !== 0 : props.selectable}
+            lastColumnSticky={props.lastColumnSticky}
+            hasZebraStriping={props.hasZebraStriping}
+            condensed={props.condensed}
+          >
+            {rows &&
+              columns &&
+              rows.map((row, index) => {
+                const rawRecord = rawRecords?.[index];
+                return (
+                  <IndexTable.Row
+                    key={row.id as string}
+                    id={row.id as string}
+                    position={index}
+                    onClick={onClick ? onClickCallback(row, rawRecord) : undefined}
+                    selected={selection.recordIds.includes(row.id as string)}
+                  >
+                    {columns.map((column) => (
+                      <IndexTable.Cell key={column.identifier}>
+                        <div style={{ maxWidth: "200px" }}>
+                          {column.type == "CustomRenderer" ? (
+                            (row[column.identifier] as ReactNode)
+                          ) : (
+                            <PolarisAutoTableCellRenderer column={column} value={row[column.identifier] as ColumnValueType} />
+                          )}
+                        </div>
+                      </IndexTable.Cell>
+                    ))}
+                  </IndexTable.Row>
+                );
+              })}
+          </IndexTable>
+        </BlockStack>
+      </Frame>
     </AutoTableContext.Provider>
   );
 };


### PR DESCRIPTION
- UPDATE
  - After talking to design, it was decided that we would use a toast system to indicate the result of running actions in AutoTable instead of having a multi-state modal system
  - Updated `AutoTable` to automatically deselect records and close after running Gadget bulk actions
