### PR TITLE
Fix unable to delete values in hasMany field in useActionForm

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gadgetinc/react
 
+## 0.18.6
+
+### Patch Changes
+
+- Fixed bug with `useActionForm` hook where it failed to properly update or delete records in `hasMany` fields if the IDs have more than 2 digits
+
 ## 0.18.5
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "files": [
     "README.md",
     "dist/**/*",

--- a/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
+++ b/packages/react/spec/__recordings__/useActionFormNested_1974165259/with-polly_2612993081/can-update-multiple-HasMany-relationships-that-are-reordered_1591436327/recording.har
@@ -164,7 +164,7 @@
         }
       },
       {
-        "_id": "0523aa94388d3d9c8c46302084a73ecf",
+        "_id": "92f0993ea7a9aba2b2055384d7e2c25b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -212,7 +212,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"1775\",\"text\":\"test question updated - 2\"}},{\"update\":{\"id\":\"1774\",\"text\":\"test question updated - 1\"}}],\"text\":\"test quiz updated\"}}}"
+            "text": "{\"operationName\":\"updateQuiz\",\"query\":\"mutation updateQuiz($id: GadgetID!, $quiz: UpdateQuizInput) {\\n  updateQuiz(id: $id, quiz: $quiz) {\\n    success\\n    errors {\\n      message\\n      code\\n      ... on InvalidRecordError {\\n        model {\\n          apiIdentifier\\n          __typename\\n        }\\n        validationErrors {\\n          message\\n          apiIdentifier\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    quiz {\\n      id\\n      text\\n      questions {\\n        edges {\\n          node {\\n            id\\n            text\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n  gadgetMeta {\\n    hydrations(modelName: \\n\\\"quiz\\\")\\n    __typename\\n  }\\n}\",\"variables\":{\"id\":\"168\",\"quiz\":{\"questions\":[{\"update\":{\"id\":\"1774\",\"text\":\"test question updated - 1\"}},{\"update\":{\"id\":\"1775\",\"text\":\"test question updated - 2\"}}],\"text\":\"test quiz updated\"}}}"
           },
           "queryString": [
             {
@@ -228,13 +228,13 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 432,
-            "text": "[\"H4sIAAAAAAAAA5yRy07DMBBFfyWatSEJpXl4VwFCLFgUwQqhyrIH1yJ1gj2R+lD+Hblpi9QoqtSlZ+6cO567AyVIAN9B2yhBOG/NNrx8KyV6D5xciwzQudp54LatKga/B5FRwCHNCmBAuCbgQOgpCu2oxykIavRkauvDCCqNHvjnDmyt8B+S5/cDSj92JEU3UQoMFgvaNGjFCoHD/KCBbqTxpDRCx4Zu08tud1e6fY10H2prUY4AzHZQ/DgF8oa+rSgItFAa6RX7yJYb5cTptNJh2HwW/vQoCN/NCoEdcj0rn3s977mzpqmM3BP3Fl3HANeE1h89qlp74LAkajyPY63ptjL2Jw71OJ0mWVLEQpRqkucqK8qJKPNpkWYqS4qs/C4nhUQZLu+ExJcQxUVx1/0BAAD//wMAgXoqlqMCAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA5yRy2rDMBBFf8XMWq3jxk4c7UJbShddpLSrUoKQRoqoI7vSGPLA/16UVyHBBLLUzJ1zR3O3oAQJ4FtoGyUIZ63dxFdopcQQgJNvkQF6X/sA3LVVxeD3ILIKOGSjEhgQrgg4EAZKYjvZ4xRENQaytQtxBJXBAPxrC65W+A8Zj/MLyn7sSErukgwYzOe0btCJJQKH2UEDXU/jWRmEjl26FdfdHm50++7pPtbOoewB2M1F8fMUyDuGtqIoMEIZpDfcR7ZYKy9Op5Ue4+bT+KcnQfhhlwjskOtZ+dzrZcedNk1l5Y64s+g6BrgidOHoUdUmAIcFURN4mhpD95V1P2msp1kxGA3KVOvBJB9lY11qnGgtM6ELlQ9FPsxEOczjWckLia8xiqvirvsDAAD//wMADUUduqMCAAA=\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 06 Dec 2024 18:26:09 GMT"
+              "value": "Tue, 07 Jan 2025 21:02:45 GMT"
             },
             {
               "name": "content-type",
@@ -246,7 +246,7 @@
             },
             {
               "name": "connection",
-              "value": "keep-alive"
+              "value": "close"
             },
             {
               "name": "vary",
@@ -266,11 +266,11 @@
             },
             {
               "name": "x-request-id",
-              "value": "dd9c1c42bb00562cc941b60f9875c713"
+              "value": "0156942aef23942a95f428e359420f1c"
             },
             {
               "name": "x-trace-id",
-              "value": "aa9d377d6893a975816d60869f938cec"
+              "value": "ff094617f8fe9ffc1af5d43a431a8342"
             },
             {
               "name": "strict-transport-security",
@@ -290,7 +290,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "8ede5285385d6a57-EWR"
+              "value": "8fe6e3f029c6a235-YYZ"
             },
             {
               "name": "content-encoding",
@@ -301,14 +301,14 @@
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 617,
+          "headersSize": 612,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-12-06T18:26:06.129Z",
-        "time": 3295,
+        "startedDateTime": "2025-01-07T21:02:43.029Z",
+        "time": 2698,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -316,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3295
+          "wait": 2698
         }
       }
     ],

--- a/packages/react/spec/useActionFormNested.spec.tsx
+++ b/packages/react/spec/useActionFormNested.spec.tsx
@@ -2177,6 +2177,62 @@ describe("useActionFormNested", () => {
                       },
                     },
                   },
+                  {
+                    node: {
+                      id: "11",
+                      name: "John Doe",
+                      followerFriendships: {
+                        edges: [
+                          {
+                            node: {
+                              id: "11",
+                              follower: {
+                                id: "1100",
+                                name: "Jane Doe",
+                              },
+                            },
+                          },
+                          {
+                            node: {
+                              id: "12",
+                              follower: {
+                                id: "1101",
+                                name: "John Smith",
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      id: "12",
+                      name: "Bob Sacamano",
+                      followerFriendships: {
+                        edges: [
+                          {
+                            node: {
+                              id: "13",
+                              follower: {
+                                id: "1102",
+                                name: "Jim Doe",
+                              },
+                            },
+                          },
+                          {
+                            node: {
+                              id: "14",
+                              follower: {
+                                id: "1103",
+                                name: "Jill Doe",
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
                 ],
               },
             },
@@ -2198,6 +2254,7 @@ describe("useActionFormNested", () => {
 
       await act(async () => {
         tweetersFieldArrayHook.current.remove(0);
+        tweetersFieldArrayHook.current.remove(2);
         tweetersFieldArrayHook.current.append({
           name: "Joe Davola",
           followerFriendships: [{ followerId: "1001" }],
@@ -2249,6 +2306,41 @@ describe("useActionFormNested", () => {
                   ],
                   "id": "2",
                   "name": "Bob Sacamano",
+                },
+              },
+              {
+                "update": {
+                  "followerFriendships": [
+                    {
+                      "update": {
+                        "follower": {
+                          "update": {
+                            "id": "1100",
+                            "name": "Jane Doe",
+                          },
+                        },
+                        "id": "11",
+                      },
+                    },
+                    {
+                      "update": {
+                        "follower": {
+                          "update": {
+                            "id": "1101",
+                            "name": "John Smith",
+                          },
+                        },
+                        "id": "12",
+                      },
+                    },
+                  ],
+                  "id": "11",
+                  "name": "John Doe",
+                },
+              },
+              {
+                "delete": {
+                  "id": "12",
                 },
               },
               {

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -180,7 +180,7 @@ function getRecordIdsAtPath(data: any): Record<string, number[]> {
       }
 
       if (depth > 1) {
-        const newPath = isInArray ? path?.substring(0, path.length - 2) : path;
+        const newPath = isInArray ? path?.split(".").slice(0, -1).join(".") : path;
 
         if ("id" in input) {
           if (!updateList[newPath!]) {


### PR DESCRIPTION
Previously, if the edge ID value had more than one digit, it triggered a bug that prevented the edge item from being deleted. 

When we generate a map that maps the default values and their related paths, we set the new path by using the string of the current path - 2 characters. Therefore, if the ID has more than one digit, the new path becomes `foo.bar.`, which causes the transform to fail to determine whether it should update or delete its value.

This PR fixes the issue by doing the `string.split(".")` and skipping the last value in the array to remove the ID.

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
