### PR TITLE
Removed deprecated Polaris `Frame` usage from AutoTable

### DIFF
--- a/packages/react/.changeset/eight-pans-beg.md
+++ b/packages/react/.changeset/eight-pans-beg.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Removed deprecated Polaris `Frame` usage from AutoTable

--- a/packages/react/.changeset/fair-files-repair.md
+++ b/packages/react/.changeset/fair-files-repair.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Fixed bug in `AutoForm` where dynamically changing findBy object props did not cause the form to re-render

--- a/packages/react/cypress/component/auto/table/AutoTableBulkActions.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableBulkActions.cy.tsx
@@ -115,16 +115,17 @@ describe("AutoTable - Bulk actions", () => {
     cy.wait("@getWidgets").its("request.body.variables").should("deep.equal", { first: 50 }); // No search value
 
     cy.contains(ActionSuccessMessage);
+    cy.get("button").contains("Close").click();
 
     // Now ensure that error response appears in the modal
     selectRecordIds(["20", "21", "22"]);
+
     openBulkAction("Delete");
 
     mockBulkDeleteWidgets(bulkDeleteFailureResponse, "bulkDeleteWidgets2");
 
     cy.get("button").contains("Run").click();
     cy.wait("@bulkDeleteWidgets2");
-
     cy.contains(ActionErrorMessage);
   });
 
@@ -152,6 +153,7 @@ describe("AutoTable - Bulk actions", () => {
       cy.wait("@getWidgets").its("request.body.variables").should("deep.equal", { first: 50 }); // No search value
 
       cy.contains(ActionSuccessMessage);
+      cy.get("button").contains("Close").click();
     });
   });
 });

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -6,13 +6,11 @@ import {
   Box,
   DataTable,
   EmptySearchResult,
-  Frame,
   IndexFilters,
   IndexTable,
   SkeletonBodyText,
   useSetIndexFiltersMode,
 } from "@shopify/polaris";
-
 import pluralize from "pluralize";
 import type { ReactNode } from "react";
 import React, { useCallback, useMemo } from "react";
@@ -153,105 +151,102 @@ const PolarisAutoTableComponent = <
 
   return (
     <AutoTableContext.Provider value={[methods, refresh]}>
-      <Frame>
-        <BlockStack>
-          <PolarisAutoBulkActionModal
-            model={props.model}
-            modelActionDetails={selectedModelActionDetails}
-            ids={selection.recordIds}
-            selectedRows={selectedRows}
-            clearSelection={selection.clearAll}
-          />
-
-          {searchable && (
-            <IndexFilters
-              mode={mode}
-              setMode={setMode}
-              appliedFilters={[]}
-              filters={[]}
-              onClearAll={() => undefined}
-              tabs={[]}
-              canCreateNewView={false}
-              selected={1}
-              loading={fetching}
-              cancelAction={{ onAction: () => search.clear() }}
-              disabled={!!error}
-              // Search
-              queryValue={search.value}
-              onQueryChange={search.set}
-              onQueryClear={search.clear}
-            />
-          )}
-
-          {error && (
-            <Box paddingBlockStart="200" paddingBlockEnd="1000">
-              <Banner title={error.message} tone="critical" />
-            </Box>
-          )}
-
-          <IndexTable
-            selectedItemsCount={selection.recordIds.length}
-            {...disablePaginatedSelectAllButton}
-            onSelectionChange={selection.onSelectionChange}
-            {...polarisTableProps}
-            promotedBulkActions={promotedBulkActions.length ? promotedBulkActions : undefined}
-            bulkActions={bulkActions.length ? bulkActions : undefined}
-            resourceName={resourceName}
-            emptyState={props.emptyState ?? <EmptySearchResult title={`No ${resourceName.plural} yet`} description={""} withIllustration />}
+      <BlockStack>
+        <PolarisAutoBulkActionModal
+          model={props.model}
+          modelActionDetails={selectedModelActionDetails}
+          ids={selection.recordIds}
+          selectedRows={selectedRows}
+          clearSelection={selection.clearAll}
+        />
+        {searchable && (
+          <IndexFilters
+            mode={mode}
+            setMode={setMode}
+            appliedFilters={[]}
+            filters={[]}
+            onClearAll={() => undefined}
+            tabs={[]}
+            canCreateNewView={false}
+            selected={1}
             loading={fetching}
-            hasMoreItems={page.hasNextPage}
-            itemCount={
-              error
-                ? 1 // Don't show the empty state if there's an error
-                : rows?.length ?? 0
-            }
-            pagination={
-              paginate
-                ? {
-                    hasNext: page.hasNextPage,
-                    hasPrevious: page.hasPreviousPage,
-                    onNext: page.goToNextPage,
-                    onPrevious: page.goToPreviousPage,
-                  }
-                : undefined
-            }
-            sortDirection={gadgetToPolarisDirection(sort.direction)}
-            sortColumnIndex={columns ? getColumnIndex(columns, sort.column) : undefined}
-            onSort={(headingIndex) => handleColumnSort(headingIndex)}
-            selectable={props.selectable === undefined ? bulkActionOptions.length !== 0 : props.selectable}
-            lastColumnSticky={props.lastColumnSticky}
-            hasZebraStriping={props.hasZebraStriping}
-            condensed={props.condensed}
-          >
-            {rows &&
-              columns &&
-              rows.map((row, index) => {
-                const rawRecord = rawRecords?.[index];
-                return (
-                  <IndexTable.Row
-                    key={row.id as string}
-                    id={row.id as string}
-                    position={index}
-                    onClick={onClick ? onClickCallback(row, rawRecord) : undefined}
-                    selected={selection.recordIds.includes(row.id as string)}
-                  >
-                    {columns.map((column) => (
-                      <IndexTable.Cell key={column.identifier}>
-                        <div style={{ maxWidth: "200px" }}>
-                          {column.type == "CustomRenderer" ? (
-                            (row[column.identifier] as ReactNode)
-                          ) : (
-                            <PolarisAutoTableCellRenderer column={column} value={row[column.identifier] as ColumnValueType} />
-                          )}
-                        </div>
-                      </IndexTable.Cell>
-                    ))}
-                  </IndexTable.Row>
-                );
-              })}
-          </IndexTable>
-        </BlockStack>
-      </Frame>
+            cancelAction={{ onAction: () => search.clear() }}
+            disabled={!!error}
+            // Search
+            queryValue={search.value}
+            onQueryChange={search.set}
+            onQueryClear={search.clear}
+          />
+        )}
+
+        {error && (
+          <Box paddingBlockStart="200" paddingBlockEnd="1000">
+            <Banner title={error.message} tone="critical" />
+          </Box>
+        )}
+
+        <IndexTable
+          selectedItemsCount={selection.recordIds.length}
+          {...disablePaginatedSelectAllButton}
+          onSelectionChange={selection.onSelectionChange}
+          {...polarisTableProps}
+          promotedBulkActions={promotedBulkActions.length ? promotedBulkActions : undefined}
+          bulkActions={bulkActions.length ? bulkActions : undefined}
+          resourceName={resourceName}
+          emptyState={props.emptyState ?? <EmptySearchResult title={`No ${resourceName.plural} yet`} description={""} withIllustration />}
+          loading={fetching}
+          hasMoreItems={page.hasNextPage}
+          itemCount={
+            error
+              ? 1 // Don't show the empty state if there's an error
+              : rows?.length ?? 0
+          }
+          pagination={
+            paginate
+              ? {
+                  hasNext: page.hasNextPage,
+                  hasPrevious: page.hasPreviousPage,
+                  onNext: page.goToNextPage,
+                  onPrevious: page.goToPreviousPage,
+                }
+              : undefined
+          }
+          sortDirection={gadgetToPolarisDirection(sort.direction)}
+          sortColumnIndex={columns ? getColumnIndex(columns, sort.column) : undefined}
+          onSort={(headingIndex) => handleColumnSort(headingIndex)}
+          selectable={props.selectable === undefined ? bulkActionOptions.length !== 0 : props.selectable}
+          lastColumnSticky={props.lastColumnSticky}
+          hasZebraStriping={props.hasZebraStriping}
+          condensed={props.condensed}
+        >
+          {rows &&
+            columns &&
+            rows.map((row, index) => {
+              const rawRecord = rawRecords?.[index];
+              return (
+                <IndexTable.Row
+                  key={row.id as string}
+                  id={row.id as string}
+                  position={index}
+                  onClick={onClick ? onClickCallback(row, rawRecord) : undefined}
+                  selected={selection.recordIds.includes(row.id as string)}
+                >
+                  {columns.map((column) => (
+                    <IndexTable.Cell key={column.identifier}>
+                      <div style={{ maxWidth: "200px" }}>
+                        {column.type == "CustomRenderer" ? (
+                          (row[column.identifier] as ReactNode)
+                        ) : (
+                          <PolarisAutoTableCellRenderer column={column} value={row[column.identifier] as ColumnValueType} />
+                        )}
+                      </div>
+                    </IndexTable.Cell>
+                  ))}
+                </IndexTable.Row>
+              );
+            })}
+        </IndexTable>
+      </BlockStack>
     </AutoTableContext.Provider>
   );
 };


### PR DESCRIPTION
- Previously, the toast system for bulk action completion in AutoTable required a `Frame` wrapper to house the Toast component. This `Frame` unfortunately had some extra side effects that would cause the table to take on extra height, disrupting existing app user interfaces
- The frame component has been removed and the toast based bulk action feedback system has been reverted to the banner in modal approach 