### PR TITLE
Update js-clients to process action responses

### DIFF
--- a/packages/react-bigcommerce/package.json
+++ b/packages/react-bigcommerce/package.json
@@ -27,7 +27,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.35"
+    "@gadgetinc/api-client-core": "^0.15.36"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -27,7 +27,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.35",
+    "@gadgetinc/api-client-core": "^0.15.36",
     "crypto-js": "^4.2.0",
     "tslib": "^2.6.2"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.4",
-    "@gadgetinc/api-client-core": "^0.15.35",
+    "@gadgetinc/api-client-core": "^0.15.36",
     "@hookform/resolvers": "^3.3.1",
     "filesize": "^10.1.2",
     "pluralize": "^8.0.0",

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -11,8 +11,8 @@ import {
   capitalizeIdentifier,
   disambiguateActionVariables,
   get,
-  hydrateRecord,
   namespaceDataPath,
+  processActionResponse,
 } from "@gadgetinc/api-client-core";
 import { useCallback, useContext, useEffect, useMemo } from "react";
 import type { AnyVariables, OperationContext, UseMutationState } from "urql";
@@ -142,14 +142,13 @@ const processResult = <Data, Variables extends AnyVariables>(
   let data = null;
   if (result.data) {
     const dataPath = namespaceDataPath([action.operationName], action.namespace);
-
     const mutationData = get(result.data, dataPath);
     if (mutationData) {
       const errors = mutationData["errors"];
       if (errors && errors[0]) {
         error = ErrorWrapper.forErrorsResponse(errors, error?.response);
       } else {
-        data = action.hasReturnType ? mutationData.result : hydrateRecord(result, mutationData[action.modelSelectionField]);
+        data = processActionResponse(action.defaultSelection, result, mutationData, action.modelSelectionField, action.hasReturnType);
       }
     }
   }

--- a/packages/shopify-extensions/package.json
+++ b/packages/shopify-extensions/package.json
@@ -33,7 +33,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.35"
+    "@gadgetinc/api-client-core": "^0.15.36"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",


### PR DESCRIPTION
The response from an upsert action was not being properly handled by `useAction` and therefore the data was not being returned to the user. This was because the `action.hasReturnType` looks like:

```
{
  "... on CreatePostResult": { hasReturnType: false },
  "... on UpdatePostResult": { hasReturnType: true },
}
```

in the useAction processResult it would just check if `action.hasReturnType` is truthy and if so use `mutationData.result`. However in this case the value is truthy but an object not a boolean value. 

We already have the utility inside the `api-client-core` to process the action results (which is used both by the core action runner and background actions) which handles this case correctly so this updates the code to use that instead.


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
