### PR TITLE
Omitted erroneous pagination options from useTable type

### DIFF
--- a/packages/react/src/useTable.tsx
+++ b/packages/react/src/useTable.tsx
@@ -45,7 +45,10 @@ export const useTable = <
   Options extends F["optionsType"] & ReadOperationOptions & TableOptions
 >(
   manager: { findMany: F },
-  options?: LimitToKnownKeys<Options, Omit<F["optionsType"], "sort"> & ReadOperationOptions & TableOptions>
+  options?: LimitToKnownKeys<
+    Options,
+    Omit<F["optionsType"], "sort" | "first" | "last" | "after" | "before"> & ReadOperationOptions & TableOptions
+  >
 ): TableResult<
   GadgetRecord<Select<Exclude<F["schemaType"], null | undefined>, DefaultSelection<F["selectionType"], Options, F["defaultSelection"]>>>[]
 > => {


### PR DESCRIPTION
- The removed props can come from the findMany, but are not relevant to the usage of `useTable`
- The `initialCursor` property is preferred for controlling `useTable`