### PR TITLE
Fix custom action params in AutoForm

### DIFF
--- a/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
@@ -51,9 +51,22 @@ export const Primary = {
   },
 };
 
+export const CreateWithCustomParams = {
+  args: {
+    action: api.widget.createWithCustomParams,
+  },
+};
+
 export const UpdateRecord = {
   args: {
     action: api.widget.update,
+    findBy: "999",
+  },
+};
+
+export const UpdateRecordWithCustomParams = {
+  args: {
+    action: api.widget.updateWithCustomParams,
     findBy: "999",
   },
 };

--- a/packages/react/src/auto/hooks/useFieldMetadata.tsx
+++ b/packages/react/src/auto/hooks/useFieldMetadata.tsx
@@ -1,20 +1,29 @@
+import { type FieldMetadata } from "../../metadata.js";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
 
 export const useFieldMetadata = (fieldApiIdentifier: string) => {
   const { model, fields } = useAutoFormMetadata();
-  const metaDataPath =
-    model && model.apiIdentifier
-      ? model.apiIdentifier + "." + fieldApiIdentifier // Model action
-      : fieldApiIdentifier; // Global action
 
-  const targetFieldMetadata = fields.find((field) => field.path === metaDataPath);
+  const isModelAction = model && model.apiIdentifier;
+  const metaDataPath = isModelAction
+    ? model.apiIdentifier + "." + fieldApiIdentifier // Model action
+    : fieldApiIdentifier; // Global action
+
+  const targetFieldMetadata = fields.find(
+    (field) => field.path === metaDataPath || isFieldCustomParamOnModelAction(fieldApiIdentifier, field)
+  );
 
   if (!targetFieldMetadata) {
     throw new Error(`Field "${fieldApiIdentifier}" not found in metadata`);
   }
 
-  return {
-    path: metaDataPath,
-    metadata: targetFieldMetadata.metadata,
-  };
+  return targetFieldMetadata;
 };
+
+const isFieldCustomParamOnModelAction = (
+  fieldApiIdentifier: string,
+  fieldCandidate: {
+    path: string;
+    metadata: FieldMetadata;
+  }
+) => fieldCandidate.metadata.__typename !== "GadgetModelField" && fieldCandidate.path === fieldApiIdentifier;

--- a/packages/react/src/use-table/helpers.tsx
+++ b/packages/react/src/use-table/helpers.tsx
@@ -347,7 +347,12 @@ const roleAssignmentsSelection = {
   name: true,
 };
 
-const getNonRelationshipSelectionValue = (field: FieldMetadata) => {
+const getNonRelationshipSelectionValue = (field: FieldMetadata, onlyAllowModelFields = false) => {
+  if (field.__typename !== "GadgetModelField" && onlyAllowModelFields) {
+    // Only model fields are selectable
+    return false;
+  }
+
   switch (field.fieldType) {
     case GadgetFieldType.RichText:
       return richTextSelection;
@@ -524,7 +529,7 @@ export const pathListToSelection = (modelIdentifier: string, pathList: string[],
       }
     } else {
       // Non relationship field
-      selection[field.apiIdentifier] = getNonRelationshipSelectionValue(field);
+      selection[field.apiIdentifier] = getNonRelationshipSelectionValue(field, true);
     }
   }
 


### PR DESCRIPTION
- **UPDATE**
  - Previously, custom model action params would break AutoForm
    - The inputs could not be rendered because their path in the form state is simply the field name, but the `useFieldMetadata` hook would try to find an input with the path `modelName.customParamName`
    - The submission would cause a GQL API error because we would include the custom field in the response query, and it would not be in the model schema because it is not a field

 