### PR TITLE
Add required field indicators to JSON and belongsTo fields

### DIFF
--- a/packages/react/.changeset/slow-pets-give.md
+++ b/packages/react/.changeset/slow-pets-give.md
@@ -2,4 +2,4 @@
 "@gadgetinc/react": patch
 ---
 
-Added required indicator and required error message to date fields in <AutoForm/> contexts
+Added required indicator and required error message to date/time, belongsTo, and JSON fields in <AutoForm/> contexts

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
@@ -22,6 +22,7 @@ export const PolarisAutoJSONInput = (
       <TextField
         multiline={4}
         monospaced
+        requiredIndicator={controller.metadata.requiredArgumentForInput}
         error={!isFocused && errorMessage && `Invalid JSON: ${errorMessage}`}
         {...getPropsWithoutRef(controller)}
         {...getPropsWithoutRef(focusProps)}

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
@@ -45,6 +45,7 @@ export const PolarisAutoBelongsToInput = (props: AutoRelationshipInputProps) => 
       <Combobox
         activator={
           <Combobox.TextField
+            requiredIndicator={metadata.requiredArgumentForInput}
             onChange={search.set}
             value={search.value}
             name={path}


### PR DESCRIPTION
- See title. These 2 were simply forgotten on the first sweep