### PR TITLE
Make `submitResult` in `AutoFormMetadataContext` type always defined

### DIFF
--- a/packages/react/spec/auto/MockForm.tsx
+++ b/packages/react/spec/auto/MockForm.tsx
@@ -15,7 +15,13 @@ export const MockForm = ({ submit, metadata, submitResult, resolver }: Partial<A
     return (
       <MockClientProvider api={api}>
         <FormProvider {...methods}>
-          <AutoFormMetadataContext.Provider value={{ submit: submit!, metadata, submitResult }}>
+          <AutoFormMetadataContext.Provider
+            value={{
+              submit: submit!,
+              metadata,
+              submitResult: submitResult ?? {},
+            }}
+          >
             <AppProvider i18n={translations}>
               {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
               <form onSubmit={methods.handleSubmit(submit as any)}>

--- a/packages/react/src/auto/AutoFormContext.ts
+++ b/packages/react/src/auto/AutoFormContext.ts
@@ -12,7 +12,7 @@ export interface AutoFormMetadataContext {
   findBy?: RecordIdentifier;
   metadata: ModelWithOneActionMetadata | GlobalActionMetadata | undefined;
   submit: UseActionFormSubmit<any>;
-  submitResult?: AutoFormSubmitResult;
+  submitResult: AutoFormSubmitResult;
   model?: {
     namespace?: string | string[] | null;
     apiIdentifier?: string;

--- a/packages/react/src/auto/hooks/useResultBannerController.tsx
+++ b/packages/react/src/auto/hooks/useResultBannerController.tsx
@@ -10,19 +10,19 @@ export const useResultBannerController = () => {
 
   useEffect(() => {
     setIsDismissed(false);
-  }, [submitResult?.isSuccessful, submitResult?.error]);
+  }, [submitResult.isSuccessful, submitResult.error]);
 
   let title;
-  if (submitResult?.isSuccessful) {
+  if (submitResult.isSuccessful) {
     title = metadata && isModelActionMetadata(metadata) ? `Saved ${`${metadata?.name} `}successfully.` : `${metadata?.name} succeeded.`;
   } else {
-    title = submitResult?.error?.message;
+    title = submitResult.error?.message;
   }
 
   return {
-    show: !isDismissed && (submitResult?.isSuccessful || submitResult?.error),
+    show: !isDismissed && (submitResult.isSuccessful || submitResult.error),
     hide,
-    successful: submitResult?.isSuccessful,
+    successful: submitResult.isSuccessful,
     title,
   };
 };

--- a/packages/react/src/auto/mui/submit/MUIAutoSubmit.tsx
+++ b/packages/react/src/auto/mui/submit/MUIAutoSubmit.tsx
@@ -14,7 +14,7 @@ import { useAutoFormMetadata } from "../../AutoFormContext.js";
  */
 export const MUIAutoSubmit = (props: LoadingButtonProps) => {
   const { submitResult } = useAutoFormMetadata();
-  const isSubmitting = submitResult?.isSubmitting;
+  const isSubmitting = submitResult.isSubmitting;
 
   return (
     <LoadingButton type="submit" loading={isSubmitting} {...props}>

--- a/packages/react/src/auto/polaris/submit/PolarisAutoSubmit.tsx
+++ b/packages/react/src/auto/polaris/submit/PolarisAutoSubmit.tsx
@@ -20,7 +20,7 @@ export const PolarisAutoSubmit = (
   } & Omit<ButtonProps, "children">
 ) => {
   const { submitResult } = useAutoFormMetadata();
-  const isSubmitting = submitResult?.isSubmitting;
+  const isSubmitting = submitResult.isSubmitting;
 
   return (
     <Button submit loading={props.isSubmitting ?? isSubmitting} {...props}>


### PR DESCRIPTION
- **UPDATE**
  - `AutoFormMetadataContext.submitResult` used to be potentially undefined in the type, but it was always defined in practice
  - Now the type is always defined so that less null checks are necessary in code, increasing readability 😄 

