### PR TITLE
Fixed default field label for `PolarisAutoInput` with `File` fields

### DIFF
--- a/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
@@ -71,17 +71,18 @@ export const PolarisAutoFileInput = autoInput((props: { field: string; control?:
     );
   }, [canClearFileValue, clearFileValue, fieldApiIdentifier, fieldProps.value, imageThumbnailURL]);
 
-  const inputLabel = (
-    <>
-      {metadata.name} {metadata.requiredArgumentForInput ? <span style={{ color: "var(--p-color-text-critical)" }}>*</span> : null}
-    </>
+  const inputLabel = props.label ?? (
+    <div style={{ display: "flex", gap: "4px" }}>
+      {metadata.name}
+      {metadata.requiredArgumentForInput ? <span style={{ color: "var(--p-color-text-critical)" }}>{"*"}</span> : null}
+    </div>
   );
 
   return (
     <>
+      {inputLabel}
       <DropZone
         variableHeight
-        label={inputLabel}
         allowMultiple={false}
         onDrop={(_droppedFiles, acceptedFiles) => {
           void onFileUpload(acceptedFiles);


### PR DESCRIPTION
- **UPDATE**
  - When file fields appeared in Polaris `AutoForm` components, the input labels did not appear correctly. 
  - The input label is defined in these cases, but the polaris `DropZone` component does not seem to reliably render the label. 
  - The fix is to simply render the label separate from the `DropZone` component