### PR TITLE
api-client-core should propagate error for live queries

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.34",
+  "version": "0.15.35",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/src/graphql-live-query-utils/createApplyLiveQueryPatch.ts
+++ b/packages/api-client-core/src/graphql-live-query-utils/createApplyLiveQueryPatch.ts
@@ -38,12 +38,14 @@ export const createApplyLiveQueryPatch =
           const valueToPublish: ExecutionLivePatchResult = {};
 
           if (next.value.revision === 1) {
-            if (!next.value.data) {
+            if (next.value.data !== undefined) {
+              valueToPublish.data = next.value.data;
+
+              mutableData = next.value.data;
+              lastRevision = 1;
+            } else {
               throw new Error("Missing data.");
             }
-            valueToPublish.data = next.value.data;
-            mutableData = next.value.data;
-            lastRevision = 1;
           } else {
             if (!mutableData) {
               throw new Error("No previousData available.");


### PR DESCRIPTION
See https://github.com/gadget-inc/js-clients/pull/697 for details. 

This PR just merges the api-client-core portion of the PR as it seems like you can't bump api-client-core and it's usage in a single PR. This is because the vite test does an `pnpm install` with the new version number, however that can't be found because it hasn't been released yet (until the PR is merged).

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
