### PR TITLE
Updated AutoForm enum inputs such that their search value does not get pre-populated

### DIFF
--- a/packages/react/.changeset/lazy-mirrors-smile.md
+++ b/packages/react/.changeset/lazy-mirrors-smile.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated AutoForm enum inputs such that their search value does not get pre-populated

--- a/packages/react/src/auto/hooks/useEnumInputController.tsx
+++ b/packages/react/src/auto/hooks/useEnumInputController.tsx
@@ -21,7 +21,7 @@ export const useEnumInputController = (props: {
     control,
     name: path,
   });
-  const [searchValue, setSearchValue] = useState(typeof fieldProps.value === "string" ? fieldProps.value : "");
+  const [searchValue, setSearchValue] = useState("");
 
   const selectedOptions = useMemo(
     () => (typeof fieldProps.value === "string" ? [fieldProps.value] : fieldProps.value ?? []) as string[],


### PR DESCRIPTION
- UPDATE
  - Pre-populating the search bar for enum inputs makes it such that the options are pre-filtered once you click on the input. 
    - It would be better to see all available options when you clock the input
  - Now, the enum input search input is always initialized as empty