### PR TITLE
Shadcn Encrypted Auto Text Inputs

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoFormInputLabels.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormInputLabels.cy.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jest/valid-expect */
 import React from "react";
+import { Button } from "../../../../spec/auto/shadcn-defaults/components/Button.js";
 import { Checkbox } from "../../../../spec/auto/shadcn-defaults/components/Checkbox.js";
 import { Input } from "../../../../spec/auto/shadcn-defaults/components/Input.js";
 import { Label } from "../../../../spec/auto/shadcn-defaults/components/Label.js";
@@ -10,7 +11,7 @@ import { api } from "../../../support/api.js";
 import { describeForEachAutoAdapter } from "../../../support/auto.js";
 import { SUITE_NAMES } from "../../../support/constants.js";
 
-const ShadcnAutoInput = makeShadcnAutoInput({ Input, Label, Checkbox });
+const ShadcnAutoInput = makeShadcnAutoInput({ Input, Label, Checkbox, Button });
 
 const AutoInput = (props: { suiteName: string; field: string; label?: string }) => {
   if (props.suiteName === SUITE_NAMES.POLARIS) {

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoEncryptedStringInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoEncryptedStringInput.tsx
@@ -1,0 +1,32 @@
+import { EyeIcon, EyeOffIcon } from "lucide-react";
+import React, { useState } from "react";
+import type { Control } from "../../../useActionForm.js";
+import { autoInput } from "../../AutoInput.js";
+import type { ShadcnElements } from "../elements.js";
+import { makeShadcnAutoTextInput } from "./ShadcnAutoTextInput.js";
+
+export const makeShadcnAutoEncryptedStringInput = ({ Input, Label, Button }: Pick<ShadcnElements, "Input" | "Label" | "Button">) => {
+  const TextInput = makeShadcnAutoTextInput({ Input, Label });
+
+  function ShadcnAutoEncryptedStringInput(props: { field: string; control?: Control<any>; className?: string; suffix?: React.ReactNode }) {
+    const [isShown, setIsShown] = useState(false);
+    const { suffix, ...restProps } = props;
+
+    const showHideToggleButton = (
+      <Button
+        variant="ghost"
+        size="icon"
+        type="button"
+        onClick={() => setIsShown(!isShown)}
+        className="h-8 w-8"
+        role={`${props.field}ToggleShowHideButton`}
+      >
+        {isShown ? <EyeOffIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+      </Button>
+    );
+
+    return <TextInput {...restProps} type={isShown ? "text" : "password"} suffix={suffix ?? showHideToggleButton} />;
+  }
+
+  return autoInput(ShadcnAutoEncryptedStringInput);
+};

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoInput.tsx
@@ -3,11 +3,18 @@ import { autoInput } from "../../AutoInput.js";
 import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoBooleanInput } from "./ShadcnAutoBooleanInput.js";
+import { makeShadcnAutoEncryptedStringInput } from "./ShadcnAutoEncryptedStringInput.js";
 import { makeShadcnAutoIdInput } from "./ShadcnAutoIdInput.js";
 import { makeShadcnAutoNumberInput } from "./ShadcnAutoNumberInput.js";
+import { makeShadcnAutoPasswordInput } from "./ShadcnAutoPasswordInput.js";
 import { makeShadcnAutoTextInput } from "./ShadcnAutoTextInput.js";
 
-export const makeShadcnAutoInput = ({ Input, Label, Checkbox }: Pick<ShadcnElements, "Input" | "Label" | "Checkbox">) => {
+export const makeShadcnAutoInput = ({
+  Input,
+  Label,
+  Checkbox,
+  Button,
+}: Pick<ShadcnElements, "Input" | "Label" | "Checkbox" | "Button">) => {
   function ShadcnAutoInput(props: { field: string; label?: string }) {
     const { metadata } = useFieldMetadata(props.field);
     const config = metadata.configuration;
@@ -24,6 +31,13 @@ export const makeShadcnAutoInput = ({ Input, Label, Checkbox }: Pick<ShadcnEleme
       }
       case FieldType.Number: {
         return makeShadcnAutoNumberInput({ Input, Label })(props);
+      }
+
+      case FieldType.EncryptedString: {
+        return makeShadcnAutoEncryptedStringInput({ Input, Label, Button })(props);
+      }
+      case FieldType.Password: {
+        return makeShadcnAutoPasswordInput({ Input, Label, Button })(props);
       }
 
       case FieldType.Boolean: {

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoPasswordInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoPasswordInput.tsx
@@ -1,0 +1,59 @@
+import { PencilIcon } from "lucide-react";
+import React, { useCallback, useState } from "react";
+import type { Control } from "../../../useActionForm.js";
+import { useController } from "../../../useActionForm.js";
+import { useAutoFormMetadata } from "../../AutoFormContext.js";
+import { autoInput } from "../../AutoInput.js";
+import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
+import type { ShadcnElements } from "../elements.js";
+import { makeShadcnAutoEncryptedStringInput } from "./ShadcnAutoEncryptedStringInput.js";
+
+/**
+ * The salted password hash is not retrieved from the DB.
+ * Regardless of the password being defined or not, this placeholder is shown as exposing an unset password is a security risk.
+ */
+const existingPasswordPlaceholder = "********";
+
+export function makeShadcnAutoPasswordInput({ Input, Label, Button }: Pick<ShadcnElements, "Input" | "Label" | "Button">) {
+  const EncryptedInput = makeShadcnAutoEncryptedStringInput({ Input, Label, Button });
+
+  function ShadcnAutoPasswordInput(props: { field: string; control?: Control<any>; className?: string }) {
+    const { findBy } = useAutoFormMetadata();
+    const { path } = useFieldMetadata(props.field);
+    const { field: fieldProps } = useController({ name: path });
+
+    const [isEditing, setIsEditing] = useState(!findBy);
+
+    const startEditing = useCallback(() => {
+      fieldProps.onChange(""); // Touch the field to mark it as dirty
+      setIsEditing(true);
+    }, [fieldProps]);
+
+    return (
+      <EncryptedInput
+        {...props}
+        {...(isEditing
+          ? { placeholder: "Password" }
+          : {
+              placeholder: existingPasswordPlaceholder,
+              disabled: true,
+              className: "pr-20",
+              suffix: (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  type="button"
+                  onClick={startEditing}
+                  className="h-8 w-8"
+                  role={`${props.field}EditPasswordButton`}
+                >
+                  <PencilIcon className="h-4 w-4" />
+                </Button>
+              ),
+            })}
+      />
+    );
+  }
+
+  return autoInput(ShadcnAutoPasswordInput);
+}

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoTextInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoTextInput.tsx
@@ -10,9 +10,10 @@ export const makeShadcnAutoTextInput = ({ Input, Label }: Pick<ShadcnElements, "
       field: string;
       control?: Control<any>;
       label?: string;
+      suffix?: React.ReactNode;
     } & Partial<InputHTMLAttributes<HTMLInputElement>>
   ) {
-    const { field, control, label: customLabel, ...restProps } = props;
+    const { field, control, label: customLabel, suffix, ...restProps } = props;
     const stringInputController = useStringInputController({ field, control });
     const id = `${field}-input`;
     const {
@@ -46,6 +47,7 @@ export const makeShadcnAutoTextInput = ({ Input, Label }: Pick<ShadcnElements, "
             {...restProps}
             placeholder={placeholder || inputLabel}
           />
+          {suffix && <div className="">{suffix}</div>}
         </div>
         {errorMessage && <p className="text-sm text-red-500">{errorMessage}</p>}
       </div>


### PR DESCRIPTION
Integrating Shadcn AutoInputs for Encrypted Texts e.g Password Inputs

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
