### PR TITLE
Add functionName and actionApiIdentifier when sending stubbed action event

### DIFF
--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -143,6 +143,7 @@ export interface StubbedActionFunctionMetadata {
   functionName: string;
   operationName?: string;
   errorMessage: string;
+  actionApiIdentifier: string;
   modelApiIdentifier?: string;
   variables: VariablesOptions;
   reason: StubbedActionReason;

--- a/packages/react/spec/useAction.spec.tsx
+++ b/packages/react/spec/useAction.spec.tsx
@@ -820,7 +820,8 @@ describe("useAction", () => {
           type: "stubbedAction",
           reason: "MissingApiTrigger",
           dataPath: "fakePath",
-          functionName: "fakeFunction",
+          functionName: "fakeAction",
+          actionApiIdentifier: "fakeAction",
           modelApiIdentifier: "fakeModel",
           variables: {},
         }),
@@ -833,7 +834,8 @@ describe("useAction", () => {
     expect(eventDispatched!.detail).toEqual({
       reason: "MissingApiTrigger",
       action: {
-        actionApiIdentifier: "fakeFunction",
+        functionName: "fakeAction",
+        actionApiIdentifier: "fakeAction",
         dataPath: "fakePath",
         modelApiIdentifier: "fakeModel",
       },

--- a/packages/react/spec/useGlobalAction.spec.ts
+++ b/packages/react/spec/useGlobalAction.spec.ts
@@ -270,7 +270,8 @@ describe("useGlobalAction", () => {
           type: "stubbedAction",
           reason: "MissingApiTrigger",
           dataPath: "fakePath",
-          functionName: "fakeFunction",
+          functionName: "fakeAction",
+          actionApiIdentifier: "fakeAction",
           variables: {},
         }),
       {
@@ -282,7 +283,8 @@ describe("useGlobalAction", () => {
     expect(eventDispatched!.detail).toEqual({
       reason: "MissingApiTrigger",
       action: {
-        actionApiIdentifier: "fakeFunction",
+        functionName: "fakeAction",
+        actionApiIdentifier: "fakeAction",
         dataPath: "fakePath",
       },
     });

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -72,7 +72,7 @@ export const useAction = <
   useEffect(() => {
     if (action.type === ("stubbedAction" as string)) {
       const stubbedAction = action as unknown as StubbedActionFunction<GivenOptions>;
-      if (!("reason" in stubbedAction) || !("dataPath" in stubbedAction)) {
+      if (!("reason" in stubbedAction) || !("dataPath" in stubbedAction) || !("actionApiIdentifier" in stubbedAction)) {
         // Don't dispatch an event if the generated client has not yet been updated with the updated parameters
         return;
       }
@@ -81,7 +81,8 @@ export const useAction = <
         detail: {
           reason: stubbedAction.reason,
           action: {
-            actionApiIdentifier: stubbedAction.functionName,
+            functionName: stubbedAction.functionName,
+            actionApiIdentifier: stubbedAction.actionApiIdentifier,
             modelApiIdentifier: stubbedAction.modelApiIdentifier,
             dataPath: stubbedAction.dataPath,
           },

--- a/packages/react/src/useBulkAction.ts
+++ b/packages/react/src/useBulkAction.ts
@@ -67,7 +67,7 @@ export const useBulkAction = <
   useEffect(() => {
     if (action.type === ("stubbedAction" as string)) {
       const stubbedAction = action as unknown as StubbedActionFunction<GivenOptions>;
-      if (!("reason" in stubbedAction) || !("dataPath" in stubbedAction)) {
+      if (!("reason" in stubbedAction) || !("dataPath" in stubbedAction) || !("actionApiIdentifier" in stubbedAction)) {
         // Don't dispatch an event if the generated client has not yet been updated with the updated parameters
         return;
       }
@@ -76,7 +76,8 @@ export const useBulkAction = <
         detail: {
           reason: stubbedAction.reason,
           action: {
-            actionApiIdentifier: stubbedAction.functionName,
+            functionName: stubbedAction.functionName,
+            actionApiIdentifier: stubbedAction.actionApiIdentifier,
             modelApiIdentifier: stubbedAction.modelApiIdentifier,
             dataPath: stubbedAction.dataPath,
           },

--- a/packages/react/src/useGlobalAction.ts
+++ b/packages/react/src/useGlobalAction.ts
@@ -42,7 +42,8 @@ export const useGlobalAction = <F extends GlobalActionFunction<any>>(
         detail: {
           reason: stubbedAction.reason,
           action: {
-            actionApiIdentifier: stubbedAction.functionName,
+            functionName: stubbedAction.functionName,
+            actionApiIdentifier: stubbedAction.actionApiIdentifier,
             dataPath: stubbedAction.dataPath,
           },
         },


### PR DESCRIPTION
This fixes bug introduced in https://github.com/gadget-inc/js-clients/pull/638 where a wrong action API identifier being sent when it is a bulk action.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
