### PR TITLE
Add `onStart` property in AutoButton

### DIFF
--- a/packages/react/.changeset/shy-ways-perform.md
+++ b/packages/react/.changeset/shy-ways-perform.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": minor
+---
+
+New `onStart` callback on `AutoButton` is available. This callback is called when the button is clicked and before the action is run.

--- a/packages/react/cypress/component/auto/AutoButton.cy.tsx
+++ b/packages/react/cypress/component/auto/AutoButton.cy.tsx
@@ -183,4 +183,45 @@ describeForEachAutoAdapter("AutoButton", ({ name, adapter: { AutoButton }, wrapp
 
     cy.contains("Flip all succeeded.");
   });
+
+  it("runs the onStart callback when the button is clicked, then runs the action as normal", () => {
+    let onStartCalled = false;
+    cy.mountWithWrapper(
+      <AutoButton
+        action={api.widget.create}
+        variables={{ widget: { name: "foobar" } }}
+        onStart={() => {
+          onStartCalled = true;
+        }}
+      />,
+      wrapper
+    );
+    cy.contains("Create Widget");
+
+    cy.intercept("POST", `${api.connection.options.endpoint}?operation=createWidget`, {
+      body: {
+        data: {
+          widget: {
+            __typename: "Widget",
+            id: "123",
+          },
+        },
+      },
+    }).as("createWidget");
+
+    cy.get("button")
+      .click()
+      .then(() => {
+        expect(onStartCalled).to.be.true;
+      });
+
+    cy.wait("@createWidget");
+    cy.get("@createWidget")
+      .its("request.body.variables")
+      .should("deep.equal", {
+        widget: { name: "foobar" },
+      });
+
+    cy.contains("Create Widget succeeded.");
+  });
 });

--- a/packages/react/src/auto/hooks/useAutoButtonController.tsx
+++ b/packages/react/src/auto/hooks/useAutoButtonController.tsx
@@ -16,6 +16,10 @@ export type AutoButtonProps<
   /** The variables to pass to the action when run */
   variables?: ActionFunc["variablesType"];
   /**
+   * Callback function to run when the button is clicked. The action will run after this is called.
+   */
+  onStart?: () => void;
+  /**
    * Callback function to run when the button succeeded at running the action
    * Overrides the default behavior of rendering a message to the user to display success
    **/
@@ -34,7 +38,7 @@ export const useAutoButtonController = <
 >(
   props: AutoButtonProps<GivenOptions, SchemaT, ActionFunc>
 ) => {
-  const { action, variables, onSuccess, onError, ...buttonProps } = props;
+  const { action, variables, onStart, onSuccess, onError, ...buttonProps } = props;
   const { metadata, fetching: fetchingMetadata, error: metadataError } = useActionMetadata(action);
 
   const [{ data: result, fetching: fetchingActionResult, error }, runAction] =
@@ -55,13 +59,15 @@ export const useAutoButtonController = <
   }
 
   const run = useCallback(async () => {
+    onStart?.();
+
     const result = await runAction(variables);
     if (result.error) {
       onError?.(result.error, result);
     } else {
       onSuccess?.(result);
     }
-  }, [runAction, variables, onSuccess, onError]) as () => void;
+  }, [onStart, runAction, variables, onError, onSuccess]) as () => void;
 
   return {
     result,


### PR DESCRIPTION
This PR introduces a new `onStart` callback on `AutoButton`. This callback is called when the button is clicked and before the action is run. Useful for changing form state or other UI interactions when the button is clicked.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
