### PR TITLE
Polaris auto has many related model filtering

### DIFF
--- a/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
@@ -8,6 +8,7 @@ import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoS
 import { FormProvider, useForm } from "../../../src/useActionForm.ts";
 import { testApi as api } from "../../apis.ts";
 import { StorybookErrorBoundary } from "../storybook/StorybookErrorBoundary.tsx";
+import { PolarisAutoHasManyInput } from "../../../src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
@@ -132,7 +133,7 @@ const ConditionalAppearingAutoInput = () => {
         <>
           <PolarisAutoInput field="isChecked" />
           <PolarisAutoInput field="section" />
-          <PolarisAutoInput field="gizmos" />
+          <PolarisAutoHasManyInput field="gizmos" optionFilter={{ name: { equals: "gizmo 2" } }} />
           <PolarisAutoInput field="customStringParam" />
         </>
       )}

--- a/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
@@ -133,7 +133,7 @@ const ConditionalAppearingAutoInput = () => {
         <>
           <PolarisAutoInput field="isChecked" />
           <PolarisAutoInput field="section" />
-          <PolarisAutoHasManyInput field="gizmos" optionFilter={{ name: { equals: "gizmo 2" } }} />
+          <PolarisAutoHasManyInput field="gizmos" recordFilter={{ name: { equals: "gizmo 2" } }} />
           <PolarisAutoInput field="customStringParam" />
         </>
       )}

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -7,7 +7,7 @@ import { useDebouncedSearch } from "../../useDebouncedSearch.js";
 import { useFindMany } from "../../useFindMany.js";
 import { sortByProperty, uniqByProperty } from "../../utils.js";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
-import type { Option, OptionFilter, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
+import type { Option, RecordFilter, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
 import type { RelationshipFieldConfig } from "../interfaces/RelationshipFieldConfig.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useModelManager } from "./useModelManager.js";
@@ -15,7 +15,7 @@ import { useModelManager } from "./useModelManager.js";
 export const optionRecordsToLoadCount = 25;
 export const selectedRecordsToLoadCount = 25;
 
-const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabel; optionFilter?: OptionFilter }) => {
+const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabel; recordFilter?: RecordFilter }) => {
   const { field } = props;
   const { metadata } = useFieldMetadata(field);
   const { findBy } = useAutoFormMetadata();
@@ -32,7 +32,7 @@ const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabe
     relatedModel: { apiIdentifier: relatedModelApiIdentifier!, namespace: relatedModelNamespace },
 
     filter:
-      props?.optionFilter ??
+      props?.recordFilter ??
       (isHasManyField
         ? omitRelatedModelRecordsAssociatedWithOtherRecords({ enabled: false, relatedModelInverseFieldApiId, findBy })
         : undefined),
@@ -73,7 +73,7 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 
   return assert(
     optionLabel ?? relationshipFieldConfig.relatedModel?.defaultDisplayField.apiIdentifier,
-    "Option label is required for relationships"
+    "Option label is required for relationships",
   );
 };
 
@@ -82,7 +82,7 @@ export const useRelatedModelOptions = (props: {
   optionLabel?: OptionLabel; // The label to display for each related model record
   secondaryLabel?: OptionLabel;
   tertiaryLabel?: OptionLabel;
-  optionFilter?: OptionFilter;
+  recordFilter?: RecordFilter;
 }) => {
   const { field } = props;
 
@@ -123,8 +123,8 @@ const getRecordLabel = (record: Record<string, any>, optionLabel: OptionLabel): 
   typeof optionLabel === "string"
     ? record[optionLabel] // Related model field API id
     : Array.isArray(optionLabel)
-    ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
-    : optionLabel(record); // Callback on the whole related model record
+      ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
+      : optionLabel(record); // Callback on the whole related model record
 
 const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: string }) => string) => string[] }) =>
   records
@@ -136,7 +136,7 @@ export const getRecordAsOption = (
   record: Record<string, any>,
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel
+  tertiaryLabel?: OptionLabel,
 ): Option => {
   return {
     id: record.id as string,
@@ -150,7 +150,7 @@ export const getRecordsAsOptions = (
   records: Record<string, any>[],
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel
+  tertiaryLabel?: OptionLabel,
 ) => {
   return records?.map((record: Record<string, any>) => getRecordAsOption(record, optionLabel, secondaryLabel, tertiaryLabel)) ?? [];
 };
@@ -172,7 +172,7 @@ const useAllRelatedModelRecords = (props: {
         acc[fieldName] = true;
         return acc;
       },
-      { id: true } as FieldSelection
+      { id: true } as FieldSelection,
     );
   }
 

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -73,7 +73,7 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 
   return assert(
     optionLabel ?? relationshipFieldConfig.relatedModel?.defaultDisplayField.apiIdentifier,
-    "Option label is required for relationships"
+    "Option label is required for relationships",
   );
 };
 
@@ -123,8 +123,8 @@ const getRecordLabel = (record: Record<string, any>, optionLabel: OptionLabel): 
   typeof optionLabel === "string"
     ? record[optionLabel] // Related model field API id
     : Array.isArray(optionLabel)
-    ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
-    : optionLabel(record); // Callback on the whole related model record
+      ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
+      : optionLabel(record); // Callback on the whole related model record
 
 const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: string }) => string) => string[] }) =>
   records
@@ -136,7 +136,7 @@ export const getRecordAsOption = (
   record: Record<string, any>,
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel
+  tertiaryLabel?: OptionLabel,
 ): Option => {
   return {
     id: record.id as string,
@@ -150,7 +150,7 @@ export const getRecordsAsOptions = (
   records: Record<string, any>[],
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel
+  tertiaryLabel?: OptionLabel,
 ) => {
   return records?.map((record: Record<string, any>) => getRecordAsOption(record, optionLabel, secondaryLabel, tertiaryLabel)) ?? [];
 };
@@ -172,7 +172,7 @@ const useAllRelatedModelRecords = (props: {
         acc[fieldName] = true;
         return acc;
       },
-      { id: true } as FieldSelection
+      { id: true } as FieldSelection,
     );
   }
 

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -7,7 +7,7 @@ import { useDebouncedSearch } from "../../useDebouncedSearch.js";
 import { useFindMany } from "../../useFindMany.js";
 import { sortByProperty, uniqByProperty } from "../../utils.js";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
-import type { Option, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
+import type { Option, OptionLabel, OptionFilter } from "../interfaces/AutoRelationshipInputProps.js";
 import type { RelationshipFieldConfig } from "../interfaces/RelationshipFieldConfig.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useModelManager } from "./useModelManager.js";
@@ -15,7 +15,7 @@ import { useModelManager } from "./useModelManager.js";
 export const optionRecordsToLoadCount = 25;
 export const selectedRecordsToLoadCount = 25;
 
-const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabel }) => {
+const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabel; optionFilter?: OptionFilter }) => {
   const { field } = props;
   const { metadata } = useFieldMetadata(field);
   const { findBy } = useAutoFormMetadata();
@@ -31,9 +31,11 @@ const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabe
   const relatedModelRecords = useAllRelatedModelRecords({
     relatedModel: { apiIdentifier: relatedModelApiIdentifier!, namespace: relatedModelNamespace },
 
-    filter: isHasManyField
-      ? omitRelatedModelRecordsAssociatedWithOtherRecords({ enabled: false, relatedModelInverseFieldApiId, findBy })
-      : undefined,
+    filter:
+      props?.optionFilter ??
+      (isHasManyField
+        ? omitRelatedModelRecordsAssociatedWithOtherRecords({ enabled: false, relatedModelInverseFieldApiId, findBy })
+        : undefined),
   });
 
   return {
@@ -71,7 +73,7 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 
   return assert(
     optionLabel ?? relationshipFieldConfig.relatedModel?.defaultDisplayField.apiIdentifier,
-    "Option label is required for relationships"
+    "Option label is required for relationships",
   );
 };
 
@@ -80,6 +82,7 @@ export const useRelatedModelOptions = (props: {
   optionLabel?: OptionLabel; // The label to display for each related model record
   secondaryLabel?: OptionLabel;
   tertiaryLabel?: OptionLabel;
+  optionFilter?: OptionFilter;
 }) => {
   const { field } = props;
 
@@ -120,8 +123,8 @@ const getRecordLabel = (record: Record<string, any>, optionLabel: OptionLabel): 
   typeof optionLabel === "string"
     ? record[optionLabel] // Related model field API id
     : Array.isArray(optionLabel)
-    ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
-    : optionLabel(record); // Callback on the whole related model record
+      ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
+      : optionLabel(record); // Callback on the whole related model record
 
 const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: string }) => string) => string[] }) =>
   records
@@ -133,7 +136,7 @@ export const getRecordAsOption = (
   record: Record<string, any>,
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel
+  tertiaryLabel?: OptionLabel,
 ): Option => {
   return {
     id: record.id as string,
@@ -147,7 +150,7 @@ export const getRecordsAsOptions = (
   records: Record<string, any>[],
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel
+  tertiaryLabel?: OptionLabel,
 ) => {
   return records?.map((record: Record<string, any>) => getRecordAsOption(record, optionLabel, secondaryLabel, tertiaryLabel)) ?? [];
 };
@@ -169,7 +172,7 @@ const useAllRelatedModelRecords = (props: {
         acc[fieldName] = true;
         return acc;
       },
-      { id: true } as FieldSelection
+      { id: true } as FieldSelection,
     );
   }
 

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -7,7 +7,7 @@ import { useDebouncedSearch } from "../../useDebouncedSearch.js";
 import { useFindMany } from "../../useFindMany.js";
 import { sortByProperty, uniqByProperty } from "../../utils.js";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
-import type { Option, OptionLabel, OptionFilter } from "../interfaces/AutoRelationshipInputProps.js";
+import type { Option, OptionFilter, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
 import type { RelationshipFieldConfig } from "../interfaces/RelationshipFieldConfig.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useModelManager } from "./useModelManager.js";
@@ -73,7 +73,7 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 
   return assert(
     optionLabel ?? relationshipFieldConfig.relatedModel?.defaultDisplayField.apiIdentifier,
-    "Option label is required for relationships",
+    "Option label is required for relationships"
   );
 };
 
@@ -123,8 +123,8 @@ const getRecordLabel = (record: Record<string, any>, optionLabel: OptionLabel): 
   typeof optionLabel === "string"
     ? record[optionLabel] // Related model field API id
     : Array.isArray(optionLabel)
-      ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
-      : optionLabel(record); // Callback on the whole related model record
+    ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
+    : optionLabel(record); // Callback on the whole related model record
 
 const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: string }) => string) => string[] }) =>
   records
@@ -136,7 +136,7 @@ export const getRecordAsOption = (
   record: Record<string, any>,
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel,
+  tertiaryLabel?: OptionLabel
 ): Option => {
   return {
     id: record.id as string,
@@ -150,7 +150,7 @@ export const getRecordsAsOptions = (
   records: Record<string, any>[],
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel,
+  tertiaryLabel?: OptionLabel
 ) => {
   return records?.map((record: Record<string, any>) => getRecordAsOption(record, optionLabel, secondaryLabel, tertiaryLabel)) ?? [];
 };
@@ -172,7 +172,7 @@ const useAllRelatedModelRecords = (props: {
         acc[fieldName] = true;
         return acc;
       },
-      { id: true } as FieldSelection,
+      { id: true } as FieldSelection
     );
   }
 

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -73,7 +73,7 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 
   return assert(
     optionLabel ?? relationshipFieldConfig.relatedModel?.defaultDisplayField.apiIdentifier,
-    "Option label is required for relationships",
+    "Option label is required for relationships"
   );
 };
 
@@ -123,8 +123,8 @@ const getRecordLabel = (record: Record<string, any>, optionLabel: OptionLabel): 
   typeof optionLabel === "string"
     ? record[optionLabel] // Related model field API id
     : Array.isArray(optionLabel)
-      ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
-      : optionLabel(record); // Callback on the whole related model record
+    ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
+    : optionLabel(record); // Callback on the whole related model record
 
 const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: string }) => string) => string[] }) =>
   records
@@ -136,7 +136,7 @@ export const getRecordAsOption = (
   record: Record<string, any>,
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel,
+  tertiaryLabel?: OptionLabel
 ): Option => {
   return {
     id: record.id as string,
@@ -150,7 +150,7 @@ export const getRecordsAsOptions = (
   records: Record<string, any>[],
   optionLabel: OptionLabel,
   secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel,
+  tertiaryLabel?: OptionLabel
 ) => {
   return records?.map((record: Record<string, any>) => getRecordAsOption(record, optionLabel, secondaryLabel, tertiaryLabel)) ?? [];
 };
@@ -172,7 +172,7 @@ const useAllRelatedModelRecords = (props: {
         acc[fieldName] = true;
         return acc;
       },
-      { id: true } as FieldSelection,
+      { id: true } as FieldSelection
     );
   }
 

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -1,4 +1,4 @@
-import { FindManyOptions } from "@gadgetinc/api-client-core";
+import type { FindManyOptions } from "@gadgetinc/api-client-core";
 import type { ReactNode } from "react";
 import type { Control } from "../../useActionForm.js";
 

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode } from "react";
 import type { Control } from "../../useActionForm.js";
+import { AnyModelFinderMetadata, FindManyOptions } from "@gadgetinc/api-client-core";
 
 export interface AutoRelationshipInputProps {
   field: string;
   control?: Control<any>;
   optionLabel?: OptionLabel;
   label?: string;
+  relatedModelRecordFilter?: { relatedModelManager?: AnyModelFinderMetadata["modelApiIdentifier"]; filter: FindManyOptions["filter"] };
 }
 
 export interface Option {

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -2,14 +2,14 @@ import type { FindManyOptions } from "@gadgetinc/api-client-core";
 import type { ReactNode } from "react";
 import type { Control } from "../../useActionForm.js";
 
-export type OptionFilter = FindManyOptions["filter"];
+export type RecordFilter = FindManyOptions["filter"];
 
 export interface AutoRelationshipInputProps {
   field: string;
   control?: Control<any>;
   optionLabel?: OptionLabel;
   label?: string;
-  optionFilter?: OptionFilter;
+  recordFilter?: RecordFilter;
 }
 
 export interface Option {

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -1,6 +1,6 @@
+import { FindManyOptions } from "@gadgetinc/api-client-core";
 import type { ReactNode } from "react";
 import type { Control } from "../../useActionForm.js";
-import { FindManyOptions } from "@gadgetinc/api-client-core";
 
 export type OptionFilter = FindManyOptions["filter"];
 

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -1,13 +1,15 @@
 import type { ReactNode } from "react";
 import type { Control } from "../../useActionForm.js";
-import { AnyModelFinderMetadata, FindManyOptions } from "@gadgetinc/api-client-core";
+import { FindManyOptions } from "@gadgetinc/api-client-core";
+
+export type OptionFilter = FindManyOptions["filter"];
 
 export interface AutoRelationshipInputProps {
   field: string;
   control?: Control<any>;
   optionLabel?: OptionLabel;
   label?: string;
-  relatedModelRecordFilter?: { relatedModelManager?: AnyModelFinderMetadata["modelApiIdentifier"]; filter: FindManyOptions["filter"] };
+  optionFilter?: OptionFilter;
 }
 
 export interface Option {

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -13,7 +13,7 @@ const noopUseFindExistingRecordResponse = [
 export const useFindExistingRecord = (
   modelManager: AnyModelManager | undefined,
   findBy: string | { [key: string]: any } | undefined,
-  options: { select?: Record<string, any>; pause?: boolean; throwOnInvalidFindByObject?: boolean },
+  options: { select?: Record<string, any>; pause?: boolean; throwOnInvalidFindByObject?: boolean }
 ): [{ data?: GadgetRecord<any>; fetching: boolean; error?: ErrorWrapper }, () => void] => {
   if (!modelManager || !findBy) {
     return noopUseFindExistingRecordResponse;
@@ -33,7 +33,7 @@ export const useFindExistingRecord = (
     if (!(findByOperationName in modelManager)) {
       if (options.throwOnInvalidFindByObject === undefined || options.throwOnInvalidFindByObject) {
         throw new Error(
-          `Invalid findBy object: ${JSON.stringify(findBy)}. ${findByOperationName} is not a valid findBy operation for this model.`,
+          `Invalid findBy object: ${JSON.stringify(findBy)}. ${findByOperationName} is not a valid findBy operation for this model.`
         );
       }
       return noopUseFindExistingRecordResponse;
@@ -131,7 +131,7 @@ export const disambiguateDefaultValues = (data: any, initialData: any, action: a
       }
 
       return [[key, value]];
-    }),
+    })
   );
 
   const modelData = { ...data[action.modelApiIdentifier] };
@@ -208,7 +208,7 @@ class ReshapeDataContext {
     public readonly idPath?: string,
     public readonly fieldType?: { type: string; model: string } | null,
     public readonly fieldRelationships?: Record<string, { type: string; model: string }> | null,
-    public readonly parent?: ReshapeDataContext | null,
+    public readonly parent?: ReshapeDataContext | null
   ) {}
 }
 
@@ -305,7 +305,7 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
                 parent: context,
               }); // transform the item
             }
-          }),
+          })
         );
       }
 
@@ -324,7 +324,7 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
               fieldRelationships,
               parent: context,
             });
-          }),
+          })
       );
 
       return results.flatMap((result) => result);
@@ -360,13 +360,10 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
       const belongsToRelationships: Record<string, { type: string; model: string }> | null = fieldRelationships // grab the belongsTo relationships from the fieldRelationships object
         ? Object.entries(fieldRelationships)
             .filter(([_key, value]) => value.type === "BelongsTo")
-            .reduce(
-              (obj, [key, value]) => {
-                obj[key] = value;
-                return obj;
-              },
-              {} as Record<string, { type: string; model: string }>,
-            )
+            .reduce((obj, [key, value]) => {
+              obj[key] = value;
+              return obj;
+            }, {} as Record<string, { type: string; model: string }>)
         : null;
 
       for (const key of Object.keys(belongsToRelationships ?? {})) {
@@ -408,8 +405,8 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
                 referencedTypes,
               },
               null,
-              2,
-            )}`,
+              2
+            )}`
           );
       }
     }

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -13,7 +13,7 @@ const noopUseFindExistingRecordResponse = [
 export const useFindExistingRecord = (
   modelManager: AnyModelManager | undefined,
   findBy: string | { [key: string]: any } | undefined,
-  options: { select?: Record<string, any>; pause?: boolean; throwOnInvalidFindByObject?: boolean }
+  options: { select?: Record<string, any>; pause?: boolean; throwOnInvalidFindByObject?: boolean },
 ): [{ data?: GadgetRecord<any>; fetching: boolean; error?: ErrorWrapper }, () => void] => {
   if (!modelManager || !findBy) {
     return noopUseFindExistingRecordResponse;
@@ -33,7 +33,7 @@ export const useFindExistingRecord = (
     if (!(findByOperationName in modelManager)) {
       if (options.throwOnInvalidFindByObject === undefined || options.throwOnInvalidFindByObject) {
         throw new Error(
-          `Invalid findBy object: ${JSON.stringify(findBy)}. ${findByOperationName} is not a valid findBy operation for this model.`
+          `Invalid findBy object: ${JSON.stringify(findBy)}. ${findByOperationName} is not a valid findBy operation for this model.`,
         );
       }
       return noopUseFindExistingRecordResponse;
@@ -131,7 +131,7 @@ export const disambiguateDefaultValues = (data: any, initialData: any, action: a
       }
 
       return [[key, value]];
-    })
+    }),
   );
 
   const modelData = { ...data[action.modelApiIdentifier] };
@@ -208,7 +208,7 @@ class ReshapeDataContext {
     public readonly idPath?: string,
     public readonly fieldType?: { type: string; model: string } | null,
     public readonly fieldRelationships?: Record<string, { type: string; model: string }> | null,
-    public readonly parent?: ReshapeDataContext | null
+    public readonly parent?: ReshapeDataContext | null,
   ) {}
 }
 
@@ -305,7 +305,7 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
                 parent: context,
               }); // transform the item
             }
-          })
+          }),
         );
       }
 
@@ -324,7 +324,7 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
               fieldRelationships,
               parent: context,
             });
-          })
+          }),
       );
 
       return results.flatMap((result) => result);
@@ -360,10 +360,13 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
       const belongsToRelationships: Record<string, { type: string; model: string }> | null = fieldRelationships // grab the belongsTo relationships from the fieldRelationships object
         ? Object.entries(fieldRelationships)
             .filter(([_key, value]) => value.type === "BelongsTo")
-            .reduce((obj, [key, value]) => {
-              obj[key] = value;
-              return obj;
-            }, {} as Record<string, { type: string; model: string }>)
+            .reduce(
+              (obj, [key, value]) => {
+                obj[key] = value;
+                return obj;
+              },
+              {} as Record<string, { type: string; model: string }>,
+            )
         : null;
 
       for (const key of Object.keys(belongsToRelationships ?? {})) {
@@ -405,8 +408,8 @@ export const reshapeDataForGraphqlApi = async (client: AnyClient, defaultValues:
                 referencedTypes,
               },
               null,
-              2
-            )}`
+              2,
+            )}`,
           );
       }
     }


### PR DESCRIPTION
Adding the ability to filter related model record for the dropdown of the AutoHasManyInput

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
