### PR TITLE
Fix setting belongsTo fields with AutoHiddenInput

### DIFF
--- a/packages/react/spec/auto/inputs/PolarisAutoHiddenInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoHiddenInput.spec.tsx
@@ -28,6 +28,7 @@ describe("PolarisAutoHiddenInput", () => {
       <PolarisAutoForm action={api.widget.create}>
         <PolarisAutoHiddenInput field="name" value="Bob" />
         <PolarisAutoHiddenInput field="inventoryCount" value={42} />
+        <PolarisAutoHiddenInput field="section" value="123" />
         <PolarisAutoSubmit />
       </PolarisAutoForm>,
       { wrapper: PolarisMockedProviders }
@@ -46,6 +47,7 @@ describe("PolarisAutoHiddenInput", () => {
     expect(mutationName).toEqual("createWidget");
     expect(variables.inventoryCount).toEqual(42);
     expect(variables.name).toEqual("Bob");
+    expect(variables.section).toEqual({ _link: "123" });
   });
 
   it("should override the pre-filled value", async () => {

--- a/packages/react/spec/auto/inputs/PolarisAutoHiddenInput.spec.tsx
+++ b/packages/react/spec/auto/inputs/PolarisAutoHiddenInput.spec.tsx
@@ -9,7 +9,7 @@ import { PolarisAutoHiddenInput } from "../../../src/auto/polaris/inputs/Polaris
 import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoSubmit.js";
 import { testApi as api } from "../../apis.js";
 import { MockClientProvider, mockUrqlClient } from "../../testWrappers.js";
-import { mockWidgetFindBy } from "../support/helper.js";
+import { mockGameStadiumFindBy, mockWidgetFindBy } from "../support/helper.js";
 import { getWidgetModelMetadata } from "../support/widgetModel.js";
 
 const PolarisMockedProviders = (props: { children: ReactNode }) => {
@@ -21,7 +21,7 @@ const PolarisMockedProviders = (props: { children: ReactNode }) => {
 };
 
 describe("PolarisAutoHiddenInput", () => {
-  it("should set the value", async () => {
+  it("should set the value of scalar fields", async () => {
     const user = userEvent.setup();
 
     const { getByRole } = render(
@@ -104,6 +104,69 @@ describe("PolarisAutoHiddenInput", () => {
 
     expect(mutationName).toEqual("updateWidget");
     expect(variables.name).toEqual("Alice");
+  });
+
+  it("supports setting the value of has many fields", async () => {
+    const user = userEvent.setup();
+
+    const { getByRole } = render(
+      <PolarisAutoForm action={api.widget.create}>
+        <PolarisAutoHiddenInput field="name" value="Bob" />
+        <PolarisAutoHiddenInput field="inventoryCount" value={42} />
+        <PolarisAutoHiddenInput
+          field="gizmos"
+          value={[
+            {
+              id: "1",
+              name: "updated gizmo",
+            },
+            { name: "created gizmo" },
+          ]}
+        />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      { wrapper: PolarisMockedProviders }
+    );
+
+    loadMockWidgetCreateMetadata();
+
+    await act(async () => {
+      await user.click(getByRole("button"));
+    });
+
+    const mutation = mockUrqlClient.executeMutation.mock.calls[0][0];
+    const mutationName = mutation.query.definitions[0].name.value;
+    const variables = mutation.variables.widget;
+
+    expect(mutationName).toEqual("createWidget");
+    expect(variables.gizmos).toEqual([{ update: { id: "1", name: "updated gizmo" } }, { create: { name: "created gizmo" } }]);
+  });
+
+  it("shouldn't allow hidden inputs for file fields", async () => {
+    render(
+      <PolarisAutoForm action={api.game.stadium.update} findBy="42">
+        <PolarisAutoHiddenInput field="photo" value={{ url: "https://example.com/photo.jpg" }} />
+        <PolarisAutoSubmit />
+      </PolarisAutoForm>,
+      { wrapper: PolarisMockedProviders }
+    );
+
+    expect(() => {
+      mockGameStadiumFindBy(
+        {
+          name: "Update",
+          apiIdentifier: "update",
+          operatesWithRecordIdentity: true,
+        },
+
+        {
+          id: "42",
+          name: "Foo",
+        }
+      );
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Hidden inputs don't support file fields -- please use a real input so the upload is managed properly"`
+    );
   });
 });
 

--- a/packages/react/spec/auto/support/helper.ts
+++ b/packages/react/spec/auto/support/helper.ts
@@ -1,5 +1,5 @@
 import { mockUrqlClient } from "../../testWrappers.js";
-import { getGameCityModelMetadata, getGameCityRecord } from "./gameCityModel.js";
+import { getStadiumModelMetadata, getStadiumRecord } from "./stadiumModel.js";
 import { getUserModelMetadata, getUserRecord } from "./userModel.js";
 import { getWidgetModelMetadata, getWidgetRecord } from "./widgetModel.js";
 
@@ -44,18 +44,18 @@ export const mockWidgetFindBy = (
 };
 
 export const mockGameStadiumFindBy = (
-  action: Parameters<typeof getGameCityModelMetadata>[0],
-  overridesRecord?: Parameters<typeof getGameCityRecord>[0]
+  action: Parameters<typeof getStadiumModelMetadata>[0],
+  overridesRecord?: Parameters<typeof getStadiumRecord>[0]
 ) => {
   mockUrqlClient.executeQuery.pushResponse("ModelActionMetadata", {
     stale: false,
     hasNext: false,
-    data: getGameCityModelMetadata(action),
+    data: getStadiumModelMetadata(action),
   });
 
-  mockUrqlClient.executeQuery.pushResponse("city", {
+  mockUrqlClient.executeQuery.pushResponse("stadium", {
     stale: false,
     hasNext: false,
-    data: getGameCityRecord(overridesRecord),
+    data: getStadiumRecord(overridesRecord),
   });
 };

--- a/packages/react/src/auto/hooks/useHiddenInput.tsx
+++ b/packages/react/src/auto/hooks/useHiddenInput.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 
 export const useHiddenInput = (props: { field: string; value: any }) => {
@@ -8,10 +9,16 @@ export const useHiddenInput = (props: { field: string; value: any }) => {
   const { setValue, formState } = useFormContext();
 
   useEffect(() => {
-    setValue(path, value, {
+    let setAtPath = path;
+
+    if (metadata.fieldType == GadgetFieldType.BelongsTo) {
+      setAtPath = `${path}.id`;
+    }
+
+    setValue(setAtPath, value, {
       shouldDirty: true,
     });
-  }, [formState.defaultValues, path, setValue, value]);
+  }, [formState.defaultValues, path, setValue, value, metadata.fieldType]);
 
   return {
     value,

--- a/packages/react/src/auto/hooks/useHiddenInput.tsx
+++ b/packages/react/src/auto/hooks/useHiddenInput.tsx
@@ -15,6 +15,10 @@ export const useHiddenInput = (props: { field: string; value: any }) => {
       setAtPath = `${path}.id`;
     }
 
+    if (metadata.fieldType == GadgetFieldType.File) {
+      throw new Error("Hidden inputs don't support file fields -- please use a real input so the upload is managed properly");
+    }
+
     setValue(setAtPath, value, {
       shouldDirty: true,
     });


### PR DESCRIPTION
This fixes using hidden inputs against belongs tos. Previously, the hidden input would set the string ID right into the form values as the value at the field, which doesn't match what `useActionForm` is expecting or what the belongs to controller already does. For belongstos, we need to suffix the path with a `.id` to have useActionForm process the form properly. Without this, the validator complains that the field value is not an object -- it's expecting it to be a `{_link: "123"}` sort of deal. We overcome this by setting the id.

This makes me think there may be other transformations we need to do within AutoHiddenInput -- are yall aware of any others?