### PR TITLE
Fixed bug with `AutoForm` belongsTo field inputs occasionally not showing their related record upon component re-render

### DIFF
--- a/packages/react/.changeset/dull-walls-exist.md
+++ b/packages/react/.changeset/dull-walls-exist.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Fixed bug with `AutoForm` belongsTo field inputs occasionally not showing their related record upon component re-render

--- a/packages/react/src/auto/hooks/useBelongsToInputController.tsx
+++ b/packages/react/src/auto/hooks/useBelongsToInputController.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { useController } from "react-hook-form";
+import { useController, useFormContext } from "react-hook-form";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
 import type { AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
@@ -15,6 +15,10 @@ export const useBelongsToInputController = (props: AutoRelationshipInputProps) =
   const { selected, relatedModel } = relatedModelOptions;
 
   const {
+    formState: { defaultValues },
+  } = useFormContext();
+
+  const {
     field: fieldProps,
     fieldState: { error: fieldError },
   } = useController({
@@ -27,7 +31,7 @@ export const useBelongsToInputController = (props: AutoRelationshipInputProps) =
 
   const retrievedSelectedRecordId = useMemo(() => {
     return !selected.fetching && selected.records && selected.records.length ? selected.records[0][`${field}Id`] : null;
-  }, [selected.fetching]);
+  }, [selected.fetching, selected.records]);
 
   const selectedRelatedModelRecordMissing = useMemo(() => {
     if (!findBy) {
@@ -38,14 +42,14 @@ export const useBelongsToInputController = (props: AutoRelationshipInputProps) =
     return !selected.fetching && selected.records && selected.records.length
       ? !selected.records[0].id && !relatedModel.records.map((r) => r.id).includes(fieldProps.value)
       : true;
-  }, [findBy, selected.fetching, fieldProps.value, relatedModel.records]);
+  }, [findBy, selected.fetching, fieldProps.value, relatedModel.records, retrievedSelectedRecordId]);
 
   useEffect(() => {
     // Initializing the controller with the selected record ID from the DB
     if (!selected.fetching && retrievedSelectedRecordId) {
       fieldProps.onChange(retrievedSelectedRecordId);
     }
-  }, [selected.fetching]);
+  }, [selected.fetching, retrievedSelectedRecordId, defaultValues]);
 
   const onSelectRecord = useCallback((recordId: string) => {
     fieldProps.onChange(recordId);


### PR DESCRIPTION
- **UPDATE**
  - Previously, re-rendering an AutoForm with a findBy containing a belongsTo input would sometimes not show the related model record, despite the fact that there is a related record
    - The race condition
      - `useActionForm` will replace all fields in the formState with a retrieved record value. 
        - This fetch DOES NOT includes relationship field values by default. This sets relationship field values to null in the form state
      - `AutoForm` relationship hooks set the formState field values after doing a fetch for the related model record
      - Sometimes the `useActionForm` fetch finishes after the relationship hook fetch which overwrites the relationship hook. 
  - Fixed by adding the `formState.defaultValues` to the dependency array in `useBelongsToInputController`
    - This way, if the `useActionForm` fetch loses the race, the value will be immediately reset to the related record values from 


## Test this out 
- Switch between the stories in the `findByUniqueField` file. 
  - Those stories are based on existing records that have related records on their belongsTo fields
-  Observe that the belongsTo field stays properly rendered as you switch between stories