### PR TITLE
Send dev harness event from react hook when it is a stubbed action

### DIFF
--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -136,6 +136,21 @@ export interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, Schema
   hasCreateOrUpdateEffect?: boolean;
 }
 
+export type StubbedActionReason = "MissingApiTrigger";
+
+export interface StubbedActionFunctionMetadata {
+  type: "stubbedAction";
+  functionName: string;
+  operationName?: string;
+  errorMessage: string;
+  modelApiIdentifier?: string;
+  variables: VariablesOptions;
+  reason: StubbedActionReason;
+  dataPath: string;
+}
+
+export type StubbedActionFunction<OptionsT> = StubbedActionFunctionMetadata & ActionWithNoIdAndNoVariables<OptionsT>;
+
 export type ActionFunction<OptionsT, VariablesT, SelectionT, SchemaT, DefaultsT> = ActionFunctionMetadata<
   OptionsT,
   VariablesT,

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -805,4 +805,38 @@ describe("useAction", () => {
 
     expect(result.current[0]).toBe(beforeObject);
   });
+
+  test("sends a stubbedActionError event when the action is stubbed", () => {
+    let eventDispatched: CustomEvent | undefined;
+
+    globalThis.addEventListener("gadget:devharness:stubbedActionError", (event) => {
+      eventDispatched = event as CustomEvent;
+    });
+
+    const { result, rerender } = renderHook(
+      () =>
+        useAction({
+          // @ts-expect-error intentionally passing the wrong type
+          type: "stubbedAction",
+          reason: "MissingApiTrigger",
+          dataPath: "fakePath",
+          functionName: "fakeFunction",
+          modelApiIdentifier: "fakeModel",
+          variables: {},
+        }),
+      {
+        wrapper: MockClientWrapper(relatedProductsApi),
+      }
+    );
+
+    expect(eventDispatched).toBeTruthy();
+    expect(eventDispatched!.detail).toEqual({
+      reason: "MissingApiTrigger",
+      action: {
+        actionApiIdentifier: "fakeFunction",
+        dataPath: "fakePath",
+        modelApiIdentifier: "fakeModel",
+      },
+    });
+  });
 });

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -255,4 +255,36 @@ describe("useGlobalAction", () => {
 
     expect(result.current[0]).toBe(beforeObject);
   });
+
+  test("sends a stubbedActionError event when the action is stubbed", () => {
+    let eventDispatched: CustomEvent | undefined;
+
+    globalThis.addEventListener("gadget:devharness:stubbedActionError", (event) => {
+      eventDispatched = event as CustomEvent;
+    });
+
+    const { result, rerender } = renderHook(
+      () =>
+        useGlobalAction({
+          // @ts-expect-error intentionally passing the wrong type
+          type: "stubbedAction",
+          reason: "MissingApiTrigger",
+          dataPath: "fakePath",
+          functionName: "fakeFunction",
+          variables: {},
+        }),
+      {
+        wrapper: MockClientWrapper(bulkExampleApi),
+      }
+    );
+
+    expect(eventDispatched).toBeTruthy();
+    expect(eventDispatched!.detail).toEqual({
+      reason: "MissingApiTrigger",
+      action: {
+        actionApiIdentifier: "fakeFunction",
+        dataPath: "fakePath",
+      },
+    });
+  });
 });


### PR DESCRIPTION
This PR sends a dev harness event when the action is a stubbed action (i.e. no API trigger)

Gadget side to consume this new event type: https://github.com/gadget-inc/gadget/pull/12894

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
