### PR TITLE
Fixed the `findBy` object parameter for the `AutoForm` component such that related records are correctly shown and forms can be properly submitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.499.0-development.1964",
+    "@gadget-client/js-clients-test": "1.499.0-development.2005",
     "@gadget-client/kitchen-sink": "1.5.0-development.200",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/react/.changeset/proud-cameras-push.md
+++ b/packages/react/.changeset/proud-cameras-push.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+- Fixed the `findBy` object parameter for the `AutoForm` component such that related records are correctly shown and forms can be properly submitted

--- a/packages/react/cypress/component/auto/form/AutoFormFindByObjects.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormFindByObjects.cy.tsx
@@ -1,0 +1,293 @@
+import React from "react";
+import { api } from "../../../support/api.js";
+import { describeForEachAutoAdapter } from "../../../support/auto.js";
+describeForEachAutoAdapter("AutoForm - FindBy object parameters", ({ name, adapter: { AutoForm }, wrapper }) => {
+  const interceptModelActionMetadata = () =>
+    cy
+      .intercept({ method: "POST", url: `${api.connection.endpoint}?operation=ModelActionMetadata` }, uniqueFieldsMainModelMetadata)
+      .as("ModelActionMetadata");
+
+  const interceptMainModelQueryDefaultValues = () =>
+    cy
+      .intercept({ method: "POST", url: `${api.connection.endpoint}?operation=mainModels` }, mainModelQueryDefaultValuesResponse)
+      .as("mainModelQueryDefaultValues");
+
+  const mockSuccessfulUpdate = () => {
+    cy.intercept({ method: "POST", url: `${api.connection.endpoint}?operation=updateMainModel` }, (req) => {
+      req.reply(successfulUpdateResponse);
+    }).as("updateMainModel");
+  };
+
+  beforeEach(() => {
+    cy.viewport("macbook-13");
+    interceptModelActionMetadata();
+    interceptMainModelQueryDefaultValues();
+  });
+
+  it("can submit update forms with findBy object properties", () => {
+    cy.mountWithWrapper(<AutoForm action={api.uniqueFields.mainModel.update} findBy={{ uniqueBelongsTo: "22" }} />, wrapper);
+
+    cy.wait(["@ModelActionMetadata", "@mainModelQueryDefaultValues"]);
+
+    mockSuccessfulUpdate();
+
+    cy.contains("Submit").click({ force: true });
+
+    cy.wait("@updateMainModel")
+      .its("request.body.variables")
+      .should("deep.equal", {
+        id: "2",
+        mainModel: {
+          childModelEntries: null,
+          nonUniqueString: "example",
+          uniqueBelongsTo: {},
+          uniqueEmail: "u2@email.com",
+          uniqueString: "u2",
+        },
+      });
+  });
+});
+
+const uniqueFieldsMainModelMetadata = {
+  data: {
+    gadgetMeta: {
+      model: {
+        name: "Main model",
+        apiIdentifier: "mainModel",
+        defaultRecord: {
+          __typename: "UniqueFieldsMainModel",
+        },
+        action: {
+          name: "Update",
+          apiIdentifier: "update",
+          operatesWithRecordIdentity: true,
+          isDeleteAction: false,
+          inputFields: [
+            {
+              name: "Main model",
+              apiIdentifier: "mainModel",
+              fieldType: "Object",
+              requiredArgumentForInput: false,
+              configuration: {
+                __typename: "GadgetObjectFieldConfig",
+                fieldType: "Object",
+                validations: [],
+                name: null,
+                fields: [
+                  {
+                    name: "Unique string",
+                    apiIdentifier: "uniqueString",
+                    fieldType: "String",
+                    requiredArgumentForInput: false,
+                    sortable: true,
+                    filterable: true,
+                    __typename: "GadgetModelField",
+                    configuration: {
+                      __typename: "GadgetGenericFieldConfig",
+                      fieldType: "String",
+                      validations: [
+                        {
+                          __typename: "GadgetGenericFieldValidation",
+                          name: "Uniqueness",
+                          specID: "gadget/validation/unique",
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    name: "Unique email",
+                    apiIdentifier: "uniqueEmail",
+                    fieldType: "Email",
+                    requiredArgumentForInput: false,
+                    sortable: true,
+                    filterable: true,
+                    __typename: "GadgetModelField",
+                    configuration: {
+                      __typename: "GadgetGenericFieldConfig",
+                      fieldType: "Email",
+                      validations: [
+                        {
+                          __typename: "GadgetGenericFieldValidation",
+                          name: "Uniqueness",
+                          specID: "gadget/validation/unique",
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    name: "Unique belongs to",
+                    apiIdentifier: "uniqueBelongsTo",
+                    fieldType: "BelongsTo",
+                    requiredArgumentForInput: false,
+                    sortable: false,
+                    filterable: true,
+                    __typename: "GadgetModelField",
+                    configuration: {
+                      __typename: "GadgetBelongsToConfig",
+                      fieldType: "BelongsTo",
+                      validations: [
+                        {
+                          __typename: "GadgetGenericFieldValidation",
+                          name: "Uniqueness",
+                          specID: "gadget/validation/unique",
+                        },
+                      ],
+                      relatedModel: {
+                        key: "RK96To6wLTyn",
+                        apiIdentifier: "parentModel",
+                        namespace: ["uniqueFields"],
+                        defaultDisplayField: {
+                          name: "Parent unique string",
+                          apiIdentifier: "parentUniqueString",
+                          fieldType: "String",
+                          __typename: "GadgetModelField",
+                        },
+                        __typename: "GadgetModel",
+                      },
+                    },
+                  },
+                  {
+                    name: "Non unique string",
+                    apiIdentifier: "nonUniqueString",
+                    fieldType: "String",
+                    requiredArgumentForInput: false,
+                    sortable: true,
+                    filterable: true,
+                    __typename: "GadgetModelField",
+                    configuration: {
+                      __typename: "GadgetGenericFieldConfig",
+                      fieldType: "String",
+                      validations: [],
+                    },
+                  },
+                  {
+                    name: "Child model entries",
+                    apiIdentifier: "childModelEntries",
+                    fieldType: "HasMany",
+                    requiredArgumentForInput: false,
+                    sortable: false,
+                    filterable: false,
+                    __typename: "GadgetModelField",
+                    configuration: {
+                      __typename: "GadgetHasManyConfig",
+                      fieldType: "HasMany",
+                      validations: [],
+                      isJoinModelHasManyField: false,
+                      relatedModel: {
+                        key: "ZOw07DfjlSXQ",
+                        apiIdentifier: "childModel",
+                        namespace: ["uniqueFields"],
+                        defaultDisplayField: {
+                          name: "Alias",
+                          apiIdentifier: "alias",
+                          fieldType: "String",
+                          __typename: "GadgetModelField",
+                        },
+                        __typename: "GadgetModel",
+                      },
+                      inverseField: {
+                        apiIdentifier: "mainModelParent",
+                        __typename: "GadgetModelField",
+                      },
+                    },
+                  },
+                ],
+              },
+              __typename: "GadgetObjectField",
+            },
+            {
+              name: "Id",
+              apiIdentifier: "id",
+              fieldType: "ID",
+              requiredArgumentForInput: true,
+              configuration: {
+                __typename: "GadgetGenericFieldConfig",
+                fieldType: "ID",
+                validations: [],
+              },
+              __typename: "GadgetObjectField",
+            },
+          ],
+          triggers: [
+            {
+              specID: "gadget/trigger/graphql_api",
+              __typename: "GadgetTrigger",
+            },
+          ],
+          __typename: "GadgetAction",
+        },
+        __typename: "GadgetModel",
+      },
+      __typename: "GadgetApplicationMeta",
+    },
+  },
+};
+
+const mainModelQueryDefaultValuesResponse = {
+  data: {
+    uniqueFields: {
+      mainModels: {
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: "eyJpZCI6IjIifQ==",
+          endCursor: "eyJpZCI6IjIifQ==",
+          __typename: "PageInfo",
+        },
+        edges: [
+          {
+            cursor: "eyJpZCI6IjIifQ==",
+            node: {
+              __typename: "UniqueFieldsMainModel",
+              id: "2",
+              createdAt: "2024-09-30T20:52:14.419Z",
+              nonUniqueString: "example",
+              uniqueEmail: "u2@email.com",
+              uniqueString: "u2",
+              updatedAt: "2024-10-01T20:58:39.300Z",
+            },
+            __typename: "UniqueFieldsMainModelEdge",
+          },
+        ],
+        __typename: "UniqueFieldsMainModelConnection",
+      },
+      __typename: "UniqueFieldsQueries",
+    },
+    gadgetMeta: {
+      hydrations: {
+        createdAt: "DateTime",
+        updatedAt: "DateTime",
+      },
+      __typename: "GadgetApplicationMeta",
+    },
+  },
+};
+
+const successfulUpdateResponse = {
+  data: {
+    uniqueFields: {
+      updateMainModel: {
+        success: true,
+        errors: null,
+        mainModel: {
+          __typename: "UniqueFieldsMainModel",
+          id: "1",
+          createdAt: "2024-09-30T20:52:04.272Z",
+          nonUniqueString: "updated",
+          uniqueEmail: "u1@email.com",
+          uniqueString: "u1",
+          updatedAt: "2024-10-01T23:02:47.585Z",
+        },
+        __typename: "UpdateUniqueFieldsMainModelResult",
+      },
+      __typename: "UniqueFieldsMutations",
+    },
+    gadgetMeta: {
+      hydrations: {
+        createdAt: "DateTime",
+        updatedAt: "DateTime",
+      },
+      __typename: "GadgetApplicationMeta",
+    },
+  },
+};

--- a/packages/react/spec/auto/form/PolarisAutoFormFindByUniqueField.stories.jsx
+++ b/packages/react/spec/auto/form/PolarisAutoFormFindByUniqueField.stories.jsx
@@ -1,0 +1,57 @@
+import { AppProvider, Card, Page } from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
+import React from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { Provider } from "../../../src/GadgetProvider.tsx";
+import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.tsx";
+import { testApi as api } from "../../apis.ts";
+
+export default {
+  title: "Polaris/AutoForm/FindByUniqueField",
+  component: PolarisAutoForm,
+  decorators: [
+    (Story) => {
+      return (
+        <Provider api={api}>
+          <AppProvider i18n={translations}>
+            <FormProvider {...useForm()}>
+              <Page>
+                <Card>
+                  <Story />
+                </Card>
+              </Page>
+            </FormProvider>
+          </AppProvider>
+        </Provider>
+      );
+    },
+  ],
+};
+
+export const FindByUniqueString = {
+  args: {
+    action: api.uniqueFields.mainModel.update,
+    findBy: { uniqueString: "u1" },
+  },
+};
+
+export const FindByUniqueBelongsTo = {
+  args: {
+    action: api.uniqueFields.mainModel.update,
+    findBy: { uniqueBelongsTo: "22" },
+  },
+};
+
+export const FindByUniqueEmail = {
+  args: {
+    action: api.uniqueFields.mainModel.update,
+    findBy: { uniqueEmail: "u3@email.com" },
+  },
+};
+
+export const FindByNonIUniqueField = {
+  args: {
+    action: api.uniqueFields.mainModel.update,
+    findBy: { nonUniqueString: "example" },
+  },
+};

--- a/packages/react/src/auto/hooks/useBelongsToInputController.tsx
+++ b/packages/react/src/auto/hooks/useBelongsToInputController.tsx
@@ -34,8 +34,11 @@ export const useBelongsToInputController = (props: AutoRelationshipInputProps) =
       // Without a find by, there is no retrieved record ID
       return false;
     }
-    return !selected.fetching && selected.records && selected.records.length ? !selected.records[0][field] : true;
-  }, [findBy, selected.fetching]);
+
+    return !selected.fetching && selected.records && selected.records.length
+      ? !selected.records[0].id && !relatedModel.records.map((r) => r.id).includes(fieldProps.value)
+      : true;
+  }, [findBy, selected.fetching, fieldProps.value, relatedModel.records]);
 
   useEffect(() => {
     // Initializing the controller with the selected record ID from the DB

--- a/packages/react/src/useActionForm.ts
+++ b/packages/react/src/useActionForm.ts
@@ -74,6 +74,10 @@ type ActionFormOptions<
          * Should be undefined for create actions, or a record ID (or finder) for update / etc actions
          **/
         findBy?: RecordIdentifier;
+        /**
+         * If false, don't throw an error if the the given findBy value is an invalid object
+         */
+        throwOnInvalidFindByObject?: boolean;
       }
     : // eslint-disable-next-line @typescript-eslint/ban-types
       {});
@@ -102,6 +106,7 @@ export const useActionForm = <
   options?: ActionFormOptions<GivenOptions, SchemaT, ActionFunc, ExtraFormVariables>
 ): UseActionFormResult<GivenOptions, SchemaT, ActionFunc, ExtraFormVariables, FormContext> => {
   const findById = options && "findBy" in options ? options.findBy : undefined;
+  const throwOnInvalidFindByObject = options && "findBy" in options ? options?.throwOnInvalidFindByObject ?? true : true;
   const api = useApi();
   const findExistingRecord = !!findById;
   const hasSetInitialValues = useRef<boolean>(!findExistingRecord);
@@ -113,6 +118,7 @@ export const useActionForm = <
   const [findResult] = useFindExistingRecord(modelManager, findById || "1", {
     pause: !findExistingRecord,
     select: actionSelect,
+    throwOnInvalidFindByObject,
   });
 
   const isReady = !findExistingRecord || !!findResult.data;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.499.0-development.1964
-        version: 1.499.0-development.1964
+        specifier: 1.499.0-development.2005
+        version: 1.499.0-development.2005
       '@gadget-client/kitchen-sink':
         specifier: 1.5.0-development.200
         version: 1.5.0-development.200
@@ -3927,8 +3927,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.499.0-development.1964:
-    resolution: {integrity: sha1-0sKOfKCzudn+alCNLLNS1VZIpOs=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/9716}
+  /@gadget-client/js-clients-test@1.499.0-development.2005:
+    resolution: {integrity: sha1-7lAuG6QGUkGHdj2yknr0OMwx+tQ=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/9952}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true


### PR DESCRIPTION
- **UPDATE**
  - Previously, when the `AutoForm` findBy prop was an object representing a unique field, form submissions were broken and relationship fields did not properly load related model data
    - The form submission was broken because we had included the whole object as the id value on submission. This became a type error that could not be shown without advanced `react-hook-form` techniques
    - The relationship fields were broken because we did not have a system for translating those object values into IDs for the model containing the action. The only way to know this is through a lookup, and a hook has been added to do so
  - NOW, the findBy property should work as expected when using objects like `{uniqueFieldApiId: "uniqueValue"}`
- **TESTING**
  - I've added a namespace with inter-related models containing a lot of unique fields here. Great for storybook
    - https://js-clients-test.gadget.app/edit/development/model/nu84_-GxRnkx/
  - Cases of interest 
    - findBy object keys that are not unique model fields
    - Valid unique model field, but the value does not exist in the model
    - Relationships and showing related model records