### PR TITLE
Updated AutoButton type to accept non-string children

### DIFF
--- a/packages/react/.changeset/famous-garlics-enjoy.md
+++ b/packages/react/.changeset/famous-garlics-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated AutoButton type to accept non-string children

--- a/packages/react/src/auto/polaris/PolarisAutoButton.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoButton.tsx
@@ -16,7 +16,8 @@ export const PolarisAutoButton = <
   SchemaT,
   ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
 >(
-  props: AutoButtonProps<GivenOptions, SchemaT, ActionFunc> & ComponentProps<typeof Button>
+  props: AutoButtonProps<GivenOptions, SchemaT, ActionFunc> &
+    Omit<ComponentProps<typeof Button>, "children"> & { children?: React.ReactNode }
 ) => {
   const { fetching, running, isDestructive, run, label, buttonProps } = useAutoButtonController({
     onSuccess: (_result) => {
@@ -38,6 +39,7 @@ export const PolarisAutoButton = <
 
   return (
     <Button loading={running} disabled={fetching} tone={isDestructive ? "critical" : undefined} onClick={run} {...buttonProps}>
+      {/* @ts-expect-error  // Polaris Button children types demands strings, but ReactComponents work*/}
       {props?.children ?? label}
     </Button>
   );


### PR DESCRIPTION
- Previously, the type was restricted to `string | string[] | undefined` but react components would work
  - This was an unnecessary restriction imposed by Polaris 
- Updated the type to allow for react components 