### PR TITLE
Strip nulls from the form state type for maximum polaris compatability

### DIFF
--- a/packages/react/spec/useActionFormController.spec.tsx
+++ b/packages/react/spec/useActionFormController.spec.tsx
@@ -1,0 +1,27 @@
+import { Form, TextField } from "@shopify/polaris";
+import React from "react";
+import { Controller, useActionForm } from "../src/useActionForm.js";
+import { relatedProductsApi } from "./apis.js";
+
+describe("useActionFormController", () => {
+  test("null is removed from possible form states to remain compatible with polaris", () => {
+    const Component = () => {
+      const { control, submit } = useActionForm(relatedProductsApi.user.create, {
+        defaultValues: { id: "123" },
+      });
+
+      return (
+        <Form onSubmit={submit}>
+          <Controller
+            name="email"
+            control={control}
+            render={({ field: { ref, ...fieldProps } }) => <TextField label="yay" autoComplete="off" {...fieldProps} />}
+          />
+        </Form>
+      );
+    };
+
+    // this file just does type checks above
+    expect(true).toBe(true);
+  });
+});

--- a/packages/react/src/use-action-form/types.ts
+++ b/packages/react/src/use-action-form/types.ts
@@ -41,13 +41,25 @@ export type FormInput<InputT, Depth extends number = 9, CurrentDepth extends num
   ? { [K in keyof InputT]: FormInput<InputT[K], Depth, Increment<CurrentDepth>> }
   : InputT | null | undefined;
 
+/**
+ * Type helper to convert `null` to undefined recursively within the form values type
+ * Many Gadget users use Shopify Polaris as a design system, and many of its input components do not accept `null` values. For maximum compatibility with Polaris, we convert `null` to `undefined` within the form values type, knowing that the Polaris components handle both at runtime just fine.
+ */
+export type StripNulls<T> = T extends null
+  ? undefined
+  : T extends (infer U)[]
+  ? StripNulls<U>[]
+  : T extends object
+  ? { [K in keyof T]: StripNulls<T[K]> }
+  : T;
+
 export type UseActionFormResult<
   GivenOptions extends OptionsType,
   SchemaT,
   ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>,
   FormVariables extends FieldValues,
   FormContext = any
-> = Omit<UseFormReturn<FormVariables & FormInput<ActionFunc["variablesType"]>, FormContext>, "handleSubmit" | "formState"> & {
+> = Omit<UseFormReturn<FormVariables & StripNulls<FormInput<ActionFunc["variablesType"]>>, FormContext>, "handleSubmit" | "formState"> & {
   formState: UseActionFormState<ActionFunc, FormVariables, FormContext> & { isReady: boolean };
   /**
    * Any error that occurred during initial data fetching or action submission


### PR DESCRIPTION
Shopify Polaris, in its infinite wisdom, accepts only `string | undefined` for the `value` prop on its `<TextInput/>` component. `<input/>` in the DOM accepts `string | readonly string[] | number | undefined;`, which you'd think Polaris would be ok with, but alas no. At runtime, it's absolutely fine to pass `null` to the TextInput, it works fine, it's just the type that is not ok with it. Because Gadget's API responds with `null`, not `undefined` for fields that haven't been set yet, it means that the form values type have `string | null | undefined` in them, which causes a type error by default when wiring up to a Polaris `<TextInput/>` with a `<Controller/>`.

Because so many of our users use Polaris, we think we should adjust our default types to work correctly with Polaris inputs. Technically speaking, this type lies -- it suppresses nulls in the output types in favour of undefineds. That said, Gadget always quacks undefined and null for these fields, so the fact that it is optional is still captured in this output type, but the exact type is not captured correctly. I think that since we can't really change Polaris, this is still the right decision so that the base case works nicely for people.

I'm super open to other ideas but I ain't got any! 
