### PR TITLE
Removed `AutoTextInput` from the package export because this component is made redundant by the Gadget field specific inputs 

### DIFF
--- a/packages/react/.changeset/rude-onions-compete.md
+++ b/packages/react/.changeset/rude-onions-compete.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": major
+---
+
+Removed `AutoTextInput` from the package export because this component is made redundant by the Gadget field specific inputs (Breaking change)

--- a/packages/react/src/auto/mui/test-index.ts
+++ b/packages/react/src/auto/mui/test-index.ts
@@ -14,7 +14,6 @@ export {
   MUIAutoTextInput as AutoEmailInput,
   MUIAutoTextInput as AutoNumberInput,
   MUIAutoTextInput as AutoStringInput,
-  MUIAutoTextInput as AutoTextInput,
   MUIAutoTextInput as AutoUrlInput,
 } from "./inputs/MUIAutoTextInput.js";
 export { MUIAutoBelongsToInput as AutoBelongsToInput } from "./inputs/relationships/MUIAutoBelongsToInput.js";

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -15,7 +15,6 @@ export { PolarisAutoRolesInput as AutoRolesInput } from "./inputs/PolarisAutoRol
 export {
   PolarisAutoTextInput as AutoEmailInput,
   PolarisAutoTextInput as AutoStringInput,
-  PolarisAutoTextInput as AutoTextInput,
   PolarisAutoTextInput as AutoUrlInput,
 } from "./inputs/PolarisAutoTextInput.js";
 export { PolarisAutoBelongsToInput as AutoBelongsToInput } from "./inputs/relationships/PolarisAutoBelongsToInput.js";


### PR DESCRIPTION
- Removed `AutoTextInput` from the package export because this component is made redundant by the Gadget field specific inputs 
- The component will continue to be used internally