### PR TITLE
extended timeouts and added test specific retries to reduce flake impact

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -16,7 +16,7 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
 
   const submit = (modelName: string) => {
     cy.get("form [type=submit][aria-hidden!=true]").click();
-    cy.contains(`Saved ${modelName} successfully`);
+    cy.contains(`Saved ${modelName} successfully`, { timeout: 10000 });
   };
 
   it("renders an error if the backend returns one when fetching the model data", () => {

--- a/packages/react/cypress/component/auto/form/AutoPasswordInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoPasswordInput.cy.tsx
@@ -41,7 +41,7 @@ describeForEachAutoAdapter("AutoPasswordInput", ({ name, adapter: { AutoForm }, 
     cy.wait("@updateUser");
     cy.get("@updateUser").its("request.body.variables").should("deep.equal", expectedQueryValue);
 
-    cy.contains(`Saved ${modelName} successfully`);
+    cy.contains(`Saved ${modelName} successfully`, { timeout: 10000 });
   };
 
   it("only allows existing passwords to be replaced, not edited", () => {

--- a/packages/react/cypress/support/component.tsx
+++ b/packages/react/cypress/support/component.tsx
@@ -72,8 +72,8 @@ before(() => {
 
 beforeEach(() => {
   cy.window().then((win) => {
-    const mockToasts = win.document.getElementsByClassName("mock-toast");
-    while (mockToasts.length > 0) {
+    const mockToasts = win?.document?.getElementsByClassName("mock-toast");
+    while (mockToasts?.length > 0) {
       try {
         mockToasts[0].parentNode?.removeChild(mockToasts[0]);
       } catch (e) {

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -229,22 +229,22 @@ export const useAutoForm = <
   const isUpsertWithFindBy = isUpsertMetaAction && !!findBy;
   const fieldPathsToValidate = useMemo(() => fields.map(({ path }) => path), [fields]);
 
-  const defaultValues: Record<string, unknown> = useMemo(
-    () =>
+  const defaultValues: Record<string, unknown> = useMemo(() => {
+    return (
       props.defaultValues ??
       (action.type === "globalAction"
         ? {}
         : {
             [modelApiIdentifier!]:
               record ??
-              (!(operatesWithRecordId || isUpsertWithFindBy) && metadata && isModelActionMetadata(metadata) && metadata?.defaultRecord),
+              (!(operatesWithRecordId || isUpsertWithFindBy) && metadata && isModelActionMetadata(metadata) && metadata.defaultRecord),
             id:
               typeof findBy === "string"
                 ? findBy // ID is given directly
                 : undefined, // Set by the retrieved existing record if object based findBy value
-          }),
-    [props.defaultValues, action.type, modelApiIdentifier, record, operatesWithRecordId, metadata, findBy]
-  );
+          })
+    );
+  }, [props.defaultValues, action.type, modelApiIdentifier, record, operatesWithRecordId, metadata, isUpsertWithFindBy, findBy]);
 
   const pauseExistingRecordLookup = !("findBy" in props)
     ? true // Always pause without findBy. No need to do a lookup


### PR DESCRIPTION
PolarisAutoDateTimePicker.cy.tsx was quite flakey due to async access to the default record from the metadata and this only happened when running the whole test file, and never when running the test in isolation.

Added longer timeouts for checking for the submit result banner