### PR TITLE
Added required indicator and required error message to date fields in AutoForm

### DIFF
--- a/packages/react/.changeset/slow-pets-give.md
+++ b/packages/react/.changeset/slow-pets-give.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Added required indicator and required error message to date fields in <AutoForm/> contexts

--- a/packages/react/src/auto/mui/inputs/MUIAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoDateTimePicker.tsx
@@ -16,14 +16,16 @@ export const MUIAutoDateTimePicker = (props: {
   const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const { path, metadata } = useFieldMetadata(props.field);
   const config = metadata.configuration;
-  const { field: fieldProps } = useController({
-    name: path,
-  });
+  const isRequired = metadata.requiredArgumentForInput;
+  const label = (props.label ?? metadata.name) + (isRequired ? " *" : "");
+
+  const { field: fieldProps, fieldState } = useController({ name: path });
 
   return (
     <Box sx={{ display: "flex" }}>
       <DatePicker
-        label={props.label ?? metadata.name}
+        label={label}
+        slotProps={{ textField: { error: !!fieldState.error, helperText: fieldState.error?.message } }}
         onChange={(newValue: string | number | Date | null) => {
           props.onChange?.(zonedTimeToUtc(new Date(newValue ?? ""), localTz));
           fieldProps.onChange(zonedTimeToUtc(new Date(newValue ?? ""), localTz));

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -53,9 +53,7 @@ export const PolarisAutoDateTimePicker = (props: {
 }) => {
   const { path, metadata } = useFieldMetadata(props.field);
 
-  const { field: fieldProps } = useController({
-    name: path,
-  });
+  const { field: fieldProps, fieldState } = useController({ name: path });
 
   const { onChange, value } = props;
   const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -110,7 +108,8 @@ export const PolarisAutoDateTimePicker = (props: {
             autoComplete="off"
             value={localTime ? formatShortDateString(localTime) : ""}
             onFocus={toggleDatePopoverActive}
-            error={props.error}
+            requiredIndicator={metadata.requiredArgumentForInput}
+            error={props.error ?? fieldState.error?.message}
           />
         }
         onClose={toggleDatePopoverActive}


### PR DESCRIPTION
- **UPDATE**
  - Previously, the required field `*` error did not appear for dateTime fields and the error message for having a missing value was not shown 
  - Now, the `*` indicator appears when the date field is required and the input properly shows the error message when caught by the frontend required field validator 