### PR TITLE
Remove unreleased AutoComponents updates from index files

### DIFF
--- a/packages/react/cypress/component/auto/form/ShadcnAutoBelongsToInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/ShadcnAutoBelongsToInput.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { elements } from "../../../../spec/auto/shadcn-defaults/index.js";
 import { apiTriggerOnly } from "../../../../spec/auto/support/Triggers.js";
-import { makeAutocomponents } from "../../../../src/auto/shadcn/index.js";
+import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.js";
 import { api } from "../../../support/api.js";
 import { ShadcnWrapper } from "../../../support/auto.js";
 

--- a/packages/react/cypress/support/PolarisAdapter.ts
+++ b/packages/react/cypress/support/PolarisAdapter.ts
@@ -1,0 +1,7 @@
+export * from "../../src/auto/polaris/index.js";
+
+// Unreleased components
+export { PolarisAutoBelongsToForm as AutoBelongsToForm } from "../../src/auto/polaris/inputs/relationships/PolarisAutoBelongsToForm.js";
+export { PolarisAutoHasManyForm as AutoHasManyForm } from "../../src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.js";
+export { PolarisAutoHasManyThroughForm as AutoHasManyThroughForm } from "../../src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.js";
+export { PolarisAutoHasOneForm as AutoHasOneForm } from "../../src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.js";

--- a/packages/react/cypress/support/auto.tsx
+++ b/packages/react/cypress/support/auto.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { Toaster, elements } from "../../spec/auto/shadcn-defaults/index.js";
 import type { AutoAdapter } from "../../src/auto/index.js";
 import * as PolarisAdapter from "../../src/auto/polaris/index.js";
-import { makeAutocomponents } from "../../src/auto/shadcn/index.js";
+import { makeAutocomponents } from "../../src/auto/shadcn/unreleasedIndex.js";
 import { FormProvider, useForm } from "../../src/useActionForm.js";
 import { SUITE_NAMES } from "./constants.js";
 

--- a/packages/react/cypress/support/auto.tsx
+++ b/packages/react/cypress/support/auto.tsx
@@ -5,9 +5,9 @@ import type { ComponentType, ReactNode } from "react";
 import React from "react";
 import { Toaster, elements } from "../../spec/auto/shadcn-defaults/index.js";
 import type { AutoAdapter } from "../../src/auto/index.js";
-import * as PolarisAdapter from "../../src/auto/polaris/index.js";
 import { makeAutocomponents } from "../../src/auto/shadcn/unreleasedIndex.js";
 import { FormProvider, useForm } from "../../src/useActionForm.js";
+import * as PolarisAdapter from "./PolarisAdapter.js";
 import { SUITE_NAMES } from "./constants.js";
 
 interface AutoSuiteConfig {

--- a/packages/react/spec/auto/shadcn-defaults/ShadcnAutoForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/ShadcnAutoForm.stories.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Provider } from "../../../src/GadgetProvider.tsx";
-import { makeAutocomponents } from "../../../src/auto/shadcn/index.ts";
+import { makeAutocomponents } from "../../../src/auto/shadcn/unreleasedIndex.js";
 import { FormProvider, useForm } from "../../../src/useActionForm.ts";
 import { testApi as api } from "../../apis.ts";
 import { StorybookErrorBoundary } from "../storybook/StorybookErrorBoundary.tsx";

--- a/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnAutoEnumInput.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnAutoEnumInput.stories.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Provider } from "../../../../src/GadgetProvider.tsx";
-import { makeAutocomponents } from "../../../../src/auto/shadcn/index.ts";
 import { makeShadcnAutoEnumInput } from "../../../../src/auto/shadcn/inputs/ShadcnAutoEnumInput.tsx";
+import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.js";
 import { FormProvider, useForm } from "../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../apis.ts";
 import { StorybookErrorBoundary } from "../../storybook/StorybookErrorBoundary.tsx";

--- a/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnAutoJSONInput.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnAutoJSONInput.stories.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Provider } from "../../../../src/GadgetProvider.tsx";
+import { makeShadcnAutoJSONInput } from "../../../../src/auto/shadcn/inputs/ShadcnAutoJSONInput.tsx";
+import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.js";
 import { FormProvider, useForm } from "../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../apis.ts";
-import { makeAutocomponents } from "../../../../src/auto/shadcn/index.ts";
 import { elements } from "../index";
-import { makeShadcnAutoJSONInput } from "../../../../src/auto/shadcn/inputs/ShadcnAutoJSONInput.tsx";
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 
 const ShadcnAutoForm = makeAutocomponents(elements).AutoForm;

--- a/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnFileInput.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnFileInput.stories.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Provider } from "../../../../src/GadgetProvider.tsx";
+import { makeShadcnAutoFileInput } from "../../../../src/auto/shadcn/inputs/ShadcnAutoFileInput.tsx";
+import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.js";
 import { FormProvider, useForm } from "../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../apis.ts";
-import { makeAutocomponents } from "../../../../src/auto/shadcn/index.ts";
 import { elements } from "../index";
-import { makeShadcnAutoFileInput } from "../../../../src/auto/shadcn/inputs/ShadcnAutoFileInput.tsx";
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 
 const ShadcnAutoForm = makeAutocomponents(elements).AutoForm;

--- a/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Provider } from "../../../../../src/GadgetProvider.tsx";
 
+import { makeAutocomponents } from "../../../../../src/auto/shadcn/unreleasedIndex.js";
 import { FormProvider, useForm } from "../../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../../apis.ts";
 import { StorybookErrorBoundary } from "../../../storybook/StorybookErrorBoundary.tsx";
-import { makeAutocomponents } from "../../../../../src/auto/shadcn/index.ts";
 import { elements } from "../../index.tsx";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
@@ -15,8 +15,11 @@ const Component = (props) => {
   return (
     <AutoForm {...props} action={api.widget.create}>
       <SubmitResultBanner />
-      <AutoHasOneForm field="doodad" primaryLabel="name"
-        secondaryLabel={(record) => `${record.weight ?? 'N/A'} (${record.active ?? 'N/A'})`} tertiaryLabel="size"
+      <AutoHasOneForm
+        field="doodad"
+        primaryLabel="name"
+        secondaryLabel={(record) => `${record.weight ?? "N/A"} (${record.active ?? "N/A"})`}
+        tertiaryLabel="size"
       >
         <div className="flex flex-col gap-4">
           <AutoInput field="name" />
@@ -57,8 +60,6 @@ export default {
   },
   tags: ["autodocs"],
 };
-
-
 
 export const Create = {
   args: {

--- a/packages/react/spec/auto/storybook/table/SelectableDesignSystemAutoTableStory.tsx
+++ b/packages/react/spec/auto/storybook/table/SelectableDesignSystemAutoTableStory.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { SUITE_NAMES } from "../../../../cypress/support/constants.js";
 import { type AutoTableProps } from "../../../../src/auto/AutoTable.js";
 import { PolarisAutoTable } from "../../../../src/auto/polaris/PolarisAutoTable.js";
-import { makeAutocomponents } from "../../../../src/auto/shadcn/index.js";
+import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.js";
 import { type OptionsType } from "../../../../src/utils.js";
 import { elements } from "../../shadcn-defaults/index.js";
 

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -19,13 +19,9 @@ export {
   PolarisAutoTextInput as AutoStringInput,
   PolarisAutoTextInput as AutoUrlInput,
 } from "./inputs/PolarisAutoTextInput.js";
-export { PolarisAutoBelongsToForm as AutoBelongsToForm } from "./inputs/relationships/PolarisAutoBelongsToForm.js";
 export { PolarisAutoBelongsToInput as AutoBelongsToInput } from "./inputs/relationships/PolarisAutoBelongsToInput.js";
-export { PolarisAutoHasManyForm as AutoHasManyForm } from "./inputs/relationships/PolarisAutoHasManyForm.js";
 export { PolarisAutoHasManyInput as AutoHasManyInput } from "./inputs/relationships/PolarisAutoHasManyInput.js";
-export { PolarisAutoHasManyThroughForm as AutoHasManyThroughForm } from "./inputs/relationships/PolarisAutoHasManyThroughForm.js";
 export { PolarisAutoHasManyThroughInput as AutoHasManyThroughInput } from "./inputs/relationships/PolarisAutoHasManyThroughInput.js";
-export { PolarisAutoHasOneForm as AutoHasOneForm } from "./inputs/relationships/PolarisAutoHasOneForm.js";
 export { PolarisAutoHasOneInput as AutoHasOneInput } from "./inputs/relationships/PolarisAutoHasOneInput.js";
 export { PolarisAutoSubmit as AutoSubmit } from "./submit/PolarisAutoSubmit.js";
 export {

--- a/packages/react/src/auto/shadcn/index.ts
+++ b/packages/react/src/auto/shadcn/index.ts
@@ -1,17 +1,1 @@
-import type { ShadcnElements } from "./elements.js";
-import { makeAutoButton } from "./ShadcnAutoButton.js";
-import { makeAutoForm } from "./ShadcnAutoForm.js";
-import { makeAutoTable } from "./ShadcnAutoTable.js";
-export * from "./elements.js";
-
-/**
- * Build the Autocomponents library for your shadcn presentation components.
- * Autocomponents will render these given components, so they need to take the same base props that mainline shadcn components do.
- */
-export const makeAutocomponents = (elements: ShadcnElements) => {
-  return {
-    AutoButton: makeAutoButton(elements),
-    AutoTable: makeAutoTable(elements),
-    ...makeAutoForm(elements),
-  };
-};
+// Intentional empty file.

--- a/packages/react/src/auto/shadcn/unreleasedIndex.ts
+++ b/packages/react/src/auto/shadcn/unreleasedIndex.ts
@@ -1,0 +1,17 @@
+import type { ShadcnElements } from "./elements.js";
+import { makeAutoButton } from "./ShadcnAutoButton.js";
+import { makeAutoForm } from "./ShadcnAutoForm.js";
+import { makeAutoTable } from "./ShadcnAutoTable.js";
+export * from "./elements.js";
+
+/**
+ * Build the Autocomponents library for your shadcn presentation components.
+ * Autocomponents will render these given components, so they need to take the same base props that mainline shadcn components do.
+ */
+export const makeAutocomponents = (elements: ShadcnElements) => {
+  return {
+    AutoButton: makeAutoButton(elements),
+    AutoTable: makeAutoTable(elements),
+    ...makeAutoForm(elements),
+  };
+};


### PR DESCRIPTION
- A new react version needs to be released in order to upgrade the api-client-core version.
- This PR removes the indexes for the new and unreleased AutoCompoent changes 