### PR TITLE
Added descriptions for AutoComponents

### DIFF
--- a/packages/react/.changeset/fuzzy-nails-do.md
+++ b/packages/react/.changeset/fuzzy-nails-do.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Added descriptions for AutoComponents

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -4,7 +4,7 @@ import type { TableOptions, TableRow } from "../use-table/types.js";
 import type { OptionsType } from "../utils.js";
 
 /**
- * The props to pass to an AutoTable. Includes both the Gadget-land props as well as the adapter specific props.
+ * Props for AutoTable, including Gadget-land and adapter-specific props.
  **/
 export type AutoTableProps<
   GivenOptions extends OptionsType,
@@ -18,8 +18,8 @@ export type AutoTableProps<
   model: { findMany: FinderFunction };
   /**
    * The selection object to pass to the table.
-   * This will override the default selection based on included columns.
-   * This is necessary for representing nested relationship fields in the table
+   * Overrides the default selection based on included columns.
+   * Needed for displaying nested relationships in the table.
    */
   select?: Options["select"];
   /**
@@ -27,30 +27,31 @@ export type AutoTableProps<
    */
   pageSize?: number;
   /**
-   * The initial pagination cursor to control the initial page of records to show.
+   * The initial pagination cursor to control the first page of records.
    * Pagination cursors are returned from the API.
    */
   initialCursor?: string;
   /**
-   * Determines if the table should be live updated when the data changes.
+   * Determines if the table should be live updated when data changes.
    */
   live?: boolean;
 
+
   /**
-   * The columns to show in the table represented as (string | CellDetailColumn | CustomCellColumn)[]
-   * - As a string, this represents the API identifier of the field to display.
-   * - As a CellDetailColumn, this a
-   * - As a CustomCellColumn, this represents a custom column to display.
+   * The columns to display in the table, represented as (string | CellDetailColumn | CustomCellColumn)[]
+   * - A string represents the API identifier of the field.
+   * - A CellDetailColumn is a detailed field representation.
+   * - A CustomCellColumn is a custom column.
    */
   columns?: TableOptions["columns"];
 
   /**
-   * An array of strings corresponding to model fields to exclude from the table.
+   * An array of model fields excluded from the table.
    */
   excludeColumns?: string[];
 
   /**
-   * callback function that gets called when a row is clicked.
+   * Callback triggered when a row is clicked.
    */
   onClick?: (
     row: TableRow,
@@ -63,7 +64,7 @@ export type AutoTableProps<
   ) => void;
 
   /**
-   * The initial column sort order that the table will be initialized with.
+   * The initial column sort order.
    * @example
    * ```tsx
    * <AutoTable model={api.user} initialSort={{ id: "Descending" }} />
@@ -72,49 +73,49 @@ export type AutoTableProps<
   initialSort?: Options["sort"];
 
   /**
-   * The model record filter to apply to the table.
+   * The model record filter to apply.
    */
   filter?: Options["filter"];
 
-  /**
-   * The actions to be shown in the table for selected records, represented as (string | ActionCallback)[]
-   * - strings in the array represent the API identifies of actions in the model that can be run on the selected records
-   * - ActionCallback is an object with a label and action property. The action property can be a string representing a model action or a function on that will be called with the selected records
+    /**
+   * The actions available for selected records, represented as (string | ActionCallback)[]
+   * - A string represents the API identifier of the model action.
+   * - ActionCallback contains a label and an action property, which can be an action API identifier or a function.
    */
   actions?: TableOptions["actions"];
 
   /**
-   * A string array of API identifiers for model actions to be excluded from the table.
+   * API identifiers of model actions to exclude from the table.
    */
   excludeActions?: TableOptions["excludeActions"];
 
   /**
-   * Indicates if the table rows are selectable.
+   * Indicates if table rows are selectable.
    */
   selectable?: boolean;
 
   /**
-   * The content to display in the table when there are no records to show.
+   * The content displayed when no records exist.
    */
   emptyState?: ReactNode;
 
   /**
-   * The resource name to display in the table.
+   * The resource name displayed in the table.
    */
   resourceName?: { singular: string; plural: string };
 
   /**
-   * Toggle whether the search bar is visible. Defaults to `true`
+   * Controls search bar visibility. Defaults to `true`.
    */
   searchable?: boolean;
 
   /**
-   * Optional search value to programmatically search for the model records
+   * A preset search term.  
    */
   searchValue?: string;
 
   /**
-   * Indicates if the table should be paginated.
+   * Indicates if pagination is enabled. Defaults to `true`.
    */
   paginate?: boolean;
 };

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -1,5 +1,5 @@
-import type { FindManyFunction, GadgetRecord } from "@gadgetinc/api-client-core";
-import { type DefaultSelection, type Select } from "@gadgetinc/api-client-core";
+import type { DefaultSelection, FindManyFunction, GadgetRecord, Select } from "@gadgetinc/api-client-core";
+import type { ReactNode } from "react";
 import type { TableOptions, TableRow } from "../use-table/types.js";
 import type { OptionsType } from "../utils.js";
 
@@ -12,14 +12,46 @@ export type AutoTableProps<
   FinderFunction extends FindManyFunction<GivenOptions, any, SchemaT, any>,
   Options extends FinderFunction["optionsType"]
 > = {
+  /**
+   * The Gadget model with records that will be shown in the table.
+   */
   model: { findMany: FinderFunction };
+  /**
+   * The selection object to pass to the table.
+   * This will override the default selection based on included columns.
+   * This is necessary for representing nested relationship fields in the table
+   */
   select?: Options["select"];
+  /**
+   * The number of records to show per page.
+   */
   pageSize?: number;
+  /**
+   * The initial pagination cursor to control the initial page of records to show.
+   * Pagination cursors are returned from the API.
+   */
   initialCursor?: string;
-  initialDirection?: string;
+  /**
+   * Determines if the table should be live updated when the data changes.
+   */
   live?: boolean;
+
+  /**
+   * The columns to show in the table represented as (string | CellDetailColumn | CustomCellColumn)[]
+   * - As a string, this represents the API identifier of the field to display.
+   * - As a CellDetailColumn, this a
+   * - As a CustomCellColumn, this represents a custom column to display.
+   */
   columns?: TableOptions["columns"];
+
+  /**
+   * An array of strings corresponding to model fields to exclude from the table.
+   */
   excludeColumns?: string[];
+
+  /**
+   * callback function that gets called when a row is clicked.
+   */
   onClick?: (
     row: TableRow,
     record: GadgetRecord<
@@ -29,17 +61,60 @@ export type AutoTableProps<
       >
     >
   ) => void;
+
+  /**
+   * The initial column sort order that the table will be initialized with.
+   * @example
+   * ```tsx
+   * <AutoTable model={api.user} initialSort={{ id: "Descending" }} />
+   * ```
+   */
   initialSort?: Options["sort"];
+
+  /**
+   * The model record filter to apply to the table.
+   */
   filter?: Options["filter"];
+
+  /**
+   * The actions to be shown in the table for selected records, represented as (string | ActionCallback)[]
+   * - strings in the array represent the API identifies of actions in the model that can be run on the selected records
+   * - ActionCallback is an object with a label and action property. The action property can be a string representing a model action or a function on that will be called with the selected records
+   */
   actions?: TableOptions["actions"];
+
+  /**
+   * A string array of API identifiers for model actions to be excluded from the table.
+   */
   excludeActions?: TableOptions["excludeActions"];
+
+  /**
+   * Indicates if the table rows are selectable.
+   */
   selectable?: boolean;
-  emptyState?: React.ReactNode;
-  lastColumnSticky?: boolean;
-  hasZebraStriping?: boolean;
+
+  /**
+   * The content to display in the table when there are no records to show.
+   */
+  emptyState?: ReactNode;
+
+  /**
+   * The resource name to display in the table.
+   */
   resourceName?: { singular: string; plural: string };
-  condensed?: boolean;
+
+  /**
+   * Toggle whether the search bar is visible. Defaults to `true`
+   */
   searchable?: boolean;
+
+  /**
+   * Optional search value to programmatically search for the model records
+   */
   searchValue?: string;
+
+  /**
+   * Indicates if the table should be paginated.
+   */
   paginate?: boolean;
 };

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -36,7 +36,6 @@ export type AutoTableProps<
    */
   live?: boolean;
 
-
   /**
    * The columns to display in the table, represented as (string | CellDetailColumn | CustomCellColumn)[]
    * - A string represents the API identifier of the field.
@@ -77,7 +76,7 @@ export type AutoTableProps<
    */
   filter?: Options["filter"];
 
-    /**
+  /**
    * The actions available for selected records, represented as (string | ActionCallback)[]
    * - A string represents the API identifier of the model action.
    * - ActionCallback contains a label and an action property, which can be an action API identifier or a function.
@@ -110,7 +109,7 @@ export type AutoTableProps<
   searchable?: boolean;
 
   /**
-   * A preset search term.  
+   * A preset search term.
    */
   searchValue?: string;
 

--- a/packages/react/src/auto/hooks/useHasManyThroughController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyThroughController.tsx
@@ -119,36 +119,37 @@ export const useHasManyThroughInputController = (props: AutoRelationshipInputPro
 };
 
 /**
- * A form component for the join model of a hasManyThrough relationship that associates the contained <AutoInput/> components in the children with the hasManyThrough relationship join model.
+ * A form for including join model fields in a hasManyThrough relationship.
  *
  * @example
  * ```tsx
+ * 
+ * //`course` hasMany `students` through `registration`
+ * 
  * <AutoForm action={api.course.create}>
- *   <AutoInput // `name` field on `course` model
- *     field="name"
- *   />
- *   <AutoHasManyThroughForm // `students` field on `course` model - `course` hasMany `students` through `registration`
+ *   <AutoInput field="name" />
+ *   <AutoHasManyThroughForm // `students` relationship field on `course` model 
  *     field="students"
  *   >
- *     <AutoHasManyThroughJoinModelForm // Join model field inputs
- *     >
- *       <AutoInput // `isTuitionPaid` field on `registration` model
+ *     <AutoHasManyThroughJoinModelForm>
+ *       <AutoInput // `isTuitionPaid` boolean field on `registration` model
  *         field="isTuitionPaid"
  *       />
  *     </AutoHasManyThroughJoinModelForm>
- *     <AutoInput // Sibling model field inputs
+ *     <AutoInput
  *       field="firstName"
  *     />
  *   </AutoHasManyThroughForm>
  *   <AutoSubmit />
  * </AutoForm>
+ * 
  * ```
  *
- * @param props.children - The React children containing inputs on the join model in an AutoHasManyThroughForm component
- * @returns The React children containing inputs on the join model in an AutoHasManyThroughForm component
+ * @param props.children - Inputs on the join model inside AutoHasManyThroughForm.
+ * @returns  Inputs on the join model inside AutoHasManyThroughForm.
  */
 export const AutoHasManyThroughJoinModelForm = (props: {
-  /** The React children containing inputs on the join model in an AutoHasManyThroughForm component */
+  /** Inputs on the join model inside AutoHasManyThroughForm. */
   children?: ReactNode;
 }) => {
   useEnsureInHasManyThroughForm();
@@ -156,13 +157,15 @@ export const AutoHasManyThroughJoinModelForm = (props: {
   return <HasManyThroughJoinModelContext.Provider value={true}>{props.children}</HasManyThroughJoinModelContext.Provider>;
 };
 
+/** Context to track if inside a HasManyThrough join model. */
 export const HasManyThroughJoinModelContext = createContext<null | true>(null);
 
-// Export a hook that just checks if we're inside the component
+/** Export a hook that checks if inside the component. */
 export const useIsInHasManyThroughJoinModelInput = () => {
   return useContext(HasManyThroughJoinModelContext) !== null;
 };
 
+/** Ensures component is used inside AutoHasManyThroughForm. */
 export const useEnsureInHasManyThroughForm = () => {
   const relationshipContext = useRelationshipContext();
 

--- a/packages/react/src/auto/hooks/useHasManyThroughController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyThroughController.tsx
@@ -118,6 +118,35 @@ export const useHasManyThroughInputController = (props: AutoRelationshipInputPro
   };
 };
 
+/**
+ * A form component for the join model of a hasManyThrough relationship that associates the contained <AutoInput/> components in the children with the hasManyThrough relationship join model.
+ *
+ * @example
+ * ```tsx
+ * <AutoForm action={api.course.create}>
+ *   <AutoInput // `name` field on `course` model
+ *     field="name"
+ *   />
+ *   <AutoHasManyThroughForm // `students` field on `course` model - `course` hasMany `students` through `registration`
+ *     field="students"
+ *   >
+ *     <AutoHasManyThroughJoinModelForm // Join model field inputs
+ *     >
+ *       <AutoInput // `isTuitionPaid` field on `registration` model
+ *         field="isTuitionPaid"
+ *       />
+ *     </AutoHasManyThroughJoinModelForm>
+ *     <AutoInput // Sibling model field inputs
+ *       field="firstName"
+ *     />
+ *   </AutoHasManyThroughForm>
+ *   <AutoSubmit />
+ * </AutoForm>
+ * ```
+ *
+ * @param props.children - The React children containing inputs on the join model in an AutoHasManyThroughForm component
+ * @returns The React children containing inputs on the join model in an AutoHasManyThroughForm component
+ */
 export const AutoHasManyThroughJoinModelForm = (props: {
   /** The React children containing inputs on the join model in an AutoHasManyThroughForm component */
   children?: ReactNode;

--- a/packages/react/src/auto/hooks/useHasManyThroughController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyThroughController.tsx
@@ -123,12 +123,11 @@ export const useHasManyThroughInputController = (props: AutoRelationshipInputPro
  *
  * @example
  * ```tsx
- * 
  * //`course` hasMany `students` through `registration`
- * 
+ *
  * <AutoForm action={api.course.create}>
  *   <AutoInput field="name" />
- *   <AutoHasManyThroughForm // `students` relationship field on `course` model 
+ *   <AutoHasManyThroughForm // `students` relationship field on `course` model
  *     field="students"
  *   >
  *     <AutoHasManyThroughJoinModelForm>
@@ -142,7 +141,7 @@ export const useHasManyThroughInputController = (props: AutoRelationshipInputPro
  *   </AutoHasManyThroughForm>
  *   <AutoSubmit />
  * </AutoForm>
- * 
+ *
  * ```
  *
  * @param props.children - Inputs on the join model inside AutoHasManyThroughForm.

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -1,19 +1,17 @@
 import type { FindManyOptions } from "@gadgetinc/api-client-core";
 import type { ReactNode } from "react";
-import type { Control } from "../../useActionForm.js";
+import type { ControllableWithReactHookForm } from "../shared/AutoInputTypes.js";
 
 export type RecordFilter = FindManyOptions["filter"];
 
-export interface AutoRelationshipInputProps {
+/**
+ * Props for the relationship input component in AutoForm
+ */
+export interface AutoRelationshipInputProps extends ControllableWithReactHookForm {
   /**
    * The API identifier of the field.
    */
   field: string;
-
-  /**
-   * The control to use for the input.
-   */
-  control?: Control<any>;
 
   /**
    * The label to display for each related model record option in the input.

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -5,29 +5,29 @@ import type { ControllableWithReactHookForm } from "../shared/AutoInputTypes.js"
 export type RecordFilter = FindManyOptions["filter"];
 
 /**
- * Props for the relationship input component in AutoForm
+ * Props for the relationships in AutoForm.
  */
 export interface AutoRelationshipInputProps extends ControllableWithReactHookForm {
   /**
-   * The API identifier of the field.
+   * The API identifier of the relationship field.
    */
   field: string;
 
   /**
-   * The label to display for each related model record option in the input.
-   * - As a string, this represents the API identifier of the field to display.
-   * - As a string[], this represents the API identifiers of the fields to display in the order they are provided.
-   * - As a function, this represents the a callback to be applied to the record that returns a custom label component.
+   * Label for related model records.
+   * - A string, represents the API identifier of the related field.
+   * - A string[], represents the API identifiers of the fields in the order provided.
+   * - A function, represents the a callback applied to the record that returns a custom label.
    */
   optionLabel?: OptionLabel;
 
   /**
-   * The label to display above the input. Defaults to the field name.
+   * The input label. Defaults to the field name.
    */
   label?: ReactNode;
 
   /**
-   * Optional filter for the related model options to display in the input
+   * Optional filter for the related model options.
    */
   recordFilter?: RecordFilter;
 }
@@ -37,51 +37,51 @@ export type DisplayedRecordOption = RecordLabel<ReactNode> & {
 };
 
 /**
- * Type for the option label when displaying a list of records from a related model
- * - As a string, this represents the API identifier of the field to display.
- * - As a string[], this represents the API identifiers of the fields to display in the order they are provided.
- * - As a function, this represents the a callback to be applied to the record that returns a custom label component.
+ * Label for related model records.
+ * - A string, represents the API identifier of the related field.
+ * - A string[], represents the API identifiers of the fields in the order provided.
+ * - A function, represents the a callback applied to the record that returns a custom label.
  */
 export type OptionLabel = string | string[] | ((props: { record: Record<string, any> }) => ReactNode);
 
 export type RecordLabel<T = OptionLabel> = {
   /**
-   * The primary label to display for the record.
+   * Primary label.
    */
   primary?: T;
   /**
-   * The secondary label to display for the record.
+   * Secondary label.
    */
   secondary?: T;
   /**
-   * The tertiary label to display for the record.
+   * Tertiary label.
    */
   tertiary?: T;
 };
 
 export type AutoRelationshipFormProps = {
   /**
-   * The API identifier of the field.
+   * The API identifier for the related field.
    */
   field: string;
 
   /**
-   * The label to display at the top of the form. Defaults to the field name.
+   * Label at the top of the form. Defaults to the field name.
    */
   label?: ReactNode;
 
   /**
-   * The React children to render within the relationship form component
+   * Children inside relationship form.
    */
   children: ReactNode;
 
   /**
-   * Optional control for how related model records are shown in the relationship form
+   * Control for displaying related model records in the relationship form.
    */
   recordLabel?: OptionLabel | RecordLabel;
 
   /**
-   * Optional filter for the related model options to display in the input
+   * Filter for the related model options to display in the input.
    */
   recordFilter?: RecordFilter;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -12,6 +12,16 @@ import { PolarisAutoInput } from "./inputs/PolarisAutoInput.js";
 import { PolarisAutoSubmit } from "./submit/PolarisAutoSubmit.js";
 import { PolarisSubmitErrorBanner, PolarisSubmitSuccessfulBanner } from "./submit/PolarisSubmitResultBanner.js";
 
+/**
+ * A skeleton component for the form to display while the form is loading
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   {isLoading ? <AutoFormSkeleton /> : <AutoFormContent />}
+ * </AutoForm>
+ * ```
+ * @returns Skeleton component for the form
+ */
 export const PolarisAutoFormSkeleton = () => (
   <>
     <FormLayout>

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -20,7 +20,6 @@ import { PolarisSubmitErrorBanner, PolarisSubmitSuccessfulBanner } from "./submi
  *   {isLoading ? <AutoFormSkeleton /> : <AutoFormContent />}
  * </AutoForm>
  * ```
- * @returns 
  */
 export const PolarisAutoFormSkeleton = () => (
   <>

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -13,14 +13,14 @@ import { PolarisAutoSubmit } from "./submit/PolarisAutoSubmit.js";
 import { PolarisSubmitErrorBanner, PolarisSubmitSuccessfulBanner } from "./submit/PolarisSubmitResultBanner.js";
 
 /**
- * A skeleton component for the form to display while the form is loading
+ * Skeleton loader
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   {isLoading ? <AutoFormSkeleton /> : <AutoFormContent />}
  * </AutoForm>
  * ```
- * @returns Skeleton component for the form
+ * @returns 
  */
 export const PolarisAutoFormSkeleton = () => (
   <>
@@ -38,7 +38,7 @@ export type PolarisAutoFormProps<
 > = AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action">;
 
 /**
- * Renders a form for an action on a model automatically using Polaris
+ * Renders a form for an action on a model using Polaris.
  */
 export const PolarisAutoForm = <
   GivenOptions extends OptionsType,
@@ -51,7 +51,7 @@ export const PolarisAutoForm = <
 
   validateAutoFormProps(props);
 
-  // Component key to force re-render when the action or findBy changes
+  // Forces re-render when the action or findBy changes.
   const componentKey = `${"modelApiIdentifier" in action ? `${action.modelApiIdentifier}.` : ""}${action.operationName}.${JSON.stringify(
     findBy
   )}`;
@@ -71,7 +71,7 @@ const PolarisAutoFormComponent = <
   SchemaT,
   ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
 >(
-  //polaris form props also take an 'action' property, which we need to omit here.
+  //Polaris form props also take an 'action' property, which we must omit here.
   props: PolarisAutoFormProps<GivenOptions, SchemaT, ActionFunc>
 ) => {
   const { record: _record, action, findBy, ...rest } = props as PolarisAutoFormProps<GivenOptions, SchemaT, ActionFunc> & { findBy: any };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -60,28 +60,28 @@ export type PolarisAutoTableProps<
   Options extends FinderFunction["optionsType"]
 > = AutoTableProps<GivenOptions, SchemaT, FinderFunction, Options> & {
   /**
-   * Condense the table, so that the user does not have to scroll horizontally. Defaults to false
+   * Condenses the table to avoid horizontal scrolling. Defaults to `false`.
    */
   condensed?: boolean;
 
   /**
-   * Add zebra striping to table rows. Defaults to false
+   * Adds zebra striping to table rows. Defaults to `false`.
    */
   hasZebraStriping?: boolean;
 
   /**
-   * Toggle whether the last column is always visible. Defaults to false
+   * Keeps last column always visible. Defaults to `false`.
    */
   lastColumnSticky?: boolean;
 };
 
 /**
- * Renders a table of records from the backend automatically for a given model using Polaris
+ * Renders a table of records from given model using Shopify Polaris
  * @example
  * ```tsx
  * <AutoTable model={api.user} />
  * ```
- * @param props.model - The Gadget model to show in the table
+ * @param props.model - The Gadget model displayed
  */
 export const PolarisAutoTable = <
   GivenOptions extends OptionsType,
@@ -233,7 +233,7 @@ const PolarisAutoTableComponent = <
           hasMoreItems={page.hasNextPage}
           itemCount={
             error
-              ? 1 // Don't show the empty state if there's an error
+              ? 1 // Don't show the empty state if there's are no errors.
               : rows?.length ?? 0
           }
           pagination={
@@ -290,7 +290,7 @@ const PolarisAutoTableComponent = <
 };
 
 const PolarisIndexTableCellStyleOverride = () => {
-  // !important to override the default padding from a class that gets applied afterwards
+  // !important to override the default padding from a class that gets applied afterwards.
   const css = /*css*/ `
   .Gadget_PolarisAutoTable_IndexTableCell {
     padding: 0px !important; 
@@ -300,7 +300,7 @@ const PolarisIndexTableCellStyleOverride = () => {
 };
 
 const disablePaginatedSelectAllButton = {
-  paginatedSelectAllActionText: "", // Empty string to hide the select all button. We only allow selection on the current page
+  paginatedSelectAllActionText: "", // Empty string to hide the select all button. We only allow selections on the current page.
 };
 
 const bulkActionOptionMapper = (selectedRows: TableRow[], clearSelection: () => void) => {

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -58,10 +58,30 @@ export type PolarisAutoTableProps<
   SchemaT,
   FinderFunction extends FindManyFunction<GivenOptions, any, SchemaT, any>,
   Options extends FinderFunction["optionsType"]
-> = AutoTableProps<GivenOptions, SchemaT, FinderFunction, Options>;
+> = AutoTableProps<GivenOptions, SchemaT, FinderFunction, Options> & {
+  /**
+   * Condense the table, so that the user does not have to scroll horizontally. Defaults to false
+   */
+  condensed?: boolean;
+
+  /**
+   * Add zebra striping to table rows. Defaults to false
+   */
+  hasZebraStriping?: boolean;
+
+  /**
+   * Toggle whether the last column is always visible. Defaults to false
+   */
+  lastColumnSticky?: boolean;
+};
 
 /**
  * Renders a table of records from the backend automatically for a given model using Polaris
+ * @example
+ * ```tsx
+ * <AutoTable model={api.user} />
+ * ```
+ * @param props.model - The Gadget model to show in the table
  */
 export const PolarisAutoTable = <
   GivenOptions extends OptionsType,

--- a/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
+++ b/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
@@ -4,53 +4,56 @@ import React, { useCallback, useMemo, useState, type ReactNode } from "react";
 
 export interface EnumOption {
   /**
-   * The label for the option
+   * Label for the option.
    */
   label: string;
   /**
-   * The value for the option
+   * Value for the option.
    */
   value: string;
 }
 
+/** Base props for a combobox with fixed options. */
 type BaseComboboxProps = Omit<AutocompleteProps, "selected" | "onSelect" | "textField"> & {
   /**
-   * The label for the combobox
+   * Label for the combobox.
    */
   label?: ReactNode;
 
   /**
-   * The selectable options in the combobox
+   * Selectable options in the combobox.
    */
   options: EnumOption[];
 };
 
+/** Props for a single-selection combobox. */
 export type PolarisFixedOptionsSingleComboboxProps = BaseComboboxProps & {
   /**
-   * The selected value
+   * Selected value.
    */
   value?: string;
   /**
-   * Called with the new selected value on value change
+   * Called with the new selected value on value change.
    */
   onChange: (value: string) => void;
   /**
-   * Indicates that the combobox does not allow multiple selections
+   * Disables mutiple selections.
    */
   allowMultiple?: false;
 };
 
+/** Props for a multi-selection combobox. */
 export type PolarisFixedOptionsMultiComboboxProps = BaseComboboxProps & {
   /**
-   * The selected values
+   * Selected value.
    */
   value?: string[];
   /**
-   * Called with the new selected values on value change
+   * Called with the new selected values on value change.
    */
   onChange: (value: string[]) => void;
   /**
-   * Indicates that the combobox allows multiple selections
+   * Disables mutiple selections.
    */
   allowMultiple: true;
 };

--- a/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
+++ b/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
@@ -3,24 +3,55 @@ import { Autocomplete, InlineStack, Tag } from "@shopify/polaris";
 import React, { useCallback, useMemo, useState, type ReactNode } from "react";
 
 export interface EnumOption {
+  /**
+   * The label for the option
+   */
   label: string;
+  /**
+   * The value for the option
+   */
   value: string;
 }
 
 type BaseComboboxProps = Omit<AutocompleteProps, "selected" | "onSelect" | "textField"> & {
+  /**
+   * The label for the combobox
+   */
   label?: ReactNode;
+
+  /**
+   * The selectable options in the combobox
+   */
   options: EnumOption[];
 };
 
 export type PolarisFixedOptionsSingleComboboxProps = BaseComboboxProps & {
+  /**
+   * The selected value
+   */
   value?: string;
+  /**
+   * Called with the new selected value on value change
+   */
   onChange: (value: string) => void;
+  /**
+   * Indicates that the combobox does not allow multiple selections
+   */
   allowMultiple?: false;
 };
 
 export type PolarisFixedOptionsMultiComboboxProps = BaseComboboxProps & {
+  /**
+   * The selected values
+   */
   value?: string[];
+  /**
+   * Called with the new selected values on value change
+   */
   onChange: (value: string[]) => void;
+  /**
+   * Indicates that the combobox allows multiple selections
+   */
   allowMultiple: true;
 };
 

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -21,9 +21,9 @@ export { PolarisAutoNumberInput as AutoNumberInput } from "./inputs/PolarisAutoN
 export { PolarisAutoPasswordInput as AutoPasswordInput } from "./inputs/PolarisAutoPasswordInput.js";
 export { PolarisAutoRolesInput as AutoRolesInput } from "./inputs/PolarisAutoRolesInput.js";
 export {
-  PolarisAutoTextInput as AutoEmailInput,
-  PolarisAutoTextInput as AutoStringInput,
-  PolarisAutoTextInput as AutoUrlInput,
+  PolarisAutoEmailInput as AutoEmailInput,
+  PolarisAutoStringInput as AutoStringInput,
+  PolarisAutoUrlInput as AutoUrlInput,
 } from "./inputs/PolarisAutoTextInput.js";
 export { PolarisAutoBelongsToForm as AutoBelongsToForm } from "./inputs/relationships/PolarisAutoBelongsToForm.js";
 export { PolarisAutoBelongsToInput as AutoBelongsToInput } from "./inputs/relationships/PolarisAutoBelongsToInput.js";

--- a/packages/react/src/auto/polaris/inputs/LazyLoadedPolarisAutoRichTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/LazyLoadedPolarisAutoRichTextInput.tsx
@@ -4,6 +4,19 @@ import type { AutoRichTextInputProps } from "../../shared/AutoRichTextInputProps
 
 const LazyLoadedPolarisAutoRichTextInput = React.lazy(() => import("./PolarisAutoRichTextInput.js"));
 
+/**
+ * A rich text input component for use within <AutoForm></AutoForm> components.
+ * Requires `"@mdxeditor/editor"` as a peer dependency to be rendered
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoRichTextInput field="richTextField" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The RichText field API identifier
+ * @param props.label - The label of the RichText input component
+ * @returns The rich text input component
+ */
 export const PolarisAutoRichTextInput = autoInput((props: AutoRichTextInputProps) => {
   return (
     <>

--- a/packages/react/src/auto/polaris/inputs/LazyLoadedPolarisAutoRichTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/LazyLoadedPolarisAutoRichTextInput.tsx
@@ -5,7 +5,7 @@ import type { AutoRichTextInputProps } from "../../shared/AutoRichTextInputProps
 const LazyLoadedPolarisAutoRichTextInput = React.lazy(() => import("./PolarisAutoRichTextInput.js"));
 
 /**
- * A rich text input component for use within <AutoForm></AutoForm> components.
+ * A rich text input component for use within <AutoForm></AutoForm>
  * Requires `"@mdxeditor/editor"` as a peer dependency to be rendered
  * @example
  * ```tsx
@@ -13,9 +13,9 @@ const LazyLoadedPolarisAutoRichTextInput = React.lazy(() => import("./PolarisAut
  *   <AutoRichTextInput field="richTextField" />
  * </AutoForm>
  * ```
- * @param props.field - The RichText field API identifier
- * @param props.label - The label of the RichText input component
- * @returns The rich text input component
+ * @param props.field - The API identifier of the RichText field.
+ * @param props.label - Label of the RichText input.
+ * @returns The AutoRichTextInput component.
  */
 export const PolarisAutoRichTextInput = autoInput((props: AutoRichTextInputProps) => {
   return (

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoBooleanInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoBooleanInput.tsx
@@ -2,10 +2,24 @@ import type { CheckboxProps } from "@shopify/polaris";
 import { Checkbox } from "@shopify/polaris";
 import React from "react";
 import { useBooleanInputController } from "../../../auto/hooks/useBooleanInputController.js";
-import type { Control } from "../../../useActionForm.js";
 import { autoInput } from "../../AutoInput.js";
+import { type AutoBooleanInputProps } from "../../shared/AutoInputTypes.js";
 
-export const PolarisAutoBooleanInput = autoInput((props: { field: string; control?: Control<any> } & Partial<CheckboxProps>) => {
+export type PolarisAutoBooleanInputProps = AutoBooleanInputProps & Partial<CheckboxProps>;
+
+/**
+ * A checkbox input that is controlled by react-hook-form
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoBooleanInput field="isActive" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The API identifier of the Boolean field
+ * @param props.label - The label of the checkbox
+ * @returns The checkbox input component
+ */
+export const PolarisAutoBooleanInput = autoInput((props: PolarisAutoBooleanInputProps) => {
   const { field: _field, control: _control, ...rest } = props;
   const { error, fieldProps, metadata } = useBooleanInputController(props);
 

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoBooleanInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoBooleanInput.tsx
@@ -8,16 +8,16 @@ import { type AutoBooleanInputProps } from "../../shared/AutoInputTypes.js";
 export type PolarisAutoBooleanInputProps = AutoBooleanInputProps & Partial<CheckboxProps>;
 
 /**
- * A checkbox input that is controlled by react-hook-form
+ * A boolean checkbox within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoBooleanInput field="isActive" />
  * </AutoForm>
  * ```
- * @param props.field - The API identifier of the Boolean field
- * @param props.label - The label of the checkbox
- * @returns The checkbox input component
+ * @param props.field - The API identifier of the Boolean field.
+ * @param props.label - Label of the Boolean checkbox.
+ * @returns The AutoBooleanInput component.
  */
 export const PolarisAutoBooleanInput = autoInput((props: PolarisAutoBooleanInputProps) => {
   const { field: _field, control: _control, ...rest } = props;

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -18,25 +18,25 @@ import PolarisAutoTimePicker from "./PolarisAutoTimePicker.js";
 
 export interface PolarisAutoDateTimePickerProps extends AutoDateTimeInputProps {
   /**
-   * The HTML ID of the DateTime field
+   * The HTML ID of the DateTime field.
    */
   id?: string;
   /**
-   * Indicates if the time popover should be hidden
+   * Hides the time popover.
    */
   hideTimePopover?: boolean;
   /**
-   * Props to pass to the Polaris DatePicker component
+   * Additional Polaris DatePicker props.
    */
   datePickerProps?: Partial<DatePickerProps>;
   /**
-   * Props to pass to the Polaris TimePicker component
+   * Additional Polaris TimePicker props.
    */
   timePickerProps?: Partial<TextFieldProps>;
 }
 
 /**
- * A date and time picker for use within <AutoForm></AutoForm> components.
+ * A date and time picker within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
@@ -44,12 +44,12 @@ export interface PolarisAutoDateTimePickerProps extends AutoDateTimeInputProps {
  * </AutoForm>
  * ```
  * @param props.field - The API identifier of the DateTime field.
- * @param props.label - The label of the date and time picker.
- * @param props.includeTime - Indicates if the the time picker component should be shown. Defaults to the value of the includeTime field metadata configuration.
- * @param props.hideTimePopover - Indicates if the time popover should be hidden.
- * @param props.datePickerProps - Additional props passed to the Polaris DatePicker component.
- * @param props.timePickerProps - Additional props passed to the Polaris TimePicker component.
- * @returns The date and time picker component.
+ * @param props.label - Label of the DateTime picker.
+ * @param props.includeTime - Show the time picker component. Defaults to the metadata config.
+ * @param props.hideTimePopover - Hide the time popover.
+ * @param props.datePickerProps - Additional Polaris DatePicker props.
+ * @param props.timePickerProps - Additional Polaris TimePicker props.
+ * @returns The AutoDateTimePicker component.
  */
 export const PolarisAutoDateTimePicker = autoInput((props: PolarisAutoDateTimePickerProps) => {
   const { localTz, localTime, onChange, value, fieldProps, metadata, fieldState } = useDateTimeField({

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -22,10 +22,6 @@ export interface PolarisAutoDateTimePickerProps extends AutoDateTimeInputProps {
    */
   id?: string;
   /**
-   * Indicates if the Gadget DateTime field includes a time component
-   */
-  includeTime?: boolean;
-  /**
    * Indicates if the time popover should be hidden
    */
   hideTimePopover?: boolean;

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -1,7 +1,6 @@
 import type { DatePickerProps, TextFieldProps } from "@shopify/polaris";
 import { DatePicker, Icon, InlineStack, Popover, TextField } from "@shopify/polaris";
 import { CalendarIcon } from "@shopify/polaris-icons";
-import type { ReactNode } from "react";
 import React, { useCallback, useState } from "react";
 import {
   copyTime,
@@ -14,108 +13,135 @@ import {
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
 import { autoInput } from "../../AutoInput.js";
 import { useDateTimeField } from "../../hooks/useDateTimeField.js";
+import type { AutoDateTimeInputProps } from "../../shared/AutoInputTypes.js";
 import PolarisAutoTimePicker from "./PolarisAutoTimePicker.js";
 
-export const PolarisAutoDateTimePicker = autoInput(
-  (props: {
-    field: string;
-    id?: string;
-    value?: Date;
-    onChange?: (value?: Date) => void;
-    error?: string;
-    includeTime?: boolean;
-    hideTimePopover?: boolean;
-    label?: ReactNode;
-    datePickerProps?: Partial<DatePickerProps>;
-    timePickerProps?: Partial<TextFieldProps>;
-  }) => {
-    const { localTz, localTime, onChange, value, fieldProps, metadata, fieldState } = useDateTimeField({
-      field: props.field,
-      value: props.value,
-      onChange: props?.onChange,
-    });
+export interface PolarisAutoDateTimePickerProps extends AutoDateTimeInputProps {
+  /**
+   * The HTML ID of the DateTime field
+   */
+  id?: string;
+  /**
+   * Indicates if the Gadget DateTime field includes a time component
+   */
+  includeTime?: boolean;
+  /**
+   * Indicates if the time popover should be hidden
+   */
+  hideTimePopover?: boolean;
+  /**
+   * Props to pass to the Polaris DatePicker component
+   */
+  datePickerProps?: Partial<DatePickerProps>;
+  /**
+   * Props to pass to the Polaris TimePicker component
+   */
+  timePickerProps?: Partial<TextFieldProps>;
+}
 
-    const [datePopoverActive, setDatePopoverActive] = useState(false);
+/**
+ * A date and time picker for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoDateTimePicker field="dueDate" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The API identifier of the DateTime field.
+ * @param props.label - The label of the date and time picker.
+ * @param props.includeTime - Indicates if the the time picker component should be shown. Defaults to the value of the includeTime field metadata configuration.
+ * @param props.hideTimePopover - Indicates if the time popover should be hidden.
+ * @param props.datePickerProps - Additional props passed to the Polaris DatePicker component.
+ * @param props.timePickerProps - Additional props passed to the Polaris TimePicker component.
+ * @returns The date and time picker component.
+ */
+export const PolarisAutoDateTimePicker = autoInput((props: PolarisAutoDateTimePickerProps) => {
+  const { localTz, localTime, onChange, value, fieldProps, metadata, fieldState } = useDateTimeField({
+    field: props.field,
+    value: props.value,
+    onChange: props?.onChange,
+  });
 
-    const [popoverMonth, setPopoverMonth] = useState(getDateTimeObjectFromDate(localTime ?? utcToZonedTime(new Date(), localTz)).month);
-    const [popoverYear, setPopoverYear] = useState(getDateTimeObjectFromDate(localTime ?? utcToZonedTime(new Date(), localTz)).year);
+  const [datePopoverActive, setDatePopoverActive] = useState(false);
 
-    const config = metadata.configuration;
+  const [popoverMonth, setPopoverMonth] = useState(getDateTimeObjectFromDate(localTime ?? utcToZonedTime(new Date(), localTz)).month);
+  const [popoverYear, setPopoverYear] = useState(getDateTimeObjectFromDate(localTime ?? utcToZonedTime(new Date(), localTz)).year);
 
-    const onDateChange = useCallback<Exclude<DatePickerProps["onChange"], undefined>>(
-      (range) => {
-        (fieldProps || value) && copyTime(range.start, zonedTimeToUtc(range.start, localTz));
-        const dateOverride = value ?? new Date(fieldProps.value);
-        if (isValidDate(dateOverride)) {
-          range.start.setHours(dateOverride.getHours());
-          range.start.setMinutes(dateOverride.getMinutes());
-          range.start.setSeconds(dateOverride.getSeconds());
-          range.start.setMilliseconds(dateOverride.getMilliseconds());
+  const config = metadata.configuration;
+
+  const onDateChange = useCallback<Exclude<DatePickerProps["onChange"], undefined>>(
+    (range) => {
+      (fieldProps || value) && copyTime(range.start, zonedTimeToUtc(range.start, localTz));
+      const dateOverride = value ?? new Date(fieldProps.value);
+      if (isValidDate(dateOverride)) {
+        range.start.setHours(dateOverride.getHours());
+        range.start.setMinutes(dateOverride.getMinutes());
+        range.start.setSeconds(dateOverride.getSeconds());
+        range.start.setMilliseconds(dateOverride.getMilliseconds());
+      }
+      onChange?.(zonedTimeToUtc(range.start, localTz));
+      fieldProps.onChange(zonedTimeToUtc(range.start, localTz));
+      setDatePopoverActive(false);
+    },
+    [fieldProps, value, localTz, onChange]
+  );
+
+  const toggleDatePopoverActive = useCallback(() => {
+    setPopoverMonth(getDateTimeObjectFromDate(isValidDate(localTime) && localTime ? localTime : new Date()).month);
+    setPopoverYear(getDateTimeObjectFromDate(isValidDate(localTime) && localTime ? localTime : new Date()).year);
+    setDatePopoverActive((active) => !active);
+  }, [localTime]);
+
+  const handleMonthChange = useCallback((month: number, year: number) => {
+    setPopoverMonth(month);
+    setPopoverYear(year);
+  }, []);
+
+  return (
+    <InlineStack gap="400">
+      <Popover
+        preferredPosition="above"
+        active={datePopoverActive}
+        activator={
+          <TextField
+            id={props.id ? `${props.id}-date` : undefined}
+            label={props.label ?? metadata.name ?? "Date"}
+            prefix={<Icon source={CalendarIcon} />}
+            autoComplete="off"
+            value={localTime ? formatShortDateString(localTime) : ""}
+            onFocus={toggleDatePopoverActive}
+            requiredIndicator={metadata.requiredArgumentForInput}
+            error={props.error ?? fieldState.error?.message}
+          />
         }
-        onChange?.(zonedTimeToUtc(range.start, localTz));
-        fieldProps.onChange(zonedTimeToUtc(range.start, localTz));
-        setDatePopoverActive(false);
-      },
-      [fieldProps, value, localTz, onChange]
-    );
-
-    const toggleDatePopoverActive = useCallback(() => {
-      setPopoverMonth(getDateTimeObjectFromDate(isValidDate(localTime) && localTime ? localTime : new Date()).month);
-      setPopoverYear(getDateTimeObjectFromDate(isValidDate(localTime) && localTime ? localTime : new Date()).year);
-      setDatePopoverActive((active) => !active);
-    }, [localTime]);
-
-    const handleMonthChange = useCallback((month: number, year: number) => {
-      setPopoverMonth(month);
-      setPopoverYear(year);
-    }, []);
-
-    return (
-      <InlineStack gap="400">
-        <Popover
-          preferredPosition="above"
-          active={datePopoverActive}
-          activator={
-            <TextField
-              id={props.id ? `${props.id}-date` : undefined}
-              label={props.label ?? metadata.name ?? "Date"}
-              prefix={<Icon source={CalendarIcon} />}
-              autoComplete="off"
-              value={localTime ? formatShortDateString(localTime) : ""}
-              onFocus={toggleDatePopoverActive}
-              requiredIndicator={metadata.requiredArgumentForInput}
-              error={props.error ?? fieldState.error?.message}
-            />
-          }
-          onClose={toggleDatePopoverActive}
-        >
-          <div style={{ padding: "16px" }}>
-            <DatePicker
-              month={popoverMonth}
-              year={popoverYear}
-              allowRange={false}
-              onChange={onDateChange}
-              onMonthChange={handleMonthChange}
-              selected={localTime ?? new Date()}
-              {...props.datePickerProps}
-            />
-          </div>
-        </Popover>
-        {(props.includeTime ?? (config as GadgetDateTimeConfig).includeTime) && (
-          <div style={{ width: "130px" }}>
-            <PolarisAutoTimePicker
-              fieldProps={fieldProps}
-              id={props.id}
-              localTime={localTime}
-              onChange={onChange}
-              hideTimePopover={props.hideTimePopover}
-              localTz={localTz}
-              timePickerProps={props.timePickerProps}
-              value={value}
-            />
-          </div>
-        )}
-      </InlineStack>
-    );
-  }
-);
+        onClose={toggleDatePopoverActive}
+      >
+        <div style={{ padding: "16px" }}>
+          <DatePicker
+            month={popoverMonth}
+            year={popoverYear}
+            allowRange={false}
+            onChange={onDateChange}
+            onMonthChange={handleMonthChange}
+            selected={localTime ?? new Date()}
+            {...props.datePickerProps}
+          />
+        </div>
+      </Popover>
+      {(props.includeTime ?? (config as GadgetDateTimeConfig).includeTime) && (
+        <div style={{ width: "130px" }}>
+          <PolarisAutoTimePicker
+            fieldProps={fieldProps}
+            id={props.id}
+            localTime={localTime}
+            onChange={onChange}
+            hideTimePopover={props.hideTimePopover}
+            localTz={localTz}
+            timePickerProps={props.timePickerProps}
+            value={value}
+          />
+        </div>
+      )}
+    </InlineStack>
+  );
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEncryptedStringInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEncryptedStringInput.tsx
@@ -2,31 +2,38 @@ import type { TextFieldProps } from "@shopify/polaris";
 import { Button } from "@shopify/polaris";
 import { HideIcon, ViewIcon } from "@shopify/polaris-icons";
 import React, { useState } from "react";
-import type { Control } from "../../../useActionForm.js";
 import { autoInput } from "../../AutoInput.js";
+import { type AutoEncryptedStringInputProps } from "../../shared/AutoInputTypes.js";
 import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 
-export const PolarisAutoEncryptedStringInput = autoInput(
-  (
-    props: {
-      field: string; // The field API identifier
-      control?: Control<any>;
-    } & Partial<TextFieldProps>
-  ) => {
-    const [isShown, setIsShown] = useState(false);
+export type PolarisAutoEncryptedStringInputProps = AutoEncryptedStringInputProps & Partial<TextFieldProps>;
 
-    const showHideToggleButton = (
-      <div style={{ display: "flex" }}>
-        <Button
-          variant="plain"
-          size="slim"
-          icon={isShown ? HideIcon : ViewIcon}
-          onClick={() => setIsShown(!isShown)}
-          role={`${props.field}ToggleShowHideButton`}
-        />
-      </div>
-    );
+/**
+ * An encrypted string input for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoEncryptedStringInput field="encryptedStringField" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The API identifier for the EncryptedString field.
+ * @param props.label - The label of the EncryptedString field.
+ * @returns The AutoEncryptedStringInput component.
+ */
+export const PolarisAutoEncryptedStringInput = autoInput((props: PolarisAutoEncryptedStringInputProps) => {
+  const [isShown, setIsShown] = useState(false);
 
-    return <PolarisAutoTextInput type={isShown ? "text" : "password"} suffix={showHideToggleButton} {...props} />;
-  }
-);
+  const showHideToggleButton = (
+    <div style={{ display: "flex" }}>
+      <Button
+        variant="plain"
+        size="slim"
+        icon={isShown ? HideIcon : ViewIcon}
+        onClick={() => setIsShown(!isShown)}
+        role={`${props.field}ToggleShowHideButton`}
+      />
+    </div>
+  );
+
+  return <PolarisAutoTextInput type={isShown ? "text" : "password"} suffix={showHideToggleButton} {...props} />;
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEncryptedStringInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEncryptedStringInput.tsx
@@ -9,15 +9,15 @@ import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 export type PolarisAutoEncryptedStringInputProps = AutoEncryptedStringInputProps & Partial<TextFieldProps>;
 
 /**
- * An encrypted string input for use within <AutoForm></AutoForm> components.
+ * An encrypted string input within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoEncryptedStringInput field="encryptedStringField" />
  * </AutoForm>
  * ```
- * @param props.field - The API identifier for the EncryptedString field.
- * @param props.label - The label of the EncryptedString field.
+ * @param props.field - API identifier of the EncryptedString field.
+ * @param props.label - Label of the EncryptedString input.
  * @returns The AutoEncryptedStringInput component.
  */
 export const PolarisAutoEncryptedStringInput = autoInput((props: PolarisAutoEncryptedStringInputProps) => {

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
@@ -8,15 +8,15 @@ import { type AutoEnumInputProps } from "../../shared/AutoInputTypes.js";
 export type PolarisAutoEnumInputProps = AutoEnumInputProps & Partial<Omit<ComboboxProps, "allowMultiple">>;
 
 /**
- * An enum option picker for use within <AutoForm></AutoForm> components.
+ * An enum option picker within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoEnumInput field="enumField" />
  * </AutoForm>
  * ```
- * @param props.field - The API identifier for the Enum field.
- * @param props.label - The label of the input.
+ * @param props.field - The API identifier of the Enum field.
+ * @param props.label - Label of the Enum input.
  * @returns The AutoEnumInput component.
  */
 export const PolarisAutoEnumInput = autoInput((props: PolarisAutoEnumInputProps) => {

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
@@ -1,134 +1,146 @@
 import type { ComboboxProps } from "@shopify/polaris";
 import { AutoSelection, Box, Combobox, InlineStack, Listbox, Tag, Text } from "@shopify/polaris";
-import React, { useCallback, type ReactNode } from "react";
-import type { Control } from "../../../useActionForm.js";
+import React, { useCallback } from "react";
 import { autoInput } from "../../AutoInput.js";
 import { useEnumInputController } from "../../hooks/useEnumInputController.js";
+import { type AutoEnumInputProps } from "../../shared/AutoInputTypes.js";
 
-export const PolarisAutoEnumInput = autoInput(
-  (props: { field: string; control?: Control<any>; label?: ReactNode } & Partial<Omit<ComboboxProps, "allowMultiple">>) => {
-    const { field: fieldApiIdentifier, control, label: labelProp, ...comboboxProps } = props;
-    const {
-      allowMultiple,
-      allowOther,
-      onSelectionChange,
-      selectedOptions,
-      allOptions,
-      filteredOptions,
-      searchQuery,
-      label,
-      metadata,
-      isError,
-      errorMessage,
-    } = useEnumInputController({ field: fieldApiIdentifier, control });
-    const { value: searchValue, setValue: setSearchValue } = searchQuery;
+export type PolarisAutoEnumInputProps = AutoEnumInputProps & Partial<Omit<ComboboxProps, "allowMultiple">>;
 
-    let selectedTagsElement = null;
-    if (selectedOptions.length > 0) {
-      selectedTagsElement = (
-        <InlineStack gap="150">
-          {selectedOptions.map((tag) => (
-            <Tag key={`option-${tag}`} onRemove={() => onSelectionChange(tag)}>
-              {tag}
-            </Tag>
-          ))}
-        </InlineStack>
-      );
-    }
+/**
+ * An enum option picker for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoEnumInput field="enumField" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The API identifier for the Enum field.
+ * @param props.label - The label of the input.
+ * @returns The AutoEnumInput component.
+ */
+export const PolarisAutoEnumInput = autoInput((props: PolarisAutoEnumInputProps) => {
+  const { field: fieldApiIdentifier, control, label: labelProp, ...comboboxProps } = props;
+  const {
+    allowMultiple,
+    allowOther,
+    onSelectionChange,
+    selectedOptions,
+    allOptions,
+    filteredOptions,
+    searchQuery,
+    label,
+    metadata,
+    isError,
+    errorMessage,
+  } = useEnumInputController({ field: fieldApiIdentifier, control });
+  const { value: searchValue, setValue: setSearchValue } = searchQuery;
 
-    const formatOptionText = useCallback(
-      (option: string) => {
-        const trimValue = searchValue.trim().toLocaleLowerCase();
-        const matchIndex = option.toLocaleLowerCase().indexOf(trimValue);
-
-        if (!searchValue || matchIndex === -1) return option;
-
-        const start = option.slice(0, matchIndex);
-        const highlight = option.slice(matchIndex, matchIndex + trimValue.length);
-        const end = option.slice(matchIndex + trimValue.length, option.length);
-
-        return (
-          <p>
-            {start}
-            <Text fontWeight="bold" as="span">
-              {highlight}
-            </Text>
-            {end}
-          </p>
-        );
-      },
-      [searchValue]
-    );
-
-    let optionItemElement = null;
-    if (allOptions.length > 0) {
-      optionItemElement = filteredOptions.map((option) => {
-        return (
-          <Listbox.Option key={option} value={option} selected={selectedOptions.includes(option)} accessibilityLabel={option}>
-            <Listbox.TextOption selected={selectedOptions.includes(option)}>{formatOptionText(option)}</Listbox.TextOption>
-          </Listbox.Option>
-        );
-      });
-    }
-
-    let addExtraOptionElement = null;
-    if (allowOther && searchValue && !allOptions.includes(searchValue) && searchValue.trim().length > 0) {
-      addExtraOptionElement = <Listbox.Action value={searchValue}>{`Add "${searchValue}"`}</Listbox.Action>;
-    }
-
-    let emptyStateElement = null;
-    if (!allowOther && (!optionItemElement || optionItemElement.length === 0) && searchValue) {
-      emptyStateElement = (
-        <Box padding="100">
-          <Text as="span" alignment="center" tone="subdued">{`No options found matching "${searchValue}"`}</Text>
-        </Box>
-      );
-    }
-
-    let listBoxElement = null;
-    if (optionItemElement || addExtraOptionElement || emptyStateElement) {
-      listBoxElement = (
-        <Listbox
-          autoSelection={AutoSelection.None}
-          onSelect={(selected) => {
-            onSelectionChange(selected);
-            if (allowMultiple) {
-              setSearchValue("");
-            }
-          }}
-        >
-          {emptyStateElement}
-          {addExtraOptionElement}
-          {optionItemElement}
-        </Listbox>
-      );
-    }
-
-    const inputLabel = (
-      <>
-        {labelProp ?? label} {metadata.requiredArgumentForInput ? <span style={{ color: "var(--p-color-text-critical)" }}>*</span> : null}
-      </>
-    );
-
-    return (
-      <Combobox
-        allowMultiple={allowMultiple}
-        activator={
-          <Combobox.TextField
-            autoComplete="off"
-            label={inputLabel}
-            value={searchValue}
-            placeholder="Search"
-            verticalContent={selectedTagsElement}
-            onChange={setSearchValue}
-            id={`${props.field}-combobox-textfield`}
-            error={errorMessage}
-          />
-        }
-        {...comboboxProps}
-      >
-        {listBoxElement}
-      </Combobox>
+  let selectedTagsElement = null;
+  if (selectedOptions.length > 0) {
+    selectedTagsElement = (
+      <InlineStack gap="150">
+        {selectedOptions.map((tag) => (
+          <Tag key={`option-${tag}`} onRemove={() => onSelectionChange(tag)}>
+            {tag}
+          </Tag>
+        ))}
+      </InlineStack>
     );
   }
-);
+
+  const formatOptionText = useCallback(
+    (option: string) => {
+      const trimValue = searchValue.trim().toLocaleLowerCase();
+      const matchIndex = option.toLocaleLowerCase().indexOf(trimValue);
+
+      if (!searchValue || matchIndex === -1) return option;
+
+      const start = option.slice(0, matchIndex);
+      const highlight = option.slice(matchIndex, matchIndex + trimValue.length);
+      const end = option.slice(matchIndex + trimValue.length, option.length);
+
+      return (
+        <p>
+          {start}
+          <Text fontWeight="bold" as="span">
+            {highlight}
+          </Text>
+          {end}
+        </p>
+      );
+    },
+    [searchValue]
+  );
+
+  let optionItemElement = null;
+  if (allOptions.length > 0) {
+    optionItemElement = filteredOptions.map((option) => {
+      return (
+        <Listbox.Option key={option} value={option} selected={selectedOptions.includes(option)} accessibilityLabel={option}>
+          <Listbox.TextOption selected={selectedOptions.includes(option)}>{formatOptionText(option)}</Listbox.TextOption>
+        </Listbox.Option>
+      );
+    });
+  }
+
+  let addExtraOptionElement = null;
+  if (allowOther && searchValue && !allOptions.includes(searchValue) && searchValue.trim().length > 0) {
+    addExtraOptionElement = <Listbox.Action value={searchValue}>{`Add "${searchValue}"`}</Listbox.Action>;
+  }
+
+  let emptyStateElement = null;
+  if (!allowOther && (!optionItemElement || optionItemElement.length === 0) && searchValue) {
+    emptyStateElement = (
+      <Box padding="100">
+        <Text as="span" alignment="center" tone="subdued">{`No options found matching "${searchValue}"`}</Text>
+      </Box>
+    );
+  }
+
+  let listBoxElement = null;
+  if (optionItemElement || addExtraOptionElement || emptyStateElement) {
+    listBoxElement = (
+      <Listbox
+        autoSelection={AutoSelection.None}
+        onSelect={(selected) => {
+          onSelectionChange(selected);
+          if (allowMultiple) {
+            setSearchValue("");
+          }
+        }}
+      >
+        {emptyStateElement}
+        {addExtraOptionElement}
+        {optionItemElement}
+      </Listbox>
+    );
+  }
+
+  const inputLabel = (
+    <>
+      {labelProp ?? label} {metadata.requiredArgumentForInput ? <span style={{ color: "var(--p-color-text-critical)" }}>*</span> : null}
+    </>
+  );
+
+  return (
+    <Combobox
+      allowMultiple={allowMultiple}
+      activator={
+        <Combobox.TextField
+          autoComplete="off"
+          label={inputLabel}
+          value={searchValue}
+          placeholder="Search"
+          verticalContent={selectedTagsElement}
+          onChange={setSearchValue}
+          id={`${props.field}-combobox-textfield`}
+          error={errorMessage}
+        />
+      }
+      {...comboboxProps}
+    >
+      {listBoxElement}
+    </Combobox>
+  );
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
@@ -2,12 +2,27 @@ import type { DropZoneProps } from "@shopify/polaris";
 import { Box, Button, DropZone, InlineError, InlineStack, Thumbnail } from "@shopify/polaris";
 import { DeleteIcon, NoteIcon } from "@shopify/polaris-icons";
 import React, { useMemo } from "react";
-import type { Control } from "../../../useActionForm.js";
 import { isAutoFileFieldValue } from "../../../validationSchema.js";
 import { autoInput } from "../../AutoInput.js";
 import { imageFileTypes, useFileInputController } from "../../hooks/useFileInputController.js";
+import { type AutoFileInputProps } from "../../shared/AutoInputTypes.js";
 
-export const PolarisAutoFileInput = autoInput((props: { field: string; control?: Control<any> } & Omit<DropZoneProps, "allowMultiple">) => {
+export type PolarisAutoFileInputProps = AutoFileInputProps & Omit<DropZoneProps, "allowMultiple">;
+
+/**
+ * A file input for use within <AutoForm></AutoForm> components
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoFileInput field="fileField" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The API identifier of the File field
+ * @param props.label - The label of the File field
+ * @param props.onChange - called when the file input changes
+ * @returns The file input component
+ */
+export const PolarisAutoFileInput = autoInput((props: PolarisAutoFileInputProps) => {
   const { field: fieldApiIdentifier, control, ...rest } = props;
 
   const {

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
@@ -10,17 +10,17 @@ import { type AutoFileInputProps } from "../../shared/AutoInputTypes.js";
 export type PolarisAutoFileInputProps = AutoFileInputProps & Omit<DropZoneProps, "allowMultiple">;
 
 /**
- * A file input for use within <AutoForm></AutoForm> components
+ * A file input within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoFileInput field="fileField" />
  * </AutoForm>
  * ```
- * @param props.field - The API identifier of the File field
- * @param props.label - The label of the File field
- * @param props.onChange - called when the file input changes
- * @returns The file input component
+ * @param props.field - The API identifier of the File field.
+ * @param props.label - Label of the File input.
+ * @param props.onChange - Called when the file input changes.
+ * @returns The AutoFileInput component.
  */
 export const PolarisAutoFileInput = autoInput((props: PolarisAutoFileInputProps) => {
   const { field: fieldApiIdentifier, control, ...rest } = props;

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoHiddenInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoHiddenInput.tsx
@@ -4,16 +4,16 @@ import { useHiddenInput } from "../../hooks/useHiddenInput.js";
 import { type AutoHiddenInputProps } from "../../shared/AutoInputTypes.js";
 
 /**
- * A hidden input for use within <AutoForm></AutoForm> components. The value is included in form submission without rendering a visible input.
+ * A hidden input within AutoForm. The value is included in form submission without rendering an input.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoHiddenInput field="fieldA" value="Value included in submission for fieldA" />
  * </AutoForm>
  * ```
- * @param props.field - The field API identifier
- * @param props.value - The value to be included in form submission
- * @returns The hidden input component
+ * @param props.field - The API identifier of field.
+ * @param props.value - The value included in form submission.
+ * @returns The AutoHiddenInput component.
  */
 export const PolarisAutoHiddenInput = autoInput((props: AutoHiddenInputProps) => {
   const fieldProps = useHiddenInput(props);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoHiddenInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoHiddenInput.tsx
@@ -1,14 +1,22 @@
 import React from "react";
 import { autoInput } from "../../AutoInput.js";
 import { useHiddenInput } from "../../hooks/useHiddenInput.js";
+import { type AutoHiddenInputProps } from "../../shared/AutoInputTypes.js";
 
-export const PolarisAutoHiddenInput = autoInput(
-  (props: {
-    field: string; // The field API identifier
-    value: any;
-  }) => {
-    const fieldProps = useHiddenInput(props);
+/**
+ * A hidden input for use within <AutoForm></AutoForm> components. The value is included in form submission without rendering a visible input.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoHiddenInput field="fieldA" value="Value included in submission for fieldA" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The field API identifier
+ * @param props.value - The value to be included in form submission
+ * @returns The hidden input component
+ */
+export const PolarisAutoHiddenInput = autoInput((props: AutoHiddenInputProps) => {
+  const fieldProps = useHiddenInput(props);
 
-    return <input type="hidden" {...fieldProps} />;
-  }
-);
+  return <input type="hidden" {...fieldProps} />;
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoIdInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoIdInput.tsx
@@ -1,21 +1,29 @@
-import React, { type ReactNode } from "react";
+import React from "react";
 import { FieldType } from "../../../metadata.js";
 import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { type AutoIdInputProps } from "../../shared/AutoInputTypes.js";
 import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 
-export const PolarisAutoIdInput = autoInput(
-  (props: {
-    field: string; // The field API identifier
-    label?: ReactNode;
-  }) => {
-    const { field, label } = props;
-    const { name, metadata } = useStringInputController({ field });
+/**
+ * An id input component for use within <AutoForm></AutoForm> components
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoIdInput field="id" />
+ * </AutoForm>
+ * ```
+ * @param props.field The API identifier of the Id field
+ * @param props.label The label of the Id field
+ * @returns The id input component
+ */
+export const PolarisAutoIdInput = autoInput((props: AutoIdInputProps) => {
+  const { field, label } = props;
+  const { name, metadata } = useStringInputController({ field });
 
-    if (metadata.fieldType !== FieldType.Id || field !== "id") {
-      throw new Error(`PolarisAutoIdInput: field ${field} is not of type Id`);
-    }
-
-    return <PolarisAutoTextInput step={1} field={field} min={1} type="number" label={label || "ID"} name={name} />;
+  if (metadata.fieldType !== FieldType.Id || field !== "id") {
+    throw new Error(`PolarisAutoIdInput: field ${field} is not of type Id`);
   }
-);
+
+  return <PolarisAutoTextInput step={1} field={field} min={1} type="number" label={label || "ID"} name={name} />;
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoIdInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoIdInput.tsx
@@ -6,16 +6,16 @@ import { type AutoIdInputProps } from "../../shared/AutoInputTypes.js";
 import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 
 /**
- * An id input component for use within <AutoForm></AutoForm> components
+ * An id input within Autoform
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoIdInput field="id" />
  * </AutoForm>
  * ```
- * @param props.field The API identifier of the Id field
- * @param props.label The label of the Id field
- * @returns The id input component
+ * @param props.field - The API identifier of the Id field.
+ * @param props.label - Label of the Id input.
+ * @returns The AutoIdInput component
  */
 export const PolarisAutoIdInput = autoInput((props: AutoIdInputProps) => {
   const { field, label } = props;

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
@@ -1,7 +1,8 @@
-import React, { type ReactNode } from "react";
+import React from "react";
 import { FieldType } from "../../../metadata.js";
 import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
+import { type AutoInputProps } from "../../shared/AutoInputTypes.js";
 import { PolarisAutoRichTextInput } from "./LazyLoadedPolarisAutoRichTextInput.js";
 import { PolarisAutoBooleanInput } from "./PolarisAutoBooleanInput.js";
 import { PolarisAutoDateTimePicker } from "./PolarisAutoDateTimePicker.js";
@@ -19,75 +20,82 @@ import { PolarisAutoHasManyInput } from "./relationships/PolarisAutoHasManyInput
 import { PolarisAutoHasManyThroughInput } from "./relationships/PolarisAutoHasManyThroughInput.js";
 import { PolarisAutoHasOneInput } from "./relationships/PolarisAutoHasOneInput.js";
 
-export const PolarisAutoInput = autoInput(
-  (props: {
-    /** The field API identifier this auto input should render for */
-    field: string;
-    /** The label this auto input should use to identify the input to the user */
-    label?: ReactNode;
-  }) => {
-    const { metadata } = useFieldMetadata(props.field);
-    const config = metadata.configuration;
+/**
+ * An automatically generated input component based on the given field's type for use within <AutoForm></AutoForm> components
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoInput field="stringField" />
+ *   <AutoInput field="booleanField" />
+ *   <AutoInput field="numberField" label="Count" />
+ * </AutoForm>
+ * ```
+ * @param props.field The API identifier of the field
+ * @param props.label The label of the field
+ * @returns The input component
+ */
+export const PolarisAutoInput = autoInput((props: AutoInputProps) => {
+  const { metadata } = useFieldMetadata(props.field);
+  const config = metadata.configuration;
 
-    switch (config.fieldType) {
-      case FieldType.Id: {
-        return <PolarisAutoIdInput field={props.field} label={props.label} />;
-      }
-      case FieldType.String:
-      case FieldType.Email:
-      case FieldType.Color:
-      case FieldType.Url: {
-        return <PolarisAutoTextInput field={props.field} label={props.label} />;
-      }
-      case FieldType.Number: {
-        return <PolarisAutoNumberInput field={props.field} label={props.label} />;
-      }
-      case FieldType.EncryptedString: {
-        return <PolarisAutoEncryptedStringInput field={props.field} label={props.label} />;
-      }
-      case FieldType.Password: {
-        return <PolarisAutoPasswordInput field={props.field} label={props.label} />;
-      }
-      case FieldType.Boolean: {
-        return <PolarisAutoBooleanInput field={props.field} label={props.label} />;
-      }
-      case FieldType.DateTime: {
-        return <PolarisAutoDateTimePicker field={props.field} label={props.label} />;
-      }
-      case FieldType.Json: {
-        return <PolarisAutoJSONInput field={props.field} label={props.label} />;
-      }
-      case FieldType.Enum: {
-        return <PolarisAutoEnumInput field={props.field} label={props.label} />;
-      }
-      case FieldType.File: {
-        return <PolarisAutoFileInput field={props.field} label={props.label} />;
-      }
-      case FieldType.RoleAssignments: {
-        return <PolarisAutoRolesInput field={props.field} label={props.label} />;
-      }
-      case FieldType.BelongsTo: {
-        return <PolarisAutoBelongsToInput field={props.field} label={props.label} />;
-      }
-      case FieldType.HasOne: {
-        return <PolarisAutoHasOneInput field={props.field} label={props.label} />;
-      }
-      case FieldType.HasMany: {
-        return <PolarisAutoHasManyInput field={props.field} label={props.label} />;
-      }
-      case FieldType.HasManyThrough: {
-        return <PolarisAutoHasManyThroughInput field={props.field} label={props.label} />;
-      }
-      case FieldType.RichText: {
-        return <PolarisAutoRichTextInput field={props.field} label={props.label} />;
-      }
-
-      // Not rendered as an input
-      case FieldType.Money:
-      case FieldType.Vector:
-      case FieldType.Computed:
-      default:
-        return null;
+  switch (config.fieldType) {
+    case FieldType.Id: {
+      return <PolarisAutoIdInput field={props.field} label={props.label} />;
     }
+    case FieldType.String:
+    case FieldType.Email:
+    case FieldType.Color:
+    case FieldType.Url: {
+      return <PolarisAutoTextInput field={props.field} label={props.label} />;
+    }
+    case FieldType.Number: {
+      return <PolarisAutoNumberInput field={props.field} label={props.label} />;
+    }
+    case FieldType.EncryptedString: {
+      return <PolarisAutoEncryptedStringInput field={props.field} label={props.label} />;
+    }
+    case FieldType.Password: {
+      return <PolarisAutoPasswordInput field={props.field} label={props.label} />;
+    }
+    case FieldType.Boolean: {
+      return <PolarisAutoBooleanInput field={props.field} label={props.label} />;
+    }
+    case FieldType.DateTime: {
+      return <PolarisAutoDateTimePicker field={props.field} label={props.label} />;
+    }
+    case FieldType.Json: {
+      return <PolarisAutoJSONInput field={props.field} label={props.label} />;
+    }
+    case FieldType.Enum: {
+      return <PolarisAutoEnumInput field={props.field} label={props.label} />;
+    }
+    case FieldType.File: {
+      return <PolarisAutoFileInput field={props.field} label={props.label} />;
+    }
+    case FieldType.RoleAssignments: {
+      return <PolarisAutoRolesInput field={props.field} label={props.label} />;
+    }
+    case FieldType.BelongsTo: {
+      return <PolarisAutoBelongsToInput field={props.field} label={props.label} />;
+    }
+    case FieldType.HasOne: {
+      return <PolarisAutoHasOneInput field={props.field} label={props.label} />;
+    }
+    case FieldType.HasMany: {
+      return <PolarisAutoHasManyInput field={props.field} label={props.label} />;
+    }
+    case FieldType.HasManyThrough: {
+      return <PolarisAutoHasManyThroughInput field={props.field} label={props.label} />;
+    }
+    case FieldType.RichText: {
+      return <PolarisAutoRichTextInput field={props.field} label={props.label} />;
+    }
+
+    // Not rendered as an input
+    case FieldType.Money:
+    case FieldType.Vector:
+    case FieldType.Computed:
+    default:
+      return null;
   }
-);
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
@@ -21,7 +21,7 @@ import { PolarisAutoHasManyThroughInput } from "./relationships/PolarisAutoHasMa
 import { PolarisAutoHasOneInput } from "./relationships/PolarisAutoHasOneInput.js";
 
 /**
- * An automatically generated input component based on the given field's type for use within <AutoForm></AutoForm> components
+ * An auto-generated input based on the given field types used within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
@@ -30,9 +30,9 @@ import { PolarisAutoHasOneInput } from "./relationships/PolarisAutoHasOneInput.j
  *   <AutoInput field="numberField" label="Count" />
  * </AutoForm>
  * ```
- * @param props.field The API identifier of the field
- * @param props.label The label of the field
- * @returns The input component
+ * @param props.field - The API identifier of the field.
+ * @param props.label - Label of the component.
+ * @returns The AutoInput component.
  */
 export const PolarisAutoInput = autoInput((props: AutoInputProps) => {
   const { metadata } = useFieldMetadata(props.field);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
@@ -10,16 +10,16 @@ import { type AutoJSONInputProps } from "../../shared/AutoInputTypes.js";
 type PolarisAutoJSONInputProps = AutoJSONInputProps & Partial<Omit<TextFieldProps, "onChange">>;
 
 /**
- * JSON field input component for use within <AutoForm></AutoForm> components.
+ * A JSON editor within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoJSONInput field="fieldA" label="Field A" />
  * </AutoForm>
  * ```
- * @param props.field - The JSON field API identifier
- * @param props.label - The label of the JSON input component
- * @returns The JSON input component
+ * @param props.field - The JSON field API identifier.
+ * @param props.label - Label of the JSON editor.
+ * @returns The AutoJSONInput component
  */
 export const PolarisAutoJSONInput = autoInput((props: PolarisAutoJSONInputProps) => {
   const [isFocused, focusProps] = useFocus();

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
@@ -1,37 +1,44 @@
 import type { TextFieldProps } from "@shopify/polaris";
 import { TextField } from "@shopify/polaris";
 import React from "react";
-import type { Control } from "../../../useActionForm.js";
 import { useFocus } from "../../../useFocus.js";
 import { getPropsWithoutRef } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
 import { useJSONInputController } from "../../hooks/useJSONInputController.js";
+import { type AutoJSONInputProps } from "../../shared/AutoInputTypes.js";
 
-export const PolarisAutoJSONInput = autoInput(
-  (
-    props: {
-      field: string; // The field API identifier
-      control?: Control<any>;
-    } & Partial<Omit<TextFieldProps, "onChange">>
-  ) => {
-    const [isFocused, focusProps] = useFocus();
-    const { field: _field, control: _control, ...restOfProps } = props;
-    const { type: _type, errorMessage, ...controller } = useJSONInputController(props);
+type PolarisAutoJSONInputProps = AutoJSONInputProps & Partial<Omit<TextFieldProps, "onChange">>;
 
-    const label = props.label ?? controller.label;
-    return (
-      <>
-        <TextField
-          multiline={4}
-          monospaced
-          requiredIndicator={controller.metadata.requiredArgumentForInput}
-          error={!isFocused && errorMessage && `Invalid JSON: ${errorMessage}`}
-          {...getPropsWithoutRef(controller)}
-          {...getPropsWithoutRef(focusProps)}
-          {...restOfProps}
-          label={label}
-        />
-      </>
-    );
-  }
-);
+/**
+ * JSON field input component for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoJSONInput field="fieldA" label="Field A" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The JSON field API identifier
+ * @param props.label - The label of the JSON input component
+ * @returns The JSON input component
+ */
+export const PolarisAutoJSONInput = autoInput((props: PolarisAutoJSONInputProps) => {
+  const [isFocused, focusProps] = useFocus();
+  const { field: _field, control: _control, ...restOfProps } = props;
+  const { type: _type, errorMessage, ...controller } = useJSONInputController(props);
+
+  const label = props.label ?? controller.label;
+  return (
+    <>
+      <TextField
+        multiline={4}
+        monospaced
+        requiredIndicator={controller.metadata.requiredArgumentForInput}
+        error={!isFocused && errorMessage && `Invalid JSON: ${errorMessage}`}
+        {...getPropsWithoutRef(controller)}
+        {...getPropsWithoutRef(focusProps)}
+        {...restOfProps}
+        label={label}
+      />
+    </>
+  );
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoNumberInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoNumberInput.tsx
@@ -9,16 +9,16 @@ import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 type PolarisAutoNumberInputProps = AutoNumberInputProps & Partial<TextFieldProps>;
 
 /**
- * A number input component for use within <AutoForm></AutoForm> components.
+ * A number input within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoNumberInput field="count" />
  * </AutoForm>
  * ```
- * @param props.field - The number field API identifier
- * @param props.label - The label of the number input component
- * @returns The number input component
+ * @param props.field - The number field API identifier.
+ * @param props.label - Label of the number input.
+ * @returns The AutoNumberInput component
  */
 export const PolarisAutoNumberInput = autoInput((props: PolarisAutoNumberInputProps) => {
   const { field, control } = props;

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoNumberInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoNumberInput.tsx
@@ -1,32 +1,39 @@
 import type { TextFieldProps } from "@shopify/polaris";
 import React from "react";
-import type { Control } from "../../../useActionForm.js";
 import { countNumberOfDecimals, getStepFromNumberOfDecimals } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
+import type { AutoNumberInputProps } from "../../shared/AutoInputTypes.js";
 import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 
-export const PolarisAutoNumberInput = autoInput(
-  (
-    props: {
-      field: string; // The field API identifier
-      control?: Control<any>;
-    } & Partial<TextFieldProps>
-  ) => {
-    const { field, control } = props;
-    const { type, metadata, value } = useStringInputController({ field, control });
-    const fieldType = type as TextFieldProps["type"];
+type PolarisAutoNumberInputProps = AutoNumberInputProps & Partial<TextFieldProps>;
 
-    const step =
-      fieldType === "number" &&
-      metadata.configuration.__typename === "GadgetNumberConfig" &&
-      metadata.configuration.decimals &&
-      metadata.configuration.decimals > 0
-        ? getStepFromNumberOfDecimals(metadata.configuration.decimals)
-        : value
-        ? getStepFromNumberOfDecimals(countNumberOfDecimals(`${value}`))
-        : 1;
+/**
+ * A number input component for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoNumberInput field="count" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The number field API identifier
+ * @param props.label - The label of the number input component
+ * @returns The number input component
+ */
+export const PolarisAutoNumberInput = autoInput((props: PolarisAutoNumberInputProps) => {
+  const { field, control } = props;
+  const { type, metadata, value } = useStringInputController({ field, control });
+  const fieldType = type as TextFieldProps["type"];
 
-    return <PolarisAutoTextInput step={step} {...props} />;
-  }
-);
+  const step =
+    fieldType === "number" &&
+    metadata.configuration.__typename === "GadgetNumberConfig" &&
+    metadata.configuration.decimals &&
+    metadata.configuration.decimals > 0
+      ? getStepFromNumberOfDecimals(metadata.configuration.decimals)
+      : value
+      ? getStepFromNumberOfDecimals(countNumberOfDecimals(`${value}`))
+      : 1;
+
+  return <PolarisAutoTextInput step={step} {...props} />;
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
@@ -10,16 +10,16 @@ import { PolarisAutoEncryptedStringInput } from "./PolarisAutoEncryptedStringInp
 type PolarisAutoPasswordInputProps = AutoPasswordInputProps & Partial<TextFieldProps>;
 
 /**
- * A password input component for use within <AutoForm></AutoForm> components.
+ * A password input within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoPasswordInput field="passwordFieldApiId" />
  * </AutoForm>
  * ```
- * @param props.field - The password field API identifier
- * @param props.label - The label of the password input component
- * @returns The password input component
+ * @param props.field - The password field API identifier.
+ * @param props.label - Label of the password input.
+ * @returns The AutoPasswordInput component.
  */
 export const PolarisAutoPasswordInput = autoInput((props: PolarisAutoPasswordInputProps) => {
   const { isEditing, startEditing } = usePasswordController(props);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
@@ -3,36 +3,43 @@ import { Button } from "@shopify/polaris";
 import { EditIcon } from "@shopify/polaris-icons";
 import React from "react";
 import { existingPasswordPlaceholder, usePasswordController } from "../../../auto/hooks/usePasswordController.js";
-import { type Control } from "../../../useActionForm.js";
 import { autoInput } from "../../AutoInput.js";
+import type { AutoPasswordInputProps } from "../../shared/AutoInputTypes.js";
 import { PolarisAutoEncryptedStringInput } from "./PolarisAutoEncryptedStringInput.js";
 
-export const PolarisAutoPasswordInput = autoInput(
-  (
-    props: {
-      field: string; // The field API identifier
-      control?: Control<any>;
-    } & Partial<TextFieldProps>
-  ) => {
-    const { isEditing, startEditing } = usePasswordController(props);
+type PolarisAutoPasswordInputProps = AutoPasswordInputProps & Partial<TextFieldProps>;
 
-    const startEditingButton = (
-      <div style={{ display: "flex" }}>
-        <Button variant="plain" size="slim" icon={EditIcon} onClick={startEditing} role={`${props.field}EditPasswordButton`} />
-      </div>
-    );
+/**
+ * A password input component for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoPasswordInput field="passwordFieldApiId" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The password field API identifier
+ * @param props.label - The label of the password input component
+ * @returns The password input component
+ */
+export const PolarisAutoPasswordInput = autoInput((props: PolarisAutoPasswordInputProps) => {
+  const { isEditing, startEditing } = usePasswordController(props);
 
-    return (
-      <PolarisAutoEncryptedStringInput
-        {...(isEditing
-          ? { placeholder: "Password" }
-          : {
-              placeholder: existingPasswordPlaceholder,
-              suffix: startEditingButton,
-              disabled: true,
-            })}
-        {...props}
-      />
-    );
-  }
-);
+  const startEditingButton = (
+    <div style={{ display: "flex" }}>
+      <Button variant="plain" size="slim" icon={EditIcon} onClick={startEditing} role={`${props.field}EditPasswordButton`} />
+    </div>
+  );
+
+  return (
+    <PolarisAutoEncryptedStringInput
+      {...(isEditing
+        ? { placeholder: "Password" }
+        : {
+            placeholder: existingPasswordPlaceholder,
+            suffix: startEditingButton,
+            disabled: true,
+          })}
+      {...props}
+    />
+  );
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoRolesInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoRolesInput.tsx
@@ -9,16 +9,16 @@ import { PolarisFixedOptionsCombobox } from "../PolarisFixedOptionsCombobox.js";
 type PolarisAutoRolesInputProps = AutoRolesInputProps & Partial<PolarisFixedOptionsMultiComboboxProps>;
 
 /**
- * A role list input component for use within <AutoForm></AutoForm> components.
+ * A RoleList selector within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoRolesInput field="roles" />
  * </AutoForm>
  * ```
- * @param props.field - The role list field API identifier
- * @param props.label - The label of the role list field
- * @returns The Polaris Auto Roles Input component
+ * @param props.field - The RoleList field API identifier.
+ * @param props.label - Label of the RoleList selector.
+ * @returns The AutoRolesInput component
  */
 export const PolarisAutoRolesInput = autoInput((props: PolarisAutoRolesInputProps) => {
   const { options, loading, rolesError, fieldError, selectedRoleKeys, fieldProps, metadata } = useRoleInputController(props);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoRolesInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoRolesInput.tsx
@@ -1,40 +1,47 @@
 import React from "react";
-import type { Control } from "../../../useActionForm.js";
 import { getPropsWithoutRef } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
 import { useRoleInputController } from "../../hooks/useRoleInputController.js";
+import { type AutoRolesInputProps } from "../../shared/AutoInputTypes.js";
 import type { PolarisFixedOptionsMultiComboboxProps } from "../PolarisFixedOptionsCombobox.js";
 import { PolarisFixedOptionsCombobox } from "../PolarisFixedOptionsCombobox.js";
 
-export const PolarisAutoRolesInput = autoInput(
-  (
-    props: {
-      field: string; // Field API identifier
-      control?: Control<any>;
-    } & Partial<PolarisFixedOptionsMultiComboboxProps>
-  ) => {
-    const { options, loading, rolesError, fieldError, selectedRoleKeys, fieldProps, metadata } = useRoleInputController(props);
+type PolarisAutoRolesInputProps = AutoRolesInputProps & Partial<PolarisFixedOptionsMultiComboboxProps>;
 
-    if (rolesError) {
-      throw rolesError;
-    }
-    if (fieldError) {
-      throw fieldError;
-    }
+/**
+ * A role list input component for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoRolesInput field="roles" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The role list field API identifier
+ * @param props.label - The label of the role list field
+ * @returns The Polaris Auto Roles Input component
+ */
+export const PolarisAutoRolesInput = autoInput((props: PolarisAutoRolesInputProps) => {
+  const { options, loading, rolesError, fieldError, selectedRoleKeys, fieldProps, metadata } = useRoleInputController(props);
 
-    if (loading || !options || options.length === 0) {
-      // Don't render until role options exist. There must always be at least one role option `unauthenticated`
-      return null;
-    }
-
-    return (
-      <PolarisFixedOptionsCombobox
-        options={options}
-        allowMultiple
-        label={props.label ?? metadata.name}
-        {...getPropsWithoutRef(fieldProps)}
-        value={selectedRoleKeys}
-      />
-    );
+  if (rolesError) {
+    throw rolesError;
   }
-);
+  if (fieldError) {
+    throw fieldError;
+  }
+
+  if (loading || !options || options.length === 0) {
+    // Don't render until role options exist. There must always be at least one role option `unauthenticated`
+    return null;
+  }
+
+  return (
+    <PolarisFixedOptionsCombobox
+      options={options}
+      allowMultiple
+      label={props.label ?? metadata.name}
+      {...getPropsWithoutRef(fieldProps)}
+      value={selectedRoleKeys}
+    />
+  );
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
@@ -9,16 +9,16 @@ import { type AutoTextInputProps } from "../../shared/AutoInputTypes.js";
 type PolarisAutoTextInputProps = AutoTextInputProps & Partial<TextFieldProps>;
 
 /**
- * A text input component for string based fields for use within <AutoForm></AutoForm> components.
+ * A text input within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoTextInput field="fieldA" />
  * </AutoForm>
  * ```
- * @param props.field - The field API identifier
- * @param props.label - The label of the field
- * @returns The Input component
+ * @param props.field - The field API identifier.
+ * @param props.label - Label of the input.
+ * @returns The AutoTextInput component.
  */
 export const PolarisAutoTextInput = autoInput((props: PolarisAutoTextInputProps) => {
   const { field, control } = props;
@@ -37,7 +37,7 @@ export const PolarisAutoTextInput = autoInput((props: PolarisAutoTextInputProps)
 });
 
 /**
- * An input component for email fields for use within <AutoForm></AutoForm> components.
+ * An email input within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
@@ -45,35 +45,35 @@ export const PolarisAutoTextInput = autoInput((props: PolarisAutoTextInputProps)
  * </AutoForm>
  * ```
  * @param props.field - The email field API identifier
- * @param props.label - The label of the field
- * @returns The Input component
+ * @param props.label - Label of the email input.
+ * @returns The AutoEmailInput component
  */
 export const PolarisAutoEmailInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;
 
 /**
- * A input component for string fields for use within <AutoForm></AutoForm> components.
+ * A string input within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoStringInput field="name" />
  * </AutoForm>
  * ```
- * @param props.field - The string field API identifier
- * @param props.label - The label of the string field
- * @returns The Input component
+ * @param props.field - The string field API identifier.
+ * @param props.label - Label of the string input.
+ * @returns The AutoStringInput component
  */
 export const PolarisAutoStringInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;
 
 /**
- * A input component for URL fields for use within <AutoForm></AutoForm> components.
+ * A url input within AutoForm.
  * @example
  * ```tsx
  * <AutoForm action={api.modelA.create}>
  *   <AutoUrlInput field="website" />
  * </AutoForm>
  * ```
- * @param props.field - The url field API identifier
- * @param props.label - The label of the url field
- * @returns The Input component
+ * @param props.field - The url field API identifier.
+ * @param props.label - Label of the url input.
+ * @returns The AutoUrlInput component
  */
 export const PolarisAutoUrlInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
@@ -1,30 +1,79 @@
 import type { TextFieldProps } from "@shopify/polaris";
 import { TextField } from "@shopify/polaris";
 import React from "react";
-import type { Control } from "../../../useActionForm.js";
 import { getPropsWithoutRef } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { type AutoTextInputProps } from "../../shared/AutoInputTypes.js";
 
-export const PolarisAutoTextInput = autoInput(
-  (
-    props: {
-      field: string; // The field API identifier
-      control?: Control<any>;
-    } & Partial<TextFieldProps>
-  ) => {
-    const { field, control } = props;
-    const stringInputController = useStringInputController({ field, control });
+type PolarisAutoTextInputProps = AutoTextInputProps & Partial<TextFieldProps>;
 
-    return (
-      <TextField
-        {...getPropsWithoutRef(stringInputController)}
-        requiredIndicator={stringInputController.metadata.requiredArgumentForInput}
-        type={stringInputController.type as TextFieldProps["type"]}
-        error={stringInputController.errorMessage}
-        {...props}
-        label={props.label || stringInputController.metadata.name}
-      />
-    );
-  }
-);
+/**
+ * A text input component for string based fields for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoTextInput field="fieldA" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The field API identifier
+ * @param props.label - The label of the field
+ * @returns The Input component
+ */
+export const PolarisAutoTextInput = autoInput((props: PolarisAutoTextInputProps) => {
+  const { field, control } = props;
+  const stringInputController = useStringInputController({ field, control });
+
+  return (
+    <TextField
+      {...getPropsWithoutRef(stringInputController)}
+      requiredIndicator={stringInputController.metadata.requiredArgumentForInput}
+      type={stringInputController.type as TextFieldProps["type"]}
+      error={stringInputController.errorMessage}
+      {...props}
+      label={props.label || stringInputController.metadata.name}
+    />
+  );
+});
+
+/**
+ * An input component for email fields for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoEmailInput field="fieldA" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The email field API identifier
+ * @param props.label - The label of the field
+ * @returns The Input component
+ */
+export const PolarisAutoEmailInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;
+
+/**
+ * A input component for string fields for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoStringInput field="name" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The string field API identifier
+ * @param props.label - The label of the string field
+ * @returns The Input component
+ */
+export const PolarisAutoStringInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;
+
+/**
+ * A input component for URL fields for use within <AutoForm></AutoForm> components.
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoUrlInput field="website" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The url field API identifier
+ * @param props.label - The label of the url field
+ * @returns The Input component
+ */
+export const PolarisAutoUrlInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTimePicker.tsx
@@ -63,16 +63,42 @@ export interface DateTimeState {
 
 type DateTimeKey = keyof DateTimeState;
 
-const PolarisAutoTimePicker = (props: {
+export interface PolarisAutoTimePickerProps {
+  /**
+   * React Hook Form ControllerRenderProps object that controls the DateTime field
+   */
   fieldProps: ControllerRenderProps<FieldValues, string>;
+  /**
+   * The value of the DateTime field
+   */
   value?: Date;
+  /**
+   * Called when the value of the DateTime field changes
+   */
   onChange?: (value: Date) => void;
-  localTime?: Date;
+  /**
+   * The HTML ID of the DateTime field
+   */
   id?: string;
+  /**
+   * Props to pass to the Polaris TimePicker component
+   */
   timePickerProps?: Partial<TextFieldProps>;
+  /**
+   * Indicates if the time popover should be hidden
+   */
   hideTimePopover?: boolean;
+  /**
+   * The local time of the DateTime field
+   */
+  localTime?: Date;
+  /**
+   * The local time zone of the DateTime field
+   */
   localTz?: string;
-}) => {
+}
+
+const PolarisAutoTimePicker = (props: PolarisAutoTimePickerProps) => {
   const [valueProp, setValueProp] = useState(props.value);
   const [timeString, setTimeString] = useState(props.localTime ? getTimeString(getDateTimeObjectFromDate(props.localTime)) : "");
   const [timePopoverActive, setTimePopoverActive] = useState(false);

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToForm.tsx
@@ -8,6 +8,27 @@ import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelation
 import { SearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
 import { renderOptionLabel } from "./utils.js";
 
+/**
+ * A belongsTo field form component for use within <AutoForm></AutoForm> components
+ * This component allows related model records to be created or updated from the current model.
+ * Fields on the related model record are controlled with the nested <AutoInput/> child components.
+ *
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoBelongsToForm field="parentModel" >
+ *     <AutoInput field="parentModelField" />
+ *   </AutoBelongsToForm>
+ * </AutoForm>
+ * ```
+ * @param props.field - The belongsTo field API identifier
+ * @param props.label - The label of the belongTo form component
+ * @param props.children - The child components to be rendered within the form. This is intended to be used with <AutoInput/>.
+ * @param props.optionLabel - Controls how records on the related model are displayed as options in the relationship field input component.
+ *                            When using a string, the string will indicate the field on the related model record to be displayed as the option label.
+ *                            When using a function, the function will be called with the record to return a ReactNode to be displayed as the option label
+ * @returns The belongsTo field form component
+ */
 export const PolarisAutoBelongsToForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
   const belongsToForm = useBelongsToForm(props);
 

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
@@ -6,6 +6,22 @@ import { getRecordAsOption, optionRecordsToLoadCount, useOptionLabelForField } f
 import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { RelatedModelOptions } from "./RelatedModelOptions.js";
 
+/**
+ * A belongsTo field input component for use within <AutoForm></AutoForm> components
+ * This component is used to configure relationships with records from a related model
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoBelongsToInput field="parentModel" label="Parent" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The belongsTo field API identifier
+ * @param props.label - The label of the belongTo field input component
+ * @param props.optionLabel - Controls how records on the related model are displayed as options in the relationship field input component.
+ *                            When using a string, the string will indicate the field on the related model record to be displayed as the option label.
+ *                            When using a function, the function will be called with the record to return a ReactNode to be displayed as the option label
+ * @returns The belongsTo field input component
+ */
 export const PolarisAutoBelongsToInput = autoInput((props: AutoRelationshipInputProps) => {
   const {
     fieldMetadata: { path, metadata },

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
@@ -19,6 +19,27 @@ const useRecordLabelObjectFromProps = (props: HasManyFormProps) => {
   return { ...recordLabelObject, primary: primaryLabel };
 };
 
+/**
+ * A hasMany field form component for use within <AutoForm></AutoForm> components
+ * This component allows related model records to be created, updated, or deleted from the current model.
+ * Fields on the related model record are controlled with the nested <AutoInput/> child components.
+ *
+ * @example
+ * ```tsx
+ * <AutoForm action={api.author.create}>
+ *   <AutoHasManyForm field="books" >
+ *     <AutoInput field="title" />
+ *   </AutoHasManyForm>
+ * </AutoForm>
+ * ```
+ * @param props.field - The hasMany field API identifier
+ * @param props.label - The label of the hasMany form component
+ * @param props.children - The child components to be rendered within the form. This is intended to be used with <AutoInput/> and will be rendered for each child record.
+ * @param props.recordLabel - Controls how records on the related model are displayed as options in the relationship field input component.
+ *                            When using a string, the string will indicate the field on the related model record to be displayed as the option label.
+ *                            When using a function, the function will be called with the record to return a ReactNode to be displayed as the option label
+ * @returns The hasMany field form component
+ */
 export const PolarisAutoHasManyForm = autoRelationshipForm((props: HasManyFormProps) => {
   useRequiredChildComponentsValidator(props, "AutoHasManyForm");
   const { metadata } = useAutoRelationship({ field: props.field });

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
@@ -7,6 +7,22 @@ import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelatio
 import { RelatedModelOptions } from "./RelatedModelOptions.js";
 import { getSelectedRelatedRecordTags } from "./SelectedRelatedRecordTags.js";
 
+/**
+ * A hasMany field input component for use within <AutoForm></AutoForm> components
+ * This component is used to configure relationships with records from a related model
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoHasManyInput field="children" label="Related children" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The hasMany field API identifier
+ * @param props.label - The label of the hasMany field input component
+ * @param props.optionLabel - Controls how records on the related model are displayed as options in the relationship field input component.
+ *                            When using a string, the string will indicate the field on the related model record to be displayed as the option label.
+ *                            When using a function, the function will be called with the record to return a ReactNode to be displayed as the option label
+ * @returns The hasMany field input component
+ */
 export const PolarisAutoHasManyInput = autoInput((props: AutoRelationshipInputProps) => {
   const { field } = props;
 

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -9,6 +9,41 @@ import type { AutoHasManyThroughFormProps, DisplayedRecordOption } from "../../.
 import { RelatedModelOptionsPopover, RelatedModelOptionsSearch } from "./RelatedModelOptions.js";
 import { renderOptionLabel } from "./utils.js";
 
+/**
+ * A hasManyThrough field form component for use within <AutoForm></AutoForm> components
+ * This component allows sibling model relationships to be defined through creating, updating, or deleting records on the sibling model.
+ * Fields on the related model record are controlled with the nested <AutoInput/> child components.
+ *
+ * @example
+ * ```tsx
+ * <AutoForm action={api.course.create}>
+ *   <AutoInput // `name` field on `course` model
+ *     field="name"
+ *   />
+ *   <AutoHasManyThroughForm // `students` field on `course` model - `course` hasMany `students` through `registration`
+ *     field="students"
+ *   >
+ *     <AutoHasManyThroughJoinModelForm // Join model field inputs
+ *     >
+ *       <AutoInput // `isTuitionPaid` field on `registration` model
+ *         field="isTuitionPaid"
+ *       />
+ *     </AutoHasManyThroughJoinModelForm>
+ *     <AutoInput // Sibling model field inputs
+ *       field="firstName"
+ *     />
+ *   </AutoHasManyThroughForm>
+ *   <AutoSubmit />
+ * </AutoForm>
+ * ```
+ * @param props.field - The hasMany field API identifier
+ * @param props.label - The label of the hasMany form component
+ * @param props.children - The child components to be rendered within the form. This is intended to be used with <AutoInput/> and will be rendered for each sibling model record.
+ * @param props.recordLabel - Controls how records on the related model are displayed as options in the relationship field input component.
+ *                            When using a string, the string will indicate the field on the related model record to be displayed as the option label.
+ *                            When using a function, the function will be called with the record to return a ReactNode to be displayed as the option label
+ * @returns The hasManyThrough field form component
+ */
 export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoHasManyThroughFormProps) => {
   const [addingSibling, setAddingSibling] = useState(false);
   const {

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughInput.tsx
@@ -7,6 +7,22 @@ import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelatio
 import { RelatedModelOptions } from "./RelatedModelOptions.js";
 import { getSelectedRelatedRecordTags } from "./SelectedRelatedRecordTags.js";
 
+/**
+ * A hasManyThrough field input component for use within <AutoForm></AutoForm> components
+ * This component is used to configure relationships with the sibling model by creating and deleting records in the join model
+ * @example
+ * ```tsx
+ * <AutoForm action={api.student.create}>
+ *   <AutoHasManyThroughInput field="courses" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The hasManyThrough field API identifier
+ * @param props.label - The label of the hasManyThrough field input component
+ * @param props.optionLabel - Controls how records on the related model are displayed as options in the relationship field input component.
+ *                            When using a string, the string will indicate the field on the related model record to be displayed as the option label.
+ *                            When using a function, the function will be called with the record to return a ReactNode to be displayed as the option label
+ * @returns The hasManyThrough field input component
+ */
 export const PolarisAutoHasManyThroughInput = autoInput((props: AutoRelationshipInputProps) => {
   const { field } = props;
   const {

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.tsx
@@ -8,6 +8,27 @@ import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelation
 import { EditableOptionLabelButton } from "./EditableOptionLabelButton.js";
 import { SearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
 
+/**
+ * A hasOne field form component for use within <AutoForm></AutoForm> components
+ * This component allows a single related model record to be created, updated, or deleted from the current model.
+ * Fields on the related model record are controlled with the nested <AutoInput/> child components.
+ *
+ * @example
+ * ```tsx
+ * <AutoForm action={api.car.create}>
+ *   <AutoHasOneForm field="engine" >
+ *     <AutoInput field="horsepower" />
+ *   </AutoHasOneForm>
+ * </AutoForm>
+ * ```
+ * @param props.field - The hasOne field API identifier
+ * @param props.label - The label of the hasOne form component
+ * @param props.children - The child components to be rendered within the form. This is intended to be used with <AutoInput/> and will be rendered for each child record.
+ * @param props.recordLabel - Controls how records on the related model are displayed as options in the relationship field input component.
+ *                            When using a string, the string will indicate the field on the related model record to be displayed as the option label.
+ *                            When using a function, the function will be called with the record to return a ReactNode to be displayed as the option label
+ * @returns The hasOne field form component
+ */
 export const PolarisAutoHasOneForm = autoRelationshipForm((props: Omit<AutoRelationshipFormProps, "recordFilter">) => {
   const hasOneForm = useHasOneForm(props);
   const {

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
@@ -6,6 +6,22 @@ import { getRecordAsOption, optionRecordsToLoadCount, useOptionLabelForField } f
 import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { RelatedModelOptions } from "./RelatedModelOptions.js";
 
+/**
+ * A hasOne field input component for use within <AutoForm></AutoForm> components
+ * This component is used to configure relationships with records from a related model
+ * @example
+ * ```tsx
+ * <AutoForm action={api.modelA.create}>
+ *   <AutoHasOneInput field="child" label="Single related child" />
+ * </AutoForm>
+ * ```
+ * @param props.field - The hasOne field API identifier
+ * @param props.label - The label of the hasOne field input component
+ * @param props.optionLabel - Controls how records on the related model are displayed as options in the relationship field input component.
+ *                            When using a string, the string will indicate the field on the related model record to be displayed as the option label.
+ *                            When using a function, the function will be called with the record to return a ReactNode to be displayed as the option label
+ * @returns The hasOne field input component
+ */
 export const PolarisAutoHasOneInput = autoInput((props: AutoRelationshipInputProps) => {
   const { field } = props;
   const {

--- a/packages/react/src/auto/polaris/submit/PolarisSubmitResultBanner.tsx
+++ b/packages/react/src/auto/polaris/submit/PolarisSubmitResultBanner.tsx
@@ -3,7 +3,15 @@ import { Banner } from "@shopify/polaris";
 import React from "react";
 import { useResultBannerController } from "../../hooks/useResultBannerController.js";
 
-export const PolarisSubmitResultBanner = (props: { successBannerProps?: BannerProps; errorBannerProps?: BannerProps }) => {
+type PolarisSubmitResultBannerProps = { successBannerProps?: BannerProps; errorBannerProps?: BannerProps };
+
+/**
+ * A banner that displays the result of an AutoForm submission.
+ * @param props.successBannerProps - The props for the successful banner
+ * @param props.errorBannerProps - The props for the error banner
+ * @returns The banner component
+ */
+export const PolarisSubmitResultBanner = (props: PolarisSubmitResultBannerProps) => {
   return (
     <>
       <PolarisSubmitSuccessfulBanner {...props.successBannerProps} />

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoBooleanInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoBooleanInput.tsx
@@ -1,19 +1,12 @@
-import React, { useMemo, type ReactNode } from "react";
+import React, { useMemo } from "react";
 import { useBooleanInputController } from "../../../auto/hooks/useBooleanInputController.js";
-import type { Control } from "../../../useActionForm.js";
 import { autoInput } from "../../AutoInput.js";
+import { type AutoBooleanInputProps } from "../../shared/AutoInputTypes.js";
 import { ShadcnRequired } from "../ShadcnRequired.js";
 import type { CheckboxProps, ShadcnElements } from "../elements.js";
 
 export const makeShadcnAutoBooleanInput = ({ Checkbox, Label }: Pick<ShadcnElements, "Checkbox" | "Label">) => {
-  function ShadcnAutoBooleanInput(
-    props: {
-      field: string;
-      control?: Control<any>;
-      className?: string;
-      label?: ReactNode;
-    } & Partial<CheckboxProps>
-  ) {
+  function ShadcnAutoBooleanInput(props: { className?: string } & AutoBooleanInputProps & Partial<CheckboxProps>) {
     const { field: _field, control: _control, ...rest } = props;
     const { path, error, fieldProps, metadata } = useBooleanInputController(props);
 

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
@@ -1,5 +1,6 @@
 import { CalendarIcon, X } from "lucide-react";
-import React, { Suspense, useCallback, useState, type ReactNode } from "react";
+import { default as React, Suspense, useCallback, useState, type ReactNode } from "react";
+import { type AutoDateTimeInputProps } from "src/auto/shared/AutoInputTypes.js";
 import { copyTime, formatDate, getDateTimeObjectFromDate, getTimeString, isValidDate, zonedTimeToUtc } from "../../../dateTimeUtils.js";
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
 import { autoInput } from "../../AutoInput.js";
@@ -45,19 +46,13 @@ export const makeShadcnAutoDateTimePicker = ({
       </div>
     );
   };
-
-  function ShadcnAutoDateTimePicker(props: {
-    field: string;
-    id?: string;
-    value?: Date;
-    onChange?: (value?: Date) => void;
-    error?: string;
-    includeTime?: boolean;
-    hideTimePopover?: boolean;
-    label?: ReactNode;
-    datePickerProps?: Partial<DatePickerProps>;
-    timePickerProps?: { label?: ReactNode; placeholder?: string };
-  }) {
+  function ShadcnAutoDateTimePicker(
+    props: {
+      id?: string;
+      datePickerProps?: Partial<DatePickerProps>;
+      timePickerProps?: { label?: ReactNode; placeholder?: string };
+    } & AutoDateTimeInputProps
+  ) {
     const { localTz, localTime, onChange, fieldProps, metadata, fieldState } = useDateTimeField({
       field: props.field,
       value: props.value,

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoEncryptedStringInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoEncryptedStringInput.tsx
@@ -1,20 +1,14 @@
 import { EyeIcon, EyeOffIcon } from "lucide-react";
 import React, { useState, type ReactNode } from "react";
-import type { Control } from "../../../useActionForm.js";
 import { autoInput } from "../../AutoInput.js";
+import { type AutoEncryptedStringInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoStringInput } from "./ShadcnAutoStringInput.js";
 
 export const makeShadcnAutoEncryptedStringInput = ({ Input, Label, Button }: Pick<ShadcnElements, "Input" | "Label" | "Button">) => {
   const TextInput = makeShadcnAutoStringInput({ Input, Label });
 
-  function ShadcnAutoEncryptedStringInput(props: {
-    field: string;
-    control?: Control<any>;
-    className?: string;
-    suffix?: ReactNode;
-    label?: ReactNode;
-  }) {
+  function ShadcnAutoEncryptedStringInput(props: AutoEncryptedStringInputProps & { className?: string; suffix?: ReactNode }) {
     const [isShown, setIsShown] = useState(false);
     const { suffix, ...restProps } = props;
 

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoEnumInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoEnumInput.tsx
@@ -1,36 +1,26 @@
 import { XIcon } from "lucide-react";
-import React, { useCallback, type ReactNode } from "react";
-import type { Control } from "../../../useActionForm.js";
+import React, { useCallback } from "react";
 import { debounce } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
 import { useEnumInputController } from "../../hooks/useEnumInputController.js";
+import { type AutoEnumInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoComboInput } from "./ShadcnAutoComboInput.js";
 
 export const makeShadcnAutoEnumInput = ({
   Badge,
   Button,
+  Checkbox,
   Command,
-  CommandItem,
-  CommandInput,
-  Label,
-  CommandList,
   CommandEmpty,
   CommandGroup,
-  Checkbox,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Label,
 }: Pick<
   ShadcnElements,
-  | "Badge"
-  | "Button"
-  | "Command"
-  | "CommandItem"
-  | "CommandList"
-  | "CommandEmpty"
-  | "CommandGroup"
-  | "CommandInput"
-  | "Label"
-  | "Checkbox"
-  | "Input"
+  "Badge" | "Button" | "Checkbox" | "Command" | "CommandEmpty" | "CommandGroup" | "CommandInput" | "CommandItem" | "CommandList" | "Label"
 >) => {
   const ShadcnComboInput = makeShadcnAutoComboInput({
     Command,
@@ -43,7 +33,7 @@ export const makeShadcnAutoEnumInput = ({
     Checkbox,
   });
 
-  function ShadcnAutoEnumInput(props: { field: string; control?: Control<any>; label?: ReactNode }) {
+  function ShadcnAutoEnumInput(props: AutoEnumInputProps) {
     const { field: fieldApiIdentifier, control, label: labelProp, ...comboboxProps } = props;
     const {
       allowMultiple,

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoFileInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoFileInput.tsx
@@ -1,9 +1,9 @@
 import { DeleteIcon, File } from "lucide-react";
-import React, { useEffect, useMemo, type HtmlHTMLAttributes, type ReactNode } from "react";
-import type { Control } from "../../../useActionForm.js";
+import { default as React, useEffect, useMemo, type HtmlHTMLAttributes } from "react";
 import { isAutoFileFieldValue } from "../../../validationSchema.js";
 import { autoInput } from "../../AutoInput.js";
 import { useFileInputController } from "../../hooks/useFileInputController.js";
+import { type AutoFileInputProps } from "../../shared/AutoInputTypes.js";
 import { type ShadcnElements } from "../elements.js";
 
 export const makeShadcnAutoFileInput = ({
@@ -14,13 +14,7 @@ export const makeShadcnAutoFileInput = ({
   AvatarImage,
   AvatarFallback,
 }: Pick<ShadcnElements, "Input" | "Label" | "Button" | "Avatar" | "AvatarImage" | "AvatarFallback">) => {
-  function ShadcnAutoFileInput(
-    props: {
-      field: string;
-      control?: Control<any>;
-      label?: ReactNode;
-    } & HtmlHTMLAttributes<HTMLDivElement>
-  ) {
+  function ShadcnAutoFileInput(props: AutoFileInputProps & HtmlHTMLAttributes<HTMLDivElement>) {
     const { field: fieldApiIdentifier, control, ...rest } = props;
 
     const [isFilePickerOpen, setIsFilePickerOpen] = React.useState(false);

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoHiddenInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoHiddenInput.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import { autoInput } from "../../AutoInput.js";
 import { useHiddenInput } from "../../hooks/useHiddenInput.js";
+import { type AutoHiddenInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements } from "../elements.js";
 
 export const makeShadcnAutoHiddenInput = ({ Input }: Pick<ShadcnElements, "Input">) => {
-  function ShadcnAutoHiddenInput(props: {
-    field: string; // The field API identifier
-    value: any;
-  }) {
+  function ShadcnAutoHiddenInput(props: AutoHiddenInputProps) {
     const fieldProps = useHiddenInput(props);
     return <Input type="hidden" {...fieldProps} />;
   }

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoIdInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoIdInput.tsx
@@ -1,14 +1,15 @@
-import React, { type ReactNode } from "react";
+import React from "react";
 import { FieldType } from "../../../metadata.js";
 import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { type AutoIdInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoStringInput } from "./ShadcnAutoStringInput.js";
 
 export const makeShadcnAutoIdInput = (elements: Pick<ShadcnElements, "Input" | "Label">) => {
   const ShadcnAutoStringInput = makeShadcnAutoStringInput(elements);
 
-  function ShadcnAutoIdInput(props: { field: string; label?: ReactNode }) {
+  function ShadcnAutoIdInput(props: AutoIdInputProps) {
     const { field, label } = props;
     const { name, metadata } = useStringInputController({ field });
 

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoInput.tsx
@@ -1,7 +1,8 @@
-import React, { type ReactNode } from "react";
+import React from "react";
 import { FieldType } from "../../../metadata.js";
 import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
+import { type AutoInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoBooleanInput } from "./ShadcnAutoBooleanInput.js";
 import { makeShadcnAutoDateTimePicker } from "./ShadcnAutoDateTimePicker.js";
@@ -70,7 +71,7 @@ export const makeShadcnAutoInput = (
   const AutoHasManyThroughInput = makeShadcnAutoHasManyThroughInput(elements);
   const AutoHiddenInput = makeShadcnAutoHiddenInput(elements);
 
-  const AutoInput = autoInput(function AutoInput(props: { field: string; label?: ReactNode }) {
+  const AutoInput = autoInput(function AutoInput(props: AutoInputProps) {
     const { metadata } = useFieldMetadata(props.field);
     const config = metadata.configuration;
 

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoJSONInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoJSONInput.tsx
@@ -1,20 +1,14 @@
-import React, { type ReactNode } from "react";
-import type { Control } from "react-hook-form";
+import React from "react";
 import { useFocus } from "../../../useFocus.js";
 import { getPropsWithoutRef } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
 import { useJSONInputController } from "../../hooks/useJSONInputController.js";
+import { type AutoJSONInputProps } from "../../shared/AutoInputTypes.js";
 import { ShadcnRequired } from "../ShadcnRequired.js";
 import type { ShadcnElements } from "../elements.js";
 
 export const makeShadcnAutoJSONInput = ({ Label, Textarea }: Pick<ShadcnElements, "Input" | "Label" | "Textarea">) => {
-  function ShadcnAutoJSONInput(
-    props: {
-      field: string; // The field API identifier
-      control?: Control<any>;
-      label?: ReactNode;
-    } & Partial<React.HTMLAttributes<HTMLTextAreaElement>>
-  ) {
+  function ShadcnAutoJSONInput(props: AutoJSONInputProps & Partial<React.HTMLAttributes<HTMLTextAreaElement>>) {
     const [isFocused, focusProps] = useFocus();
     const { field: _field, control: _control, ...restOfProps } = props;
     const { type: _type, errorMessage, ...controller } = useJSONInputController(props);

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoNumberInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoNumberInput.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import type { Control } from "../../../useActionForm.js";
 import { countNumberOfDecimals, getStepFromNumberOfDecimals } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { type AutoNumberInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoStringInput } from "./ShadcnAutoStringInput.js";
 
 export const makeShadcnAutoNumberInput = ({ Input, Label }: Pick<ShadcnElements, "Input" | "Label">) => {
   const AutoStringInput = makeShadcnAutoStringInput({ Input, Label });
 
-  function AutoNumberInput(props: { field: string; control?: Control<any>; className?: string }) {
+  function AutoNumberInput(props: AutoNumberInputProps & { className?: string }) {
     const { field, control } = props;
     const { metadata, value } = useStringInputController({ field, control });
 

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoPasswordInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoPasswordInput.tsx
@@ -1,15 +1,14 @@
 import { PencilIcon } from "lucide-react";
-import React, { type ReactNode } from "react";
+import React from "react";
 import { existingPasswordPlaceholder, usePasswordController } from "../../../auto/hooks/usePasswordController.js";
-import type { Control } from "../../../useActionForm.js";
 import { autoInput } from "../../AutoInput.js";
+import { type AutoPasswordInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoEncryptedStringInput } from "./ShadcnAutoEncryptedStringInput.js";
 
 export function makeShadcnAutoPasswordInput({ Input, Label, Button }: Pick<ShadcnElements, "Input" | "Label" | "Button">) {
   const EncryptedInput = makeShadcnAutoEncryptedStringInput({ Input, Label, Button });
-
-  function ShadcnAutoPasswordInput(props: { field: string; control?: Control<any>; className?: string; label?: ReactNode }) {
+  function ShadcnAutoPasswordInput(props: AutoPasswordInputProps) {
     const { isEditing, startEditing } = usePasswordController(props);
 
     return (

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoRolesInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoRolesInput.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useMemo, type ReactNode } from "react";
-import type { Control } from "../../../useActionForm.js";
+import { default as React, useCallback, useMemo } from "react";
 import { autoInput } from "../../AutoInput.js";
 import { useRoleInputController } from "../../hooks/useRoleInputController.js";
+import { type AutoRolesInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoComboInput } from "./ShadcnAutoComboInput.js";
 import { makeSelectedRecordTags } from "./relationships/SelectedRelatedRecordTags.js";
@@ -10,13 +10,6 @@ export interface EnumOption {
   label: string;
   value: string;
 }
-
-export type AutoRolesInputProps = {
-  field: string; // Field API identifier
-  control?: Control<any>;
-  label?: ReactNode;
-  options?: EnumOption[];
-};
 
 export const makeShadcnAutoRolesInput = ({
   Badge,

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoStringInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoStringInput.tsx
@@ -1,7 +1,7 @@
-import React, { type InputHTMLAttributes, type ReactNode } from "react";
-import type { Control } from "../../../useActionForm.js";
+import React, { type InputHTMLAttributes } from "react";
 import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { type AutoTextInputProps } from "../../shared/AutoInputTypes.js";
 import { ShadcnRequired } from "../ShadcnRequired.js";
 import type { ShadcnElements } from "../elements.js";
 
@@ -13,11 +13,9 @@ import type { ShadcnElements } from "../elements.js";
 export const makeShadcnAutoStringInput = ({ Input, Label }: Pick<ShadcnElements, "Input" | "Label">) => {
   function ShadcnAutoStringInput(
     props: {
-      field: string;
-      control?: Control<any>;
-      label?: ReactNode;
       suffix?: React.ReactNode;
-    } & Partial<InputHTMLAttributes<HTMLInputElement>>
+    } & AutoTextInputProps &
+      Partial<InputHTMLAttributes<HTMLInputElement>>
   ) {
     const { field, control, label: customLabel, suffix, ...restProps } = props;
     const stringInputController = useStringInputController({ field, control });

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoTextAreaInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoTextAreaInput.tsx
@@ -1,17 +1,15 @@
-import React, { type ReactNode } from "react";
-import type { Control } from "../../../useActionForm.js";
+import React from "react";
 import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { type AutoTextInputProps } from "../../shared/AutoInputTypes.js";
 import type { ShadcnElements, TextareaProps } from "../elements.js";
 
 export const makeShadcnAutoTextAreaInput = ({ Textarea, Label }: Pick<ShadcnElements, "Textarea" | "Label">) => {
   function ShadcnAutoTextAreaInput(
     props: {
-      field: string;
-      control?: Control<any>;
-      label?: ReactNode;
       suffix?: React.ReactNode;
-    } & TextareaProps
+    } & AutoTextInputProps &
+      TextareaProps
   ) {
     const { field, control, label: customLabel, suffix, ...restProps } = props;
     const {

--- a/packages/react/src/auto/shadcn/inputs/ShadcnautoRichTextInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnautoRichTextInput.tsx
@@ -1,7 +1,7 @@
-import type { ComponentProps } from "react";
 import React from "react";
 import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
+import { type AutoRichTextInputProps } from "../../shared/AutoRichTextInputProps.js";
 import { ShadcnRequired } from "../ShadcnRequired.js";
 import type { ShadcnElements } from "../elements.js";
 
@@ -9,7 +9,7 @@ import type { ShadcnElements } from "../elements.js";
 const AutoRichTextInput = React.lazy(() => import("../../shared/AutoRichTextInput.js"));
 
 export const makeShadcnAutoRichTextInput = ({ Label }: Pick<ShadcnElements, "Label">) => {
-  function ShadcnAutoRichTextInput(props: ComponentProps<typeof AutoRichTextInput>) {
+  function ShadcnAutoRichTextInput(props: AutoRichTextInputProps) {
     const controller = useStringInputController({ field: props.field, control: props.control });
 
     return (

--- a/packages/react/src/auto/shared/AutoInputTypes.tsx
+++ b/packages/react/src/auto/shared/AutoInputTypes.tsx
@@ -41,6 +41,10 @@ export interface AutoDateTimeInputProps extends ControllableWithReactHookForm {
    * The label of the DateTime field
    */
   label?: InputLabel;
+  /**
+   * Indicates if the Gadget DateTime field includes a time component
+   */
+  includeTime?: boolean;
 }
 
 export interface AutoEncryptedStringInputProps extends ControllableWithReactHookForm {

--- a/packages/react/src/auto/shared/AutoInputTypes.tsx
+++ b/packages/react/src/auto/shared/AutoInputTypes.tsx
@@ -1,0 +1,169 @@
+import type { Control } from "../../useActionForm.js";
+
+export interface ControllableWithReactHookForm {
+  /**
+   * React Hook Form control object
+   */
+  control?: Control<any>;
+}
+
+export type InputLabel = string | React.ReactNode | null;
+
+export interface AutoBooleanInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the Boolean field
+   */
+  field: string;
+  /**
+   * The label of the Boolean field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoDateTimeInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the DateTime field
+   */
+  field: string;
+  /**
+   * The value of the DateTime field
+   */
+  value?: Date;
+  /**
+   * Called when the value of the DateTime field changes
+   */
+  onChange?: (value?: Date) => void;
+  /**
+   * Error message to display if the DateTime field is invalid
+   */
+  error?: string;
+  /**
+   * The label of the DateTime field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoEncryptedStringInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the EncryptedString field
+   */
+  field: string;
+  /**
+   * The label of the EncryptedString field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoEnumInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the Enum field
+   */
+  field: string;
+  /**
+   * The label of the Enum field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoFileInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the File field
+   */
+  field: string;
+  /**
+   * The label of the File field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoHiddenInputProps {
+  /**
+   * The API identifier of the Hidden field
+   */
+  field: string;
+  /**
+   * The value of the Hidden field
+   */
+  value: any;
+}
+
+export interface AutoIdInputProps {
+  /**
+   * The API identifier of the Id field
+   */
+  field: string;
+  /**
+   * The label of the Id field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoInputProps {
+  /**
+   * The API identifier of the field
+   */
+  field: string;
+  /**
+   * The label of the field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoJSONInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the JSON field
+   */
+  field: string;
+  /**
+   * The label of the JSON field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoNumberInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the Number field
+   */
+  field: string;
+  /**
+   * The label of the Number field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoPasswordInputProps {
+  /**
+   * The API identifier of the Password field
+   */
+  field: string;
+  /**
+   * The label of the Password field
+   */
+  label?: InputLabel;
+  /**
+   * React Hook Form control object
+   */
+  control?: Control<any>;
+}
+
+export interface AutoRolesInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the Roles field
+   */
+  field: string;
+  /**
+   * The label of the Roles field
+   */
+  label?: InputLabel;
+}
+
+export interface AutoTextInputProps extends ControllableWithReactHookForm {
+  /**
+   * The API identifier of the field
+   */
+  field: string;
+  /**
+   * The label of the field
+   */
+  label?: InputLabel;
+}

--- a/packages/react/src/auto/shared/AutoRichTextInputProps.tsx
+++ b/packages/react/src/auto/shared/AutoRichTextInputProps.tsx
@@ -2,12 +2,27 @@ import type { ForwardedRef, ReactNode } from "react";
 import type { Control } from "../../useActionForm.js";
 
 export interface MDXEditorMethods {
+  /**
+   * Sets the markdown content of the editor
+   */
   setMarkdown: (markdown: string) => void;
 }
 
 export interface AutoRichTextInputProps {
+  /**
+   * The API identifier of the RichText field
+   */
   field: string;
+  /**
+   * Control object from React Hook Form
+   */
   control?: Control<any>;
+  /**
+   * Forwards ref object to setMarkdown content of the editor
+   */
   editorRef?: ForwardedRef<MDXEditorMethods> | null;
+  /**
+   * The label for the input
+   */
   label?: ReactNode;
 }

--- a/packages/react/src/use-table/types.ts
+++ b/packages/react/src/use-table/types.ts
@@ -47,19 +47,63 @@ export type TableColumn = {
 export type TableRow = Record<string, ColumnValueType | ReactNode>;
 
 export interface TableOptions {
+  /**
+   * The number of records to show per page.
+   */
   pageSize?: number;
+  /**
+   * The initial pagination cursor to control the initial page of records to show.
+   * Pagination cursors are returned from the API.
+   */
   initialCursor?: string;
-  initialDirection?: "forward" | "backward";
+  /**
+   * The initial column sort order that the table will be initialized with.
+   * @example
+   * ```tsx
+   * <AutoTable model={api.user} initialSort={{ id: "Descending" }} />
+   * ```
+   */
   initialSort?: { [column: string]: SortOrder };
+  /**
+   * The columns to show in the table represented as (string | CellDetailColumn | CustomCellColumn)[]
+   * - As a string, this represents the API identifier of the field to display.
+   * - As a CellDetailColumn, this a
+   * - As a CustomCellColumn, this represents a custom column to display.
+   */
   columns?: (string | CellDetailColumn | CustomCellColumn)[];
+  /**
+   * A string array of API identifiers for model actions to be excluded from the table.
+   */
   excludeColumns?: string[];
+  /**
+   * The actions to be shown in the table for selected records, represented as (string | ActionCallback)[]
+   * - strings in the array represent the API identifies of actions in the model that can be run on the selected records
+   * - ActionCallback is an object with a label and action property. The action property can be a string representing a model action or a function on that will be called with the selected records
+   */
   actions?: (string | ActionCallback)[];
+
+  /**
+   * A string array of API identifiers for model actions to be excluded from the table.
+   */
   excludeActions?: string[];
 }
 
 export type ActionCallback = {
+  /**
+   * Label for the action
+   */
   label: string;
+
+  /**
+   * Indicates if the action should be promoted in the table
+   */
   promoted?: boolean;
+
+  /**
+   * The action to be performed when the action is clicked
+   * - as a string, this represents the API identifier of the action in the model
+   * - as a function, this will be called with the selected records
+   */
   action: string | ((records: GadgetRecord<any>[]) => any);
 };
 


### PR DESCRIPTION
- UPDATE
  - Added descriptions for AutoComponents exported from the `@gadgetinc/react` package
  - I left out many of the optional params in the descriptions as I fear they will become foot-guns for the AI
    - Ex: Many AutoInputs re-export `onChange` from the base Polaris component. 
      - When this is overwritten, changing the input value won't include the value in the form submission unless there is some extra code to connect it to the overall form state. 
      - If a user gets something like this from the AI, it will be a tough "where is my form value?" bug to fix