### PR TITLE
Fix incorrect types for background options priority

### DIFF
--- a/packages/api-client-core/spec/operationRunners.spec.ts
+++ b/packages/api-client-core/spec/operationRunners.spec.ts
@@ -1237,13 +1237,13 @@ describe("operationRunners", () => {
         MockWidgetCreateAction,
         { widget: { name: "new widget" } },
         {
-          priority: "high",
+          priority: "HIGH",
         }
       );
 
       expect(mockUrqlClient.executeMutation.mock.calls.length).toEqual(1);
       expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
-        backgroundOptions: { priority: "high" },
+        backgroundOptions: { priority: "HIGH" },
         widget: { name: "new widget" },
       });
 

--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -138,7 +138,6 @@ export const internalBulkCreateMutation = (
   namespace: string[],
   records: RecordData[]
 ) => {
-  const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
   const capitalizedPluralApiIdentifier = capitalizeIdentifier(pluralApiIdentifier);
 
   return compileWithVariableValues({

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -289,12 +289,13 @@ export const globalActionOperation = (
 export interface GraphQLBackgroundActionOptions {
   retries?: { retryCount: number };
   queue?: { name: string; maxConcurrency?: number };
-  priority?: string;
+  priority?: "LOW" | "DEFAULT" | "HIGH";
   startAt?: string;
 }
 
 export const graphqlizeBackgroundOptions = (options?: EnqueueBackgroundActionOptions<any> | null) => {
   if (!options) return null;
+
   const obj = { ...options };
   if (typeof obj.retries == "number") {
     obj.retries = {

--- a/packages/api-client-core/src/types.ts
+++ b/packages/api-client-core/src/types.ts
@@ -825,7 +825,7 @@ export type EnqueueBackgroundActionOptions<Action extends AnyActionFunction> = {
   /**
    * How high to place this background action in it's queue. `high` priority actions will be executed before `default` priority actions, and those before `low` priority actions. If not set, the `default` priority will be used.
    */
-  priority?: "low" | "default" | "high";
+  priority?: "LOW" | "DEFAULT" | "HIGH";
 
   /**
    * A queue to put this background action in that limits the maximum concurrency of all actions in the queue. If not set, the action will go into the global queue, and won't be concurrency limited.

--- a/packages/react/spec/useEnqueue.spec.tsx
+++ b/packages/react/spec/useEnqueue.spec.tsx
@@ -345,10 +345,7 @@ describe("useEnqueue", () => {
     const startAt = new Date(new Date().getTime() + 1000);
     let mutationPromise: any;
     act(() => {
-      mutationPromise = result.current[1](
-        { id: "123", user: { email: "test@test.com" } },
-        { priority: "high", retries: 5, startAt: startAt }
-      );
+      mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } }, { priority: "HIGH", retries: 5, startAt });
     });
 
     expect(result.current[0].handle).toBeFalsy();
@@ -358,7 +355,7 @@ describe("useEnqueue", () => {
     expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
     expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
-      backgroundOptions: { priority: "high", retries: { retryCount: 5 }, startAt: startAt.toISOString() },
+      backgroundOptions: { priority: "HIGH", retries: { retryCount: 5 }, startAt: startAt.toISOString() },
       id: "123",
       user: { email: "test@test.com" },
     });
@@ -387,13 +384,13 @@ describe("useEnqueue", () => {
   });
 
   test("can pass background options as a second argument to the hook function", async () => {
-    const { result } = renderHook(() => useEnqueue(relatedProductsApi.user.update, { priority: "high", retries: 5 }), {
+    const { result } = renderHook(() => useEnqueue(relatedProductsApi.user.update, { priority: "HIGH", retries: 5 }), {
       wrapper: MockClientWrapper(relatedProductsApi),
     });
 
     let mutationPromise: any;
     act(() => {
-      mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } }, { priority: "default" });
+      mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } }, { priority: "DEFAULT" });
     });
 
     expect(result.current[0].handle).toBeFalsy();
@@ -403,7 +400,7 @@ describe("useEnqueue", () => {
     expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
     expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
-      backgroundOptions: { priority: "default", retries: { retryCount: 5 } },
+      backgroundOptions: { priority: "DEFAULT", retries: { retryCount: 5 } },
       id: "123",
       user: { email: "test@test.com" },
     });
@@ -433,7 +430,7 @@ describe("useEnqueue", () => {
 
   test("can pass urql request options in the a second argument to the hook function", async () => {
     const { result } = renderHook(
-      () => useEnqueue(relatedProductsApi.user.update, { priority: "high", retries: 5, requestPolicy: "cache-and-network" }),
+      () => useEnqueue(relatedProductsApi.user.update, { priority: "HIGH", retries: 5, requestPolicy: "cache-and-network" }),
       {
         wrapper: MockClientWrapper(relatedProductsApi),
       }
@@ -441,13 +438,13 @@ describe("useEnqueue", () => {
 
     let mutationPromise: any;
     act(() => {
-      mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } }, { priority: "default" });
+      mutationPromise = result.current[1]({ id: "123", user: { email: "test@test.com" } }, { priority: "DEFAULT" });
     });
 
     expect(mockUrqlClient.executeMutation).toBeCalledTimes(1);
 
     expect(mockUrqlClient.executeMutation.mock.calls[0][0].variables).toEqual({
-      backgroundOptions: { priority: "default", retries: { retryCount: 5 } },
+      backgroundOptions: { priority: "DEFAULT", retries: { retryCount: 5 } },
       id: "123",
       user: { email: "test@test.com" },
     });


### PR DESCRIPTION
As reported in Discord several times now, people write things to fit the types, but then when trying something out will get an error from the GraphQL API:

> [GraphQL] Variable "$backgroundOptions" got invalid value "high" at "backgroundOptions.priority"; Value "high" does not exist in "BackgroundActionPriority" enum. Did you mean the enum value "HIGH"?"

We have two options here:

1. Keep the type the same, and call `toUpperCase` to ensure we send the correct value.
2. Change the type to match the GraphQL value.

(1) is nice, because it avoids any breaking changes in the types, but I got some feedback in Discord that people would be down for (2). Specifically, the following was said:

> Easy to change and is made to cope with an initial error, so it makes sense to remove it

The thing I like about (2) is that our types mirror the GraphQL API vs diverging and that we don't have to do any data munging. The "breaking" change would only be at a type level, where people are currently doing stuff like this:

```
priority: "HIGH" as unknown as "high"
```

If we went with (1), existing apps would continue to have ☝️ or have to change everything to be lowercase. It seems like some of the Discord users would like to and be okay with driving removal of those type casts through type errors.

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
