### PR TITLE
Added `searchValue` property to `AutoTable` component to control the table's search value

### DIFF
--- a/packages/react/.changeset/eleven-carrots-press.md
+++ b/packages/react/.changeset/eleven-carrots-press.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Added `searchValue` property to `AutoTable` component to control the table's search value

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -40,5 +40,6 @@ export type AutoTableProps<
   resourceName?: { singular: string; plural: string };
   condensed?: boolean;
   searchable?: boolean;
+  searchValue?: string;
   paginate?: boolean;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -92,6 +92,7 @@ const PolarisAutoTableComponent = <
     live: props.live,
     initialSort: props.initialSort,
     filter: props.filter,
+    search: props.searchValue,
   } as any);
 
   const { columns, rows, page, fetching, error, search, selection, sort, metadata, data: rawRecords } = methods;


### PR DESCRIPTION
UPDATE
- Added `searchValue` prop to `AutoTable` to control the search value of the table from outside of the component itself
- This prop is compatible with `searchable:true` in AutoTable. In this case, the new `searchValue` prop will only be used to power the search when the user does not manually add their own search 

![CleanShot 2024-12-02 at 14 28 20](https://github.com/user-attachments/assets/230fb846-6c24-45d9-a0b6-1a045d76b6ef)