### PR TITLE
Removed `allowMultiple` from `AutoFileInput` input props since multiple file fields are not supported (Breaking change)

### DIFF
--- a/packages/react/.changeset/blue-roses-know.md
+++ b/packages/react/.changeset/blue-roses-know.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Removed `allowMultiple` from `AutoFileInput` input props since multiple file fields are not supported (Breaking change)

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
@@ -7,7 +7,7 @@ import type { Control } from "react-hook-form";
 import { isAutoFileFieldValue } from "../../../validationSchema.js";
 import { getFileSizeValidationMessage, imageFileTypes, useFileInputController } from "../../hooks/useFileInputController.js";
 
-export const PolarisAutoFileInput = (props: { field: string; control?: Control<any> } & DropZoneProps) => {
+export const PolarisAutoFileInput = (props: { field: string; control?: Control<any> } & Omit<DropZoneProps, "allowMultiple">) => {
   const { field: fieldApiIdentifier, control, ...rest } = props;
   const { fieldProps, errorMessage, imageThumbnailURL, onFileUpload, clearFileValue, canClearFileValue, validations, metadata } =
     useFileInputController({


### PR DESCRIPTION
- UPDATE
  - Multiple file selection is not supported in Gadget file fields. This forwarded prop on the Polaris AutoFiieInput component was misleading and is now removed 