### PR TITLE
Fixed bug with loading selected related model records in AutoForm HasMany inputs in framework version 1.3

### DIFF
--- a/packages/react/.changeset/lazy-pans-push.md
+++ b/packages/react/.changeset/lazy-pans-push.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Fixed bug with loading selected related model records in AutoForm HasMany inputs in framework version 1.3

--- a/packages/react/cypress/component/auto/form/PolarisAutoHasManyInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoHasManyInput.cy.tsx
@@ -68,7 +68,7 @@ describe("PolarisAutoHasManyInput", () => {
         url: `${api.connection.endpoint}?operation=gizmos`,
       },
       (req) => {
-        const queryIsForSelectedRecords = get(req.body.variables, "filter.widget.equals") === "42";
+        const queryIsForSelectedRecords = get(req.body.variables, "filter.widgetId.equals") === "42";
 
         req.reply({
           data: {

--- a/packages/react/src/auto/hooks/useRelatedModelOptions.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModelOptions.tsx
@@ -186,11 +186,13 @@ export const useLinkedParentModelRelatedModelRecords = (props: {
     );
   }
 
+  const filterField = `${inverseFieldApiIdentifier}Id`; // Filter on the `Id` suffixed inverse field for compatibility before and after framework version v1.3
+
   const [{ data: selectedRecords, fetching: fetchingSelected, error: fetchSelectedRecordError }] = useFindMany(relatedModelManager as any, {
     pause: !currentRecordId || fetchingCurrentRecord, // HasOne/HasMany need the current record to query the inverse field in the related model
 
     first: selectedRecordsToLoadCount, // Many records can point to the current record in hasOne/hasMany
-    filter: { [inverseFieldApiIdentifier]: { equals: currentRecordId } }, // Filter by the inverse field belongsTo field value
+    filter: { [filterField]: { equals: currentRecordId } }, // Filter by the inverse field belongsTo field value
   });
 
   return {


### PR DESCRIPTION
- Update
  - See title
  - This was a consequence of our test environments not being configured with framework version 1.3 and the corresponding changes to related model filtering 