### PR TITLE
Don't reexecute live queries

### DIFF
--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -441,6 +441,18 @@ export class GadgetConnection {
       requestPolicy: this.requestPolicy,
     });
     (client as any)[$gadgetConnection] = this;
+
+    const reexecuteOperation = client.reexecuteOperation.bind(client);
+    client.reexecuteOperation = (operation) => {
+      if (operation.query.definitions.some(isLiveQueryOperationDefinitionNode)) {
+        // live queries don't cleanup properly when reexecuted, plus
+        // they should never need to be reexecuted since they receive
+        // updates from the server, so we noop here
+        return;
+      }
+      reexecuteOperation(operation);
+    };
+
     return client;
   }
 

--- a/packages/react/spec/liveQueries.spec.tsx
+++ b/packages/react/spec/liveQueries.spec.tsx
@@ -1,9 +1,14 @@
 import { Client } from "@gadget-client/related-products-example";
+import { jest } from "@jest/globals";
 import { diff } from "@n1ru4l/json-patch-plus";
 import { render, renderHook, waitFor } from "@testing-library/react";
+import type { Operation, Client as UrqlClient } from "@urql/core";
 import React from "react";
+import { pipe, subscribe } from "wonka";
 import { useFindMany } from "../src/useFindMany.js";
+import { testApi } from "./apis.js";
 import { MockGraphQLWSClientWrapper, mockGraphQLWSClient } from "./testWrappers.js";
+import { sleep } from "./utils.js";
 
 describe("live queries", () => {
   let api: Client;
@@ -221,5 +226,52 @@ describe("live queries", () => {
 
     expect(result.current[0].error!.message).toEqual("[GraphQL] GGT_PERMISSION_DENIED: Permission has been denied.");
     expect(result.current[0].data).toBeNull();
+  });
+
+  test("live queries do not re-execute", async () => {
+    jest.replaceProperty(testApi.connection, "baseSubscriptionClient", mockGraphQLWSClient as any);
+
+    // @ts-expect-error baseClient is private
+    const urqlClient = testApi.connection.baseClient as UrqlClient;
+
+    let operationCount = 0;
+    let findManyOperation: Operation | null = null;
+
+    pipe(
+      urqlClient.operations$,
+      subscribe((op) => {
+        operationCount++;
+
+        expect(op.kind).toBe("query");
+        expect(
+          op.query.definitions.some(
+            (def) =>
+              def.kind === "OperationDefinition" &&
+              def.operation === "query" &&
+              def.directives?.some((directive) => directive.name.value === "live")
+          )
+        ).toBe(true);
+
+        findManyOperation = op;
+      })
+    );
+
+    // start the live query
+    testApi.modelA.findMany({ live: true })[Symbol.asyncIterator]();
+
+    // wait for the subscription to be created
+    await waitFor(() => expect(mockGraphQLWSClient.subscribe.subscriptions).toHaveLength(1));
+
+    // make sure the operation was assigned
+    expect(findManyOperation).not.toBeNull();
+
+    // re-execute the live query operation
+    urqlClient.reexecuteOperation(findManyOperation!);
+
+    // let the event loop run to give urql a chance to re-execute the operation
+    await sleep(1000);
+
+    // make sure the operation was NOT re-executed
+    expect(operationCount).toBe(1);
   });
 });


### PR DESCRIPTION
This prevents our urql client from re-executing live queries.

This change is to prevent the following scenario:
1. component uses `useFindMany` with `live: true`
2. component executes a mutation that touches the `__typename` the `useFindMany` references
3. cache exchange re-executes the `useFindMany` because the mutation invalidated its cache

Step 3 doesn't stop the existing live query, causing live queries to leak on the client and cause the server to keep track and push changes to live queries that aren't being used.

My [first attempt](https://github.com/gadget-inc/js-clients/pull/720) at fixing this issue was to prevent the cache exchange from re-executing live queries, however we realized this issue could happen again if something else decided to start re-executing live queries, so we decided to prevent live queries from ever being re-executed.

---

I've 🎩'd this change locally so I know it works, but I still need to figure out how to write a test for this.

## PR Checklist

- [x] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
