### PR TITLE
Updated `AutoButton` such that the loading state is dependant only on fetching the action result

### DIFF
--- a/packages/react/.changeset/perfect-cheetahs-hope.md
+++ b/packages/react/.changeset/perfect-cheetahs-hope.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated `AutoButton` such that the loading state is dependant only on fetching the action result instead of also being dependant on fetching action metadata

--- a/packages/react/src/auto/hooks/useAutoButtonController.tsx
+++ b/packages/react/src/auto/hooks/useAutoButtonController.tsx
@@ -37,7 +37,7 @@ export const useAutoButtonController = <
   const { action, variables, onSuccess, onError, ...buttonProps } = props;
   const { metadata, fetching: fetchingMetadata, error: metadataError } = useActionMetadata(action);
 
-  const [{ data: result, fetching: fetchingAction, error }, runAction] =
+  const [{ data: result, fetching: fetchingActionResult, error }, runAction] =
     // eslint-disable-next-line react-hooks/rules-of-hooks
     action.type == "globalAction" ? useGlobalAction(action) : useAction(action);
 
@@ -65,8 +65,8 @@ export const useAutoButtonController = <
 
   return {
     result,
-    fetching: fetchingMetadata || fetchingAction,
-    running: fetchingAction,
+    fetching: fetchingMetadata || fetchingActionResult,
+    running: fetchingActionResult,
     error: metadataError || error,
     label,
     isDestructive,

--- a/packages/react/src/auto/mui/MUIAutoButton.tsx
+++ b/packages/react/src/auto/mui/MUIAutoButton.tsx
@@ -20,7 +20,7 @@ export const MUIAutoButton = <
 >(
   props: AutoButtonProps<GivenOptions, SchemaT, ActionFunc> & ComponentProps<typeof LoadingButton>
 ) => {
-  const { fetching, isDestructive, run, label, buttonProps } = useAutoButtonController({
+  const { fetching, running, isDestructive, run, label, buttonProps } = useAutoButtonController({
     onSuccess: (_result) => {
       setSnackbar({
         open: true,
@@ -47,7 +47,7 @@ export const MUIAutoButton = <
 
   return (
     <>
-      <LoadingButton loading={fetching} disabled={fetching} color={isDestructive ? "error" : undefined} onClick={run} {...buttonProps}>
+      <LoadingButton loading={running} disabled={fetching} color={isDestructive ? "error" : undefined} onClick={run} {...buttonProps}>
         {props?.children ?? label}
       </LoadingButton>
       {snackbar && <SnackbarHack {...snackbar} />}

--- a/packages/react/src/auto/polaris/PolarisAutoButton.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoButton.tsx
@@ -18,7 +18,7 @@ export const PolarisAutoButton = <
 >(
   props: AutoButtonProps<GivenOptions, SchemaT, ActionFunc> & ComponentProps<typeof Button>
 ) => {
-  const { fetching, isDestructive, run, label, buttonProps } = useAutoButtonController({
+  const { fetching, running, isDestructive, run, label, buttonProps } = useAutoButtonController({
     onSuccess: (_result) => {
       if (window && window.shopify && window.shopify.toast) {
         window.shopify.toast.show(`${label} succeeded.`);
@@ -37,7 +37,7 @@ export const PolarisAutoButton = <
   });
 
   return (
-    <Button loading={fetching} disabled={fetching} tone={isDestructive ? "critical" : undefined} onClick={run} {...buttonProps}>
+    <Button loading={running} disabled={fetching} tone={isDestructive ? "critical" : undefined} onClick={run} {...buttonProps}>
       {props?.children ?? label}
     </Button>
   );


### PR DESCRIPTION
- Updated `AutoButton` such that the loading state is dependant only on fetching the action result instead of also being dependant on fetching action metadata
- This is useful to differentiate between when the button is not ready to be clicked yet, and when the action is submitting