### PR TITLE
Added proper Gadget record type to AutoTable onClick prop callback arguments

### DIFF
--- a/packages/react/.changeset/late-dogs-talk.md
+++ b/packages/react/.changeset/late-dogs-talk.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Added proper Gadget record type to AutoTable onClick prop callback arguments

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -1,4 +1,5 @@
 import type { FindManyFunction, GadgetRecord } from "@gadgetinc/api-client-core";
+import { type DefaultSelection, type Select } from "@gadgetinc/api-client-core";
 import type { TableOptions, TableRow } from "../use-table/types.js";
 import type { OptionsType } from "../utils.js";
 
@@ -19,7 +20,15 @@ export type AutoTableProps<
   live?: boolean;
   columns?: TableOptions["columns"];
   excludeColumns?: string[];
-  onClick?: (row: TableRow, record: GadgetRecord<any>) => void;
+  onClick?: (
+    row: TableRow,
+    record: GadgetRecord<
+      Select<
+        Exclude<FinderFunction["schemaType"], null | undefined>,
+        DefaultSelection<FinderFunction["selectionType"], Options, FinderFunction["defaultSelection"]>
+      >
+    >
+  ) => void;
   initialSort?: Options["sort"];
   filter?: Options["filter"];
   actions?: TableOptions["actions"];


### PR DESCRIPTION
- Added proper Gadget record type to AutoTable onClick prop callback arguments
- Replaced the `any` with the same type that is used elsewhere within the `useTable` hook