### PR TITLE
AutoHasOneForm - UI overhaul, allow selected record replacement, consolidate shared functions with BelongsTo

### DIFF
--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -28,11 +28,7 @@ const ExampleWidgetAutoRelatedForm = (props) => {
         </Card>
 
         <Card>
-          <PolarisAutoBelongsToForm
-            field="section"
-            primaryLabel="name"
-            renderSelectedRecord={(record) => <Text>this is a custom belongsTo render for {record.name}</Text>}
-          >
+          <PolarisAutoBelongsToForm field="section" primaryLabel="name" secondaryLabel="name" tertiaryLabel="id">
             <PolarisAutoInput field="name" />
           </PolarisAutoBelongsToForm>
         </Card>
@@ -58,6 +54,7 @@ const ExampleWidgetAutoRelatedForm = (props) => {
             selectPaths={["name", "orientation"]}
             primaryLabel="name"
             secondaryLabel="orientation"
+            tertiaryLabel={(record) => <Text>{record.id}</Text>}
           >
             <PolarisAutoInput field="name" />
             <PolarisAutoInput field="orientation" />

--- a/packages/react/src/auto/polaris/inputs/relationships/SearchableSingleRelatedModelRecordSelector.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/SearchableSingleRelatedModelRecordSelector.tsx
@@ -1,0 +1,63 @@
+import { AutoSelection, Icon, InlineStack, Listbox } from "@shopify/polaris";
+import { PlusCircleIcon } from "@shopify/polaris-icons";
+import React from "react";
+import { type useSingleRelatedRecordRelationshipForm } from "src/useSingleRelatedRecordRelationshipForm.js";
+import { RelatedModelOptionsPopover, RelatedModelOptionsSearch } from "./RelatedModelOptions.js";
+
+export const SearchableSingleRelatedModelRecordSelector = (props: {
+  form: ReturnType<typeof useSingleRelatedRecordRelationshipForm>;
+  override?: {
+    addNewRecord?: () => void;
+  };
+}) => {
+  const {
+    search,
+    searchOpen,
+    setSearchOpen,
+    pagination,
+    records,
+    isLoading,
+    searchFilterOptions,
+    relatedModelName,
+    path,
+    setValue,
+    setIsEditing,
+  } = props.form;
+  return (
+    <>
+      <RelatedModelOptionsPopover
+        active={searchOpen}
+        activator={
+          <RelatedModelOptionsSearch
+            modelName={relatedModelName}
+            value={search.value}
+            onChange={search.set}
+            onFocus={() => setSearchOpen(true)}
+          />
+        }
+        onClose={() => setSearchOpen(false)}
+        onScrolledToBottom={pagination.loadNextPage}
+        actions={[
+          <Listbox.Action key="add-new-record" value="add-new-record" divider>
+            <InlineStack gap="200">
+              <Icon source={PlusCircleIcon} />
+              Add {relatedModelName}
+            </InlineStack>
+          </Listbox.Action>,
+        ]}
+        options={searchFilterOptions}
+        records={records}
+        onSelect={(record) => {
+          if (record.id === "add-new-record") {
+            props.override?.addNewRecord?.() ?? setIsEditing(true);
+          } else {
+            setValue(path, { ...record, _link: record.id });
+          }
+          setSearchOpen(false);
+        }}
+        isLoading={isLoading}
+        autoSelection={AutoSelection.None}
+      />
+    </>
+  );
+};

--- a/packages/react/src/auto/shadcn/inputs/relationships/SearchableSingleRelatedModelRecordSelector.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/SearchableSingleRelatedModelRecordSelector.tsx
@@ -1,0 +1,107 @@
+import { CommandSeparator } from "cmdk";
+import { PlusIcon } from "lucide-react";
+import { default as React, useCallback } from "react";
+import { type useSingleRelatedRecordRelationshipForm } from "src/useSingleRelatedRecordRelationshipForm.js";
+import { debounce } from "../../../../utils.js";
+import { optionRecordsToLoadCount } from "../../../hooks/useRelatedModel.js";
+import type { ShadcnElements } from "../../elements.js";
+import { makeShadcnAutoComboInput } from "../ShadcnAutoComboInput.js";
+
+export const makeSearchableSingleRelatedModelRecordSelector = ({
+  Command,
+  CommandItem,
+  CommandInput,
+  CommandLoading,
+  Label,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  Checkbox,
+  ScrollArea,
+}: Pick<
+  ShadcnElements,
+  | "Command"
+  | "CommandItem"
+  | "CommandInput"
+  | "CommandLoading"
+  | "Label"
+  | "CommandList"
+  | "CommandEmpty"
+  | "CommandGroup"
+  | "Checkbox"
+  | "ScrollArea"
+>) => {
+  const ShadcnComboInput = makeShadcnAutoComboInput({
+    Command,
+    CommandInput,
+    Label,
+    CommandItem,
+    CommandList,
+    CommandEmpty,
+    CommandLoading,
+    CommandGroup,
+    Checkbox,
+    ScrollArea,
+  });
+
+  function SearchableSingleRelatedModelRecordSelector(props: {
+    form: ReturnType<typeof useSingleRelatedRecordRelationshipForm>;
+    field: string;
+    override?: {
+      addNewRecord?: () => void;
+    };
+  }) {
+    const { field } = props;
+    const { search, metadata, pagination, records, isLoading, searchFilterOptions, relatedModelName, path, setValue, setIsEditing } =
+      props.form;
+
+    const handleScrolledToBottom = useCallback(
+      debounce(() => {
+        if (pagination.hasNextPage && searchFilterOptions.length >= optionRecordsToLoadCount) {
+          pagination.loadNextPage();
+        }
+      }, 300),
+      [pagination, searchFilterOptions.length]
+    );
+
+    return (
+      <ShadcnComboInput
+        selectedRecordTag={null}
+        path={path}
+        hideLabel
+        metadata={metadata}
+        field={field}
+        options={searchFilterOptions}
+        onSelect={(record) => {
+          setValue(path, { ...record, _link: record.id });
+        }}
+        isLoading={isLoading}
+        errorMessage={""}
+        actions={[
+          <CommandGroup key={"add-record"}>
+            <CommandItem
+              onSelect={() => {
+                props.override?.addNewRecord?.() ?? setIsEditing(true);
+              }}
+            >
+              <div className="flex flex-row items-center gap-2">
+                <PlusIcon className="w-4 h-4" />
+                Add {relatedModelName}
+              </div>
+            </CommandItem>
+            <CommandSeparator />
+          </CommandGroup>,
+        ]}
+        records={records}
+        checkSelected={() => false}
+        allowMultiple={false}
+        willLoadMoreOptions={pagination.hasNextPage && searchFilterOptions.length >= optionRecordsToLoadCount}
+        onScrolledToBottom={handleScrolledToBottom}
+        onChange={search.set}
+        defaultValue={search.value}
+      />
+    );
+  }
+
+  return SearchableSingleRelatedModelRecordSelector;
+};

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
@@ -1,15 +1,12 @@
-import { CommandSeparator } from "cmdk";
-import { EllipsisVerticalIcon, PlusIcon } from "lucide-react";
+import { PlusCircleIcon } from "lucide-react";
 import React, { useCallback } from "react";
 import { useHasOneForm } from "../../../../useHasOneForm.js";
-import { debounce } from "../../../../utils.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
-import { optionRecordsToLoadCount } from "../../../hooks/useRelatedModel.js";
 import type { OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
 import { makeShadcnRenderOptionLabel } from "../../utils.js";
-import { makeShadcnAutoComboInput } from "../ShadcnAutoComboInput.js";
+import { makeSearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
 
 export const makeShadcnAutoHasOneForm = ({
   Badge,
@@ -18,22 +15,15 @@ export const makeShadcnAutoHasOneForm = ({
   CommandItem,
   CommandInput,
   CommandLoading,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   Label,
   CommandList,
   CommandEmpty,
   CommandGroup,
   Checkbox,
   ScrollArea,
-  Dialog,
-  DialogContent,
-  DialogClose,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
 }: Pick<
   ShadcnElements,
   | "Badge"
@@ -47,32 +37,21 @@ export const makeShadcnAutoHasOneForm = ({
   | "CommandEmpty"
   | "CommandGroup"
   | "Checkbox"
-  | "DropdownMenu"
-  | "DropdownMenuContent"
-  | "DropdownMenuItem"
-  | "DropdownMenuLabel"
-  | "DropdownMenuSeparator"
-  | "DropdownMenuTrigger"
   | "ScrollArea"
-  | "Dialog"
-  | "DialogContent"
-  | "DialogTrigger"
-  | "DialogHeader"
-  | "DialogTitle"
-  | "DialogDescription"
-  | "DialogFooter"
-  | "DialogClose"
+  | "Accordion"
+  | "AccordionItem"
+  | "AccordionTrigger"
 >) => {
   const renderOptionLabel = makeShadcnRenderOptionLabel({ Label, Badge, Button });
 
-  const ShadcnComboInput = makeShadcnAutoComboInput({
+  const SearchableSingleRelatedModelRecordSelector = makeSearchableSingleRelatedModelRecordSelector({
     Command,
-    CommandInput,
-    Label,
     CommandItem,
+    CommandInput,
+    CommandLoading,
+    Label,
     CommandList,
     CommandEmpty,
-    CommandLoading,
     CommandGroup,
     Checkbox,
     ScrollArea,
@@ -81,41 +60,42 @@ export const makeShadcnAutoHasOneForm = ({
   function ShadcnHasOneForm(props: {
     field: string;
     children: React.ReactNode;
-    renderSelectedRecord?: (record: Record<string, any>) => React.ReactNode;
     primaryLabel?: OptionLabel;
     secondaryLabel?: OptionLabel;
     tertiaryLabel?: OptionLabel;
   }) {
     const { field } = props;
+    const form = useHasOneForm(props);
     const {
-      path,
-      metadata,
-      setValue,
-      getValues,
       record,
-      actionsOpen,
-      setActionsOpen,
-      modalOpen,
-      setModalOpen,
-      search,
-      searchFilterOptions,
-      pagination,
-      records,
-      isLoading,
+      isEditing,
+      setIsEditing,
       pathPrefix,
       metaDataPathPrefix,
       hasRecord,
       recordOption,
-      childName,
-    } = useHasOneForm(props);
+      isCreatingRecord,
+      confirmEdit,
+      removeRecord,
+      relatedModelName,
+    } = form;
 
-    const handleScrolledToBottom = useCallback(
-      debounce(() => {
-        if (pagination.hasNextPage && searchFilterOptions.length >= optionRecordsToLoadCount) {
-          pagination.loadNextPage();
-        }
-      }, 300),
-      [pagination, searchFilterOptions.length]
+    const clickConfirmEdit = useCallback(
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        confirmEdit();
+      },
+      [confirmEdit]
+    );
+
+    const clickRemoveRecord = useCallback(
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        removeRecord();
+      },
+      [removeRecord]
     );
 
     return (
@@ -124,122 +104,93 @@ export const makeShadcnAutoHasOneForm = ({
       >
         <div>
           <div className="flex flex-row justify-between items-center">
-            <h2 className="text-lg font-medium">{childName}</h2>
-            {hasRecord && (
-              <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
-                <DropdownMenuTrigger data-testid={`${path}-dropdown-menu-trigger`} asChild>
-                  <Button variant="ghost">
-                    <EllipsisVerticalIcon className="w-4 h-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="bg-white">
-                  <DropdownMenuItem
-                    value="edit"
-                    onSelect={() => {
-                      setModalOpen(true);
-                      setActionsOpen(false);
-                    }}
-                  >
-                    Edit {childName.toLocaleLowerCase()}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    value="remove"
-                    onSelect={() => {
-                      if (!record) return;
-                      const { __typename, id: recordId, ...rest } = record;
-                      const nulledValues = Object.fromEntries(Object.keys(rest).map((key) => [key, null]));
-                      setValue(path, { ...nulledValues, __typename, _unlink: recordId });
-                    }}
-                    variant="destructive"
-                  >
-                    Remove {childName.toLocaleLowerCase()}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+            <h2 className="text-lg font-medium">{relatedModelName}</h2>
           </div>
-          {hasRecord ? (
-            props.renderSelectedRecord ? (
-              props.renderSelectedRecord(record as Record<string, any>)
-            ) : (
-              <div className="flex flex-col gap-2">
-                <div className="flex flex-row justify-between gap-2 mt-2">
-                  {renderOptionLabel(recordOption!.label, "primary")}
-                  {recordOption!.tertiaryLabel && renderOptionLabel(recordOption!.tertiaryLabel, "tertiary")}
-                </div>
-                {recordOption!.secondaryLabel && renderOptionLabel(recordOption!.secondaryLabel, "secondary")}
-              </div>
-            )
-          ) : (
-            <ShadcnComboInput
-              selectedRecordTag={null}
-              path={path}
-              hideLabel
-              metadata={metadata}
-              field={field}
-              options={searchFilterOptions}
-              onSelect={(record) => {
-                setValue(path, { ...record, _link: record.id });
-              }}
-              isLoading={isLoading}
-              errorMessage={""}
-              actions={[
-                <CommandGroup key={"add-record"}>
-                  <CommandItem
-                    onSelect={() => {
-                      setModalOpen(true);
+          {hasRecord || isCreatingRecord ? (
+            <Accordion type="single" collapsible className="w-full">
+              {!isEditing ? (
+                <AccordionItem value={`${pathPrefix}.${record?.id ? `update-${record.id}` : `create`}`}>
+                  <AccordionTrigger
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setIsEditing(true);
                     }}
                   >
-                    <div className="flex flex-row items-center gap-2">
-                      <PlusIcon className="w-4 h-4" />
-                      Add {childName}
+                    <div className="flex justify-between w-full items-center">
+                      <div className="flex flex-col gap-1 items-start">
+                        {recordOption?.label && renderOptionLabel(recordOption?.label, "primary")}
+                        {recordOption?.secondaryLabel && renderOptionLabel(recordOption?.secondaryLabel, "secondary")}
+                      </div>
+
+                      {recordOption?.tertiaryLabel && (
+                        <div className="flex items-center">{renderOptionLabel(recordOption?.tertiaryLabel, "tertiary")}</div>
+                      )}
                     </div>
-                  </CommandItem>
-                  <CommandSeparator />
-                </CommandGroup>,
-              ]}
-              records={records}
-              checkSelected={() => false}
-              allowMultiple={false}
-              willLoadMoreOptions={pagination.hasNextPage && searchFilterOptions.length >= optionRecordsToLoadCount}
-              onScrolledToBottom={handleScrolledToBottom}
-              onChange={search.set}
-              defaultValue={search.value}
-            />
+                  </AccordionTrigger>
+                </AccordionItem>
+              ) : (
+                <>
+                  <div className="border border-gray-300 rounded-md p-3">
+                    {props.children}
+                    <div className="flex justify-between p-4">
+                      <Button variant="destructive" id={`deleteButton_${metaDataPathPrefix}`} onClick={clickRemoveRecord}>
+                        Remove
+                      </Button>
+                      <Button variant="default" type="button" id={`confirmButton_${metaDataPathPrefix}`} onClick={clickConfirmEdit}>
+                        Confirm
+                      </Button>
+                    </div>
+                  </div>
+                </>
+              )}
+            </Accordion>
+          ) : (
+            <>
+              <EmptyFormComponent form={form} field={field} />
+            </>
           )}
         </div>
-        {
-          <Dialog open={modalOpen} onOpenChange={() => setModalOpen(!modalOpen)}>
-            <DialogContent className="bg-white">
-              <DialogHeader>
-                <DialogTitle>Add {childName}</DialogTitle>
-              </DialogHeader>
-              <div>{props.children}</div>
-              <DialogFooter className="">
-                <DialogClose asChild>
-                  <Button type="button" variant="secondary">
-                    Close
-                  </Button>
-                </DialogClose>
-                <Button
-                  type="button"
-                  variant="default"
-                  onClick={() => {
-                    const { _unlink, _link, ...rest } = getValues(path);
-                    setValue(path, rest);
-
-                    setModalOpen(false);
-                  }}
-                >
-                  Save
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        }
       </RelationshipContext.Provider>
+    );
+  }
+
+  function EmptyFormComponent(props: { field: string; form: ReturnType<typeof useHasOneForm> }) {
+    const { field, form } = props;
+
+    if (canSelectExistingRecord) {
+      return <SearchableSingleRelatedModelRecordSelector field={field} form={form} override={{ addNewRecord: form.startCreatingRecord }} />;
+    }
+    return <CreateNewChildButton form={form} />;
+  }
+
+  function CreateNewChildButton(props: { form: ReturnType<typeof useHasOneForm> }) {
+    const { startCreatingRecord, relatedModelName } = props.form;
+    return (
+      <>
+        <Button
+          type="button"
+          variant="default"
+          className="flex gap-1 border border-gray-300 rounded-md p-2 cursor-pointer"
+          onClick={startCreatingRecord}
+        >
+          <PlusCircleIcon className="w-4 h-4" />
+          <Label className="text-sm font-semibold">Add {relatedModelName}</Label>
+        </Button>
+      </>
     );
   }
 
   return autoRelationshipForm(ShadcnHasOneForm);
 };
+
+/**
+ * TODO - If this gets enabled fix this:
+ *    - Workflow
+ *      - existingSelectedRecord
+ *      - removeSelection
+ *      - reselectTheSameRecordInDropdown
+ *      - removeSelection
+ *      - send
+ *    - Right now, this workflow sends null as the hasOne field value, which does nothing. It should be _unlink
+ */
+const canSelectExistingRecord = false;

--- a/packages/react/src/use-action-form/utils.ts
+++ b/packages/react/src/use-action-form/utils.ts
@@ -468,8 +468,22 @@ const getHasOneGraphqlApiInput = (props: { input: any; result: any; defaultValue
 
   const currentId = currentValue?.id;
   const newId = rest._link ?? input.id;
+
   if ("_unlink" in input && input._unlink) {
-    return { _unlink: input._unlink };
+    const {
+      _unlink,
+      __replace, // To indicate that we are replacing the current record with a new one
+      ...nonUnlinkParams
+    } = input;
+
+    const additionalActions =
+      !__replace || Object.keys(nonUnlinkParams).length === 0
+        ? {}
+        : "id" in nonUnlinkParams && nonUnlinkParams.id
+        ? { update: nonUnlinkParams }
+        : { create: nonUnlinkParams };
+
+    return { _unlink, ...additionalActions };
   }
 
   const unlink = currentId && currentId !== newId ? { _unlink: currentId } : undefined;

--- a/packages/react/src/useBelongsToForm.ts
+++ b/packages/react/src/useBelongsToForm.ts
@@ -1,11 +1,7 @@
-import { useEffect, useState } from "react";
-import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
 import { useBelongsToController } from "./auto/hooks/useBelongsToController.js";
-import { getRecordAsOption, useOptionLabelForField } from "./auto/hooks/useRelatedModel.js";
 import { useRequiredChildComponentsValidator } from "./auto/hooks/useRequiredChildComponentsValidator.js";
 import type { OptionLabel } from "./auto/interfaces/AutoRelationshipInputProps.js";
-import { useFormContext } from "./useActionForm.js";
-import { get } from "./utils.js";
+import { useSingleRelatedRecordRelationshipForm } from "./useSingleRelatedRecordRelationshipForm.js";
 
 export const useBelongsToForm = (props: {
   field: string;
@@ -15,72 +11,11 @@ export const useBelongsToForm = (props: {
   tertiaryLabel?: OptionLabel;
 }) => {
   useRequiredChildComponentsValidator(props, "AutoBelongsToForm");
-  const { field } = props;
-  const { path, metadata } = useAutoRelationship({ field });
-  const {
-    setValue,
-    getValues,
-    formState: { defaultValues, submitCount, isSubmitSuccessful },
-  } = useFormContext();
-
   const { record, relatedModelOptions } = useBelongsToController(props);
-  const [actionsOpen, setActionsOpen] = useState(false);
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [modalOpen, setModalOpen] = useState(false);
 
-  const {
-    search,
-    searchFilterOptions,
-    pagination,
-    relatedModel: { records, fetching: isLoading },
-  } = relatedModelOptions;
-  const relationshipContext = useRelationshipContext();
-  const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;
+  const form = useSingleRelatedRecordRelationshipForm({ ...props, relationshipController: { record, relatedModelOptions } });
 
-  const defaultRecordId = get(defaultValues, path)?.id;
-
-  // each time the form is submitted if the child record is created we need to set the id to the default record id
-  // that comes from the response to the action mutation
-  useEffect(() => {
-    if (isSubmitSuccessful && record && !record.id && !("_link" in record) && !("_unlink" in record) && defaultRecordId) {
-      setValue(path + ".id", defaultRecordId);
-    }
-  }, [record, defaultRecordId, path, setValue, submitCount, isSubmitSuccessful]);
-
-  const primaryLabel = useOptionLabelForField(field, props.primaryLabel);
   const hasRecord = !!(record && !("_unlink" in record && record._unlink));
-  const recordOption = record ? getRecordAsOption(record, primaryLabel, props.secondaryLabel, props.tertiaryLabel) : null;
 
-  const parentName = metadata.name ?? "Unknown";
-
-  const metaDataPathPrefix = relationshipContext?.transformMetadataPath
-    ? relationshipContext.transformMetadataPath(props.field)
-    : props.field;
-
-  return {
-    record,
-    relatedModelOptions,
-    actionsOpen,
-    searchOpen,
-    modalOpen,
-    primaryLabel,
-    hasRecord,
-    recordOption,
-    parentName,
-    metadata,
-    defaultRecordId,
-    path,
-    pathPrefix,
-    setValue,
-    getValues,
-    search,
-    searchFilterOptions,
-    pagination,
-    records,
-    isLoading,
-    setActionsOpen,
-    setSearchOpen,
-    setModalOpen,
-    metaDataPathPrefix,
-  };
+  return { ...form, record, hasRecord };
 };

--- a/packages/react/src/useSingleRelatedRecordRelationshipForm.ts
+++ b/packages/react/src/useSingleRelatedRecordRelationshipForm.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
+import { getRecordAsOption, useOptionLabelForField, type useRelatedModelOptions } from "./auto/hooks/useRelatedModel.js";
+import type { OptionLabel } from "./auto/interfaces/AutoRelationshipInputProps.js";
+import { useFormContext } from "./useActionForm.js";
+import { get } from "./utils.js";
+
+export const useSingleRelatedRecordRelationshipForm = (props: {
+  field: string;
+  children: React.ReactNode;
+  primaryLabel?: OptionLabel;
+  secondaryLabel?: OptionLabel;
+  tertiaryLabel?: OptionLabel;
+  relationshipController: {
+    record: Record<string, any> | undefined;
+    relatedModelOptions: ReturnType<typeof useRelatedModelOptions>;
+  };
+}) => {
+  const {
+    field,
+    relationshipController: { record, relatedModelOptions },
+  } = props;
+
+  const { path, metadata } = useAutoRelationship({ field });
+  const {
+    setValue,
+    getValues,
+    formState: { defaultValues, submitCount, isSubmitSuccessful },
+  } = useFormContext();
+
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const {
+    search,
+    searchFilterOptions,
+    pagination,
+    relatedModel: { records, fetching: isLoading },
+  } = relatedModelOptions;
+
+  const relationshipContext = useRelationshipContext();
+  const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;
+  const metaDataPathPrefix = relationshipContext?.transformMetadataPath
+    ? relationshipContext.transformMetadataPath(props.field)
+    : pathPrefix;
+
+  const defaultRecordId = get(defaultValues, path)?.id;
+
+  // each time the form is submitted if the child record is created we need to set the id to the default record id
+  // that comes from the response to the action mutation
+  useEffect(() => {
+    if (isSubmitSuccessful && record && !record.id && !("_link" in record) && !("_unlink" in record) && defaultRecordId) {
+      setValue(path + ".id", defaultRecordId);
+    }
+  }, [record, defaultRecordId, path, setValue, submitCount, isSubmitSuccessful]);
+
+  const primaryLabel = useOptionLabelForField(props.field, props.primaryLabel);
+
+  const recordOption = record ? getRecordAsOption(record, primaryLabel, props.secondaryLabel, props.tertiaryLabel) : null;
+  const relatedModelName = metadata.name ?? "Unknown";
+
+  return {
+    actionsOpen,
+    defaultRecordId,
+    getValues,
+    isEditing,
+    isLoading,
+    metaDataPathPrefix,
+    metadata,
+    pagination,
+    path,
+    pathPrefix,
+    primaryLabel,
+    record,
+    recordOption,
+    records,
+    relatedModelName,
+    relatedModelOptions,
+    search,
+    searchFilterOptions,
+    searchOpen,
+    secondaryLabel: props.secondaryLabel,
+    setActionsOpen,
+    setIsEditing,
+    setSearchOpen,
+    setValue,
+    tertiaryLabel: props.tertiaryLabel,
+  };
+};


### PR DESCRIPTION
- UPDATES
	- removed `renderSelectedRecord`. This is redundant with the primary/secondary/ternary record label system 
	- `useSingleRelatedRecordRelationshipForm` 
		- There was a lot of overlap between the form hooks for belongsTo and hasOne. I've consolidated their shared logic into this one hook and added extensions where needed
			- Ex - HasOne has more complicated logic for creating a new record
	- `SearchableSingleRelatedModelRecordSelector`
		- In Polaris and Shadcn, we had an effectively identical component that was used to search and select for records on the related model. It has now been consolidated into a single component in both Polaris and Shadcn 
	- `hasOne` - GQL argument shaping
		- Previously, the inclusion of `_unlink` would ignore all of the other params in the form state. This made it impossible to unlink a record and replace it with a newly created one at the same time
	- UI overhaul for `AutoHasOneForm`
		- After discussing with designers, we decided that `AutoHasOneForm` should look basically the same as `AutoHasManyForm`, but there is only one related record available
			- Disabled `select existing related model record` functionality. It is now only possible to create new records and edit existing linked records.
			- Replaced the modal system for edit/create with a single unit accordion just like the hasManyForm