### PR TITLE
Don't reexecute live queries when their cache is invalidated

### DIFF
--- a/packages/api-client-core/spec/exchanges/cacheExchange.spec.ts
+++ b/packages/api-client-core/spec/exchanges/cacheExchange.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * This file was copied from: https://github.com/urql-graphql/urql/blob/25d114d25807f0676dbf453732602753279ba0db/packages/core/src/exchanges/cache.test.ts
+ * Any meaningful changes are documented with comments starting with "GADGET:"
+ */
+import { jest } from "@jest/globals";
+import { type Client, type ExchangeInput, type Operation, type OperationResult } from "@urql/core";
+import type { Source, Subject } from "wonka";
+import { forEach, makeSubject, map, pipe, publish, scan, toPromise } from "wonka";
+import { cacheExchange } from "../../src/exchanges/cacheExchange.js";
+import {
+  liveQueryOperation,
+  liveQueryResponse,
+  mutationOperation,
+  mutationResponse,
+  queryOperation,
+  queryResponse,
+  subscriptionOperation,
+  subscriptionResult,
+  undefinedQueryResponse,
+} from "./test-utils.js";
+
+const reexecuteOperation = jest.fn();
+const dispatchDebug = jest.fn();
+
+let response: any;
+let exchangeArgs: ExchangeInput;
+let forwardedOperations: Operation[];
+let input: Subject<Operation>;
+
+beforeEach(() => {
+  response = queryResponse;
+  forwardedOperations = [];
+  input = makeSubject<Operation>();
+
+  // Collect all forwarded operations
+  const forward = (s: Source<Operation>) => {
+    return pipe(
+      s,
+      map((op) => {
+        forwardedOperations.push(op);
+        return response;
+      })
+    );
+  };
+
+  const client = {
+    reexecuteOperation: reexecuteOperation as any,
+  } as Client;
+
+  exchangeArgs = { forward, client, dispatchDebug };
+});
+
+describe("on query", () => {
+  it("forwards to next exchange when no cache hit", () => {
+    const { source: ops$, next, complete } = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    publish(exchange);
+    next(queryOperation);
+    complete();
+    expect(forwardedOperations.length).toBe(1);
+    expect(reexecuteOperation).not.toHaveBeenCalled();
+  });
+
+  it("caches results", () => {
+    const { source: ops$, next, complete } = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    publish(exchange);
+    next(queryOperation);
+    next(queryOperation);
+    complete();
+    expect(forwardedOperations.length).toBe(1);
+    expect(reexecuteOperation).not.toHaveBeenCalled();
+  });
+
+  it("respects cache-and-network", () => {
+    const { source: ops$, next, complete } = input;
+    const result = jest.fn();
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    pipe(exchange, forEach(result));
+    next(queryOperation);
+
+    next({
+      ...queryOperation,
+      context: {
+        ...queryOperation.context,
+        requestPolicy: "cache-and-network",
+      },
+    });
+
+    complete();
+    expect(forwardedOperations.length).toBe(1);
+    expect(reexecuteOperation).toHaveBeenCalledTimes(1);
+    expect(result).toHaveBeenCalledTimes(2);
+    expect((result.mock.calls as any[])[1][0].stale).toBe(true);
+
+    expect(reexecuteOperation.mock.calls[0][0]).toEqual({
+      ...queryOperation,
+      context: { ...queryOperation.context, requestPolicy: "network-only" },
+    });
+  });
+
+  it("respects cache-only", () => {
+    const { source: ops$, next, complete } = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    publish(exchange);
+    next({
+      ...queryOperation,
+      context: {
+        ...queryOperation.context,
+        requestPolicy: "cache-only",
+      },
+    });
+    complete();
+    expect(forwardedOperations.length).toBe(0);
+    expect(reexecuteOperation).not.toHaveBeenCalled();
+  });
+
+  describe("cache hit", () => {
+    it("is miss when operation is forwarded", () => {
+      const { source: ops$, next, complete } = input;
+      const exchange = cacheExchange(exchangeArgs)(ops$);
+
+      publish(exchange);
+      next(queryOperation);
+      complete();
+
+      expect(forwardedOperations[0].context).toHaveProperty("meta.cacheOutcome", "miss");
+    });
+
+    it("is true when cached response is returned", async () => {
+      const { source: ops$, next, complete } = input;
+      const exchange = cacheExchange(exchangeArgs)(ops$);
+
+      const results$ = pipe(
+        exchange,
+        scan((acc, x) => [...acc, x], [] as OperationResult[]),
+        toPromise
+      );
+
+      publish(exchange);
+      next(queryOperation);
+      next(queryOperation);
+      complete();
+
+      const results = await results$;
+      expect(results[1].operation.context).toHaveProperty("meta.cacheOutcome", "hit");
+    });
+  });
+});
+
+describe("on mutation", () => {
+  it("does not cache", () => {
+    response = mutationResponse;
+    const { source: ops$, next, complete } = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    publish(exchange);
+    next(mutationOperation);
+    next(mutationOperation);
+    complete();
+    expect(forwardedOperations.length).toBe(2);
+    expect(reexecuteOperation).not.toHaveBeenCalled();
+  });
+});
+
+describe("on subscription", () => {
+  it("forwards subscriptions", () => {
+    response = subscriptionResult;
+    const { source: ops$, next, complete } = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    publish(exchange);
+    next(subscriptionOperation);
+    next(subscriptionOperation);
+    complete();
+    expect(forwardedOperations.length).toBe(2);
+    expect(reexecuteOperation).not.toHaveBeenCalled();
+  });
+});
+
+// Empty query response implies the data propertys is undefined
+describe("on empty query response", () => {
+  beforeEach(() => {
+    response = undefinedQueryResponse;
+    forwardedOperations = [];
+    input = makeSubject<Operation>();
+
+    // Collect all forwarded operations
+    const forward = (s: Source<Operation>) => {
+      return pipe(
+        s,
+        map((op) => {
+          forwardedOperations.push(op);
+          return response;
+        })
+      );
+    };
+
+    const client = {
+      reexecuteOperation: reexecuteOperation as any,
+    } as Client;
+
+    exchangeArgs = { forward, client, dispatchDebug };
+  });
+
+  it("does not cache response", () => {
+    const { source: ops$, next, complete } = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    publish(exchange);
+    next(queryOperation);
+    next(queryOperation);
+    complete();
+    // 2 indicates it's not cached.
+    expect(forwardedOperations.length).toBe(2);
+    expect(reexecuteOperation).not.toHaveBeenCalled();
+  });
+});
+
+// GADGET: added the below describe block
+describe("on live query", () => {
+  it("does not reexecute when cache is invalidated", () => {
+    const { source: ops$, next, complete } = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    publish(exchange);
+
+    response = liveQueryResponse;
+    next(liveQueryOperation);
+
+    response = mutationResponse;
+    next(mutationOperation);
+
+    complete();
+    expect(forwardedOperations.length).toBe(2);
+    expect(reexecuteOperation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api-client-core/spec/exchanges/test-utils.ts
+++ b/packages/api-client-core/spec/exchanges/test-utils.ts
@@ -1,0 +1,185 @@
+/**
+ * This file was copied from: https://github.com/urql-graphql/urql/blob/25d114d25807f0676dbf453732602753279ba0db/packages/core/src/test-utils/samples.ts
+ * Any meaningful changes are documented with comments starting with "GADGET:"
+ */
+import {
+  gql,
+  makeOperation,
+  type ExecutionResult,
+  type GraphQLRequest,
+  type Operation,
+  type OperationContext,
+  type OperationResult,
+} from "@urql/core";
+
+export const context: OperationContext = {
+  fetchOptions: {
+    method: "POST",
+  },
+  requestPolicy: "cache-first",
+  url: "http://localhost:3000/graphql",
+};
+
+// GADGET: added __typename
+export const queryGql: GraphQLRequest = {
+  key: 2,
+  query: gql`
+    query getUser($name: String) {
+      user(name: $name) {
+        __typename
+        id
+        firstName
+        lastName
+      }
+    }
+  `,
+  variables: {
+    name: "Clara",
+  },
+};
+
+// GADGET: added __typename
+export const mutationGql: GraphQLRequest = {
+  key: 3,
+  query: gql`
+    mutation AddUser($name: String) {
+      addUser(name: $name) {
+        __typename
+        name
+      }
+    }
+  `,
+  variables: {
+    name: "Clara",
+  },
+};
+
+export const subscriptionGql: GraphQLRequest = {
+  key: 4,
+  query: gql`
+    subscription subscribeToUser($user: String) {
+      user(user: $user) {
+        name
+      }
+    }
+  `,
+  variables: {
+    user: "colin",
+  },
+};
+
+export const queryOperation: Operation = makeOperation(
+  "query",
+  {
+    query: queryGql.query,
+    variables: queryGql.variables,
+    key: queryGql.key,
+  },
+  context
+);
+
+export const teardownOperation: Operation = makeOperation(
+  "teardown",
+  {
+    query: queryOperation.query,
+    variables: queryOperation.variables,
+    key: queryOperation.key,
+  },
+  context
+);
+
+export const mutationOperation: Operation = makeOperation(
+  "mutation",
+  {
+    query: mutationGql.query,
+    variables: mutationGql.variables,
+    key: mutationGql.key,
+  },
+  context
+);
+
+export const subscriptionOperation: Operation = makeOperation(
+  "subscription",
+  {
+    query: subscriptionGql.query,
+    variables: subscriptionGql.variables,
+    key: subscriptionGql.key,
+  },
+  context
+);
+
+export const undefinedQueryResponse: OperationResult = {
+  operation: queryOperation,
+  stale: false,
+  hasNext: false,
+};
+
+// GADGET: added __typename to the query response
+export const queryResponse: OperationResult = {
+  operation: queryOperation,
+  data: {
+    user: {
+      __typename: "User",
+      name: "Clive",
+    },
+  },
+  stale: false,
+  hasNext: false,
+};
+
+// GADGET: added addUser to the mutation response
+export const mutationResponse: OperationResult = {
+  operation: mutationOperation,
+  data: {
+    addUser: {
+      __typename: "User",
+      name: "Clara",
+    },
+  },
+  stale: false,
+  hasNext: false,
+};
+
+export const subscriptionResult: ExecutionResult = {
+  data: {},
+};
+
+// GADGET: added the below query, operation, and response
+export const liveQueryGql: GraphQLRequest = {
+  key: 5,
+  query: gql`
+    query getUser($name: String) @live {
+      user(name: $name) {
+        __typename
+        id
+        firstName
+        lastName
+      }
+    }
+  `,
+  variables: {
+    name: "Clara",
+  },
+};
+
+export const liveQueryOperation: Operation = makeOperation(
+  "query",
+  {
+    query: liveQueryGql.query,
+    variables: liveQueryGql.variables,
+    key: liveQueryGql.key,
+  },
+  context
+);
+
+export const liveQueryResponse: OperationResult = {
+  operation: liveQueryOperation,
+  data: {
+    user: {
+      __typename: "User",
+      name: "Clara",
+    },
+  },
+  stale: false,
+  hasNext: true,
+};

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -1,19 +1,19 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { DefinitionNode, DirectiveNode, OperationDefinitionNode } from "@0no-co/graphql.web";
 import type { ClientOptions, RequestPolicy } from "@urql/core";
-import { Client, cacheExchange, fetchExchange, subscriptionExchange } from "@urql/core";
+import { Client, fetchExchange, subscriptionExchange } from "@urql/core";
 import type { ExecutionResult } from "graphql";
 import type { Sink, Client as SubscriptionClient, ClientOptions as SubscriptionClientOptions } from "graphql-ws";
 import { CloseCode, createClient as createSubscriptionClient } from "graphql-ws";
-import type { Maybe } from "graphql/jsutils/Maybe.js";
 import WebSocket from "isomorphic-ws";
 import type { AuthenticationModeOptions, BrowserSessionAuthenticationModeOptions, Exchanges } from "./ClientOptions.js";
 import { BrowserSessionStorageType } from "./ClientOptions.js";
 import { GadgetTransaction, TransactionRolledBack } from "./GadgetTransaction.js";
 import type { BrowserStorage } from "./InMemoryStorage.js";
 import { InMemoryStorage } from "./InMemoryStorage.js";
+import { cacheExchange } from "./exchanges/cacheExchange.js";
 import { operationNameExchange } from "./exchanges/operationNameExchange.js";
 import { addUrlParams, urlParamExchange } from "./exchanges/urlParamExchange.js";
+import { isLiveQueryOperationDefinitionNode } from "./graphql-live-query-utils/index.js";
 import {
   GadgetTooManyRequestsError,
   GadgetUnexpectedCloseError,
@@ -628,14 +628,3 @@ function processMaybeRelativeInput(input: RequestInfo | URL, endpoint: string): 
 function isRelativeUrl(url: string) {
   return url.startsWith("/") && !url.startsWith("//");
 }
-
-const getLiveDirectiveNode = (input: DefinitionNode): Maybe<DirectiveNode> => {
-  if (input.kind !== "OperationDefinition" || input.operation !== "query") {
-    return null;
-  }
-  return input.directives?.find((d) => d.name.value === "live");
-};
-
-const isLiveQueryOperationDefinitionNode = (input: DefinitionNode): input is OperationDefinitionNode => {
-  return !!getLiveDirectiveNode(input);
-};

--- a/packages/api-client-core/src/exchanges/cacheExchange.ts
+++ b/packages/api-client-core/src/exchanges/cacheExchange.ts
@@ -1,0 +1,237 @@
+/**
+ * This file was copied from: https://github.com/urql-graphql/urql/blob/25d114d25807f0676dbf453732602753279ba0db/packages/core/src/exchanges/cache.ts
+ * Any meaningful changes are documented with comments starting with "GADGET:"
+ */
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import {
+  formatDocument,
+  makeOperation,
+  makeResult,
+  type Client,
+  type Exchange,
+  type Operation,
+  type OperationContext,
+  type OperationResult,
+} from "@urql/core";
+import { filter, map, merge, pipe, tap } from "wonka";
+import { isLiveQueryOperationDefinitionNode } from "../graphql-live-query-utils/index.js";
+
+type ResultCache = Map<number, OperationResult>;
+type OperationCache = Map<string, Set<number>>;
+
+const shouldSkip = ({ kind }: Operation) => kind !== "mutation" && kind !== "query";
+
+/** Adds unique typenames to query (for invalidating cache entries) */
+export const mapTypeNames = (operation: Operation): Operation => {
+  const query = formatDocument(operation.query);
+  if (query !== operation.query) {
+    const formattedOperation = makeOperation(operation.kind, operation);
+    formattedOperation.query = query;
+    return formattedOperation;
+  } else {
+    return operation;
+  }
+};
+
+/** Default document cache exchange.
+ *
+ * @remarks
+ * The default document cache in `urql` avoids sending the same GraphQL request
+ * multiple times by caching it using the {@link Operation.key}. It will invalidate
+ * query results automatically whenever it sees a mutation responses with matching
+ * `__typename`s in their responses.
+ *
+ * The document cache will get the introspected `__typename` fields by modifying
+ * your GraphQL operation documents using the {@link formatDocument} utility.
+ *
+ * This automatic invalidation strategy can fail if your query or mutation don’t
+ * contain matching typenames, for instance, because the query contained an
+ * empty list.
+ * You can manually add hints for this exchange by specifying a list of
+ * {@link OperationContext.additionalTypenames} for queries and mutations that
+ * should invalidate one another.
+ *
+ * @see {@link https://urql.dev/goto/docs/basics/document-caching} for more information on this cache.
+ */
+export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
+  const resultCache: ResultCache = new Map();
+  const operationCache: OperationCache = new Map();
+
+  const isOperationCached = (operation: Operation) =>
+    operation.kind === "query" &&
+    operation.context.requestPolicy !== "network-only" &&
+    (operation.context.requestPolicy === "cache-only" || resultCache.has(operation.key));
+
+  return (ops$) => {
+    const cachedOps$ = pipe(
+      ops$,
+      filter((op) => !shouldSkip(op) && isOperationCached(op)),
+      map((operation) => {
+        const cachedResult = resultCache.get(operation.key);
+
+        dispatchDebug({
+          operation,
+          ...(cachedResult
+            ? {
+                type: "cacheHit",
+                message: "The result was successfully retried from the cache",
+              }
+            : {
+                type: "cacheMiss",
+                message: "The result could not be retrieved from the cache",
+              }),
+        });
+
+        let result: OperationResult =
+          cachedResult ||
+          makeResult(operation, {
+            data: null,
+          });
+
+        result = {
+          ...result,
+          operation: addMetadata(operation, {
+            cacheOutcome: cachedResult ? "hit" : "miss",
+          }),
+        };
+
+        if (operation.context.requestPolicy === "cache-and-network") {
+          result.stale = true;
+          reexecuteOperation(client, operation);
+        }
+
+        return result;
+      })
+    );
+
+    const forwardedOps$ = pipe(
+      merge([
+        pipe(
+          ops$,
+          filter((op) => !shouldSkip(op) && !isOperationCached(op)),
+          map(mapTypeNames)
+        ),
+        pipe(
+          ops$,
+          filter((op) => shouldSkip(op))
+        ),
+      ]),
+      map((op) => addMetadata(op, { cacheOutcome: "miss" })),
+      filter((op) => op.kind !== "query" || op.context.requestPolicy !== "cache-only"),
+      forward,
+      tap((response) => {
+        let { operation } = response;
+        if (!operation) return;
+
+        let typenames = operation.context.additionalTypenames || [];
+        // NOTE: For now, we only respect `additionalTypenames` from subscriptions to
+        // avoid unexpected breaking changes
+        // We'd expect live queries or other update mechanisms to be more suitable rather
+        // than using subscriptions as “signals” to reexecute queries. However, if they’re
+        // just used as signals, it’s intuitive to hook them up using `additionalTypenames`
+        if (response.operation.kind !== "subscription") {
+          typenames = collectTypenames(response.data).concat(typenames);
+        }
+
+        // Invalidates the cache given a mutation's response
+        if (response.operation.kind === "mutation" || response.operation.kind === "subscription") {
+          const pendingOperations = new Set<number>();
+
+          dispatchDebug({
+            type: "cacheInvalidation",
+            message: `The following typenames have been invalidated: ${typenames}`,
+            operation,
+            data: { typenames, response },
+          });
+
+          for (let i = 0; i < typenames.length; i++) {
+            const typeName = typenames[i];
+            let operations = operationCache.get(typeName);
+            if (!operations) operationCache.set(typeName, (operations = new Set()));
+            for (const key of operations.values()) pendingOperations.add(key);
+            operations.clear();
+          }
+
+          for (const key of pendingOperations.values()) {
+            if (resultCache.has(key)) {
+              operation = (resultCache.get(key) as OperationResult).operation;
+              // GADGET: added the below line to skip reexecuting live queries when their data is invalidated since they should receive updates from the server
+              if (!operation.query.definitions.some(isLiveQueryOperationDefinitionNode)) {
+                resultCache.delete(key);
+                reexecuteOperation(client, operation);
+              }
+            }
+          }
+        } else if (operation.kind === "query" && response.data) {
+          resultCache.set(operation.key, response);
+          for (let i = 0; i < typenames.length; i++) {
+            const typeName = typenames[i];
+            let operations = operationCache.get(typeName);
+            if (!operations) operationCache.set(typeName, (operations = new Set()));
+            operations.add(operation.key);
+          }
+        }
+      })
+    );
+
+    return merge([cachedOps$, forwardedOps$]);
+  };
+};
+
+/** Reexecutes an `Operation` with the `network-only` request policy.
+ * @internal
+ */
+export const reexecuteOperation = (client: Client, operation: Operation) => {
+  return client.reexecuteOperation(
+    makeOperation(operation.kind, operation, {
+      requestPolicy: "network-only",
+    })
+  );
+};
+
+// GADGET: the below functions are copied from https://github.com/urql-graphql/urql/blob/25d114d25807f0676dbf453732602753279ba0db/packages/core/src/utils/collectTypenames.ts
+
+interface EntityLike {
+  [key: string]: EntityLike | EntityLike[] | any;
+  __typename: string | null | void;
+}
+
+const collectTypes = (obj: EntityLike | EntityLike[], types: Set<string>) => {
+  if (Array.isArray(obj)) {
+    for (let i = 0, l = obj.length; i < l; i++) {
+      collectTypes(obj[i], types);
+    }
+  } else if (typeof obj === "object" && obj !== null) {
+    for (const key in obj) {
+      if (key === "__typename" && typeof obj[key] === "string") {
+        types.add(obj[key] as string);
+      } else {
+        collectTypes(obj[key], types);
+      }
+    }
+  }
+
+  return types;
+};
+
+/** Finds and returns a list of `__typename` fields found in response data.
+ *
+ * @privateRemarks
+ * This is used by `@urql/core`’s document `cacheExchange` to find typenames
+ * in a given GraphQL response’s data.
+ */
+const collectTypenames = (response: object): string[] => [...collectTypes(response as EntityLike, new Set())];
+
+// GADGET: the below function is copied from https://github.com/urql-graphql/urql/blob/25d114d25807f0676dbf453732602753279ba0db/packages/core/src/utils/operation.ts
+
+/** Adds additional metadata to an `Operation`'s `context.meta` property while copying it.
+ * @see {@link OperationDebugMeta} for more information on the {@link OperationContext.meta} property.
+ */
+const addMetadata = (operation: Operation, meta: OperationContext["meta"]) => {
+  return makeOperation(operation.kind, operation, {
+    meta: {
+      ...operation.context.meta,
+      ...meta,
+    },
+  });
+};

--- a/packages/api-client-core/src/graphql-live-query-utils/index.ts
+++ b/packages/api-client-core/src/graphql-live-query-utils/index.ts
@@ -1,5 +1,7 @@
+import type { DefinitionNode, DirectiveNode, OperationDefinitionNode } from "@0no-co/graphql.web";
 import type { Delta } from "@n1ru4l/json-patch-plus";
 import { patch } from "@n1ru4l/json-patch-plus";
+import type { Maybe } from "graphql/jsutils/Maybe.js";
 import { createApplyLiveQueryPatch } from "./createApplyLiveQueryPatch.js";
 
 export type ApplyPatchFunction<PatchPayload = unknown> = (
@@ -15,3 +17,14 @@ export const applyJSONDiffPatch: ApplyPatchFunction<Delta> = (left, delta): Reco
 
 export const applyLiveQueryJSONDiffPatch = createApplyLiveQueryPatch(applyJSONDiffPatch);
 export { applyAsyncIterableIteratorToSink, makeAsyncIterableIteratorFromSink } from "@n1ru4l/push-pull-async-iterable-iterator";
+
+export const getLiveDirectiveNode = (input: DefinitionNode): Maybe<DirectiveNode> => {
+  if (input.kind !== "OperationDefinition" || input.operation !== "query") {
+    return null;
+  }
+  return input.directives?.find((d) => d.name.value === "live");
+};
+
+export const isLiveQueryOperationDefinitionNode = (input: DefinitionNode): input is OperationDefinitionNode => {
+  return !!getLiveDirectiveNode(input);
+};


### PR DESCRIPTION
This prevents the cache exchange from re-executing live queries when their cache is invalidated.

This change is to prevent the following scenario:
1. component uses `findMany` with `live: true`
2. component executes a mutation that touches the `__typename` the `findMany` references
3. cache exchange re-executes the `findMany` because the mutation invalidated its cache

Step 3 doesn't stop the existing live query either, causing live queries to leak on the client and cause the server to keep track and push changes to live queries that aren't being used.

---

I tried to implement this by "wrapping" the cache exchange using the answer [in this discussion](https://github.com/urql-graphql/urql/discussions/3559) but the suggested code doesn't work and the original author of the discussion [says that they had to fork the exchange](https://github.com/urql-graphql/urql/discussions/3559#discussioncomment-9338149) in order to skip the cache.

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
