### PR TITLE
fixed AutoForm not updating upon changes to findBy objects

### DIFF
--- a/packages/react/src/auto/mui/MUIAutoForm.tsx
+++ b/packages/react/src/auto/mui/MUIAutoForm.tsx
@@ -41,7 +41,7 @@ export const MUIAutoForm = <
   }
 
   // Component key to force re-render when the action or findBy changes
-  const componentKey = `${action.modelApiIdentifier ?? ""}.${action.operationName}.${findBy}`;
+  const componentKey = `${action.modelApiIdentifier ?? ""}.${action.operationName}.${JSON.stringify(findBy)}`;
 
   return <MUIAutoFormComponent key={componentKey} {...props} />;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -38,7 +38,7 @@ export const PolarisAutoForm = <
   }
 
   // Component key to force re-render when the action or findBy changes
-  const componentKey = `${action.modelApiIdentifier ?? ""}.${action.operationName}.${findBy}`;
+  const componentKey = `${action.modelApiIdentifier ?? ""}.${action.operationName}.${JSON.stringify(findBy)}`;
 
   return (
     <PolarisAutoFormComponent


### PR DESCRIPTION
```jsx
const X = () => {
  const [useFindBy1, setUseFindBy1] = useState(true);
  return (
    <>
      <button onClick={() => setUseFindBy1(!useFindBy1)}>Toggle Find By</button>
      <PolarisAutoForm action={api.widget.upsert} findBy={{ id: useFindBy1 ? "1" : "999" }}></PolarisAutoForm>
    </>
  );
};
```
- **UPDATE**
  - Given something like the above component, we previously did not re-render the component upon dynamically changing the findBy object. 
  - This was the result of the AutoForm key containing `[Object object]` for the find by value. Dynamic changes were lost to the simple `toString`
  - Now, the key is based on a `JSON.stringify` of the findBy object/string