### PR TITLE
Added debouncing to AutoForm related model record searching

### DIFF
--- a/packages/react/src/auto/polaris/inputs/relationships/RelatedModelOptions.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/RelatedModelOptions.tsx
@@ -44,9 +44,9 @@ export const RelatedModelOptions = (props: RelatedModelOptionsProps) => {
         listBoxOptions
       ) : errorMessage ? (
         <ListMessage message={getErrorMessage(errorMessage)} />
-      ) : (
+      ) : !isLoading ? (
         <NoRecordsMessage />
-      )}
+      ) : null}
       {isLoading && <Listbox.Loading accessibilityLabel="Loading" />}
     </Listbox>
   );

--- a/packages/react/src/useDebouncedSearch.tsx
+++ b/packages/react/src/useDebouncedSearch.tsx
@@ -8,7 +8,7 @@ export interface SearchResult {
   clear: () => void;
 }
 
-export const useDebouncedSearch = (props: { onDebouncedSearchValueChange: () => void; debounceMilliseconds?: number }) => {
+export const useDebouncedSearch = (props: { onDebouncedSearchValueChange?: () => void; debounceMilliseconds?: number }) => {
   const { onDebouncedSearchValueChange, debounceMilliseconds } = props;
   const [searchValue, setSearchValue] = useState<string>("");
   const [debouncedSearchValue, setDebouncedSearchValue] = useState<string>("");
@@ -16,7 +16,7 @@ export const useDebouncedSearch = (props: { onDebouncedSearchValueChange: () => 
   const debouncedSetSearchValue = useCallback(
     debounce((query: string) => {
       setDebouncedSearchValue(query);
-      onDebouncedSearchValueChange();
+      onDebouncedSearchValueChange?.();
     }, debounceMilliseconds),
     []
   );
@@ -32,7 +32,7 @@ export const useDebouncedSearch = (props: { onDebouncedSearchValueChange: () => 
       // Instant without debounce
       setSearchValue("");
       setDebouncedSearchValue("");
-      onDebouncedSearchValueChange();
+      onDebouncedSearchValueChange?.();
     },
   };
 


### PR DESCRIPTION
- **UPDATE**
  - Previously, we were using the search value directly in the related model record lookup in auto form relationship inputs
  - Now, that search value is debounced to prevent excessing API calls
  - The loading state of the search has also been updated to be true when the search value is in the process of debouncing 
