### PR TITLE
Update InvalidRecordError comment to match jsDoc syntax

### DIFF
--- a/packages/api-client-core/src/support.ts
+++ b/packages/api-client-core/src/support.ts
@@ -111,9 +111,9 @@ export class GadgetTooManyRequestsError extends Error {
   causedByClient = false;
 }
 
-/*
+/**
  * A Gadget API error representing a backend validation error on the input data for an action. Thrown when any of the validations configured on a model fail for the given input data. Has a `validationErrors` property describing which fields failed validation, with messages for each.
- **/
+ */
 export class InvalidRecordError extends Error {
   code = "GGT_INVALID_RECORD";
   name = "InvalidRecordError";


### PR DESCRIPTION
This PR updates the existing comment block so it becomes a valid jsDoc comment and is available in type declaration.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
