### PR TITLE
Fixed bug with AutoForm include/exclude system which prevented submission due to validations getting applied to hidden fields

### DIFF
--- a/packages/react/.changeset/nasty-crews-beam.md
+++ b/packages/react/.changeset/nasty-crews-beam.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Fixed bug with AutoForm include/exclude system which prevented submission due to validations getting applied to hidden fields

--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -235,10 +235,8 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
   });
 
   it("can render a rich text editor for markdown content", async () => {
-    cy.mountWithWrapper(<AutoForm action={api.widget.create} include={["name", "inventoryCount", "description"]} />, wrapper);
+    cy.mountWithWrapper(<AutoForm action={api.widget.create} include={["description"]} />, wrapper);
 
-    cy.get(`input[name="widget.name"]`).type("test record");
-    cy.get(`input[name="widget.inventoryCount"]`).type("42");
     cy.get(`[aria-label="editable markdown"] > p`).type("# foobar\n## foobaz");
 
     cy.intercept("POST", `${api.connection.options.endpoint}?operation=createWidget`, {
@@ -256,8 +254,7 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
 
     cy.wait("@createWidget").then((interception) => {
       const { variables } = interception.request.body;
-      expect(variables.widget.name).to.equal("test record");
-      expect(variables.widget.inventoryCount).to.equal(42);
+
       expect(variables.widget.description).to.deep.equal({ markdown: "# foobar\n\n## foobaz" });
     });
   });

--- a/packages/react/spec/auto/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/PolarisAutoForm.stories.jsx
@@ -74,7 +74,7 @@ export const UpsertRecordWithoutFindBy = {
 export const Excluded = {
   args: {
     action: api.widget.create,
-    exclude: ["birthday", "roles"],
+    exclude: ["birthday", "roles", "name"],
   },
 };
 
@@ -89,7 +89,8 @@ export const ExcludedWithDefaultValues = {
 export const Included = {
   args: {
     action: api.widget.create,
-    include: ["name", "inventoryCount"],
+    // Inventory is required and  not included. This will be a server-side error since it can be set in the action file code
+    include: ["name"],
   },
 };
 

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -54,12 +54,12 @@ export type AutoFormProps<
 /**
  * React hook for getting the validation schema for a list of fields
  */
-export const useValidationResolver = (metadata: ActionMetadata | GlobalActionMetadata | undefined) => {
+const useValidationResolver = (metadata: ActionMetadata | GlobalActionMetadata | undefined, pathsToValidate: string[]) => {
   return useMemo(() => {
     if (!metadata) return undefined;
     const action = isActionMetadata(metadata) ? metadata.action : metadata;
-    return yupResolver(validationSchema(action.inputFields));
-  }, [metadata]);
+    return yupResolver(validationSchema(action.inputFields, pathsToValidate));
+  }, [metadata, pathsToValidate]);
 };
 
 /**
@@ -180,7 +180,10 @@ export const useAutoForm = <
   } = useActionForm(action, {
     defaultValues: defaultValues as any,
     findBy: "findBy" in props ? props.findBy : undefined,
-    resolver: useValidationResolver(metadata),
+    resolver: useValidationResolver(
+      metadata,
+      fields.map(({ path }) => path)
+    ),
     send: () => {
       const fieldsToSend = fields
         .filter(({ path, metadata }) => {


### PR DESCRIPTION
- PREVIOUSLY
  - If you have a required field on a model action and it was hidden from the AutoForm with `include` or `exclude`, the form could not be submitted
  - This was due to the required validation applying to the field 
  - This issue did not have a corresponding error message
- NOW
  - Input field validations are now only run on the fields that are shown when using `include` and `exclude`
  - If a required field is excluded, the validation will occur server side, which allows for the field to be set in the model action code