### PR TITLE
fix shadcn storybook imports

### DIFF
--- a/packages/react/spec/auto/shadcn-defaults/ShadcnAutoForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/ShadcnAutoForm.stories.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Provider } from "../../../src/GadgetProvider.tsx";
-import { makeAutocomponents } from "../../../src/auto/shadcn/unreleasedIndex.js";
+import { makeAutocomponents } from "../../../src/auto/shadcn/unreleasedIndex.ts";
 import { FormProvider, useForm } from "../../../src/useActionForm.ts";
 import { testApi as api } from "../../apis.ts";
 import { StorybookErrorBoundary } from "../storybook/StorybookErrorBoundary.tsx";

--- a/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnAutoEnumInput.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnAutoEnumInput.stories.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Provider } from "../../../../src/GadgetProvider.tsx";
 import { makeShadcnAutoEnumInput } from "../../../../src/auto/shadcn/inputs/ShadcnAutoEnumInput.tsx";
-import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.js";
+import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.ts";
 import { FormProvider, useForm } from "../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../apis.ts";
 import { StorybookErrorBoundary } from "../../storybook/StorybookErrorBoundary.tsx";

--- a/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnAutoJSONInput.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnAutoJSONInput.stories.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Provider } from "../../../../src/GadgetProvider.tsx";
 import { makeShadcnAutoJSONInput } from "../../../../src/auto/shadcn/inputs/ShadcnAutoJSONInput.tsx";
-import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.js";
+import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.ts";
 import { FormProvider, useForm } from "../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../apis.ts";
-import { elements } from "../index";
+import { elements } from "../index.tsx";
+
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 
 const ShadcnAutoForm = makeAutocomponents(elements).AutoForm;

--- a/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnFileInput.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnFileInput.stories.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Provider } from "../../../../src/GadgetProvider.tsx";
 import { makeShadcnAutoFileInput } from "../../../../src/auto/shadcn/inputs/ShadcnAutoFileInput.tsx";
-import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.js";
+import { makeAutocomponents } from "../../../../src/auto/shadcn/unreleasedIndex.ts";
 import { FormProvider, useForm } from "../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../apis.ts";
-import { elements } from "../index";
+import { elements } from "../index.tsx";
+
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 
 const ShadcnAutoForm = makeAutocomponents(elements).AutoForm;

--- a/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Provider } from "../../../../../src/GadgetProvider.tsx";
-
-import { makeAutocomponents } from "../../../../../src/auto/shadcn/unreleasedIndex.js";
+import { makeAutocomponents } from "../../../../../src/auto/shadcn/unreleasedIndex.ts";
 import { FormProvider, useForm } from "../../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../../apis.ts";
 import { StorybookErrorBoundary } from "../../../storybook/StorybookErrorBoundary.tsx";


### PR DESCRIPTION
I had to rename the import file to safely release the next version of the react package. Unfortunately the `auto update imports` functionality does not use the correct file extensions to work with storybook. Fixed quick 🫡 
