### PR TITLE
Updated AutoRichTextInput to eager-load dependencies instead of in a useEffect

### DIFF
--- a/packages/react/spec/auto/PolarisAutoForm.spec.tsx
+++ b/packages/react/spec/auto/PolarisAutoForm.spec.tsx
@@ -301,7 +301,7 @@ describe("PolarisAutoForm", () => {
         category: [],
         color: null,
         description: {
-          markdown: "example _rich_ **text**",
+          markdown: "example *rich* **text**",
         },
         embedding: null,
         inventoryCount: 1234,

--- a/packages/react/spec/auto/support/widgetModel.ts
+++ b/packages/react/spec/auto/support/widgetModel.ts
@@ -405,7 +405,7 @@ export const getWidgetRecord = (overrides?: {
       color: null,
       createdAt: "2024-06-25T13:39:19.645Z",
       description: {
-        markdown: "example _rich_ **text**",
+        markdown: "example *rich* **text**",
         truncatedHTML: "<p>example <em>rich</em> <strong>text</strong></p> ",
         __typename: "RichText",
       },

--- a/packages/react/spec/useActionFormRichFields.spec.tsx
+++ b/packages/react/spec/useActionFormRichFields.spec.tsx
@@ -291,7 +291,7 @@ describe("useActionFormNFiles", () => {
             __typename: "StoredFile",
           },
           body: {
-            markdown: "example _rich_ **text**",
+            markdown: "example *rich* **text**",
             truncatedHTML: "<p>example <em>rich</em> <strong>text</strong></p> ",
             __typename: "RichText",
           },
@@ -314,7 +314,7 @@ describe("useActionFormNFiles", () => {
     });
 
     expect(result.current.getValues("post.title")).toBe("example value for title");
-    expect(result.current.getValues("post.body.markdown")).toBe("example _rich_ **text**");
+    expect(result.current.getValues("post.body.markdown")).toBe("example *rich* **text**");
 
     let submitPromise: Promise<any>;
 

--- a/packages/react/src/auto/shared/AutoRichTextInput.tsx
+++ b/packages/react/src/auto/shared/AutoRichTextInput.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import * as mdxModule from "@mdxeditor/editor";
+import "@mdxeditor/editor/style.css";
+import React, { useEffect, useRef } from "react";
 import { useFormContext } from "../../useActionForm.js";
 import { get } from "../../utils.js";
 import { autoInput } from "../AutoInput.js";
@@ -6,59 +8,39 @@ import { useStringInputController } from "../hooks/useStringInputController.js";
 import { multiref } from "../hooks/utils.js";
 import type { AutoRichTextInputProps, MDXEditorMethods } from "./AutoRichTextInputProps.js";
 
+const {
+  MDXEditor,
+  BoldItalicUnderlineToggles,
+  ListsToggle,
+  CodeToggle,
+  CreateLink,
+  headingsPlugin,
+  listsPlugin,
+  quotePlugin,
+  thematicBreakPlugin,
+  markdownShortcutPlugin,
+  linkDialogPlugin,
+  diffSourcePlugin,
+  toolbarPlugin,
+  DiffSourceToggleWrapper,
+  UndoRedo,
+  BlockTypeSelect,
+  Separator,
+} = mdxModule;
+
 const AutoRichTextInput = autoInput<AutoRichTextInputProps>((props) => {
   const { formState } = useFormContext();
   const { field, control, editorRef, ...rest } = props;
   const controller = useStringInputController({ field, control });
   const innerRef = useRef<MDXEditorMethods>(null);
-  const [isEditorLoaded, setIsEditorLoaded] = useState(false);
-  const [mdxModule, setMdxModule] = useState<any>(null);
 
   useEffect(() => {
-    const loadEditor = async () => {
-      try {
-        const module = await import("@mdxeditor/editor");
-        await import("@mdxeditor/editor/style.css");
-        setMdxModule(module);
-        setIsEditorLoaded(true);
-      } catch (error) {
-        console.warn("Optional dependency not found, some features may not be available.");
-      }
-    };
-
-    void loadEditor();
-  }, []);
-
-  useEffect(() => {
-    if (innerRef.current && isEditorLoaded) {
+    if (innerRef.current) {
       innerRef.current.setMarkdown(controller.value?.markdown ?? "");
     }
-  }, [controller.value, isEditorLoaded]);
+  }, [controller.value]);
 
-  if (!isEditorLoaded || !mdxModule) {
-    return <div>Loading editor...</div>;
-  }
-
-  const {
-    MDXEditor,
-    BoldItalicUnderlineToggles,
-    ListsToggle,
-    CodeToggle,
-    CreateLink,
-    headingsPlugin,
-    listsPlugin,
-    quotePlugin,
-    thematicBreakPlugin,
-    markdownShortcutPlugin,
-    linkDialogPlugin,
-    diffSourcePlugin,
-    toolbarPlugin,
-    DiffSourceToggleWrapper,
-    UndoRedo,
-    BlockTypeSelect,
-    Separator,
-  } = mdxModule;
-
+  const refs = multiref(innerRef, editorRef) as any;
   return (
     <MDXEditor
       plugins={[
@@ -90,7 +72,7 @@ const AutoRichTextInput = autoInput<AutoRichTextInputProps>((props) => {
       contentEditableClassName="autoform-prose"
       markdown={controller.value?.markdown ?? ""}
       onChange={(markdown: any) => controller.onChange({ markdown })}
-      ref={multiref(innerRef, editorRef)}
+      {...(refs && { ref: refs })}
       {...rest}
     />
   );


### PR DESCRIPTION
- **UPDATE**
  - `AutoRichTextInput` imported the `mdxEditor` dependency through an asynchronous function in a useEffect, and the components was stuck in a loading state until the import was resolved
    - This "lazy loaded" component was then used in `LazyLoadedPolarisAutoRichTextInput.tsx`. We were effectively doing a double lazy load when we only needed to do it once
    - `LazyLoadedPolarisAutoRichTextInput.tsx` was a later addition after the original `AutoRichTextInput` component was added. When I added that, I think I neglected to remove the useEffect based import, which was originally used to prevent errors when using AutoComponents without `mdxEditor`
  - Now the `mdxEditor` import is directly eager loaded into the `AutoRichTextInput` component. 
    - We will now rely only on the frontend library specific lazy loaded implementation of the `AutoRichTextInput` to make `mdxEditor` optional 


BEFORE - The form loads in and RichText inputs are stuck in a loading state for a short while
![CleanShot 2025-01-03 at 13 16 10](https://github.com/user-attachments/assets/5ad6cb34-6c70-4b4a-8d3e-fa8d4f1b2937)

NOW - Rich text editor loads immediately with the rest of the form
![CleanShot 2025-01-03 at 13 57 06](https://github.com/user-attachments/assets/e282e0bc-df7b-4d4b-94e0-3b545b729be0)


## 🎩 Testing Instructions

1. Use this prerelease in a new app that DOES NOT have the mdxEditor package installed 
2. `"@gadgetinc/react": "https://codeload.github.com/gadget-inc/js-clients/tar.gz/@gadgetinc/react-v0.18.5-gitpkg-45ef0664",`
3. Add an `AutoForm` on an action that has some fields. Observe everything is good when there are no rich text fields
4. Add a rich text field, and observe the big error for the missing mdxEditor package
5. Add `"@mdxeditor/editor": "^3.8.0",` to the app's `package.json`
6. Observe that using `AutoForm` no longer has errors for the missing import 
7. Observe that reloading the page does not show the `loading` state like it did previously 
