### PR TITLE
Explicitly handle null values for Polaris and Shadcn AutoDatePickers

### DIFF
--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -34,9 +34,15 @@ export const PolarisAutoDateTimePicker = autoInput(
     const { field: fieldProps, fieldState } = useController({ name: path });
 
     const { onChange, value } = props;
+
     const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const localTime = useMemo(() => {
-      return value ? value : isValidDate(new Date(fieldProps.value)) ? new Date(fieldProps.value) : undefined;
+      if (value) return value;
+
+      if (fieldProps.value == null) return undefined; // Prevents null from becoming 1970
+
+      const date = new Date(fieldProps.value);
+      return isValidDate(date) ? date : undefined;
     }, [value, fieldProps.value]);
 
     const [datePopoverActive, setDatePopoverActive] = useState(false);

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -1,7 +1,7 @@
 import type { DatePickerProps, TextFieldProps } from "@shopify/polaris";
 import { DatePicker, Icon, InlineStack, Popover, TextField } from "@shopify/polaris";
 import { CalendarIcon } from "@shopify/polaris-icons";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useState } from "react";
 import {
   copyTime,
   formatShortDateString,
@@ -11,9 +11,8 @@ import {
   zonedTimeToUtc,
 } from "../../../dateTimeUtils.js";
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
-import { useController } from "../../../useActionForm.js";
+import { useDateTimeField } from "../../../useDateTimeField.js";
 import { autoInput } from "../../AutoInput.js";
-import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import PolarisAutoTimePicker from "./PolarisAutoTimePicker.js";
 
 export const PolarisAutoDateTimePicker = autoInput(
@@ -29,21 +28,11 @@ export const PolarisAutoDateTimePicker = autoInput(
     datePickerProps?: Partial<DatePickerProps>;
     timePickerProps?: Partial<TextFieldProps>;
   }) => {
-    const { path, metadata } = useFieldMetadata(props.field);
-
-    const { field: fieldProps, fieldState } = useController({ name: path });
-
-    const { onChange, value } = props;
-
-    const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const localTime = useMemo(() => {
-      if (value) return value;
-
-      if (fieldProps.value == null) return undefined; // Prevents null from becoming 1970
-
-      const date = new Date(fieldProps.value);
-      return isValidDate(date) ? date : undefined;
-    }, [value, fieldProps.value]);
+    const { localTz, localTime, onChange, value, fieldProps, metadata, fieldState } = useDateTimeField({
+      field: props.field,
+      value: props.value,
+      onChange: props?.onChange,
+    });
 
     const [datePopoverActive, setDatePopoverActive] = useState(false);
 

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
@@ -68,7 +68,12 @@ export const makeShadcnAutoDateTimePicker = ({
 
     const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const localTime = useMemo(() => {
-      return value ? value : isValidDate(new Date(fieldProps.value)) ? new Date(fieldProps.value) : undefined;
+      if (value) return value;
+
+      if (fieldProps.value == null) return undefined; // Prevents null from becoming 1970
+
+      const date = new Date(fieldProps.value);
+      return isValidDate(date) ? date : undefined;
     }, [value, fieldProps.value]);
 
     const config = metadata.configuration;

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
@@ -10,9 +10,8 @@ import {
   zonedTimeToUtc,
 } from "../../../dateTimeUtils.js";
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
-import { useController } from "../../../useActionForm.js";
+import { useDateTimeField } from "../../../useDateTimeField.js";
 import { autoInput } from "../../AutoInput.js";
-import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { ShadcnRequired } from "../ShadcnRequired.js";
 import type { ShadcnElements } from "../elements.js";
 
@@ -61,20 +60,12 @@ export const makeShadcnAutoDateTimePicker = ({
     datePickerProps?: Partial<DatePickerProps>;
     timePickerProps?: { label?: string; placeholder?: string };
   }) {
-    const { path, metadata } = useFieldMetadata(props.field);
-    const { field: fieldProps, fieldState } = useController({ name: path });
-    const { onChange, value } = props;
     const [timeParseError, setTimeParseError] = useState(false);
-
-    const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const localTime = useMemo(() => {
-      if (value) return value;
-
-      if (fieldProps.value == null) return undefined; // Prevents null from becoming 1970
-
-      const date = new Date(fieldProps.value);
-      return isValidDate(date) ? date : undefined;
-    }, [value, fieldProps.value]);
+    const { localTz, localTime, onChange, value, fieldProps, metadata, fieldState } = useDateTimeField({
+      field: props.field,
+      value: props.value,
+      onChange: props?.onChange,
+    });
 
     const config = metadata.configuration;
 

--- a/packages/react/src/useDateTimeField.ts
+++ b/packages/react/src/useDateTimeField.ts
@@ -1,0 +1,38 @@
+import { useMemo } from "react";
+import { useFieldMetadata } from "./auto/hooks/useFieldMetadata.js";
+import { isValidDate } from "./dateTimeUtils.js";
+import { useController } from "./useActionForm.js";
+
+interface DateTimeFieldProps {
+  field: string;
+  value?: Date;
+  onChange?: (value: Date) => void;
+}
+
+export const useDateTimeField = (props: DateTimeFieldProps) => {
+  const { path, metadata } = useFieldMetadata(props.field);
+  const { field: fieldProps, fieldState } = useController({ name: path });
+  const { onChange, value } = props;
+
+  const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const localTime = useMemo(() => {
+    if (value) return value;
+
+    if (fieldProps.value == null) return undefined; // Prevents null from becoming 1970
+
+    const date = new Date(fieldProps.value);
+    return isValidDate(date) ? date : undefined;
+  }, [value, fieldProps.value]);
+
+  return {
+    path,
+    metadata,
+    fieldProps,
+    fieldState,
+    localTz,
+    localTime,
+    onChange,
+    value,
+  };
+};


### PR DESCRIPTION
Fix issue where null dates in both Shadcn and Polaris were defaulting to 1970 .

<img width="1036" alt="Screenshot 2025-02-09 at 18 17 16" src="https://github.com/user-attachments/assets/25b6132b-2daa-4dc1-b683-4df42a5f34e3" />

