### PR TITLE
Don't re-export PolarisAutoForm as PolarisAutoForm

### DIFF
--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -12,7 +12,7 @@ import { PolarisAutoInput } from "./inputs/PolarisAutoInput.js";
 import { PolarisAutoSubmit } from "./submit/PolarisAutoSubmit.js";
 import { PolarisSubmitErrorBanner, PolarisSubmitSuccessfulBanner } from "./submit/PolarisSubmitResultBanner.js";
 
-export const PolarisFormSkeleton = () => (
+export const PolarisAutoFormSkeleton = () => (
   <>
     <SkeletonDisplayText size="medium" />
     <SkeletonBodyText />
@@ -92,7 +92,7 @@ const PolarisAutoFormComponent = <
     return (
       <Form {...rest} onSubmit={submit}>
         <FormLayout>
-          <PolarisFormSkeleton />
+          <PolarisAutoFormSkeleton />
         </FormLayout>
       </Form>
     );

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -1,6 +1,5 @@
 export { PolarisAutoButton as AutoButton } from "./PolarisAutoButton.js";
-export * from "./PolarisAutoForm.js";
-export { PolarisAutoForm as AutoForm } from "./PolarisAutoForm.js";
+export { PolarisAutoForm as AutoForm, PolarisAutoFormSkeleton as AutoFormSkeleton } from "./PolarisAutoForm.js";
 export { PolarisAutoTable as AutoTable } from "./PolarisAutoTable.js";
 export { PolarisAutoBooleanInput as AutoBooleanInput } from "./inputs/PolarisAutoBooleanInput.js";
 export { PolarisAutoDateTimePicker as AutoDateTimePicker } from "./inputs/PolarisAutoDateTimePicker.js";


### PR DESCRIPTION
We already export the PolarisAutoForm component as AutoForm from the auto/polaris/index.ts file. We were accidentally also exporting it as PolarisAutoForm, which is a bit confusing for onlookers like the AI. Let's just export it once under a canonical name!

I also changed the skeleton to be explicitly exported as well using the existing naming convention.
