### PR TITLE
shadcn fixes 2

### DIFF
--- a/packages/react/cypress/support/auto.tsx
+++ b/packages/react/cypress/support/auto.tsx
@@ -60,12 +60,16 @@ export const PolarisWrapper = ({ children }: { children: ReactNode }) => (
 const ShadCNAdapter = makeAutocomponents(elements);
 
 export const ShadcnWrapper = ({ children }: { children: ReactNode }) => (
-  <>
-    <FormProvider {...useForm()}>
-      <Toaster />
-      {children}
-    </FormProvider>
-  </>
+  <div className="p-4">
+    <elements.Card className="bg-white">
+      <elements.CardContent>
+        <FormProvider {...useForm()}>
+          <Toaster />
+          {children}
+        </FormProvider>
+      </elements.CardContent>
+    </elements.Card>
+  </div>
 );
 
 const suites: AutoSuiteConfig[] = [

--- a/packages/react/spec/auto/shadcn-defaults/components/Form.tsx
+++ b/packages/react/spec/auto/shadcn-defaults/components/Form.tsx
@@ -1,9 +1,0 @@
-import * as React from "react";
-import { cn } from "../utils.js";
-
-const Form = React.forwardRef<HTMLFormElement, React.FormHTMLAttributes<HTMLFormElement>>(({ className, ...props }, ref) => {
-  return <form ref={ref} noValidate className={cn("space-y-6", className)} {...props} />;
-});
-Form.displayName = "Form";
-
-export { Form };

--- a/packages/react/spec/auto/shadcn-defaults/index.tsx
+++ b/packages/react/spec/auto/shadcn-defaults/index.tsx
@@ -37,7 +37,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./components/DropdownMenu.js";
-import { Form } from "./components/Form.js";
 import { Input } from "./components/Input.js";
 import { Label } from "./components/Label.js";
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "./components/Popover.js";
@@ -101,7 +100,6 @@ export const elements: ShadcnElements = {
   Input,
   Label,
   Textarea,
-  Form,
   Skeleton,
   Table,
   TableBody,

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -74,7 +74,10 @@ export type AutoFormProps<
         findBy?: RecordIdentifier;
       }
     : // eslint-disable-next-line @typescript-eslint/ban-types
-      {});
+      {
+        /** This action doesn't run against existing records, so you can't pass a findBy option */
+        findBy?: never;
+      });
 
 /**
  * React hook for getting the validation schema for a list of fields
@@ -207,7 +210,7 @@ export const useAutoForm = <
   SchemaT,
   ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
 >(
-  props: AutoFormProps<GivenOptions, SchemaT, ActionFunc, any, any> & { findBy?: any }
+  props: AutoFormProps<GivenOptions, SchemaT, ActionFunc, any, any>
 ): {
   select?: GivenOptions["select"];
   metadata: ModelWithOneActionMetadata | GlobalActionMetadata | undefined;

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -29,11 +29,11 @@ export const PolarisAutoForm = <
   SchemaT,
   ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>
 >(
-  //polaris form props also take an 'action' property, which we need to omit here.
-  props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action">
+  props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> &
+    // polaris form props also take an 'action' property, which we override with the Gadget form action
+    Omit<Partial<FormProps>, "action">
 ) => {
-  const { action, findBy } = props as AutoFormProps<GivenOptions, SchemaT, ActionFunc> &
-    Omit<Partial<FormProps>, "action"> & { findBy: any };
+  const { action, findBy } = props;
 
   validateAutoFormProps(props);
 

--- a/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
@@ -49,8 +49,7 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
   function AutoForm<GivenOptions extends OptionsType, SchemaT, ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>>(
     props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & ComponentProps<typeof Form>
   ) {
-    const { action, findBy } = props as AutoFormProps<GivenOptions, SchemaT, ActionFunc> &
-      Omit<Partial<FormProps>, "action"> & { findBy: any };
+    const { action, findBy } = props;
     validateAutoFormProps(props);
 
     // Component key to force re-render when the action or findBy changes
@@ -58,10 +57,7 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
 
     return (
       <AutoFormFieldsFromChildComponentsProvider hasCustomFormChildren={React.Children.count(props.children) > 0}>
-        <AutoFormInner
-          key={componentKey}
-          {...(props as AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action"> & { findBy: any })}
-        />
+        <AutoFormInner key={componentKey} {...props} />
       </AutoFormFieldsFromChildComponentsProvider>
     );
   }
@@ -70,13 +66,8 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
     GivenOptions extends OptionsType,
     SchemaT,
     ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>
-  >(props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & ComponentProps<typeof elements.Form>) {
-    const {
-      record: _record,
-      action,
-      findBy,
-      ...rest
-    } = props as AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action"> & { findBy: any };
+  >(props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<ComponentProps<typeof FormContainer>, "action">) {
+    const { record: _record, action, findBy, ...rest } = props;
 
     const {
       metadata,

--- a/packages/react/src/auto/shadcn/elements.tsx
+++ b/packages/react/src/auto/shadcn/elements.tsx
@@ -219,9 +219,6 @@ export interface ShadcnElements {
   /** The DropdownMenuSeparator component from shadcn */
   DropdownMenuSeparator: React.ComponentType<React.HTMLAttributes<HTMLDivElement>>;
 
-  /** The Form component from shadcn */
-  Form: React.ComponentType<FormProps>;
-
   /** The Input component from shadcn */
   Input: React.ComponentType<InputProps>;
 


### PR DESCRIPTION
- **Fix need for a bunch of custom casting with explicitly always included findBy type**
- **Don't use shadcn form -- it overrides react-hook-form context that we need**
- **Make the shadcn form layout a bit nicer**
