### PR TITLE
computed view endpoint for api client (GGT-7201)

### DIFF
--- a/packages/api-client-core/spec/Select-type.spec.ts
+++ b/packages/api-client-core/spec/Select-type.spec.ts
@@ -1,8 +1,11 @@
 import type { AssertTrue, IsExact } from "conditional-type-checks";
-import type { DeepFilterNever, Select } from "../src/types.js";
+import type { DeepFilterNever, Select, Select2 } from "../src/types.js";
 import type { TestSchema } from "./TestSchema.js";
 
 describe("Select<>", () => {
+  type selectAny = Select2<{ a: "thing" }, any>;
+  type _SelectingAnyYieldsNever = AssertTrue<IsExact<selectAny, never>>;
+
   type _SelectingProperties = AssertTrue<IsExact<Select<TestSchema, { num: true }>, { num: number }>>;
 
   type _ConditionallySelectingProperties = AssertTrue<

--- a/packages/api-client-core/spec/TestSchema.ts
+++ b/packages/api-client-core/spec/TestSchema.ts
@@ -1,5 +1,5 @@
 import type { GadgetRecord } from "src/index.js";
-import type { AvailableSelection, DeepFilterNever, DefaultSelection, Select, Selectable } from "../src/types.js";
+import type { AvailableSelection2, DeepFilterNever, DefaultSelection, Select, Selectable } from "../src/types.js";
 
 export type NestedThing = {
   bool: boolean;
@@ -48,7 +48,7 @@ export type TestSchema = {
   };
 };
 
-export type AvailableTestSchemaSelection = AvailableSelection<TestSchema>;
+export type AvailableTestSchemaSelection = AvailableSelection2<TestSchema>;
 
 export const DefaultPostSelection = {
   __typename: true,

--- a/packages/api-client-core/spec/default-selection.spec.ts
+++ b/packages/api-client-core/spec/default-selection.spec.ts
@@ -1,11 +1,90 @@
-import type { AssertTrue, IsExact } from "conditional-type-checks";
-import type { DefaultSelection } from "../src/types.js";
-import type { AvailableTestSchemaSelection } from "./TestSchema.js";
+import type { AssertTrue, Has, IsExact } from "conditional-type-checks";
+import type { FieldSelection } from "src/FieldSelection.js";
+import type { ComputedViewFunctionWithVariables, ComputedViewFunctionWithoutVariables } from "src/GadgetFunctions.js";
+import type { AllFieldsSelected, AvailableSelection2, DefaultSelection, DefaultSelection2 } from "../src/types.js";
+import type { AvailableTestSchemaSelection, TestSchema } from "./TestSchema.js";
+import type { ExpandRecursively } from "./helpers.js";
 
-type _NullDefault = DefaultSelection<AvailableTestSchemaSelection, { select: null }, { num: true }>;
-type _TestDefaultsNullToTheDefault = AssertTrue<IsExact<_NullDefault, { num: true }>>;
+test("DefaultSelection", () => {
+  type nullDefault = DefaultSelection<AvailableTestSchemaSelection, { select: null }, { num: true }>;
+  type _TestDefaultsNullToTheDefault = AssertTrue<IsExact<nullDefault, { num: true }>>;
 
-type _NonNullDefault = DefaultSelection<AvailableTestSchemaSelection, { select: { num: false; str: true } }, { num: true }>;
-type _TestRespectsTruthySelections = AssertTrue<IsExact<_NonNullDefault, { num: false; str: true }>>;
+  type undefinedDefault = DefaultSelection<AvailableTestSchemaSelection, { select: undefined }, { num: true }>;
+  type _TestDefaultsUndefinedToTheDefault = AssertTrue<IsExact<undefinedDefault, { num: true }>>;
 
-test("true", () => undefined);
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  type undefinedDefault2 = DefaultSelection<AvailableTestSchemaSelection, {}, { num: true }>;
+  type _TestDefaultsUndefinedToTheDefault2 = AssertTrue<IsExact<undefinedDefault2, { num: true }>>;
+
+  type anyDefault = DefaultSelection2<AvailableTestSchemaSelection, { select: any }, { num: true }>;
+  type _TestDefaultsAnyToTheDefault = AssertTrue<IsExact<anyDefault, { num: true }>>;
+
+  type nonDefault = DefaultSelection<AvailableTestSchemaSelection, { select: { num: false; str: true } }, { num: true }>;
+  type _TestRespectsTruthySelections = AssertTrue<IsExact<nonDefault, { num: false; str: true }>>;
+
+  type nonDefault2 = DefaultSelection<AvailableTestSchemaSelection, { select: { num: false } }, { num: true }>;
+  type _TestRespectsTruthySelections2 = AssertTrue<IsExact<nonDefault2, { num: false }>>;
+});
+
+test("AvailableSelection", () => {
+  type availableTestSchemaSelection = AvailableSelection2<TestSchema>;
+  type _TestAvailableTestSchemaSelection = Has<FieldSelection, availableTestSchemaSelection>;
+
+  type testType = { a: number; b: { c: string; d: { e: boolean } } };
+  type availableSelection = AvailableSelection2<testType>;
+  type _TestAvailableSelection = AssertTrue<
+    IsExact<
+      availableSelection,
+      {
+        a?: boolean | null | undefined;
+        b?:
+          | {
+              c?: boolean | null | undefined;
+              d?:
+                | {
+                    e?: boolean | null | undefined;
+                  }
+                | undefined;
+            }
+          | undefined;
+      }
+    >
+  >;
+});
+
+test("AllFieldsSelected", () => {
+  type testType = { a: number; b: { c: string; d: { e: boolean } } };
+  type availableSelection = AvailableSelection2<testType>;
+  type allFieldsSelected = ExpandRecursively<AllFieldsSelected<availableSelection>>;
+  type _TestAllFieldsSelected = AssertTrue<IsExact<allFieldsSelected, { a: true; b: { c: true; d: { e: true } } }>>;
+});
+
+test("ComputedViewFunction", () => {
+  type testType = { a: number; b: { c: string; d: { e: boolean } } };
+
+  const f: ComputedViewFunctionWithoutVariables<testType> = () => ({} as any);
+
+  const resultWithDefaultSelection = f();
+  type _TestResultWithDefaultSelection = AssertTrue<IsExact<Awaited<typeof resultWithDefaultSelection>, testType>>;
+
+  const resultWithDefaultSelection2 = f({});
+  type _TestResultWithDefaultSelection2 = AssertTrue<IsExact<Awaited<typeof resultWithDefaultSelection2>, testType>>;
+
+  const resultWithDefaultSelection3 = f({ select: null });
+  type _TestResultWithDefaultSelection3 = AssertTrue<IsExact<Awaited<typeof resultWithDefaultSelection3>, testType>>;
+
+  const resultWithSelection = f({ select: { a: true } });
+  type _TestResultWithSelection = AssertTrue<IsExact<Awaited<typeof resultWithSelection>, { a: number }>>;
+
+  const resultWithSelection2 = f({ select: { a: false, b: { c: true } } });
+  type _TestResultWithSelection2 = AssertTrue<IsExact<Awaited<typeof resultWithSelection2>, { b: { c: string } }>>;
+
+  type vars = { n?: number; b: boolean };
+  const f2: ComputedViewFunctionWithVariables<vars, testType> = () => ({} as any);
+
+  const resultWithDefaultSelection4 = f2({ b: false });
+  type _TestResultWithDefaultSelection4 = AssertTrue<IsExact<Awaited<typeof resultWithDefaultSelection4>, testType>>;
+
+  const resultWithSelection5 = f({ select: { a: false, b: { c: true } } });
+  type _TestResultWithSelection5 = AssertTrue<IsExact<Awaited<typeof resultWithSelection5>, { b: { c: string } }>>;
+});

--- a/packages/api-client-core/spec/helpers.ts
+++ b/packages/api-client-core/spec/helpers.ts
@@ -47,3 +47,19 @@ export const waitForExpectationToPass = async (run: () => void | Promise<void>, 
     })
   );
 };
+
+/**
+ * Debugging type that will display a fully resolved type
+ * in Intellisense instead of just the type aliases
+ *
+ * @type {T} The type to expand out
+ */
+export type ExpandRecursively<T> = T extends (...args: infer A) => infer R
+  ? (...args: ExpandRecursively<A>) => ExpandRecursively<R>
+  : T extends Array<infer E>
+  ? ExpandRecursively<E>[]
+  : T extends object
+  ? T extends infer O
+    ? { [K in keyof O]: ExpandRecursively<O[K]> }
+    : never
+  : T;

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -1,6 +1,7 @@
 import {
   actionOperation,
   backgroundActionResultOperation,
+  computedViewOperation,
   enqueueActionOperation,
   findManyOperation,
   findOneByFieldOperation,
@@ -1487,6 +1488,91 @@ describe("operation builders", () => {
           }
         }",
           "variables": {},
+        }
+      `);
+    });
+  });
+  describe("computedViewOperation", () => {
+    test("global view without variables", () => {
+      expect(computedViewOperation("boom", { a: true, b: true })).toMatchInlineSnapshot(`
+        {
+          "query": "query boom {
+          boom {
+            a
+            b
+            __typename
+          }
+        }",
+          "variables": {},
+        }
+      `);
+      expect(computedViewOperation("boom", { a: true, b: true }, {}, { a: true })).toMatchInlineSnapshot(`
+        {
+          "query": "query boom {
+          boom {
+            a
+            __typename
+          }
+        }",
+          "variables": {},
+        }
+      `);
+      expect(computedViewOperation("boom", { a: true, b: true }, undefined, { a: true })).toMatchInlineSnapshot(`
+        {
+          "query": "query boom {
+          boom {
+            a
+            __typename
+          }
+        }",
+          "variables": {},
+        }
+      `);
+    });
+
+    test("global view without selection", () => {
+      expect(
+        computedViewOperation(
+          "boom",
+          { a: true, b: true },
+          { a: { required: false, type: "Int", value: 42 }, b: { required: false, type: "String", value: "fortytwo" } }
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "query boom($a: Int, $b: String) {
+          boom(a: $a, b: $b) {
+            a
+            b
+            __typename
+          }
+        }",
+          "variables": {
+            "a": 42,
+            "b": "fortytwo",
+          },
+        }
+      `);
+    });
+    test("global view with selection", () => {
+      expect(
+        computedViewOperation(
+          "boom",
+          { a: true, b: true },
+          { a: { required: false, type: "Int", value: 42 }, b: { required: false, type: "String", value: "fortytwo" } },
+          { a: true }
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "query": "query boom($a: Int, $b: String) {
+          boom(a: $a, b: $b) {
+            a
+            __typename
+          }
+        }",
+          "variables": {
+            "a": 42,
+            "b": "fortytwo",
+          },
         }
       `);
     });

--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -9,6 +9,7 @@ import {
   GadgetConnection,
   actionRunner,
   backgroundActionResultRunner,
+  computedViewRunner,
   enqueueActionRunner,
   findManyRunner,
   findOneByFieldRunner,
@@ -2038,6 +2039,26 @@ describe("operationRunners", () => {
         expect(value[2].id).toEqual("789");
         expect(value[2].name).toEqual(null);
       });
+    });
+  });
+  describe("computedViewRunner", () => {
+    test("global view", () => {
+      const _promise = computedViewRunner(
+        connection,
+        "boom",
+        { a: true, b: true },
+        { a: { required: false, type: "Int", value: 42 }, b: { required: false, type: "String", value: "fortytwo" } },
+        { a: true }
+      );
+
+      expect(query).toMatchInlineSnapshot(`
+        "query boom($a: Int, $b: String) {
+          boom(a: $a, b: $b) {
+            a
+            __typename
+          }
+        }"
+      `);
     });
   });
 });

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -1,6 +1,7 @@
+import type { FieldSelection } from "./FieldSelection.js";
 import type { GadgetRecord, RecordShape } from "./GadgetRecord.js";
 import type { GadgetRecordList } from "./GadgetRecordList.js";
-import type { LimitToKnownKeys, VariablesOptions } from "./types.js";
+import type { AllFieldsSelected, AvailableSelection2, DefaultSelection2, LimitToKnownKeys, Select2, VariablesOptions } from "./types.js";
 
 export type PromiseOrLiveIterator<T> = Promise<T> | AsyncIterable<T>;
 export type AsyncRecord<T extends RecordShape> = PromiseOrLiveIterator<GadgetRecord<T>>;
@@ -206,3 +207,63 @@ export interface GlobalActionFunction<VariablesT> {
 
 export type AnyActionFunction = ActionFunctionMetadata<any, any, any, any, any, any> | GlobalActionFunction<any>;
 export type AnyBulkActionFunction = ActionFunctionMetadata<any, any, any, any, any, true>;
+
+// This is a function that represents a computed view that doesn't take any input parameters/variables.
+// Result is an explicit type parameter defining the shape of the full result.
+export type ComputedViewFunctionWithoutVariables<Result> =
+  // Available, Options and Defaults are inferred at call time.
+  <
+    // Available is the full FieldSelection type derived from the shape of the Result type, i.e. all possible selections.
+    Available extends AvailableSelection2<Result> & FieldSelection,
+    // Options holds the actual selection at call time.
+    Options extends { select?: Available | null },
+    // Defaults is the default selection to be used when one is not provided at call time,
+    // for views we default to everything being selected.
+    Defaults extends AllFieldsSelected<Available>
+  >(
+    options?: Options
+  ) => Promise<Select2<Result, DefaultSelection2<Available, Options, Defaults>>>;
+
+// Represents a computed view that doesn't take any input parameters/variables.
+// It includes the view function and the view metadata.
+export interface ComputedViewWithoutVariables<Result> extends ComputedViewFunctionWithoutVariables<Result> {
+  type: "computedView";
+  operationName: string;
+  namespace: string | string[] | null;
+  defaultSelection: FieldSelection;
+  selection?: FieldSelection;
+  selectionType: AvailableSelection2<Result>;
+  resultType: Result;
+}
+
+// This is a function that represents a computed view that takes input parameters/variables.
+// Result is an explicit type parameter defining the shape of the full result.
+// Variables is an explicit type parameter that describes the shape of the variables parameter.
+export type ComputedViewFunctionWithVariables<Variables, Result> =
+  // Available, Options and Defaults are inferred at call time.
+  <
+    // Available is the full FieldSelection type derived from the shape of the Result type, i.e. all possible selections.
+    Available extends AvailableSelection2<Result> & FieldSelection,
+    // Options holds the actual selection at call time.
+    Options extends { select?: Available | null },
+    // Defaults is the default selection to be used when one is not provided at call time,
+    // for views we default to everything being selected.
+    Defaults extends AllFieldsSelected<Available>
+  >(
+    variables: Variables,
+    options?: Options
+  ) => Promise<Select2<Result, DefaultSelection2<Available, Options, Defaults>>>;
+
+// Represents a computed view that takes input parameters/variables.
+// It includes the view function and the view metadata.
+export interface ComputedViewWithVariables<Variables, Result> extends ComputedViewFunctionWithVariables<Variables, Result> {
+  type: "computedView";
+  operationName: string;
+  namespace: string | string[] | null;
+  variables: VariablesOptions;
+  variablesType: Variables;
+  defaultSelection: FieldSelection;
+  selection?: FieldSelection;
+  selectionType: AvailableSelection2<Result>;
+  resultType: Result;
+}

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -1,5 +1,5 @@
 import type { FieldSelection as BuilderFieldSelection, BuilderOperation, Variable } from "tiny-graphql-query-compiler";
-import { Call, Var, compileWithVariableValues } from "tiny-graphql-query-compiler";
+import { Call, Var, compile, compileWithVariableValues } from "tiny-graphql-query-compiler";
 import type { FieldSelection } from "./FieldSelection.js";
 import type { AnyActionFunction, HasReturnType } from "./index.js";
 import {
@@ -284,6 +284,29 @@ export const globalActionOperation = (
     fields,
     directives: directivesForOptions(options),
   });
+};
+
+export const computedViewOperation = (
+  operation: string,
+  defaultSelection: FieldSelection,
+  variables?: VariablesOptions,
+  selection?: FieldSelection,
+  namespace?: string | string[] | null
+) => {
+  let fields = {
+    [operation]: Call(
+      variables ? variableOptionsToVariables(variables) : {},
+      fieldSelectionToQueryCompilerFields(selection ?? defaultSelection, true)
+    ),
+  };
+
+  if (namespace) {
+    fields = namespacify(namespace, fields);
+  }
+
+  return variables
+    ? compileWithVariableValues({ type: "query", name: operation, fields })
+    : { query: compile({ type: "query", name: operation, fields }), variables: {} };
 };
 
 export interface GraphQLBackgroundActionOptions {

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -19,6 +19,7 @@ import type { AnyModelManager } from "./ModelManager.js";
 import {
   actionOperation,
   backgroundActionResultOperation,
+  computedViewOperation,
   enqueueActionOperation,
   findManyOperation,
   findOneByFieldOperation,
@@ -382,6 +383,20 @@ export const globalActionRunner = async (
   const response = await connection.currentClient.mutation(plan.query, plan.variables).toPromise();
   const dataPath = namespaceDataPath([operation], namespace);
   return assertMutationSuccess(response, dataPath).result;
+};
+
+export const computedViewRunner = async (
+  connection: GadgetConnection,
+  operation: string,
+  defaultSelection: FieldSelection,
+  variableValues?: VariablesOptions,
+  selection?: FieldSelection,
+  namespace?: string | string[] | null
+) => {
+  const { query, variables } = computedViewOperation(operation, defaultSelection, variableValues, selection, namespace);
+  const response = await connection.currentClient.query(query, variables);
+  const dataPath = namespaceDataPath([operation], namespace);
+  return assertOperationSuccess(response, dataPath);
 };
 
 export async function enqueueActionRunner<SchemaT, Action extends AnyBulkActionFunction, Result = BackgroundActionHandle<SchemaT, Action>>(

--- a/packages/api-client-core/src/types.ts
+++ b/packages/api-client-core/src/types.ts
@@ -22,13 +22,64 @@ export type LimitToKnownKeys<T, U> = {
 export type VariablesOptions = Record<string, VariableOptions>;
 
 /**
+ * Allows detecting an any type, this is rather tricky:
+ * The type constraint 0 extends 1 is not satisfied (0 is not assignable to 1),
+ * so it should be impossible for 0 extends (1 & T) to be satisfied either, since (1 & T) should be even narrower than 1.
+ * However, when T is any, it reduces 0 extends (1 & any) to 0 extends any, which is satisfied.
+ * That's because any is intentionally unsound and acts as both a supertype and subtype of almost every other type.
+ * source: https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
+ */
+
+type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
+
+/**
+ * Convert a schema type into the type that a selection of it must extend
+ *
+ * Example Schema:
+ *
+ * {
+ *   foo: boolean;
+ *   bar?: string;
+ *   nested?: {
+ *     count: number
+ *   }
+ * }
+ *
+ * Example available selection:
+ *
+ * {
+ *   foo?: boolean | null | undefined;
+ *   bar?: boolean | null | undefined;
+ *   nested?: {
+ *     count: boolean | null | undefined
+ *   }
+ * }
+ */
+export type AvailableSelection<Schema> = Schema extends string | number | bigint | null | undefined
+  ? boolean | null | undefined
+  : { [key in keyof Schema]?: AvailableSelection<Schema[key]> };
+
+export type AvailableSelection2<Schema> = Schema extends Array<infer T>
+  ? AvailableSelection2<T>
+  : Schema extends object
+  ? { [key in keyof Schema]?: AvailableSelection2<Schema[key]> }
+  : boolean | null | undefined;
+
+/**
  * Given an options object from a find method, default the type of the selection to a default if no selection is passed
  */
+
 export type DefaultSelection<
   SelectionType,
   Options extends { select?: SelectionType | null },
   Defaults extends SelectionType
 > = Options["select"] extends SelectionType ? Options["select"] : Defaults;
+
+export type DefaultSelection2<
+  Available extends FieldSelection,
+  Options extends { select?: Available | null },
+  Defaults extends SomeFieldsSelected<Available>
+> = IfAny<Options, Defaults, IfAny<Options["select"], Defaults, Options["select"] extends Available ? Options["select"] : Defaults>>;
 
 /**
  * Describes an option set that accepts a selection
@@ -37,6 +88,21 @@ export interface Selectable<SelectionType = any> {
   /** Select fields other than the defaults of the record to return */
   select?: SelectionType | null;
 }
+
+/**
+ * Take a FieldSelection type and construct a type with all its fields required and selected.
+ */
+export type AllFieldsSelected<Selection extends FieldSelection> = {
+  [K in keyof Selection]-?: NonNullable<Selection[K]> extends FieldSelection ? AllFieldsSelected<NonNullable<Selection[K]>> : true;
+};
+
+/**
+ * Take a FieldSelection type and construct a type with its fields set to true
+ * rather than (boolean | null | undefined)
+ */
+export type SomeFieldsSelected<Selection extends FieldSelection> = {
+  [K in keyof Selection]?: NonNullable<Selection[K]> extends FieldSelection ? SomeFieldsSelected<NonNullable<Selection[K]>> : true;
+};
 
 /**
  * Describes the base options that many record finders accept
@@ -74,6 +140,24 @@ type InnerSelect<Schema, Selection extends FieldSelection | null | undefined> = 
         : never;
     };
 
+type InnerSelect2<Schema, Selection extends FieldSelection | null | undefined> = IfAny<
+  Selection,
+  never,
+  Selection extends null | undefined
+    ? never
+    : Schema extends (infer T)[]
+    ? InnerSelect2<T, Selection>[]
+    : Schema extends null
+    ? InnerSelect2<Exclude<Schema, null>, Selection> | null
+    : {
+        [Key in keyof Selection & keyof Schema]: Selection[Key] extends true
+          ? Schema[Key]
+          : Selection[Key] extends FieldSelection
+          ? InnerSelect2<Schema[Key], Selection[Key]>
+          : never;
+      }
+>;
+
 /**
  * Filter out any keys in `T` that are mapped to `never` recursively. Any nested objects that are empty after having never valued keys removed are also removed.
  *
@@ -100,6 +184,7 @@ export type DeepFilterNever<T> = T extends Record<string, unknown>
  * ```
  */
 export type Select<Schema, Selection extends FieldSelection | null | undefined> = DeepFilterNever<InnerSelect<Schema, Selection>>;
+export type Select2<Schema, Selection extends FieldSelection | null | undefined> = DeepFilterNever<InnerSelect2<Schema, Selection>>;
 
 /** Represents an amount of some currency. Specified as a string so user's aren't tempted to do math on the value. */
 export type CurrencyAmount = string;
@@ -748,33 +833,6 @@ export type PaginateOptions = {
   last?: number | null;
   select?: AnySelection | InternalFieldSelection | null;
 };
-
-/**
- * Convert a schema type into the type that a selection of it must extend
- *
- * Example Schema:
- *
- * {
- *   foo: boolean;
- *   bar?: string;
- *   nested?: {
- *     count: number
- *   }
- * }
- *
- * Example available selection:
- *
- * {
- *   foo?: boolean | null | undefined;
- *   bar?: boolean | null | undefined;
- *   nested?: {
- *     count: boolean | null | undefined
- *   }
- * }
- */
-export type AvailableSelection<Schema> = Schema extends string | number | bigint | null | undefined
-  ? boolean | null | undefined
-  : { [key in keyof Schema]?: AvailableSelection<Schema[key]> };
 
 /** Options for configuring the queue for a background action */
 export interface BackgroundActionQueue {


### PR DESCRIPTION
This is the counterpart to https://github.com/gadget-inc/gadget/pull/13298

It adds operation builder and runner for computed view as well as generic ComputeView function types and interfaces with metadata. It introduces two variants "with variables" and "without variables" to keep things simpler. The types probably could be merged, but I had enough trouble sorting the types out as is, we can try in a follow up.

Chunk of the work was debugging and tweaking the various utility types to allow TS to infer types correctly. It was a crazy learning curve for me, it's quite possible that I still got some things wrong here. I introduced second versions of the utility types as some of the tweaks broke the dependent packages that use the original ones (react). Not all tweaks are likely necessary for the purposes of this particular PR, but they all are addressing actual issues in the older types, so probably worth keeping. I'll explain more about each inline.

If this passes the review I'll need some guidance on how to roll this out.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
