### PR TITLE
Removed `allowMultiple` from `AutoEnumInput` props type

### DIFF
--- a/packages/react/.changeset/sixty-flowers-burn.md
+++ b/packages/react/.changeset/sixty-flowers-burn.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated `AutoEnumInput` props type to no longer include `allowMultiple` as it could not override the configuration of the corresponding Gadget field

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
@@ -6,7 +6,7 @@ import { autoInput } from "../../AutoInput.js";
 import { useEnumInputController } from "../../hooks/useEnumInputController.js";
 
 export const PolarisAutoEnumInput = autoInput(
-  (props: { field: string; control?: Control<any>; label?: string } & Partial<ComboboxProps>) => {
+  (props: { field: string; control?: Control<any>; label?: string } & Partial<Omit<ComboboxProps, "allowMultiple">>) => {
     const { field: fieldApiIdentifier, control, label: labelProp, ...comboboxProps } = props;
     const {
       allowMultiple,


### PR DESCRIPTION
- Updated `AutoEnumInput` props type to no longer include `allowMultiple` as it could not override the configuration of the corresponding Gadget field
- This prop was included by the Polaris Combobox props spread, and gave users the wrong idea about what could be configured in the input