### PR TITLE
Fix double delete on use action form

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.499.0-development.2005",
+    "@gadget-client/js-clients-test": "1.508.0-development.2265",
     "@gadget-client/kitchen-sink": "1.9.0-development.206",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/react/cypress/component/auto/form/PolarisAutoBelongsToInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoBelongsToInput.cy.tsx
@@ -45,7 +45,6 @@ describe("PolarisAutoBelongsToInput", () => {
                 // This simulates the response when the related record is queried to get the related model record value
                 id: "42",
                 sectionId: "1",
-                section: { id: "1", name: "Section 1" },
                 __typename: "Widget",
               }
             : {

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
@@ -164,7 +164,7 @@
         }
       },
       {
-        "_id": "92f0993ea7a9aba2b2055384d7e2c25b",
+        "_id": "0523aa94388d3d9c8c46302084a73ecf",
         "_order": 0,
         "cache": {},
         "request": {
@@ -212,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"1774\",\"text\":\"test question updated - 1\"}},{\"update\":{\"id\":\"1775\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"1775\",\"text\":\"test question updated - 2\"}},{\"update\":{\"id\":\"1774\",\"text\":\"test question updated - 1\"}}],\"text\":\"test quiz updated\"}}}"
           },
           "queryString": [
             {
@@ -228,13 +228,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 432,
-            "text": "[\"H4sIAAAAAAAAA5yRy2rDMBBFf8XMWq3t4FiJdqEtpYsuUtpVKUGRJoqoI7vSGPLA/16UVyEmBLrUzJ1zR3N3oCVJEDtoGy0Jp63dxldolcIQQJBvkQF6X/sAwrVVxeDnKLIaBOTlCBgQrgkEEAZKYjs54DRENQaytQtxBLXBAOJzB67W+AfhvOhRDmMnUnKX5MBgNqNNg06uEARMjxrorjSetEHoWN9teNtt8E+3ryvdh9o5VFcAdtsrfpwDecPQVhQFRmqD9IqHyJYb7eX5tMpj3HwS//QoCd/tCoEdc70oX3o977mTpqms2hP3Fl3HANeELpw8qtoEELAkaoJIU2PovrLuO431NB9mZTZK52qecZ4PcIyLsZRFKTmOJceyyDTP1SJe3kuFLzGKm+Ku+wUAAP//AwCwUnbFowIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA5yRy07DMBBFfyWatSEJpXl4VwFCLFgUwQqhyrIH1yJ1gj2R+lD+Hblpi9QoqtSlZ+6cO567AyVIAN9B2yhBOG/NNrx8KyV6D5xciwzQudp54LatKga/B5FRwCHNCmBAuCbgQOgpCu2oxykIavRkauvDCCqNHvjnDmyt8B+S5/cDSj92JEU3UQoMFgvaNGjFCoHD/KCBbqTxpDRCx4Zu08tud1e6fY10H2prUY4AzHZQ/DgF8oa+rSgItFAa6RX7yJYb5cTptNJh2HwW/vQoCN/NCoEdcj0rn3s977mzpqmM3BP3Fl3HANeE1h89qlp74LAkajyPY63ptjL2Jw71OJ0mWVLEQpRqkucqK8qJKPNpkWYqS4qs/C4nhUQZLu+ExJcQxUVx1/0BAAD//wMAgXoqlqMCAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 28 Aug 2024 23:51:06 GMT"
+              "value": "Fri, 06 Dec 2024 18:26:09 GMT"
             },
             {
               "name": "content-type",
@@ -246,7 +246,7 @@
             },
             {
               "name": "connection",
-              "value": "close"
+              "value": "keep-alive"
             },
             {
               "name": "vary",
@@ -266,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "71e6f976bdf5819fc5352d25a97baf5e"
+              "value": "dd9c1c42bb00562cc941b60f9875c713"
             },
             {
               "name": "x-trace-id",
-              "value": "bcb07712e9ef9aa46a7e9a7e640d71cf"
+              "value": "aa9d377d6893a975816d60869f938cec"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "8ba8351979ccac96-YYZ"
+              "value": "8ede5285385d6a57-EWR"
             },
             {
               "name": "content-encoding",
@@ -301,14 +301,14 @@
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 612,
+          "headersSize": 617,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-08-28T23:51:06.347Z",
-        "time": 328,
+        "startedDateTime": "2024-12-06T18:26:06.129Z",
+        "time": 3295,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -316,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 328
+          "wait": 3295
         }
       }
     ],

--- a/packages/react/spec/auto/hooks/useTable.spec.tsx
+++ b/packages/react/spec/auto/hooks/useTable.spec.tsx
@@ -788,6 +788,7 @@ describe("useTable hook", () => {
                   name
                 }
                 secretKey
+                sectionId
                 startsAt
                 updatedAt
               }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.499.0-development.2005
-        version: 1.499.0-development.2005
+        specifier: 1.508.0-development.2265
+        version: 1.508.0-development.2265
       '@gadget-client/kitchen-sink':
         specifier: 1.9.0-development.206
         version: 1.9.0-development.206
@@ -3930,10 +3930,11 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.499.0-development.2005:
-    resolution: {integrity: sha1-7lAuG6QGUkGHdj2yknr0OMwx+tQ=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/9952}
+  /@gadget-client/js-clients-test@1.508.0-development.2265:
+    resolution: {integrity: sha1-8pJsuLZtOy5aDklKaHF18/23OvI=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/11368}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
+      tiny-graphql-query-compiler: link:packages/tiny-graphql-query-compiler
     dev: true
 
   /@gadget-client/kitchen-sink@1.9.0-development.206:


### PR DESCRIPTION
we had a nasty issue with how we determined which ids have been updated/created/deleted when there are grandchildren. The ids for each array element were being addressed by the array index which the form can change (by reordering the children or deleting and appending)

This PR fixes that by addressing the existing ids not by array index but by the id of the array element

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
