### PR TITLE
Make delete typed bulkActions appear red in AutoTable

### DIFF
--- a/packages/react/src/auto/hooks/useTableBulkActions.tsx
+++ b/packages/react/src/auto/hooks/useTableBulkActions.tsx
@@ -74,6 +74,7 @@ const getModelActionsForTableAsBulkActionOptions = (props: {
       selectModelAction: () => setSelectedModelActionDetails(actionDetails), // To open the corresponding modal
       apiIdentifier: lowercaseFirstChar(removeBulkPrefix(actionDetails.apiIdentifier)), // `bulk` prefix removed
       promoted: true,
+      isDeleter: "isDeleter" in actionDetails ? actionDetails.isDeleter : false,
     }));
 };
 

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -283,6 +283,7 @@ const disablePaginatedSelectAllButton = {
 const bulkActionOptionMapper = (selectedRows: TableRow[], clearSelection: () => void) => {
   return (option: BulkActionOption) => ({
     id: option.humanizedName,
+    destructive: "isDeleter" in option ? option.isDeleter : false,
     content: option.humanizedName,
     onAction: option.action
       ? () => {


### PR DESCRIPTION
- Update
  - `actionType: "delete"` bulk actions used in AutoTable will now appear as red-text buttons to differentiate their destructive nature
  - Unfortunately, the controllability of the buttons in Polaris seems to be limited to that `destructive` bool value