### PR TITLE
Auto input hoc

### DIFF
--- a/packages/react/src/auto/AutoInput.tsx
+++ b/packages/react/src/auto/AutoInput.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export interface AutoInputComponent<P> extends React.FC<P> {
+  __autoInput: true;
+}
+
+export function autoInput<P extends { field: string }>(Component: React.FC<P>): AutoInputComponent<P> {
+  const WrappedComponent: React.FC<P> = (props) => {
+    return <Component {...props} />;
+  };
+
+  (WrappedComponent as AutoInputComponent<P>).__autoInput = true;
+
+  return WrappedComponent as AutoInputComponent<P>;
+}
+
+export function isAutoInput(component: React.ReactElement): component is React.ReactElement<any, AutoInputComponent<any>> {
+  return typeof component.type === "function" && "__autoInput" in component.type;
+}

--- a/packages/react/src/auto/mui/inputs/LazyLoadedMUIAutoRichTextInput.tsx
+++ b/packages/react/src/auto/mui/inputs/LazyLoadedMUIAutoRichTextInput.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-import { AutoRichTextInputProps } from "../../../auto/shared/AutoRichTextInputProps.js";
+import type { AutoRichTextInputProps } from "../../../auto/shared/AutoRichTextInputProps.js";
+import { autoInput } from "../../AutoInput.js";
 
 // lazy import for smaller bundle size by default
 const LazyLoadedMUIAutoRichTextInput = React.lazy(() => import("./MUIAutoRichTextInput.js"));
 
-export const MUIAutoRichTextInput = (props: AutoRichTextInputProps) => {
+export const MUIAutoRichTextInput = autoInput((props: AutoRichTextInputProps) => {
   return (
     <>
       <LazyLoadedMUIAutoRichTextInput {...props} />
     </>
   );
-};
+});

--- a/packages/react/src/auto/mui/inputs/MUIAutoBooleanInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoBooleanInput.tsx
@@ -2,24 +2,27 @@ import type { CheckboxProps } from "@mui/material";
 import { Checkbox } from "@mui/material";
 import React from "react";
 import { useController, type Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { MUIAutoFormControl } from "./MUIAutoFormControl.js";
 
-export const MUIAutoBooleanInput = (props: { field: string; control?: Control<any>; label?: string } & Partial<CheckboxProps>) => {
-  const { field: fieldApiIdentifier, label, control, ...rest } = props;
+export const MUIAutoBooleanInput = autoInput(
+  (props: { field: string; control?: Control<any>; label?: string } & Partial<CheckboxProps>) => {
+    const { field: fieldApiIdentifier, label, control, ...rest } = props;
 
-  const { path } = useFieldMetadata(fieldApiIdentifier);
+    const { path } = useFieldMetadata(fieldApiIdentifier);
 
-  const { field: fieldProps } = useController({
-    control,
-    name: path,
-  });
+    const { field: fieldProps } = useController({
+      control,
+      name: path,
+    });
 
-  const { value: _value, ...restFieldProps } = fieldProps;
+    const { value: _value, ...restFieldProps } = fieldProps;
 
-  return (
-    <MUIAutoFormControl field={props.field} label={label}>
-      <Checkbox {...restFieldProps} checked={fieldProps.value} {...rest} />
-    </MUIAutoFormControl>
-  );
-};
+    return (
+      <MUIAutoFormControl field={props.field} label={label}>
+        <Checkbox {...restFieldProps} checked={fieldProps.value} {...rest} />
+      </MUIAutoFormControl>
+    );
+  }
+);

--- a/packages/react/src/auto/mui/inputs/MUIAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoDateTimePicker.tsx
@@ -4,43 +4,40 @@ import React from "react";
 import { zonedTimeToUtc } from "../../../dateTimeUtils.js";
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
 import { useController } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 
-export const MUIAutoDateTimePicker = (props: {
-  field: string;
-  value?: Date;
-  onChange?: (value: Date) => void;
-  error?: string;
-  label?: string;
-}) => {
-  const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const { path, metadata } = useFieldMetadata(props.field);
-  const config = metadata.configuration;
-  const isRequired = metadata.requiredArgumentForInput;
-  const label = (props.label ?? metadata.name) + (isRequired ? " *" : "");
+export const MUIAutoDateTimePicker = autoInput(
+  (props: { field: string; value?: Date; onChange?: (value: Date) => void; error?: string; label?: string }) => {
+    const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const { path, metadata } = useFieldMetadata(props.field);
+    const config = metadata.configuration;
+    const isRequired = metadata.requiredArgumentForInput;
+    const label = (props.label ?? metadata.name) + (isRequired ? " *" : "");
 
-  const { field: fieldProps, fieldState } = useController({ name: path });
+    const { field: fieldProps, fieldState } = useController({ name: path });
 
-  return (
-    <Box sx={{ display: "flex" }}>
-      <DatePicker
-        label={label}
-        slotProps={{ textField: { error: !!fieldState.error, helperText: fieldState.error?.message } }}
-        onChange={(newValue: string | number | Date | null) => {
-          props.onChange?.(zonedTimeToUtc(new Date(newValue ?? ""), localTz));
-          fieldProps.onChange(zonedTimeToUtc(new Date(newValue ?? ""), localTz));
-        }}
-      />
-      {(config as GadgetDateTimeConfig).includeTime && (
-        <TimePicker
+    return (
+      <Box sx={{ display: "flex" }}>
+        <DatePicker
+          label={label}
+          slotProps={{ textField: { error: !!fieldState.error, helperText: fieldState.error?.message } }}
           onChange={(newValue: string | number | Date | null) => {
             props.onChange?.(zonedTimeToUtc(new Date(newValue ?? ""), localTz));
             fieldProps.onChange(zonedTimeToUtc(new Date(newValue ?? ""), localTz));
           }}
         />
-      )}
-    </Box>
-  );
-};
+        {(config as GadgetDateTimeConfig).includeTime && (
+          <TimePicker
+            onChange={(newValue: string | number | Date | null) => {
+              props.onChange?.(zonedTimeToUtc(new Date(newValue ?? ""), localTz));
+              fieldProps.onChange(zonedTimeToUtc(new Date(newValue ?? ""), localTz));
+            }}
+          />
+        )}
+      </Box>
+    );
+  }
+);
 
 export default MUIAutoDateTimePicker;

--- a/packages/react/src/auto/mui/inputs/MUIAutoEncryptedStringInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoEncryptedStringInput.tsx
@@ -2,16 +2,19 @@ import type { TextFieldProps } from "@mui/material";
 import { IconButton } from "@mui/material";
 import React, { useState } from "react";
 import type { Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { MUIAutoTextInput } from "./MUIAutoTextInput.js";
 
-export const MUIAutoEncryptedStringInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<TextFieldProps>
-) => {
-  const [isShown, setIsShown] = useState(false);
-  const showHideToggleButton = <IconButton onClick={() => setIsShown(!isShown)}>{isShown ? `🔒` : `👁️`}</IconButton>;
+export const MUIAutoEncryptedStringInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<TextFieldProps>
+  ) => {
+    const [isShown, setIsShown] = useState(false);
+    const showHideToggleButton = <IconButton onClick={() => setIsShown(!isShown)}>{isShown ? `🔒` : `👁️`}</IconButton>;
 
-  return <MUIAutoTextInput InputProps={{ endAdornment: showHideToggleButton }} type={isShown ? "text" : "password"} {...props} />;
-};
+    return <MUIAutoTextInput InputProps={{ endAdornment: showHideToggleButton }} type={isShown ? "text" : "password"} {...props} />;
+  }
+);

--- a/packages/react/src/auto/mui/inputs/MUIAutoEnumInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoEnumInput.tsx
@@ -1,40 +1,43 @@
 import type { AutocompleteProps, ChipTypeMap } from "@mui/material";
 import { Autocomplete, TextField } from "@mui/material";
 import React from "react";
+import { autoInput } from "../../AutoInput.js";
 import { useEnumInputController } from "../../hooks/useEnumInputController.js";
 
-export const MUIAutoEnumInput = <
-  Value,
-  Multiple extends boolean | undefined = false,
-  DisableClearable extends boolean | undefined = false,
-  FreeSolo extends boolean | undefined = false,
-  ChipComponent extends React.ElementType = ChipTypeMap["defaultComponent"]
->(
-  props: { field: string; label?: string } & Partial<AutocompleteProps<Value, Multiple, DisableClearable, FreeSolo, ChipComponent>>
-) => {
-  const { allowMultiple, selectedOptions, onSelectionChange, allOptions, label } = useEnumInputController(props);
+export const MUIAutoEnumInput = autoInput(
+  <
+    Value,
+    Multiple extends boolean | undefined = false,
+    DisableClearable extends boolean | undefined = false,
+    FreeSolo extends boolean | undefined = false,
+    ChipComponent extends React.ElementType = ChipTypeMap["defaultComponent"]
+  >(
+    props: { field: string; label?: string } & Partial<AutocompleteProps<Value, Multiple, DisableClearable, FreeSolo, ChipComponent>>
+  ) => {
+    const { allowMultiple, selectedOptions, onSelectionChange, allOptions, label } = useEnumInputController(props);
 
-  return (
-    <Autocomplete
-      disablePortal
-      multiple={allowMultiple}
-      options={allOptions}
-      renderInput={(params) => <TextField {...params} label={props.label ?? label} />}
-      value={allowMultiple ? selectedOptions : selectedOptions[0]}
-      onChange={(event, value) => {
-        if (value === null || (Array.isArray(value) && value.length === 0)) {
-          onSelectionChange(null);
-          return;
-        }
-
-        if (typeof value === "string") {
-          onSelectionChange(value);
-        } else {
-          for (const option of value) {
-            onSelectionChange(option);
+    return (
+      <Autocomplete
+        disablePortal
+        multiple={allowMultiple}
+        options={allOptions}
+        renderInput={(params) => <TextField {...params} label={props.label ?? label} />}
+        value={allowMultiple ? selectedOptions : selectedOptions[0]}
+        onChange={(event, value) => {
+          if (value === null || (Array.isArray(value) && value.length === 0)) {
+            onSelectionChange(null);
+            return;
           }
-        }
-      }}
-    />
-  );
-};
+
+          if (typeof value === "string") {
+            onSelectionChange(value);
+          } else {
+            for (const option of value) {
+              onSelectionChange(option);
+            }
+          }
+        }}
+      />
+    );
+  }
+);

--- a/packages/react/src/auto/mui/inputs/MUIAutoFileInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoFileInput.tsx
@@ -1,6 +1,7 @@
 import { Button, styled } from "@mui/material";
 import React from "react";
 import type { Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFileInputController } from "../../hooks/useFileInputController.js";
 import { MUIAutoFormControl } from "./MUIAutoFormControl.js";
 
@@ -21,7 +22,7 @@ const VisuallyHiddenInput = styled("input")({
   width: 1,
 });
 
-export const MUIAutoFileInput = (props: { field: string; control?: Control<any>; label?: string }) => {
+export const MUIAutoFileInput = autoInput((props: { field: string; control?: Control<any>; label?: string }) => {
   const { field: fieldApiIdentifier, control, label } = props;
   const { onFileUpload, metadata } = useFileInputController({
     field: fieldApiIdentifier,
@@ -43,4 +44,4 @@ export const MUIAutoFileInput = (props: { field: string; control?: Control<any>;
       </Button>
     </MUIAutoFormControl>
   );
-};
+});

--- a/packages/react/src/auto/mui/inputs/MUIAutoFormControl.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoFormControl.tsx
@@ -2,9 +2,10 @@ import { FormControl, FormControlLabel, FormGroup, FormHelperText } from "@mui/m
 import type { ReactElement } from "react";
 import React from "react";
 import { useController } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 
-export const MUIAutoFormControl = (props: { field: string; children: ReactElement; label?: string }) => {
+export const MUIAutoFormControl = autoInput((props: { field: string; children: ReactElement; label?: string }) => {
   const { path, metadata } = useFieldMetadata(props.field);
   const {
     fieldState: { error },
@@ -20,4 +21,4 @@ export const MUIAutoFormControl = (props: { field: string; children: ReactElemen
       {error && <FormHelperText>{error?.message}</FormHelperText>}
     </FormControl>
   );
-};
+});

--- a/packages/react/src/auto/mui/inputs/MUIAutoHiddenInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoHiddenInput.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { autoInput } from "../../AutoInput.js";
 import { useHiddenInput } from "../../hooks/useHiddenInput.js";
 
-export const MUIAutoHiddenInput = (props: {
-  field: string; // The field API identifier
-  value: any;
-}) => {
-  const fieldProps = useHiddenInput(props);
+export const MUIAutoHiddenInput = autoInput(
+  (props: {
+    field: string; // The field API identifier
+    value: any;
+  }) => {
+    const fieldProps = useHiddenInput(props);
 
-  return <input type="hidden" {...fieldProps} />;
-};
+    return <input type="hidden" {...fieldProps} />;
+  }
+);

--- a/packages/react/src/auto/mui/inputs/MUIAutoIdInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoIdInput.tsx
@@ -1,31 +1,33 @@
-import { FieldType } from "../../../metadata.js";
-
 import type { TextFieldProps } from "@mui/material";
 import React from "react";
+import { FieldType } from "../../../metadata.js";
+import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
 import { MUIAutoTextInput } from "./MUIAutoTextInput.js";
 
-export const MUIAutoIdInput = (
-  props: {
-    field: string;
-  } & Partial<TextFieldProps>
-) => {
-  const { field } = props;
-  const { name, metadata } = useStringInputController({ field });
+export const MUIAutoIdInput = autoInput(
+  (
+    props: {
+      field: string;
+    } & Partial<TextFieldProps>
+  ) => {
+    const { field } = props;
+    const { name, metadata } = useStringInputController({ field });
 
-  if (metadata.fieldType !== FieldType.Id || field !== "id") {
-    throw new Error(`PolarisAutoIdInput: field ${field} is not of type Id`);
+    if (metadata.fieldType !== FieldType.Id || field !== "id") {
+      throw new Error(`PolarisAutoIdInput: field ${field} is not of type Id`);
+    }
+
+    return (
+      <MUIAutoTextInput
+        field={field}
+        label="ID"
+        name={name}
+        InputProps={{
+          inputProps: { min: 1, step: 1 },
+        }}
+        type="number"
+      />
+    );
   }
-
-  return (
-    <MUIAutoTextInput
-      field={field}
-      label="ID"
-      name={name}
-      InputProps={{
-        inputProps: { min: 1, step: 1 },
-      }}
-      type="number"
-    />
-  );
-};
+);

--- a/packages/react/src/auto/mui/inputs/MUIAutoInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoInput.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FieldType } from "../../../metadata.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { MUIAutoRichTextInput } from "./LazyLoadedMUIAutoRichTextInput.js";
 import { MUIAutoBooleanInput } from "./MUIAutoBooleanInput.js";
@@ -15,7 +16,7 @@ import { MUIAutoTextInput } from "./MUIAutoTextInput.js";
 import { MUIAutoBelongsToInput } from "./relationships/MUIAutoBelongsToInput.js";
 import { MUIAutoHasManyInput } from "./relationships/MUIAutoHasManyInput.js";
 
-export const MUIAutoInput = (props: { field: string; label?: string }) => {
+export const MUIAutoInput = autoInput((props: { field: string; label?: string }) => {
   const { metadata } = useFieldMetadata(props.field);
   const config = metadata.configuration;
 
@@ -85,4 +86,4 @@ export const MUIAutoInput = (props: { field: string; label?: string }) => {
       throw new Error(`Unsupported field type for MUI AutoForm: ${metadata.fieldType}`);
     }
   }
-};
+});

--- a/packages/react/src/auto/mui/inputs/MUIAutoJSONInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoJSONInput.tsx
@@ -3,32 +3,35 @@ import { TextField } from "@mui/material";
 import React from "react";
 import type { Control } from "../../../useActionForm.js";
 import { useFocus } from "../../../useFocus.js";
+import { autoInput } from "../../AutoInput.js";
 import { useJSONInputController } from "../../hooks/useJSONInputController.js";
 
-export const MUIAutoJSONInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<Omit<TextFieldProps, "onChange">>
-) => {
-  const [isFocused, focusProps] = useFocus();
-  const { field: _field, control: _control, ...restOfProps } = props;
-  const { type: _type, errorMessage, ...controller } = useJSONInputController(props);
+export const MUIAutoJSONInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<Omit<TextFieldProps, "onChange">>
+  ) => {
+    const [isFocused, focusProps] = useFocus();
+    const { field: _field, control: _control, ...restOfProps } = props;
+    const { type: _type, errorMessage, ...controller } = useJSONInputController(props);
 
-  const inErrorState = !isFocused && !!errorMessage;
-  const label = props.label ?? controller.label;
-  return (
-    <TextField
-      multiline
-      maxRows={4}
-      inputProps={{ style: { fontFamily: "monospace" } }}
-      error={inErrorState}
-      helperText={inErrorState && `Invalid JSON: ${errorMessage}`}
-      {...controller}
-      {...focusProps}
-      {...restOfProps}
-      label={label}
-      onChange={(event) => controller.onChange(event.target.value)}
-    />
-  );
-};
+    const inErrorState = !isFocused && !!errorMessage;
+    const label = props.label ?? controller.label;
+    return (
+      <TextField
+        multiline
+        maxRows={4}
+        inputProps={{ style: { fontFamily: "monospace" } }}
+        error={inErrorState}
+        helperText={inErrorState && `Invalid JSON: ${errorMessage}`}
+        {...controller}
+        {...focusProps}
+        {...restOfProps}
+        label={label}
+        onChange={(event) => controller.onChange(event.target.value)}
+      />
+    );
+  }
+);

--- a/packages/react/src/auto/mui/inputs/MUIAutoPasswordInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoPasswordInput.tsx
@@ -3,6 +3,7 @@ import { IconButton } from "@mui/material";
 import React, { useState } from "react";
 import { useController, type Control } from "../../../useActionForm.js";
 import { useAutoFormMetadata } from "../../AutoFormContext.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { MUIAutoEncryptedStringInput } from "./MUIAutoEncryptedStringInput.js";
 
@@ -13,39 +14,41 @@ import { MUIAutoEncryptedStringInput } from "./MUIAutoEncryptedStringInput.js";
 const existingPasswordPlaceholder = "********";
 const pencilEmoji = `✏️`;
 
-export const MUIAutoPasswordInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<TextFieldProps>
-) => {
-  const { findBy } = useAutoFormMetadata();
-  const { path } = useFieldMetadata(props.field);
-  const { field: fieldProps } = useController({ name: path });
+export const MUIAutoPasswordInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<TextFieldProps>
+  ) => {
+    const { findBy } = useAutoFormMetadata();
+    const { path } = useFieldMetadata(props.field);
+    const { field: fieldProps } = useController({ name: path });
 
-  const [isEditing, setIsEditing] = useState(!findBy);
+    const [isEditing, setIsEditing] = useState(!findBy);
 
-  const startEditing = () => {
-    fieldProps.onChange(""); // Touch the field to mark it as dirty
-    setIsEditing(true);
-  };
+    const startEditing = () => {
+      fieldProps.onChange(""); // Touch the field to mark it as dirty
+      setIsEditing(true);
+    };
 
-  const startEditingButton = (
-    <IconButton onClick={startEditing} role={`${props.field}EditPasswordButton`}>
-      {pencilEmoji}
-    </IconButton>
-  );
+    const startEditingButton = (
+      <IconButton onClick={startEditing} role={`${props.field}EditPasswordButton`}>
+        {pencilEmoji}
+      </IconButton>
+    );
 
-  return (
-    <MUIAutoEncryptedStringInput
-      {...(isEditing
-        ? { placeholder: "Password" }
-        : {
-            InputProps: { endAdornment: startEditingButton },
-            placeholder: existingPasswordPlaceholder,
-            disabled: true,
-          })}
-      {...props}
-    />
-  );
-};
+    return (
+      <MUIAutoEncryptedStringInput
+        {...(isEditing
+          ? { placeholder: "Password" }
+          : {
+              InputProps: { endAdornment: startEditingButton },
+              placeholder: existingPasswordPlaceholder,
+              disabled: true,
+            })}
+        {...props}
+      />
+    );
+  }
+);

--- a/packages/react/src/auto/mui/inputs/MUIAutoRichTextInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoRichTextInput.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from "react";
 import React from "react";
+import { autoInput } from "../../AutoInput.js";
 import AutoRichTextInput from "../../shared/AutoRichTextInput.js";
 import "../styles/rich-text.css";
 import { MUIAutoFormControl } from "./MUIAutoFormControl.js";
@@ -7,10 +8,12 @@ import { MUIAutoFormControl } from "./MUIAutoFormControl.js";
 /**
  * Prefer using the LazyLoadedMUIAutoRichTextInput.tsx variant of this component to reduce the bundle size by default.
  */
-export default function MUIAutoRichTextInput(props: ComponentProps<typeof AutoRichTextInput>) {
+export const MUIAutoRichTextInput = autoInput((props: ComponentProps<typeof AutoRichTextInput>) => {
   return (
     <MUIAutoFormControl {...props}>
       <AutoRichTextInput {...props} />
     </MUIAutoFormControl>
   );
-}
+});
+
+export default MUIAutoRichTextInput;

--- a/packages/react/src/auto/mui/inputs/MUIAutoRolesInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoRolesInput.tsx
@@ -2,50 +2,53 @@ import type { AutocompleteProps } from "@mui/material";
 import { Autocomplete, TextField } from "@mui/material";
 import React from "react";
 import type { Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useRoleInputController } from "../../hooks/useRoleInputController.js";
 
-export const MUIAutoRolesInput = (
-  props: {
-    field: string; // Field API identifier
-    control?: Control<any>;
-    label?: string;
-  } & Partial<AutocompleteProps<{ id: string; label: string }, true, any, any>>
-) => {
-  const { options, loading, rolesError, fieldError, selectedRoleKeys, fieldProps, metadata } = useRoleInputController(props);
+export const MUIAutoRolesInput = autoInput(
+  (
+    props: {
+      field: string; // Field API identifier
+      control?: Control<any>;
+      label?: string;
+    } & Partial<AutocompleteProps<{ id: string; label: string }, true, any, any>>
+  ) => {
+    const { options, loading, rolesError, fieldError, selectedRoleKeys, fieldProps, metadata } = useRoleInputController(props);
 
-  if (rolesError) {
-    throw rolesError;
-  }
-  if (fieldError) {
-    throw fieldError;
-  }
+    if (rolesError) {
+      throw rolesError;
+    }
+    if (fieldError) {
+      throw fieldError;
+    }
 
-  const label = props.label ?? metadata.name;
-  if (loading) {
-    return <TextField label={label} autoComplete="off" disabled={loading} />;
-  }
+    const label = props.label ?? metadata.name;
+    if (loading) {
+      return <TextField label={label} autoComplete="off" disabled={loading} />;
+    }
 
-  return (
-    <Autocomplete
-      disablePortal
-      id={`${label}_Autocomplete_Textfield`}
-      multiple
-      renderInput={(params) => <TextField {...params} label={label} />}
-      renderOption={(optionAttributes, option) => (
-        <li {...optionAttributes} data-listbox-option-value={option.id}>
-          {option.label}
-        </li>
-      )}
-      {...fieldProps}
-      onChange={(_event, value) => {
-        const uniqueSelectedRoleKeys = new Set(value.map((option) => (typeof option === "string" ? option : option.id)));
-        fieldProps.onChange(Array.from(uniqueSelectedRoleKeys));
-      }}
-      value={options.filter((option) => selectedRoleKeys.includes(option.value)).map(idLabelMapper)}
-      options={options.map(idLabelMapper)}
-      {...props}
-    />
-  );
-};
+    return (
+      <Autocomplete
+        disablePortal
+        id={`${label}_Autocomplete_Textfield`}
+        multiple
+        renderInput={(params) => <TextField {...params} label={label} />}
+        renderOption={(optionAttributes, option) => (
+          <li {...optionAttributes} data-listbox-option-value={option.id}>
+            {option.label}
+          </li>
+        )}
+        {...fieldProps}
+        onChange={(_event, value) => {
+          const uniqueSelectedRoleKeys = new Set(value.map((option) => (typeof option === "string" ? option : option.id)));
+          fieldProps.onChange(Array.from(uniqueSelectedRoleKeys));
+        }}
+        value={options.filter((option) => selectedRoleKeys.includes(option.value)).map(idLabelMapper)}
+        options={options.map(idLabelMapper)}
+        {...props}
+      />
+    );
+  }
+);
 
 const idLabelMapper = (option: { value: string; label: string }) => ({ id: option.value, label: option.label });

--- a/packages/react/src/auto/mui/inputs/MUIAutoTextInput.tsx
+++ b/packages/react/src/auto/mui/inputs/MUIAutoTextInput.tsx
@@ -2,26 +2,29 @@ import type { TextFieldProps } from "@mui/material";
 import { TextField } from "@mui/material";
 import React from "react";
 import type { Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
 
-export const MUIAutoTextInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<TextFieldProps>
-) => {
-  const { field, control } = props;
-  const stringInputController = useStringInputController({ field, control });
+export const MUIAutoTextInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<TextFieldProps>
+  ) => {
+    const { field, control } = props;
+    const stringInputController = useStringInputController({ field, control });
 
-  const isRequired = stringInputController.metadata.requiredArgumentForInput;
-  const label = (props.label ?? stringInputController.label) + (isRequired ? " *" : "");
-  return (
-    <TextField
-      {...stringInputController}
-      error={stringInputController.isError}
-      helperText={stringInputController.errorMessage}
-      {...props}
-      label={label}
-    />
-  );
-};
+    const isRequired = stringInputController.metadata.requiredArgumentForInput;
+    const label = (props.label ?? stringInputController.label) + (isRequired ? " *" : "");
+    return (
+      <TextField
+        {...stringInputController}
+        error={stringInputController.isError}
+        helperText={stringInputController.errorMessage}
+        {...props}
+        label={label}
+      />
+    );
+  }
+);

--- a/packages/react/src/auto/mui/inputs/relationships/MUIAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/mui/inputs/relationships/MUIAutoBelongsToInput.tsx
@@ -1,9 +1,10 @@
 import { Autocomplete, Box, TextField, Typography } from "@mui/material";
 import React from "react";
+import { autoInput } from "../../../AutoInput.js";
 import { useBelongsToInputController } from "../../../hooks/useBelongsToInputController.js";
 import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 
-export const MUIAutoBelongsToInput = (props: AutoRelationshipInputProps) => {
+export const MUIAutoBelongsToInput = autoInput((props: AutoRelationshipInputProps) => {
   const {
     fieldMetadata: { path, metadata },
     relatedModelOptions: { options, pagination, search },
@@ -54,6 +55,6 @@ export const MUIAutoBelongsToInput = (props: AutoRelationshipInputProps) => {
       )}
     ></Autocomplete>
   );
-};
+});
 
 const showMoreHoverOption = { recordId: "-1", label: "Show more" };

--- a/packages/react/src/auto/mui/inputs/relationships/MUIAutoHasManyInput.tsx
+++ b/packages/react/src/auto/mui/inputs/relationships/MUIAutoHasManyInput.tsx
@@ -1,9 +1,10 @@
 import { Autocomplete, Box, TextField, Typography } from "@mui/material";
 import React from "react";
+import { autoInput } from "../../../AutoInput.js";
 import { useHasManyInputController } from "../../../hooks/useHasManyInputController.js";
 import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 
-export const MUIAutoHasManyInput = (props: AutoRelationshipInputProps) => {
+export const MUIAutoHasManyInput = autoInput((props: AutoRelationshipInputProps) => {
   const {
     fieldMetadata: { path, metadata },
     relatedModelOptions: { options, search, pagination },
@@ -53,6 +54,6 @@ export const MUIAutoHasManyInput = (props: AutoRelationshipInputProps) => {
       )}
     ></Autocomplete>
   );
-};
+});
 
 const showMoreHoverOption = { recordId: "-1", label: "Show more" };

--- a/packages/react/src/auto/mui/inputs/relationships/MUIAutoHasOneInput.tsx
+++ b/packages/react/src/auto/mui/inputs/relationships/MUIAutoHasOneInput.tsx
@@ -1,5 +1,6 @@
 import { Alert, Autocomplete, Box, TextField, Typography } from "@mui/material";
 import React from "react";
+import { autoInput } from "../../../AutoInput.js";
 import { useHasOneInputController } from "../../../hooks/useHasOneInputController.js";
 import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 
@@ -8,7 +9,7 @@ import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelatio
  */
 const showErrorBannerWhenTooManyRelatedRecords = false;
 
-export const MUIAutoHasOneInput = (props: AutoRelationshipInputProps) => {
+export const MUIAutoHasOneInput = autoInput((props: AutoRelationshipInputProps) => {
   const { field } = props;
   const {
     fieldMetadata: { path, metadata },
@@ -60,6 +61,6 @@ export const MUIAutoHasOneInput = (props: AutoRelationshipInputProps) => {
       )}
     ></Autocomplete>
   );
-};
+});
 
 const showMoreHoverOption = { recordId: "-1", label: "Show more" };

--- a/packages/react/src/auto/polaris/inputs/LazyLoadedPolarisAutoRichTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/LazyLoadedPolarisAutoRichTextInput.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { AutoRichTextInputProps } from "../../shared/AutoRichTextInputProps.js";
+import { autoInput } from "../../AutoInput.js";
+import type { AutoRichTextInputProps } from "../../shared/AutoRichTextInputProps.js";
 
 const LazyLoadedPolarisAutoRichTextInput = React.lazy(() => import("./PolarisAutoRichTextInput.js"));
 
-export const PolarisAutoRichTextInput = (props: AutoRichTextInputProps) => {
+export const PolarisAutoRichTextInput = autoInput((props: AutoRichTextInputProps) => {
   return (
     <>
       <LazyLoadedPolarisAutoRichTextInput {...props} />
     </>
   );
-};
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoBooleanInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoBooleanInput.tsx
@@ -3,9 +3,10 @@ import { Checkbox } from "@shopify/polaris";
 import React from "react";
 import type { Control } from "../../../useActionForm.js";
 import { useController } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 
-export const PolarisAutoBooleanInput = (props: { field: string; control?: Control<any> } & Partial<CheckboxProps>) => {
+export const PolarisAutoBooleanInput = autoInput((props: { field: string; control?: Control<any> } & Partial<CheckboxProps>) => {
   const { field: fieldApiIdentifier, control, ...rest } = props;
 
   const { path, metadata } = useFieldMetadata(fieldApiIdentifier);
@@ -22,4 +23,4 @@ export const PolarisAutoBooleanInput = (props: { field: string; control?: Contro
   const { value: _value, ...restFieldProps } = fieldProps;
 
   return <Checkbox {...restFieldProps} checked={!!fieldProps.value} error={error?.message} {...rest} label={label} />;
-};
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { formatShortDateString, isValidDate, utcToZonedTime, zonedTimeToUtc } from "../../../dateTimeUtils.js";
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
 import { useController } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import type { DateTimeState } from "./PolarisAutoTimePicker.js";
 import PolarisAutoTimePicker from "./PolarisAutoTimePicker.js";
@@ -39,107 +40,109 @@ export const getDateFromDateTimeObject = (dateTime: DateTimeState) => {
   return date;
 };
 
-export const PolarisAutoDateTimePicker = (props: {
-  field: string;
-  id?: string;
-  value?: Date;
-  onChange?: (value: Date) => void;
-  error?: string;
-  includeTime?: boolean;
-  hideTimePopover?: boolean;
-  label?: string;
-  datePickerProps?: Partial<DatePickerProps>;
-  timePickerProps?: Partial<TextFieldProps>;
-}) => {
-  const { path, metadata } = useFieldMetadata(props.field);
+export const PolarisAutoDateTimePicker = autoInput(
+  (props: {
+    field: string;
+    id?: string;
+    value?: Date;
+    onChange?: (value: Date) => void;
+    error?: string;
+    includeTime?: boolean;
+    hideTimePopover?: boolean;
+    label?: string;
+    datePickerProps?: Partial<DatePickerProps>;
+    timePickerProps?: Partial<TextFieldProps>;
+  }) => {
+    const { path, metadata } = useFieldMetadata(props.field);
 
-  const { field: fieldProps, fieldState } = useController({ name: path });
+    const { field: fieldProps, fieldState } = useController({ name: path });
 
-  const { onChange, value } = props;
-  const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const localTime = useMemo(() => {
-    return value ? value : isValidDate(new Date(fieldProps.value)) ? new Date(fieldProps.value) : undefined;
-  }, [value, fieldProps.value]);
+    const { onChange, value } = props;
+    const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const localTime = useMemo(() => {
+      return value ? value : isValidDate(new Date(fieldProps.value)) ? new Date(fieldProps.value) : undefined;
+    }, [value, fieldProps.value]);
 
-  const [datePopoverActive, setDatePopoverActive] = useState(false);
+    const [datePopoverActive, setDatePopoverActive] = useState(false);
 
-  const [popoverMonth, setPopoverMonth] = useState(getDateTimeObjectFromDate(localTime ?? utcToZonedTime(new Date(), localTz)).month);
-  const [popoverYear, setPopoverYear] = useState(getDateTimeObjectFromDate(localTime ?? utcToZonedTime(new Date(), localTz)).year);
+    const [popoverMonth, setPopoverMonth] = useState(getDateTimeObjectFromDate(localTime ?? utcToZonedTime(new Date(), localTz)).month);
+    const [popoverYear, setPopoverYear] = useState(getDateTimeObjectFromDate(localTime ?? utcToZonedTime(new Date(), localTz)).year);
 
-  const config = metadata.configuration;
+    const config = metadata.configuration;
 
-  const onDateChange = useCallback<Exclude<DatePickerProps["onChange"], undefined>>(
-    (range) => {
-      (fieldProps || value) && copyTime(range.start, zonedTimeToUtc(range.start, localTz));
-      const dateOverride = value ?? new Date(fieldProps.value);
-      if (isValidDate(dateOverride)) {
-        range.start.setHours(dateOverride.getHours());
-        range.start.setMinutes(dateOverride.getMinutes());
-        range.start.setSeconds(dateOverride.getSeconds());
-        range.start.setMilliseconds(dateOverride.getMilliseconds());
-      }
-      onChange?.(zonedTimeToUtc(range.start, localTz));
-      fieldProps.onChange(zonedTimeToUtc(range.start, localTz));
-      setDatePopoverActive(false);
-    },
-    [fieldProps, value, localTz, onChange]
-  );
-
-  const toggleDatePopoverActive = useCallback(() => {
-    setPopoverMonth(getDateTimeObjectFromDate(isValidDate(localTime) && localTime ? localTime : new Date()).month);
-    setPopoverYear(getDateTimeObjectFromDate(isValidDate(localTime) && localTime ? localTime : new Date()).year);
-    setDatePopoverActive((active) => !active);
-  }, [localTime]);
-  const handleMonthChange = useCallback((month: number, year: number) => {
-    setPopoverMonth(month);
-    setPopoverYear(year);
-  }, []);
-
-  return (
-    <InlineStack gap="400">
-      <Popover
-        preferredPosition="above"
-        active={datePopoverActive}
-        activator={
-          <TextField
-            id={props.id ? `${props.id}-date` : undefined}
-            label={props.label ?? metadata.name ?? "Date"}
-            prefix={<Icon source={CalendarIcon} />}
-            autoComplete="off"
-            value={localTime ? formatShortDateString(localTime) : ""}
-            onFocus={toggleDatePopoverActive}
-            requiredIndicator={metadata.requiredArgumentForInput}
-            error={props.error ?? fieldState.error?.message}
-          />
+    const onDateChange = useCallback<Exclude<DatePickerProps["onChange"], undefined>>(
+      (range) => {
+        (fieldProps || value) && copyTime(range.start, zonedTimeToUtc(range.start, localTz));
+        const dateOverride = value ?? new Date(fieldProps.value);
+        if (isValidDate(dateOverride)) {
+          range.start.setHours(dateOverride.getHours());
+          range.start.setMinutes(dateOverride.getMinutes());
+          range.start.setSeconds(dateOverride.getSeconds());
+          range.start.setMilliseconds(dateOverride.getMilliseconds());
         }
-        onClose={toggleDatePopoverActive}
-      >
-        <div style={{ padding: "16px" }}>
-          <DatePicker
-            month={popoverMonth}
-            year={popoverYear}
-            allowRange={false}
-            onChange={onDateChange}
-            onMonthChange={handleMonthChange}
-            selected={localTime ?? new Date()}
-            {...props.datePickerProps}
-          />
-        </div>
-      </Popover>
-      {(props.includeTime ?? (config as GadgetDateTimeConfig).includeTime) && (
-        <div style={{ width: "130px" }}>
-          <PolarisAutoTimePicker
-            fieldProps={fieldProps}
-            id={props.id}
-            localTime={localTime}
-            onChange={onChange}
-            hideTimePopover={props.hideTimePopover}
-            localTz={localTz}
-            timePickerProps={props.timePickerProps}
-            value={value}
-          />
-        </div>
-      )}
-    </InlineStack>
-  );
-};
+        onChange?.(zonedTimeToUtc(range.start, localTz));
+        fieldProps.onChange(zonedTimeToUtc(range.start, localTz));
+        setDatePopoverActive(false);
+      },
+      [fieldProps, value, localTz, onChange]
+    );
+
+    const toggleDatePopoverActive = useCallback(() => {
+      setPopoverMonth(getDateTimeObjectFromDate(isValidDate(localTime) && localTime ? localTime : new Date()).month);
+      setPopoverYear(getDateTimeObjectFromDate(isValidDate(localTime) && localTime ? localTime : new Date()).year);
+      setDatePopoverActive((active) => !active);
+    }, [localTime]);
+    const handleMonthChange = useCallback((month: number, year: number) => {
+      setPopoverMonth(month);
+      setPopoverYear(year);
+    }, []);
+
+    return (
+      <InlineStack gap="400">
+        <Popover
+          preferredPosition="above"
+          active={datePopoverActive}
+          activator={
+            <TextField
+              id={props.id ? `${props.id}-date` : undefined}
+              label={props.label ?? metadata.name ?? "Date"}
+              prefix={<Icon source={CalendarIcon} />}
+              autoComplete="off"
+              value={localTime ? formatShortDateString(localTime) : ""}
+              onFocus={toggleDatePopoverActive}
+              requiredIndicator={metadata.requiredArgumentForInput}
+              error={props.error ?? fieldState.error?.message}
+            />
+          }
+          onClose={toggleDatePopoverActive}
+        >
+          <div style={{ padding: "16px" }}>
+            <DatePicker
+              month={popoverMonth}
+              year={popoverYear}
+              allowRange={false}
+              onChange={onDateChange}
+              onMonthChange={handleMonthChange}
+              selected={localTime ?? new Date()}
+              {...props.datePickerProps}
+            />
+          </div>
+        </Popover>
+        {(props.includeTime ?? (config as GadgetDateTimeConfig).includeTime) && (
+          <div style={{ width: "130px" }}>
+            <PolarisAutoTimePicker
+              fieldProps={fieldProps}
+              id={props.id}
+              localTime={localTime}
+              onChange={onChange}
+              hideTimePopover={props.hideTimePopover}
+              localTz={localTz}
+              timePickerProps={props.timePickerProps}
+              value={value}
+            />
+          </div>
+        )}
+      </InlineStack>
+    );
+  }
+);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEncryptedStringInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEncryptedStringInput.tsx
@@ -3,27 +3,30 @@ import { Button } from "@shopify/polaris";
 import { HideIcon, ViewIcon } from "@shopify/polaris-icons";
 import React, { useState } from "react";
 import type { Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 
-export const PolarisAutoEncryptedStringInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<TextFieldProps>
-) => {
-  const [isShown, setIsShown] = useState(false);
+export const PolarisAutoEncryptedStringInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<TextFieldProps>
+  ) => {
+    const [isShown, setIsShown] = useState(false);
 
-  const showHideToggleButton = (
-    <div style={{ display: "flex" }}>
-      <Button
-        variant="plain"
-        size="slim"
-        icon={isShown ? HideIcon : ViewIcon}
-        onClick={() => setIsShown(!isShown)}
-        role={`${props.field}ToggleShowHideButton`}
-      />
-    </div>
-  );
+    const showHideToggleButton = (
+      <div style={{ display: "flex" }}>
+        <Button
+          variant="plain"
+          size="slim"
+          icon={isShown ? HideIcon : ViewIcon}
+          onClick={() => setIsShown(!isShown)}
+          role={`${props.field}ToggleShowHideButton`}
+        />
+      </div>
+    );
 
-  return <PolarisAutoTextInput type={isShown ? "text" : "password"} suffix={showHideToggleButton} {...props} />;
-};
+    return <PolarisAutoTextInput type={isShown ? "text" : "password"} suffix={showHideToggleButton} {...props} />;
+  }
+);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
@@ -2,130 +2,133 @@ import type { ComboboxProps } from "@shopify/polaris";
 import { AutoSelection, Box, Combobox, InlineStack, Listbox, Tag, Text } from "@shopify/polaris";
 import React, { useCallback } from "react";
 import type { Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useEnumInputController } from "../../hooks/useEnumInputController.js";
 
-export const PolarisAutoEnumInput = (props: { field: string; control?: Control<any>; label?: string } & Partial<ComboboxProps>) => {
-  const { field: fieldApiIdentifier, control, label: labelProp, ...comboboxProps } = props;
-  const {
-    allowMultiple,
-    allowOther,
-    onSelectionChange,
-    selectedOptions,
-    allOptions,
-    filteredOptions,
-    searchQuery,
-    label,
-    metadata,
-    isError,
-    errorMessage,
-  } = useEnumInputController({ field: fieldApiIdentifier, control });
-  const { value: searchValue, setValue: setSearchValue } = searchQuery;
+export const PolarisAutoEnumInput = autoInput(
+  (props: { field: string; control?: Control<any>; label?: string } & Partial<ComboboxProps>) => {
+    const { field: fieldApiIdentifier, control, label: labelProp, ...comboboxProps } = props;
+    const {
+      allowMultiple,
+      allowOther,
+      onSelectionChange,
+      selectedOptions,
+      allOptions,
+      filteredOptions,
+      searchQuery,
+      label,
+      metadata,
+      isError,
+      errorMessage,
+    } = useEnumInputController({ field: fieldApiIdentifier, control });
+    const { value: searchValue, setValue: setSearchValue } = searchQuery;
 
-  let selectedTagsElement = null;
-  if (selectedOptions.length > 0) {
-    selectedTagsElement = (
-      <InlineStack gap="150">
-        {selectedOptions.map((tag) => (
-          <Tag key={`option-${tag}`} onRemove={() => onSelectionChange(tag)}>
-            {tag}
-          </Tag>
-        ))}
-      </InlineStack>
-    );
-  }
-
-  const formatOptionText = useCallback(
-    (option: string) => {
-      const trimValue = searchValue.trim().toLocaleLowerCase();
-      const matchIndex = option.toLocaleLowerCase().indexOf(trimValue);
-
-      if (!searchValue || matchIndex === -1) return option;
-
-      const start = option.slice(0, matchIndex);
-      const highlight = option.slice(matchIndex, matchIndex + trimValue.length);
-      const end = option.slice(matchIndex + trimValue.length, option.length);
-
-      return (
-        <p>
-          {start}
-          <Text fontWeight="bold" as="span">
-            {highlight}
-          </Text>
-          {end}
-        </p>
+    let selectedTagsElement = null;
+    if (selectedOptions.length > 0) {
+      selectedTagsElement = (
+        <InlineStack gap="150">
+          {selectedOptions.map((tag) => (
+            <Tag key={`option-${tag}`} onRemove={() => onSelectionChange(tag)}>
+              {tag}
+            </Tag>
+          ))}
+        </InlineStack>
       );
-    },
-    [searchValue]
-  );
+    }
 
-  let optionItemElement = null;
-  if (allOptions.length > 0) {
-    optionItemElement = filteredOptions.map((option) => {
-      return (
-        <Listbox.Option key={option} value={option} selected={selectedOptions.includes(option)} accessibilityLabel={option}>
-          <Listbox.TextOption selected={selectedOptions.includes(option)}>{formatOptionText(option)}</Listbox.TextOption>
-        </Listbox.Option>
-      );
-    });
-  }
+    const formatOptionText = useCallback(
+      (option: string) => {
+        const trimValue = searchValue.trim().toLocaleLowerCase();
+        const matchIndex = option.toLocaleLowerCase().indexOf(trimValue);
 
-  let addExtraOptionElement = null;
-  if (allowOther && searchValue && !allOptions.includes(searchValue) && searchValue.trim().length > 0) {
-    addExtraOptionElement = <Listbox.Action value={searchValue}>{`Add "${searchValue}"`}</Listbox.Action>;
-  }
+        if (!searchValue || matchIndex === -1) return option;
 
-  let emptyStateElement = null;
-  if (!allowOther && (!optionItemElement || optionItemElement.length === 0) && searchValue) {
-    emptyStateElement = (
-      <Box padding="100">
-        <Text as="span" alignment="center" tone="subdued">{`No options found matching "${searchValue}"`}</Text>
-      </Box>
+        const start = option.slice(0, matchIndex);
+        const highlight = option.slice(matchIndex, matchIndex + trimValue.length);
+        const end = option.slice(matchIndex + trimValue.length, option.length);
+
+        return (
+          <p>
+            {start}
+            <Text fontWeight="bold" as="span">
+              {highlight}
+            </Text>
+            {end}
+          </p>
+        );
+      },
+      [searchValue]
     );
-  }
 
-  let listBoxElement = null;
-  if (optionItemElement || addExtraOptionElement || emptyStateElement) {
-    listBoxElement = (
-      <Listbox
-        autoSelection={AutoSelection.None}
-        onSelect={(selected) => {
-          onSelectionChange(selected);
-          if (allowMultiple) {
-            setSearchValue("");
-          }
-        }}
+    let optionItemElement = null;
+    if (allOptions.length > 0) {
+      optionItemElement = filteredOptions.map((option) => {
+        return (
+          <Listbox.Option key={option} value={option} selected={selectedOptions.includes(option)} accessibilityLabel={option}>
+            <Listbox.TextOption selected={selectedOptions.includes(option)}>{formatOptionText(option)}</Listbox.TextOption>
+          </Listbox.Option>
+        );
+      });
+    }
+
+    let addExtraOptionElement = null;
+    if (allowOther && searchValue && !allOptions.includes(searchValue) && searchValue.trim().length > 0) {
+      addExtraOptionElement = <Listbox.Action value={searchValue}>{`Add "${searchValue}"`}</Listbox.Action>;
+    }
+
+    let emptyStateElement = null;
+    if (!allowOther && (!optionItemElement || optionItemElement.length === 0) && searchValue) {
+      emptyStateElement = (
+        <Box padding="100">
+          <Text as="span" alignment="center" tone="subdued">{`No options found matching "${searchValue}"`}</Text>
+        </Box>
+      );
+    }
+
+    let listBoxElement = null;
+    if (optionItemElement || addExtraOptionElement || emptyStateElement) {
+      listBoxElement = (
+        <Listbox
+          autoSelection={AutoSelection.None}
+          onSelect={(selected) => {
+            onSelectionChange(selected);
+            if (allowMultiple) {
+              setSearchValue("");
+            }
+          }}
+        >
+          {emptyStateElement}
+          {addExtraOptionElement}
+          {optionItemElement}
+        </Listbox>
+      );
+    }
+
+    const inputLabel = (
+      <>
+        {labelProp ?? label} {metadata.requiredArgumentForInput ? <span style={{ color: "var(--p-color-text-critical)" }}>*</span> : null}
+      </>
+    );
+
+    return (
+      <Combobox
+        allowMultiple={allowMultiple}
+        activator={
+          <Combobox.TextField
+            autoComplete="off"
+            label={inputLabel}
+            value={searchValue}
+            placeholder="Search"
+            verticalContent={selectedTagsElement}
+            onChange={setSearchValue}
+            id={`${props.field}-combobox-textfield`}
+            error={errorMessage}
+          />
+        }
+        {...comboboxProps}
       >
-        {emptyStateElement}
-        {addExtraOptionElement}
-        {optionItemElement}
-      </Listbox>
+        {listBoxElement}
+      </Combobox>
     );
   }
-
-  const inputLabel = (
-    <>
-      {labelProp ?? label} {metadata.requiredArgumentForInput ? <span style={{ color: "var(--p-color-text-critical)" }}>*</span> : null}
-    </>
-  );
-
-  return (
-    <Combobox
-      allowMultiple={allowMultiple}
-      activator={
-        <Combobox.TextField
-          autoComplete="off"
-          label={inputLabel}
-          value={searchValue}
-          placeholder="Search"
-          verticalContent={selectedTagsElement}
-          onChange={setSearchValue}
-          id={`${props.field}-combobox-textfield`}
-          error={errorMessage}
-        />
-      }
-      {...comboboxProps}
-    >
-      {listBoxElement}
-    </Combobox>
-  );
-};
+);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
@@ -5,9 +5,10 @@ import { filesize } from "filesize";
 import React, { useMemo } from "react";
 import type { Control } from "../../../useActionForm.js";
 import { isAutoFileFieldValue } from "../../../validationSchema.js";
+import { autoInput } from "../../AutoInput.js";
 import { getFileSizeValidationMessage, imageFileTypes, useFileInputController } from "../../hooks/useFileInputController.js";
 
-export const PolarisAutoFileInput = (props: { field: string; control?: Control<any> } & Omit<DropZoneProps, "allowMultiple">) => {
+export const PolarisAutoFileInput = autoInput((props: { field: string; control?: Control<any> } & Omit<DropZoneProps, "allowMultiple">) => {
   const { field: fieldApiIdentifier, control, ...rest } = props;
   const { fieldProps, errorMessage, imageThumbnailURL, onFileUpload, clearFileValue, canClearFileValue, validations, metadata } =
     useFileInputController({
@@ -98,4 +99,4 @@ export const PolarisAutoFileInput = (props: { field: string; control?: Control<a
       )}
     </>
   );
-};
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoHiddenInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoHiddenInput.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { autoInput } from "../../AutoInput.js";
 import { useHiddenInput } from "../../hooks/useHiddenInput.js";
 
-export const PolarisAutoHiddenInput = (props: {
-  field: string; // The field API identifier
-  value: any;
-}) => {
-  const fieldProps = useHiddenInput(props);
+export const PolarisAutoHiddenInput = autoInput(
+  (props: {
+    field: string; // The field API identifier
+    value: any;
+  }) => {
+    const fieldProps = useHiddenInput(props);
 
-  return <input type="hidden" {...fieldProps} />;
-};
+    return <input type="hidden" {...fieldProps} />;
+  }
+);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoIdInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoIdInput.tsx
@@ -1,18 +1,21 @@
 import React from "react";
 import { FieldType } from "../../../metadata.js";
+import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
 import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 
-export const PolarisAutoIdInput = (props: {
-  field: string; // The field API identifier
-  label?: string;
-}) => {
-  const { field, label } = props;
-  const { name, metadata } = useStringInputController({ field });
+export const PolarisAutoIdInput = autoInput(
+  (props: {
+    field: string; // The field API identifier
+    label?: string;
+  }) => {
+    const { field, label } = props;
+    const { name, metadata } = useStringInputController({ field });
 
-  if (metadata.fieldType !== FieldType.Id || field !== "id") {
-    throw new Error(`PolarisAutoIdInput: field ${field} is not of type Id`);
+    if (metadata.fieldType !== FieldType.Id || field !== "id") {
+      throw new Error(`PolarisAutoIdInput: field ${field} is not of type Id`);
+    }
+
+    return <PolarisAutoTextInput step={1} field={field} min={1} type="number" label={label || "ID"} name={name} />;
   }
-
-  return <PolarisAutoTextInput step={1} field={field} min={1} type="number" label={label || "ID"} name={name} />;
-};
+);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoInput.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FieldType } from "../../../metadata.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { PolarisAutoRichTextInput } from "./LazyLoadedPolarisAutoRichTextInput.js";
 import { PolarisAutoBooleanInput } from "./PolarisAutoBooleanInput.js";
@@ -16,7 +17,7 @@ import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 import { PolarisAutoBelongsToInput } from "./relationships/PolarisAutoBelongsToInput.js";
 import { PolarisAutoHasManyInput } from "./relationships/PolarisAutoHasManyInput.js";
 
-export const PolarisAutoInput = (props: { field: string; label?: string }) => {
+export const PolarisAutoInput = autoInput((props: { field: string; label?: string }) => {
   const { metadata } = useFieldMetadata(props.field);
   const config = metadata.configuration;
 
@@ -88,4 +89,4 @@ export const PolarisAutoInput = (props: { field: string; label?: string }) => {
       throw new Error(`Unsupported field type for Polaris AutoForm: ${metadata.fieldType}`);
     }
   }
-};
+});

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoJSONInput.tsx
@@ -4,31 +4,34 @@ import React from "react";
 import type { Control } from "../../../useActionForm.js";
 import { useFocus } from "../../../useFocus.js";
 import { getPropsWithoutRef } from "../../../utils.js";
+import { autoInput } from "../../AutoInput.js";
 import { useJSONInputController } from "../../hooks/useJSONInputController.js";
 
-export const PolarisAutoJSONInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<Omit<TextFieldProps, "onChange">>
-) => {
-  const [isFocused, focusProps] = useFocus();
-  const { field: _field, control: _control, ...restOfProps } = props;
-  const { type: _type, errorMessage, ...controller } = useJSONInputController(props);
+export const PolarisAutoJSONInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<Omit<TextFieldProps, "onChange">>
+  ) => {
+    const [isFocused, focusProps] = useFocus();
+    const { field: _field, control: _control, ...restOfProps } = props;
+    const { type: _type, errorMessage, ...controller } = useJSONInputController(props);
 
-  const label = props.label ?? controller.label;
-  return (
-    <>
-      <TextField
-        multiline={4}
-        monospaced
-        requiredIndicator={controller.metadata.requiredArgumentForInput}
-        error={!isFocused && errorMessage && `Invalid JSON: ${errorMessage}`}
-        {...getPropsWithoutRef(controller)}
-        {...getPropsWithoutRef(focusProps)}
-        {...restOfProps}
-        label={label}
-      />
-    </>
-  );
-};
+    const label = props.label ?? controller.label;
+    return (
+      <>
+        <TextField
+          multiline={4}
+          monospaced
+          requiredIndicator={controller.metadata.requiredArgumentForInput}
+          error={!isFocused && errorMessage && `Invalid JSON: ${errorMessage}`}
+          {...getPropsWithoutRef(controller)}
+          {...getPropsWithoutRef(focusProps)}
+          {...restOfProps}
+          label={label}
+        />
+      </>
+    );
+  }
+);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoNumberInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoNumberInput.tsx
@@ -1,31 +1,34 @@
 import type { TextFieldProps } from "@shopify/polaris";
 import React from "react";
 import type { Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
 import { PolarisAutoTextInput } from "./PolarisAutoTextInput.js";
 
-export const PolarisAutoNumberInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<TextFieldProps>
-) => {
-  const { field, control } = props;
-  const { type, metadata, value } = useStringInputController({ field, control });
-  const fieldType = type as TextFieldProps["type"];
+export const PolarisAutoNumberInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<TextFieldProps>
+  ) => {
+    const { field, control } = props;
+    const { type, metadata, value } = useStringInputController({ field, control });
+    const fieldType = type as TextFieldProps["type"];
 
-  const step =
-    fieldType === "number" &&
-    metadata.configuration.__typename === "GadgetNumberConfig" &&
-    metadata.configuration.decimals &&
-    metadata.configuration.decimals > 0
-      ? getStepFromNumberOfDecimals(metadata.configuration.decimals)
-      : value
-      ? getStepFromNumberOfDecimals(countNumberOfDecimals(`${value}`))
-      : 1;
+    const step =
+      fieldType === "number" &&
+      metadata.configuration.__typename === "GadgetNumberConfig" &&
+      metadata.configuration.decimals &&
+      metadata.configuration.decimals > 0
+        ? getStepFromNumberOfDecimals(metadata.configuration.decimals)
+        : value
+        ? getStepFromNumberOfDecimals(countNumberOfDecimals(`${value}`))
+        : 1;
 
-  return <PolarisAutoTextInput step={step} {...props} />;
-};
+    return <PolarisAutoTextInput step={step} {...props} />;
+  }
+);
 
 const getStepFromNumberOfDecimals = (numberOfDecimals: number) =>
   numberOfDecimals === 0 ? 1 : Number(`0.${"0".repeat(numberOfDecimals - 1)}1`);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
@@ -4,48 +4,50 @@ import { EditIcon } from "@shopify/polaris-icons";
 import React, { useState } from "react";
 import { useController, type Control } from "../../../useActionForm.js";
 import { useAutoFormMetadata } from "../../AutoFormContext.js";
+import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { PolarisAutoEncryptedStringInput } from "./PolarisAutoEncryptedStringInput.js";
-
 /**
  * The salted password hash is not retrieved from the DB
  * Regardless of the password is defined or not, this placeholder is shown as exposing an unset password is a security risk
  */
 const existingPasswordPlaceholder = "********";
 
-export const PolarisAutoPasswordInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<TextFieldProps>
-) => {
-  const { findBy } = useAutoFormMetadata();
-  const { path } = useFieldMetadata(props.field);
-  const { field: fieldProps } = useController({ name: path });
+export const PolarisAutoPasswordInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<TextFieldProps>
+  ) => {
+    const { findBy } = useAutoFormMetadata();
+    const { path } = useFieldMetadata(props.field);
+    const { field: fieldProps } = useController({ name: path });
 
-  const [isEditing, setIsEditing] = useState(!findBy);
+    const [isEditing, setIsEditing] = useState(!findBy);
 
-  const startEditing = () => {
-    fieldProps.onChange(""); // Touch the field to mark it as dirty
-    setIsEditing(true);
-  };
+    const startEditing = () => {
+      fieldProps.onChange(""); // Touch the field to mark it as dirty
+      setIsEditing(true);
+    };
 
-  const startEditingButton = (
-    <div style={{ display: "flex" }}>
-      <Button variant="plain" size="slim" icon={EditIcon} onClick={startEditing} role={`${props.field}EditPasswordButton`} />
-    </div>
-  );
+    const startEditingButton = (
+      <div style={{ display: "flex" }}>
+        <Button variant="plain" size="slim" icon={EditIcon} onClick={startEditing} role={`${props.field}EditPasswordButton`} />
+      </div>
+    );
 
-  return (
-    <PolarisAutoEncryptedStringInput
-      {...(isEditing
-        ? { placeholder: "Password" }
-        : {
-            placeholder: existingPasswordPlaceholder,
-            suffix: startEditingButton,
-            disabled: true,
-          })}
-      {...props}
-    />
-  );
-};
+    return (
+      <PolarisAutoEncryptedStringInput
+        {...(isEditing
+          ? { placeholder: "Password" }
+          : {
+              placeholder: existingPasswordPlaceholder,
+              suffix: startEditingButton,
+              disabled: true,
+            })}
+        {...props}
+      />
+    );
+  }
+);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoRichTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoRichTextInput.tsx
@@ -1,6 +1,7 @@
 import { Label } from "@shopify/polaris";
 import type { ComponentProps } from "react";
 import React from "react";
+import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
 import AutoRichTextInput from "../../shared/AutoRichTextInput.js";
 import "../styles/rich-text.css";
@@ -8,7 +9,7 @@ import "../styles/rich-text.css";
 /**
  * Prefer using the LazyLoadedMUIAutoRichTextInput.tsx variant of this component to reduce the bundle size by default.
  */
-export default function PolarisAutoRichTextInput(props: ComponentProps<typeof AutoRichTextInput>) {
+const PolarisAutoRichTextInput = autoInput((props: ComponentProps<typeof AutoRichTextInput>) => {
   const controller = useStringInputController({ field: props.field, control: props.control });
 
   return (
@@ -23,4 +24,6 @@ export default function PolarisAutoRichTextInput(props: ComponentProps<typeof Au
       </div>
     </div>
   );
-}
+});
+
+export default PolarisAutoRichTextInput;

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoRolesInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoRolesInput.tsx
@@ -1,37 +1,40 @@
 import React from "react";
 import type { Control } from "../../../useActionForm.js";
 import { getPropsWithoutRef } from "../../../utils.js";
+import { autoInput } from "../../AutoInput.js";
 import { useRoleInputController } from "../../hooks/useRoleInputController.js";
 import type { PolarisFixedOptionsMultiComboboxProps } from "../PolarisFixedOptionsCombobox.js";
 import { PolarisFixedOptionsCombobox } from "../PolarisFixedOptionsCombobox.js";
 
-export const PolarisAutoRolesInput = (
-  props: {
-    field: string; // Field API identifier
-    control?: Control<any>;
-  } & Partial<PolarisFixedOptionsMultiComboboxProps>
-) => {
-  const { options, loading, rolesError, fieldError, selectedRoleKeys, fieldProps, metadata } = useRoleInputController(props);
+export const PolarisAutoRolesInput = autoInput(
+  (
+    props: {
+      field: string; // Field API identifier
+      control?: Control<any>;
+    } & Partial<PolarisFixedOptionsMultiComboboxProps>
+  ) => {
+    const { options, loading, rolesError, fieldError, selectedRoleKeys, fieldProps, metadata } = useRoleInputController(props);
 
-  if (rolesError) {
-    throw rolesError;
-  }
-  if (fieldError) {
-    throw fieldError;
-  }
+    if (rolesError) {
+      throw rolesError;
+    }
+    if (fieldError) {
+      throw fieldError;
+    }
 
-  if (loading || !options || options.length === 0) {
-    // Don't render until role options exist. There must always be at least one role option `unauthenticated`
-    return null;
-  }
+    if (loading || !options || options.length === 0) {
+      // Don't render until role options exist. There must always be at least one role option `unauthenticated`
+      return null;
+    }
 
-  return (
-    <PolarisFixedOptionsCombobox
-      options={options}
-      allowMultiple
-      label={props.label ?? metadata.name}
-      {...getPropsWithoutRef(fieldProps)}
-      value={selectedRoleKeys}
-    />
-  );
-};
+    return (
+      <PolarisFixedOptionsCombobox
+        options={options}
+        allowMultiple
+        label={props.label ?? metadata.name}
+        {...getPropsWithoutRef(fieldProps)}
+        value={selectedRoleKeys}
+      />
+    );
+  }
+);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
@@ -3,25 +3,28 @@ import { TextField } from "@shopify/polaris";
 import React from "react";
 import type { Control } from "../../../useActionForm.js";
 import { getPropsWithoutRef } from "../../../utils.js";
+import { autoInput } from "../../AutoInput.js";
 import { useStringInputController } from "../../hooks/useStringInputController.js";
 
-export const PolarisAutoTextInput = (
-  props: {
-    field: string; // The field API identifier
-    control?: Control<any>;
-  } & Partial<TextFieldProps>
-) => {
-  const { field, control } = props;
-  const stringInputController = useStringInputController({ field, control });
+export const PolarisAutoTextInput = autoInput(
+  (
+    props: {
+      field: string; // The field API identifier
+      control?: Control<any>;
+    } & Partial<TextFieldProps>
+  ) => {
+    const { field, control } = props;
+    const stringInputController = useStringInputController({ field, control });
 
-  return (
-    <TextField
-      {...getPropsWithoutRef(stringInputController)}
-      requiredIndicator={stringInputController.metadata.requiredArgumentForInput}
-      type={stringInputController.type as TextFieldProps["type"]}
-      error={stringInputController.errorMessage}
-      {...props}
-      label={props.label || stringInputController.metadata.name}
-    />
-  );
-};
+    return (
+      <TextField
+        {...getPropsWithoutRef(stringInputController)}
+        requiredIndicator={stringInputController.metadata.requiredArgumentForInput}
+        type={stringInputController.type as TextFieldProps["type"]}
+        error={stringInputController.errorMessage}
+        {...props}
+        label={props.label || stringInputController.metadata.name}
+      />
+    );
+  }
+);

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
@@ -1,11 +1,12 @@
 import { Combobox, Tag } from "@shopify/polaris";
 import React from "react";
+import { autoInput } from "../../../AutoInput.js";
 import { useBelongsToInputController } from "../../../hooks/useBelongsToInputController.js";
 import { optionRecordsToLoadCount } from "../../../hooks/useRelatedModelOptions.js";
 import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { RelatedModelOptions } from "./RelatedModelOptions.js";
 
-export const PolarisAutoBelongsToInput = (props: AutoRelationshipInputProps) => {
+export const PolarisAutoBelongsToInput = autoInput((props: AutoRelationshipInputProps) => {
   const {
     fieldMetadata: { path, metadata },
     relatedModelOptions: { options, searchFilterOptions, pagination, search },
@@ -68,4 +69,4 @@ export const PolarisAutoBelongsToInput = (props: AutoRelationshipInputProps) => 
       </Combobox>
     </>
   );
-};
+});

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
@@ -1,13 +1,14 @@
 import type { GadgetRecordList } from "@gadgetinc/api-client-core";
 import { Banner, Combobox } from "@shopify/polaris";
 import React from "react";
+import { autoInput } from "../../../AutoInput.js";
 import { useHasManyInputController } from "../../../hooks/useHasManyInputController.js";
 import { optionRecordsToLoadCount } from "../../../hooks/useRelatedModelOptions.js";
 import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { RelatedModelOptions } from "./RelatedModelOptions.js";
 import { getSelectedRelatedRecordTags } from "./SelectedRelatedRecordTags.js";
 
-export const PolarisAutoHasManyInput = (props: AutoRelationshipInputProps) => {
+export const PolarisAutoHasManyInput = autoInput((props: AutoRelationshipInputProps) => {
   const { field } = props;
 
   const {
@@ -58,4 +59,4 @@ export const PolarisAutoHasManyInput = (props: AutoRelationshipInputProps) => {
       </Combobox>
     </>
   );
-};
+});

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
@@ -1,5 +1,6 @@
 import { Banner, Combobox } from "@shopify/polaris";
 import React from "react";
+import { autoInput } from "../../../AutoInput.js";
 import { useHasOneInputController } from "../../../hooks/useHasOneInputController.js";
 import { optionRecordsToLoadCount } from "../../../hooks/useRelatedModelOptions.js";
 import type { AutoRelationshipInputProps } from "../../../interfaces/AutoRelationshipInputProps.js";
@@ -11,7 +12,7 @@ import { getSelectedRelatedRecordTags } from "./SelectedRelatedRecordTags.js";
  */
 const showErrorBannerWhenTooManyRelatedRecords = false;
 
-export const PolarisAutoHasOneInput = (props: AutoRelationshipInputProps) => {
+export const PolarisAutoHasOneInput = autoInput((props: AutoRelationshipInputProps) => {
   const { field } = props;
   const {
     fieldMetadata: { path, metadata },
@@ -62,4 +63,4 @@ export const PolarisAutoHasOneInput = (props: AutoRelationshipInputProps) => {
       </Combobox>
     </>
   );
-};
+});

--- a/packages/react/src/auto/shared/AutoRichTextInput.tsx
+++ b/packages/react/src/auto/shared/AutoRichTextInput.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useFormContext } from "../../useActionForm.js";
 import { get } from "../../utils.js";
+import { autoInput } from "../AutoInput.js";
 import { useStringInputController } from "../hooks/useStringInputController.js";
 import { multiref } from "../hooks/utils.js";
 import type { AutoRichTextInputProps, MDXEditorMethods } from "./AutoRichTextInputProps.js";
 
-const AutoRichTextInput: React.FC<AutoRichTextInputProps> = (props) => {
+const AutoRichTextInput = autoInput<AutoRichTextInputProps>((props) => {
   const { formState } = useFormContext();
   const { field, control, editorRef, ...rest } = props;
   const controller = useStringInputController({ field, control });
@@ -93,6 +94,6 @@ const AutoRichTextInput: React.FC<AutoRichTextInputProps> = (props) => {
       {...rest}
     />
   );
-};
+});
 
 export default AutoRichTextInput;


### PR DESCRIPTION
We want to start moving to an approach in auto components where we make a single selection on models based on the fields that are going to be active in a form. In order to do that we need to know which fields will be needed for inputs; the way that I am proposing to do this is to make all auto inputs higher order components that are wrapped in `autoInput`; doing this will allow us to look at the component tree of an auto form and determine the selection that needs to be made on the model that is being mutated

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
