### PR TITLE
Fix `label` prop on `PolarisAutoHasOneInput`

### DIFF
--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
@@ -35,7 +35,7 @@ export const PolarisAutoHasOneInput = autoInput((props: AutoRelationshipInputPro
           <Combobox.TextField
             onChange={search.set}
             value={search.value}
-            label={metadata.name}
+            label={props.label ?? metadata.name}
             name={path}
             placeholder="Search"
             autoComplete="off"


### PR DESCRIPTION
The `label` prop did nothing in this component because it was never referenced. Updated such that it will take precedence over the default `metadata.name` value 
