### PR TITLE
Fixed bug with AutoForm where the action api identifiers could not be properly determined in Gadget framework version 1.0.0

### DIFF
--- a/packages/react/.changeset/big-impalas-think.md
+++ b/packages/react/.changeset/big-impalas-think.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Fixed bug with AutoForm where the action api identifiers could not be properly determined in Gadget framework version 1.0.0

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -413,7 +413,11 @@ export const useActionMetadata = (
       }
     }
     if (!actionName) {
-      throw new Error("action function not found on model manager");
+      // Fallback to string parsing if the action name is not found
+      actionName = actionFunction.operationName.slice(0, -actionFunction.modelApiIdentifier.length);
+      if (!actionName || !(actionName in modelManager)) {
+        throw new Error("action function not found on model manager");
+      }
     }
     variables = {
       modelApiIdentifier: actionFunction.modelApiIdentifier,


### PR DESCRIPTION
- UPDATE
  - Framework version 1.0.0 apps have empty object prototypes for the model manager which makes it impossible to determine the action API id in the same way that we do in FWVersion >=1.1
  - Added a `parse the operationName to get actionApiId` system as a fallback in the event that we fail to get the action API id from the model manager
- TESTING
  - Make a v1.0.0 app with this dependency. Observe that AutoForm works as expected 
    - `"@gadgetinc/react": "https://codeload.github.com/gadget-inc/js-clients/tar.gz/@gadgetinc/react-v0.18.1-gitpkg-58f5b08a"`