### PR TITLE
Allow `useGlobalAction` callback to take no arguments

### DIFF
--- a/packages/react/src/useGlobalAction.ts
+++ b/packages/react/src/useGlobalAction.ts
@@ -3,7 +3,7 @@ import { get, globalActionOperation, namespaceDataPath } from "@gadgetinc/api-cl
 import { useCallback, useEffect, useMemo } from "react";
 import type { OperationContext, UseMutationState } from "urql";
 import { useGadgetMutation } from "./useGadgetMutation.js";
-import type { ActionHookResult } from "./utils.js";
+import type { ActionHookResultWithOptionalCallbackVariables } from "./utils.js";
 import { ErrorWrapper } from "./utils.js";
 
 /**
@@ -29,7 +29,7 @@ import { ErrorWrapper } from "./utils.js";
  */
 export const useGlobalAction = <F extends GlobalActionFunction<any>>(
   action: F
-): ActionHookResult<any, Exclude<F["variablesType"], null | undefined>> => {
+): ActionHookResultWithOptionalCallbackVariables<any, Exclude<F["variablesType"], null | undefined>> => {
   useEffect(() => {
     if (action.type === ("stubbedAction" as string)) {
       const stubbedAction = action as unknown as StubbedActionFunction<any>;
@@ -63,8 +63,8 @@ export const useGlobalAction = <F extends GlobalActionFunction<any>>(
   return [
     transformedResult,
     useCallback(
-      async (variables: F["variablesType"], context?: Partial<OperationContext>) => {
-        const result = await runMutation(variables, context);
+      async (variables?: F["variablesType"], context?: Partial<OperationContext>) => {
+        const result = await runMutation(variables ?? {}, context);
         return processResult({ fetching: false, ...result }, action);
       },
       [action, runMutation]

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -127,14 +127,18 @@ export type RequiredKeysOf<BaseType> = Exclude<
  * Includes the data result object and a function for running the mutation.
  **/
 export type ActionHookResult<Data = any, Variables extends AnyVariables = AnyVariables> = RequiredKeysOf<Variables> extends never
-  ? [
-      ActionHookState<Data, Variables>,
-      (variables?: Variables, context?: Partial<OperationContext>) => Promise<ActionHookState<Data, Variables>>
-    ]
-  : [
-      ActionHookState<Data, Variables>,
-      (variables: Variables, context?: Partial<OperationContext>) => Promise<ActionHookState<Data, Variables>>
-    ];
+  ? ActionHookResultWithOptionalCallbackVariables<Data, Variables>
+  : ActionHookResultWithRequiredCallbackVariables<Data, Variables>;
+
+export type ActionHookResultWithOptionalCallbackVariables<Data = any, Variables extends AnyVariables = AnyVariables> = [
+  ActionHookState<Data, Variables>,
+  (variables?: Variables, context?: Partial<OperationContext>) => Promise<ActionHookState<Data, Variables>>
+];
+
+export type ActionHookResultWithRequiredCallbackVariables<Data = any, Variables extends AnyVariables = AnyVariables> = [
+  ActionHookState<Data, Variables>,
+  (variables: Variables, context?: Partial<OperationContext>) => Promise<ActionHookState<Data, Variables>>
+];
 
 /**
  * The inner result object returned from a mutation result


### PR DESCRIPTION
- UPDATE
  - Some Gadget template apps have type errors because they have `useGlobalAction` and no parameter in the callback.
    - `Expected 1-2 arguments, but got 0`
  - This actually works and should be allowed by the type 

 
This will no longer have a type error with the default code snip
![CleanShot 2024-09-19 at 16 26 40@2x](https://github.com/user-attachments/assets/58de9d69-da09-4848-a738-158b184e72f7)
