### PR TITLE
Add missing typedocs in @gadgetinc/react

### DIFF
--- a/packages/react/src/auth/useSession.ts
+++ b/packages/react/src/auth/useSession.ts
@@ -11,10 +11,31 @@ import { useApi } from "../GadgetProvider.js";
 import { useGet } from "../useGet.js";
 import type { OptionsType, ReadOperationOptions } from "../utils.js";
 
+/**
+ * Represents a Gadget session record.
+ */
 export type GadgetSession = GadgetRecord<Record<string, any>>;
 
+/**
+ * Represents a Gadget user record.
+ */
 export type GadgetUser = GadgetRecord<Record<string, any>>;
 
+/**
+ * Represents a client with session and user managers.
+ *
+ * @template SessionGivenOptions - The options type for the session manager.
+ * @template SessionSchemaT - The schema type for the session manager.
+ * @template UserGivenOptions - The options type for the user manager.
+ * @template UserSchemaT - The schema type for the user manager.
+ *
+ * @extends AnyClient
+ *
+ * @property currentSession - The session manager.
+ * @property currentSession.get - A function to get the current session.
+ * @property user - The user manager.
+ * @property user.findMany - A function to find multiple users.
+ */
 export type ClientWithSessionAndUserManagers<SessionGivenOptions, SessionSchemaT, UserGivenOptions, UserSchemaT> = AnyClient & {
   currentSession: { get: GetFunction<SessionGivenOptions, any, SessionSchemaT, any> };
   user: { findMany: FindManyFunction<UserGivenOptions, any, UserSchemaT, any> };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -11,12 +11,25 @@ export * from "./auth/useUser.js";
 export * from "./useAction.js";
 export * from "./useActionForm.js";
 export * from "./useBulkAction.js";
+export { GadgetController as Controller, useGadgetController as useController } from "./useController.js";
+export type {
+  GadgetControllerProps as ControllerProps,
+  GadgetFieldError as FieldError,
+  GadgetFieldErrors as FieldErrors,
+  GadgetInternalFieldErrors as InternalFieldErrors,
+  GadgetMessage as Message,
+  GadgetMultipleFieldErrors as MultipleFieldErrors,
+  GadgetRegisterOptions as RegisterOptions,
+  GadgetUseControllerProps as UseControllerProps,
+  GadgetUseControllerReturn as UseControllerReturn,
+} from "./useController.js";
 export * from "./useEnqueue.js";
 export * from "./useFetch.js";
 export * from "./useFindBy.js";
 export * from "./useFindFirst.js";
 export * from "./useFindMany.js";
 export * from "./useFindOne.js";
+export type { GadgetFormProps as FormProps, GadgetUseFormReturn as UseFormReturn } from "./useForm.js";
 export { useGadgetMutation as useMutation } from "./useGadgetMutation.js";
 export { useGadgetQuery as useQuery } from "./useGadgetQuery.js";
 export * from "./useGet.js";

--- a/packages/react/src/useController.ts
+++ b/packages/react/src/useController.ts
@@ -1,0 +1,187 @@
+import {
+  Controller,
+  ControllerProps,
+  FieldError,
+  FieldErrors,
+  FieldPath,
+  FieldValues,
+  InternalFieldErrors,
+  Message,
+  MultipleFieldErrors,
+  RegisterOptions,
+  UseControllerProps,
+  UseControllerReturn,
+  useController,
+} from "react-hook-form";
+
+/**
+ * Custom hook to work with controlled component, this function provide you with both form and field level state. Re-render is isolated at the hook level.
+ *
+ * @see
+ * [API](https://react-hook-form.com/docs/usecontroller) • [Demo](https://codesandbox.io/s/usecontroller-0o8px)
+ *
+ * @param props - the path name to the form field value, and validation rules.
+ *
+ * @returns field properties, field and form state. {@link UseControllerReturn}
+ *
+ * @example
+ * ```tsx
+ * function Input(props) {
+ *   const { field, fieldState, formState } = useController(props);
+ *   return (
+ *     <div>
+ *       <input {...field} placeholder={props.name} />
+ *       <p>{fieldState.isTouched && "Touched"}</p>
+ *       <p>{formState.isSubmitted ? "submitted" : ""}</p>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export const useGadgetController: typeof useController = (...args) => {
+  return useController(...args);
+};
+
+/**
+ * The options for registering a field in react-hook-form.
+ *
+ * @see
+ * [API](https://react-hook-form.com/docs/useform/register)
+ *
+ */
+export type GadgetRegisterOptions<TFieldValues extends FieldValues = FieldValues> = RegisterOptions<TFieldValues>;
+
+/**
+ * The props for the useController hook in react-hook-form.
+ *
+ * @see
+ * [API](https://react-hook-form.com/docs/usecontroller) • [Demo](https://codesandbox.io/s/usecontroller-0o8px)
+ *
+ */
+export type GadgetUseControllerProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = UseControllerProps<TFieldValues, TName>;
+
+/**
+ * The return type for the useController hook in react-hook-form.
+ *
+ * @see
+ * [API](https://react-hook-form.com/docs/usecontroller) • [Demo](https://codesandbox.io/s/usecontroller-0o8px)
+ *
+ */
+export type GadgetUseControllerReturn<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = UseControllerReturn<TFieldValues, TName>;
+
+/**
+ * The props for the Controller component in react-hook-form.
+ *
+ * @see
+ * [API](https://react-hook-form.com/docs/usecontroller) • [Demo](https://codesandbox.io/s/usecontroller-0o8px)
+ *
+ */
+export type GadgetControllerProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = ControllerProps<TFieldValues, TName>;
+
+/**
+ * Component based on `useController` hook to work with controlled component in react-hook-form.
+ *
+ * @see
+ * [API](https://react-hook-form.com/docs/usecontroller/controller) • [Demo](https://codesandbox.io/s/react-hook-form-v6-controller-ts-jwyzw) • [Video](https://www.youtube.com/watch?v=N2UNk_UCVyA)
+ *
+ * @param props - the path name to the form field value, and validation rules.
+ *
+ * @returns provide field handler functions, field and form state.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const { control } = useForm<FormValues>({
+ *     defaultValues: {
+ *       test: ""
+ *     }
+ *   });
+ *
+ *   return (
+ *     <form>
+ *       <Controller
+ *         control={control}
+ *         name="test"
+ *         render={({ field: { onChange, onBlur, value, ref }, formState, fieldState }) => (
+ *           <>
+ *             <input
+ *               onChange={onChange} // send value to hook form
+ *               onBlur={onBlur} // notify when input is touched
+ *               value={value} // return updated value
+ *               ref={ref} // set ref for focus management
+ *             />
+ *             <p>{formState.isSubmitted ? "submitted" : ""}</p>
+ *             <p>{fieldState.isTouched ? "touched" : ""}</p>
+ *           </>
+ *         )}
+ *       />
+ *     </form>
+ *   );
+ * }
+ * ```
+ */
+export const GadgetController: typeof Controller = (...args) => {
+  return Controller(...args);
+};
+
+/**
+ * Represents multiple field errors for a form field in react-hook-form.
+ *
+ * @remarks
+ * It represents a collection of validation errors for a single field, where each key
+ * corresponds to a validation rule and the value is the validation result.
+ *
+ * @see {@link https://react-hook-form.com/docs/useform/errors#types React Hook Form Errors}
+ */
+export type GadgetMultipleFieldErrors = MultipleFieldErrors;
+
+/**
+ * Represents a single field error for a form field in react-hook-form.
+ *
+ * @remarks
+ * It represents an error for a single field, containing information about
+ * the error type and message.
+ *
+ * @see {@link https://react-hook-form.com/docs/useform/errors#types React Hook Form Errors}
+ */
+export type GadgetFieldError = FieldError;
+
+/**
+ * Represents a collection of field errors for a form in react-hook-form.
+ *
+ * @remarks
+ * It represents a nested structure of errors for all fields in a form,
+ * including potential global errors.
+ *
+ * @see {@link https://react-hook-form.com/docs/useform/errors#types React Hook Form Errors}
+ */
+export type GadgetFieldErrors<TFieldValues extends FieldValues = FieldValues> = FieldErrors<TFieldValues>;
+
+/**
+ * Represents internal field errors used by react-hook-form.
+ *
+ * @remarks
+ * It represents a partial record of internal field names mapped to their corresponding field errors in react-hook-form.
+ *
+ * @see {@link https://react-hook-form.com/docs/useform/errors#types React Hook Form Errors}
+ */
+export type GadgetInternalFieldErrors = InternalFieldErrors;
+
+/**
+ * Represents an error message string in react-hook-form.
+ *
+ * @remarks
+ * It is used to represent error messages throughout the form validation process.
+ *
+ * @see {@link https://react-hook-form.com/docs/useform/errors#types React Hook Form Errors}
+ */
+export type GadgetMessage = Message;

--- a/packages/react/src/useForm.ts
+++ b/packages/react/src/useForm.ts
@@ -1,0 +1,30 @@
+import { FieldValues, FormProps, UseFormReturn } from "react-hook-form";
+
+/**
+ * The return type for the useForm hook in react-hook-form.
+ *
+ * @remarks
+ * This type includes all methods and properties returned by the useForm hook,
+ * such as form state, field registration, value manipulation, and submission handling.
+ *
+ * @see {@link https://react-hook-form.com/docs/useform React Hook Form useForm API}
+ */
+export type GadgetUseFormReturn<
+  TFieldValues extends FieldValues = FieldValues,
+  TContext = any,
+  TTransformedValues extends FieldValues | undefined = undefined
+> = UseFormReturn<TFieldValues, TContext, TTransformedValues>;
+
+/**
+ * Props for the Form component in react-hook-form.
+ *
+ * @remarks
+ * This type extends React's form attributes and includes additional properties
+ * for form handling, such as custom submit handlers, error handling, and HTTP methods.
+ *
+ * @see {@link https://react-hook-form.com/docs/useform/form React Hook Form Form API}
+ */
+export type GadgetFormProps<TFieldValues extends FieldValues, TTransformedValues extends FieldValues | undefined = undefined> = FormProps<
+  TFieldValues,
+  TTransformedValues
+>;

--- a/packages/react/src/useGadgetMutation.ts
+++ b/packages/react/src/useGadgetMutation.ts
@@ -3,6 +3,24 @@ import { useMutation } from "urql";
 import { GadgetUrqlClientContext } from "./GadgetProvider.js";
 import { noProviderErrorMessage } from "./utils.js";
 
+/**
+ * A React hook for executing GraphQL mutations using urql.
+ *
+ * @template TData The shape of the mutation result data.
+ * @template TVariables The shape of the mutation variables.
+ *
+ * @param {DocumentNode | TypedDocumentNode<TData, TVariables> | string} mutation - The GraphQL mutation document.
+ * @param {Partial<UseMutationOptions>} [options] - Optional configuration for the mutation.
+ *
+ * @returns {UseMutationResponse<TData, TVariables>} A tuple containing the mutation execution function and the mutation state.
+ * @property {UseMutationState<TData, TVariables>} [0] - The current state of the mutation.
+ * @property {UseMutationExecute<TData, TVariables>} [1] - A function to execute the mutation.
+ *
+ * @example
+ * const [mutationResult, executeMutation] = useMutation(MY_MUTATION);
+ *
+ * @see {@link https://commerce.nearform.com/open-source/urql/docs/api/urql/#usemutation Read more about useMutation in the urql documentation}
+ */
 export const useGadgetMutation: typeof useMutation = (query) => {
   if (!useContext(GadgetUrqlClientContext)) throw new Error(noProviderErrorMessage);
   return useMutation(query);

--- a/packages/react/src/useGadgetQuery.ts
+++ b/packages/react/src/useGadgetQuery.ts
@@ -1,6 +1,5 @@
 import { useContext } from "react";
-import type { AnyVariables, UseQueryArgs, UseQueryResponse } from "urql";
-import { useQuery } from "urql";
+import { AnyVariables, UseQueryArgs, UseQueryResponse, useQuery } from "urql";
 import { GadgetUrqlClientContext } from "./GadgetProvider.js";
 import { noProviderErrorMessage, useMemoizedQueryOptions } from "./utils.js";
 
@@ -12,6 +11,27 @@ export type UseGadgetQueryArgs<Variables extends AnyVariables, Data = any> = Use
   suspense?: boolean;
 };
 
+/**
+ * A React hook for executing GraphQL queries using urql.
+ *
+ * @template TData The shape of the query result data.
+ * @template TVariables The shape of the query variables.
+ *
+ * @param {DocumentNode | TypedDocumentNode<TData, TVariables> | string} query - The GraphQL query document.
+ * @param {Partial<UseGadgetQueryArgs<TVariables>>} [options] - Optional configuration for the query.
+ * @param {boolean} [options.suspense] - If true, marks this query as one that should suspend the react component rendering while executing, instead of returning `{fetching: true}` to the caller.
+ *
+ * @returns {UseQueryResponse<TData, TVariables>} The query result object.
+ * @property {TData | undefined} data - The data returned from the query.
+ * @property {CombinedError | undefined} error - Any error that occurred during the query.
+ * @property {boolean} fetching - Whether the query is currently in flight.
+ * @property {() => void} executeQuery - A function to manually execute the query.
+ *
+ * @example
+ * const [result, reexecuteQuery] = useGadgetQuery({ query: MY_QUERY, suspense: true });
+ *
+ * @see {@link https://formidable.com/open-source/urql/docs/api/urql/#usequery Read more about useQuery in the urql documentation}
+ */
 export const useGadgetQuery = <Data = any, Variables extends AnyVariables = AnyVariables>(
   args: UseGadgetQueryArgs<Variables, Data>
 ): UseQueryResponse<Data, Variables> => {

--- a/packages/react/src/useList.ts
+++ b/packages/react/src/useList.ts
@@ -23,23 +23,82 @@ export interface PaginationResult {
   goToPreviousPage(): void;
 }
 
+/**
+ * Options for configuring the list behavior.
+ * @remarks For a full list of options, refer to https://docs.gadget.dev/reference/react#uselist
+ */
 export interface ListOptions {
+  /** The number of items to display per page. If not specified, a default value of 50 is used. */
   pageSize?: number;
 }
 
-export type ListResult<Data> = [
-  {
-    data?: Data;
-    page: PaginationResult;
-    search: SearchResult;
-    selection: RecordSelection;
-    fetching: boolean;
-    error?: ErrorWrapper;
-  },
+/**
+ * Represents the current state of the list.
+ * @template Data - The type of the data returned in the list.
+ */
+export interface ListState<Data> {
+  /** The current page of data items. May be undefined if data is not yet loaded. */
+  data?: Data;
+  /** Information and controls for pagination. */
+  page: PaginationResult;
+  /** Information about the current search state. */
+  search: SearchResult;
+  /** Information about selected records. */
+  selection: RecordSelection;
+  /** Indicates whether the list is currently being fetched. */
+  fetching: boolean;
+  /** Error information if an error occurred during fetching. */
+  error?: ErrorWrapper;
+}
 
-  (opts?: Partial<OperationContext>) => void
-];
+/**
+ * A function to refresh the list data.
+ * @param {Partial<OperationContext>} [opts] - Optional context for the refresh operation.
+ */
+export type RefreshFunction = (opts?: Partial<OperationContext>) => void;
 
+/**
+ * Represents the result of a list operation.
+ * @template Data - The type of the data returned in the list.
+ * @remarks For details, refer to https://docs.gadget.dev/reference/react#uselist
+ */
+export type ListResult<Data> = [ListState<Data>, RefreshFunction];
+
+/**
+ * A hook for managing paginated lists with search and selection capabilities.
+ *
+ * @template T - The type of the records in the list.
+ * @template F - The type of the findMany function.
+ *
+ * @param manager - An object containing the findMany function for the model.
+ * @param [options] - Optional configuration for the list.
+ * @param [options.pageSize=10] - The number of items per page.
+ * @param [options.search] - A search string to filter the records.
+ * @param [options.filter] - A filter object to limit the returned records.
+ * @param [options.sort] - A sort object to order the returned records.
+ * @param [options.select] - A select object to specify which fields to return.
+ * @param [options.live] - Whether to subscribe to real-time updates.
+ *
+ * @example
+ * const [{ data, fetching, error, page }, refresh] = useList(api.customer, {
+ *   sort: {
+ *     createdAt: "Descending",
+ *   },
+ *   live: true,
+ * });
+ *
+ * @returns A tuple containing the list state and a refresh function.
+ * @returns [0] An object containing the list state:
+ *   - data: An array of GadgetRecord objects representing the current page of records.
+ *   - page: A PaginationResult object for managing pagination.
+ *   - search: A SearchResult object for managing search functionality.
+ *   - selection: A RecordSelection object for managing selected records.
+ *   - fetching: A boolean indicating if the list is currently being fetched.
+ *   - error: An ErrorWrapper object if an error occurred, or undefined.
+ * @returns [1] A function to refresh the list data.
+ *
+ * For a full list of options, refer to https://docs.gadget.dev/reference/react#uselist
+ */
 export const useList = <
   GivenOptions extends OptionsType,
   SchemaT,


### PR DESCRIPTION
Adds missing typedocs, mainly wraps some `react-form-hooks` functions and types to add typedocs and exports them.

Edit: closing to work together on nicholas/sunday-funday to avoid merge conflicts

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
