### PR TITLE
Allow sibling edit in AutoHasManyThroughForm

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
@@ -92,17 +92,79 @@ describeForEachAutoAdapter(
       cy.get('[id="deleteButton_students.0"]').click();
 
       expectUpdateActionSubmissionVariables({
-        id: "3",
         course: {
           registrations: [
-            // Deleted first
+            //  Deleted first
             { delete: { id: "1" } },
             // Updated second
-            { update: { effectiveFrom: "2024-03-17", effectiveTo: "2025-08-21", id: "25", student: { _link: "11" } } },
+            {
+              update: {
+                effectiveFrom: "2025-02-18",
+                effectiveTo: "2025-02-22",
+                id: "50",
+                student: { update: { firstName: "Benjamin", id: "43", lastName: "Martin" } },
+              },
+            },
             // Created third
             { create: { student: { _link: "10" } } },
           ],
         },
+        id: "3",
+      });
+      cy.get('[id="submit"]').click();
+      cy.wait("@updateCourse");
+    });
+
+    it("can update fields on the sibling model", () => {
+      cy.mountWithWrapper(
+        <AutoForm action={api.university.course.update} findBy="3">
+          <AutoHasManyThroughForm
+            field="students"
+            selectPaths={["firstName", "lastName", "year", "department"]}
+            primaryLabel={["firstName", "lastName"]}
+            secondaryLabel={(record: any) => `Year: ${record.year}`}
+            tertiaryLabel="department"
+          >
+            <AutoInput field="firstName" />
+            <AutoInput field="lastName" />
+          </AutoHasManyThroughForm>
+          <AutoSubmit id="submit" />
+        </AutoForm>,
+        wrapper
+      );
+      cy.wait("@ModelCreateActionMetadata");
+      cy.wait("@course");
+      cy.wait("@students");
+
+      cy.get('[id="deleteButton_students.0"]').click();
+      cy.get('[name="course.registrations.0.student.firstName"]').click().type("- updated");
+      cy.get('[name="course.registrations.0.student.lastName"]').click().type("- updated");
+
+      expectUpdateActionSubmissionVariables({
+        course: {
+          registrations: [
+            {
+              delete: {
+                id: "1",
+              },
+            },
+            {
+              update: {
+                effectiveFrom: "2025-02-18",
+                effectiveTo: "2025-02-22",
+                id: "50",
+                student: {
+                  update: {
+                    firstName: "Benjamin- updated",
+                    id: "43",
+                    lastName: "Martin- updated",
+                  },
+                },
+              },
+            },
+          ],
+        },
+        id: "3",
       });
       cy.get('[id="submit"]').click();
       cy.wait("@updateCourse");
@@ -1336,44 +1398,67 @@ const courseLookupResponse = {
     university: {
       course: {
         id: "3",
+        title: "Math 101",
+        description: {
+          markdown: "This is an intro math course. We teach calculus",
+          truncatedHTML: "<p>This is an intro math course. We teach calculus</p> ",
+          __typename: "RichText",
+        },
         registrations: {
           edges: [
             {
               node: {
                 id: "1",
-                effectiveFrom: "2024-10-23",
-                effectiveTo: "2024-10-31",
+                effectiveFrom: "2024-11-12",
+                effectiveTo: "2024-10-17",
                 student: {
                   id: "1",
                   firstName: "Lucas",
                   lastName: "Hernandez",
-                  year: 6,
-                  department: "Arts",
                   __typename: "UniversityStudent",
                 },
+                studentId: "1",
                 __typename: "UniversityRegistration",
               },
               __typename: "UniversityRegistrationEdge",
             },
             {
               node: {
-                id: "25",
-                effectiveFrom: "2024-03-17",
-                effectiveTo: "2025-08-21",
+                id: "50",
+                effectiveFrom: "2025-02-18",
+                effectiveTo: "2025-02-22",
                 student: {
-                  id: "11",
+                  id: "43",
                   firstName: "Benjamin",
-                  lastName: "Moore",
-                  year: 10,
-                  department: "Science",
+                  lastName: "Martin",
                   __typename: "UniversityStudent",
                 },
+                studentId: "43",
                 __typename: "UniversityRegistration",
               },
               __typename: "UniversityRegistrationEdge",
             },
           ],
           __typename: "UniversityRegistrationConnection",
+        },
+        assignments: {
+          edges: [
+            {
+              node: {
+                id: "13",
+                professor: {
+                  id: "42",
+                  firstName: "Kevin",
+                  title: "Mrs",
+                  lastName: "Bailey",
+                  __typename: "UniversityProfessor",
+                },
+                __typename: "UniversityAssignment",
+              },
+              __typename: "UniversityAssignmentEdge",
+            },
+          ],
+          __typename: "UniversityAssignmentConnection",
         },
         __typename: "UniversityCourse",
       },

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -194,6 +194,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
             <InlineStack>
               <PolarisAutoInput field="registration.effectiveFrom" />
               <PolarisAutoInput field="registration.effectiveTo" />
+              <PolarisAutoInput field="registration.student.firstName" />
             </InlineStack>
           </PolarisAutoHasManyThroughForm>
         </Card>

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -192,9 +192,12 @@ const ExampleCourseCreateRelatedForm = (props) => {
             tertiaryLabel="department"
           >
             <InlineStack>
+              {/* Fields on the join model. The prefix is the model API id of the join model */}
               <PolarisAutoInput field="registration.effectiveFrom" />
               <PolarisAutoInput field="registration.effectiveTo" />
-              <PolarisAutoInput field="registration.student.firstName" />
+
+              {/* Fields on the sibling model. No prefix */}
+              <PolarisAutoInput field="firstName" />
             </InlineStack>
           </PolarisAutoHasManyThroughForm>
         </Card>

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -198,6 +198,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
 
               {/* Fields on the sibling model. No prefix */}
               <PolarisAutoInput field="firstName" />
+              <PolarisAutoInput field="lastName" />
             </InlineStack>
           </PolarisAutoHasManyThroughForm>
         </Card>

--- a/packages/react/spec/useActionFormNested.spec.tsx
+++ b/packages/react/spec/useActionFormNested.spec.tsx
@@ -2663,7 +2663,7 @@ describe("useActionFormNested", () => {
                   edges: {
                     node: {
                       id: true,
-                      // courseId: true,
+                      courseId: true,
                       course: {
                         id: true,
                         title: true,

--- a/packages/react/src/auto/AutoInput.tsx
+++ b/packages/react/src/auto/AutoInput.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from "react";
 import { useFieldsFromChildComponents } from "./AutoFormContext.js";
 import { useRelationshipContext } from "./hooks/useAutoRelationship.js";
-import { useRelationshipTransformedMetaDataPaths } from "./hooks/useFieldMetadata.js";
+import { useFieldApiIdentifier, useRelationshipTransformedMetaDataPaths } from "./hooks/useFieldMetadata.js";
 
 export interface AutoInputComponent<P> extends React.FC<P> {
   __autoInput: true;
@@ -11,17 +11,18 @@ export function autoInput<P extends { field: string }>(Component: React.FC<P>): 
   const WrappedComponent: React.FC<P> = (props) => {
     const { hasCustomFormChildren, registerFields, fieldSet } = useFieldsFromChildComponents();
     const relationshipContext = useRelationshipContext();
+    const fieldApiIdentifier = useFieldApiIdentifier(props.field);
 
     const fieldSetPath = useMemo(() => {
       if (relationshipContext) {
         return relationshipContext?.transformMetadataPath
-          ? relationshipContext.transformMetadataPath(props.field)
-          : relationshipContext.transformPath(props.field);
+          ? relationshipContext.transformMetadataPath(fieldApiIdentifier)
+          : relationshipContext.transformPath(fieldApiIdentifier);
       }
 
       // Non relationship context - Use field name directly
-      return props.field;
-    }, [relationshipContext, props.field]);
+      return fieldApiIdentifier;
+    }, [relationshipContext, fieldApiIdentifier]);
 
     useEffect(() => {
       registerFields([fieldSetPath]);

--- a/packages/react/src/auto/hooks/useAutoRelationship.tsx
+++ b/packages/react/src/auto/hooks/useAutoRelationship.tsx
@@ -10,12 +10,32 @@ export interface RelationshipContextValue {
    * Includes indexes for hasMany/hasManyThrough relationships
    */
   transformPath: (path: string) => string;
+
   /**
    * Path within the form metadata to the current relationship context.
    * Includes field names only and does not include indexes for hasMany/hasManyThrough relationships
    */
   transformMetadataPath: (path: string) => string;
+
+  /**
+   * Field array for the relationship
+   */
   fieldArray?: ReturnType<typeof useFieldArray>;
+
+  /**
+   * HasManyThrough relationship metadata
+   */
+  hasManyThrough?: {
+    /**
+     * The API identifier of the join model
+     */
+    joinModelApiIdentifier: string;
+
+    /**
+     * The API identifier of the `belongsTo` field on the join model pointing to the related model
+     */
+    inverseRelatedModelField: string;
+  };
 }
 
 export const RelationshipContext = React.createContext<RelationshipContextValue | undefined>(undefined);

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -107,6 +107,10 @@ export const PolarisAutoHasManyThroughForm = autoRelationshipForm(
                                 transformPath: (path) => `${joinModelField}.${idx}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
                                 transformMetadataPath: (path) => `${metaDataPathPrefix}.${path}`,
                                 fieldArray,
+                                hasManyThrough: {
+                                  joinModelApiIdentifier: joinModelApiIdentifier ?? "",
+                                  inverseRelatedModelField: inverseRelatedModelField ?? "",
+                                },
                               }}
                             >
                               {props.children}

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -107,10 +107,7 @@ export const PolarisAutoHasManyThroughForm = autoRelationshipForm(
                                 transformPath: (path) => `${joinModelField}.${idx}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
                                 transformMetadataPath: (path) => `${metaDataPathPrefix}.${path}`,
                                 fieldArray,
-                                hasManyThrough: {
-                                  joinModelApiIdentifier: joinModelApiIdentifier ?? "",
-                                  inverseRelatedModelField: inverseRelatedModelField ?? "",
-                                },
+                                hasManyThrough: { joinModelApiIdentifier, inverseRelatedModelField },
                               }}
                             >
                               {props.children}

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -214,6 +214,10 @@ export const makeShadcnAutoHasManyThroughForm = ({
                             transformPath: (path) => `${joinModelField}.${idx}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
                             transformMetadataPath: (path) => `${metaDataPathPrefix}.${path}`,
                             fieldArray,
+                            hasManyThrough: {
+                              joinModelApiIdentifier: joinModelApiIdentifier ?? "",
+                              inverseRelatedModelField: inverseRelatedModelField ?? "",
+                            },
                           }}
                         >
                           {props.children}

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -214,10 +214,7 @@ export const makeShadcnAutoHasManyThroughForm = ({
                             transformPath: (path) => `${joinModelField}.${idx}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
                             transformMetadataPath: (path) => `${metaDataPathPrefix}.${path}`,
                             fieldArray,
-                            hasManyThrough: {
-                              joinModelApiIdentifier: joinModelApiIdentifier ?? "",
-                              inverseRelatedModelField: inverseRelatedModelField ?? "",
-                            },
+                            hasManyThrough: { joinModelApiIdentifier, inverseRelatedModelField },
                           }}
                         >
                           {props.children}

--- a/packages/react/src/useHasManyThroughForm.ts
+++ b/packages/react/src/useHasManyThroughForm.ts
@@ -1,3 +1,4 @@
+import { assert } from "@gadgetinc/api-client-core";
 import { useEffect, useMemo } from "react";
 import { extractPathsFromChildren } from "./auto/AutoForm.js";
 import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
@@ -91,8 +92,11 @@ export const useHasManyThroughForm = (props: {
     siblingModelOptions,
     metadata,
     joinModelField,
-    joinModelApiIdentifier,
-    inverseRelatedModelField,
+    joinModelApiIdentifier: assert(joinModelApiIdentifier, `The join model in the "${field}" hasManyThrough field is required`),
+    inverseRelatedModelField: assert(
+      inverseRelatedModelField,
+      `The belongsTo field between the join model and sibling model in the "${field}" hasManyThrough field is required`
+    ),
     fieldArrayPath,
     fieldArray,
     field,

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -445,9 +445,14 @@ export const unset = (obj: any, path: string) => {
  * Omits the given properties from an object
  * From https://youmightnotneed.com/lodash
  */
-export const omit = (obj: any, omittedProperties: string[]) => {
+export const omit = (obj: any, omittedProperties: string[], safe = false) => {
   obj = { ...obj };
-  omittedProperties.forEach((prop) => delete obj[prop]);
+  omittedProperties.forEach((prop) => {
+    if (safe && !(prop in obj)) {
+      return;
+    }
+    delete obj[prop];
+  });
   return obj;
 };
 


### PR DESCRIPTION
- UPDATE
  - It was previously impossible to edit the sibling record from within a AutoHasManyThroughForm as the variable passed to the `joinModel-belongsTo-relatedModel` field would always be `_link` instead of a nested action
  - now, that join model belongs to field gets a nested action formed if it is called in the context of a AutoHasManyThroughForm.