### PR TITLE
Bump versions for react and api client core

### DIFF
--- a/packages/react-bigcommerce/package.json
+++ b/packages/react-bigcommerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-bigcommerce",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "files": [
     "README.md",
     "dist/**/*"
@@ -27,7 +27,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.39"
+    "@gadgetinc/api-client-core": "^0.15.40"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",

--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "files": [
     "README.md",
     "dist/**/*"
@@ -27,7 +27,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.39",
+    "@gadgetinc/api-client-core": "^0.15.40",
     "crypto-js": "^4.2.0",
     "tslib": "^2.6.2"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react",
-  "version": "0.18.8",
+  "version": "0.18.9",
   "files": [
     "README.md",
     "dist/**/*",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.4",
-    "@gadgetinc/api-client-core": "^0.15.39",
+    "@gadgetinc/api-client-core": "^0.15.40",
     "@hookform/resolvers": "^3.3.1",
     "filesize": "^10.1.2",
     "pluralize": "^8.0.0",

--- a/packages/shopify-extensions/package.json
+++ b/packages/shopify-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/shopify-extensions",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "files": [
     "README.md",
     "dist/**/*",
@@ -33,7 +33,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
-    "@gadgetinc/api-client-core": "^0.15.39"
+    "@gadgetinc/api-client-core": "^0.15.40"
   },
   "devDependencies": {
     "@gadgetinc/api-client-core": "workspace:*",


### PR DESCRIPTION
Bumps react versions to include api client core with revert

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
