### PR TITLE
Bump react package version

### DIFF
--- a/packages/react-bigcommerce/package.json
+++ b/packages/react-bigcommerce/package.json
@@ -41,6 +41,6 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "@gadgetinc/react": "^0.18.3"
+    "@gadgetinc/react": "^0.18.4"
   }
 }

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@gadgetinc/react": "^0.18.3",
+    "@gadgetinc/react": "^0.18.4",
     "@shopify/app-bridge-react": "^4.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "files": [
     "README.md",
     "dist/**/*",

--- a/packages/shopify-extensions/package.json
+++ b/packages/shopify-extensions/package.json
@@ -47,6 +47,6 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "@gadgetinc/react": "^0.18.3"
+    "@gadgetinc/react": "^0.18.4"
   }
 }


### PR DESCRIPTION
I forgot to release a new version of react package with the code changes. This bumps the version number.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
