### PR TITLE
Updated AutoTable bulk actions with custom callbacks to de-select all records to match the behavior of Gadget bulk actions

### DIFF
--- a/packages/react/.changeset/plenty-clouds-pretend.md
+++ b/packages/react/.changeset/plenty-clouds-pretend.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated AutoTable bulk actions with custom callbacks to de-select all records to match the behavior of Gadget bulk actions

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -140,12 +140,12 @@ const PolarisAutoTableComponent = <
   const selectedRows = (rows ?? []).filter((row) => selection.recordIds.includes(row.id as string));
 
   const promotedBulkActions = useMemo(
-    () => bulkActionOptions.filter((option) => option.promoted).map(bulkActionOptionMapper(selectedRows)),
+    () => bulkActionOptions.filter((option) => option.promoted).map(bulkActionOptionMapper(selectedRows, selection.clearAll)),
     [bulkActionOptions, selectedRows]
   );
 
   const bulkActions = useMemo(
-    () => bulkActionOptions.filter((option) => !option.promoted).map(bulkActionOptionMapper(selectedRows)),
+    () => bulkActionOptions.filter((option) => !option.promoted).map(bulkActionOptionMapper(selectedRows, selection.clearAll)),
     [bulkActionOptions, selectedRows]
   );
 
@@ -280,10 +280,15 @@ const disablePaginatedSelectAllButton = {
   paginatedSelectAllActionText: "", // Empty string to hide the select all button. We only allow selection on the current page
 };
 
-const bulkActionOptionMapper = (selectedRows: TableRow[]) => {
+const bulkActionOptionMapper = (selectedRows: TableRow[], clearSelection: () => void) => {
   return (option: BulkActionOption) => ({
     id: option.humanizedName,
     content: option.humanizedName,
-    onAction: option.action ? () => option.action?.(selectedRows) : option.selectModelAction ?? (() => undefined),
+    onAction: option.action
+      ? () => {
+          option.action?.(selectedRows);
+          clearSelection();
+        }
+      : option.selectModelAction ?? (() => undefined),
   });
 };


### PR DESCRIPTION
- UPDATE
  - AutoTable bulk actions with custom callbacks now de-select all records to match the behavior of Gadget bulk actions
  - This was a minor oversight during the previous release where the auto-record deselection system was added for Gadget bulk actions