### PR TITLE
Add field type specific validations to many AutoInputs

### DIFF
--- a/packages/react/.changeset/khaki-keys-beg.md
+++ b/packages/react/.changeset/khaki-keys-beg.md
@@ -1,0 +1,23 @@
+---
+"@gadgetinc/react": patch
+---
+
+- BREAKING CHANGE - Added validations to field type specific auto inputs to ensure that the given `field` prop corresponds to the correct Gadget field type.
+  - Affected components
+    - AutoRolesInput
+    - AutoFileInput
+    - AutoDateTimePicker
+    - AutoJSONInput
+    - AutoRichTextInput
+    - AutoPasswordInput
+    - AutoBooleanInput
+    - AutoEnumInput
+    - Relationships
+      - AutoBelongsToInput
+      - AutoHasManyInput
+      - AutoHasManyThroughInput
+      - AutoHasOneInput
+  - Effect
+    - If the given field API id corresponds to a field that is not of the expected type, the auto input will throw an error
+  - FIX
+    - Ensure that the correct field type specific auto input is used for the given field.

--- a/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnFileInput.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/ShadcnFileInput.stories.jsx
@@ -13,7 +13,7 @@ const ShadcnAutoFileInput = makeShadcnAutoFileInput(elements);
 
 const Component = (props) => {
   return (
-    <ShadcnAutoForm action={api.widget.create}>
+    <ShadcnAutoForm action={api.game.stadium.create}>
       <ShadcnAutoFileInput {...props} />
     </ShadcnAutoForm>
   );
@@ -45,6 +45,6 @@ export default {
 
 export const Primary = {
   args: {
-    field: "metafields",
+    field: "photo",
   },
 };

--- a/packages/react/src/auto/hooks/useBelongsToController.tsx
+++ b/packages/react/src/auto/hooks/useBelongsToController.tsx
@@ -1,8 +1,10 @@
 import { useCallback } from "react";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useController, useFormContext, useWatch, type Control } from "../../useActionForm.js";
 import type { AutoRelationshipInputProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModel.js";
+import { assertFieldType } from "./utils.js";
 
 export const useBelongsToController = (props: {
   field: string;
@@ -12,7 +14,12 @@ export const useBelongsToController = (props: {
 }) => {
   const { field, primaryLabel, secondaryLabel, tertiaryLabel } = props;
   const fieldMetadata = useFieldMetadata(field);
-  const { path } = fieldMetadata;
+  const { path, metadata } = fieldMetadata;
+  assertFieldType({
+    fieldApiIdentifier: field,
+    actualFieldType: metadata.fieldType,
+    expectedFieldType: GadgetFieldType.BelongsTo,
+  });
 
   const record = useWatch({ name: path });
 

--- a/packages/react/src/auto/hooks/useBooleanInputController.tsx
+++ b/packages/react/src/auto/hooks/useBooleanInputController.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import { type Control } from "react-hook-form";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
+import { useController, useFormContext } from "../../useActionForm.js";
+import { get } from "../../utils.js";
+import { useFieldMetadata } from "./useFieldMetadata.js";
+import { assertFieldType } from "./utils.js";
+
+export const useBooleanInputController = (props: { field: string; control?: Control<any> }) => {
+  const { field: fieldApiIdentifier, control } = props;
+
+  const { path, metadata } = useFieldMetadata(fieldApiIdentifier);
+
+  assertFieldType({ fieldApiIdentifier, actualFieldType: metadata.fieldType, expectedFieldType: GadgetFieldType.Boolean });
+
+  const {
+    field: fieldProps,
+    fieldState: { error },
+  } = useController({
+    control,
+    name: path,
+  });
+
+  const {
+    formState: { defaultValues },
+  } = useFormContext();
+
+  useEffect(() => {
+    if (metadata.requiredArgumentForInput) {
+      // when the field is required, this defaults to false to match the UI
+      // When not required, the field will have a null value unless it is touched by the user
+      const defaultValue = get(defaultValues ?? {}, path) ?? false;
+      fieldProps.onChange(defaultValue);
+    }
+  }, [metadata.requiredArgumentForInput, defaultValues]);
+
+  return {
+    id: path,
+    path,
+    fieldProps,
+    error,
+    metadata,
+  };
+};

--- a/packages/react/src/auto/hooks/useDateTimeField.ts
+++ b/packages/react/src/auto/hooks/useDateTimeField.ts
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
-import { useFieldMetadata } from "./auto/hooks/useFieldMetadata.js";
-import { isValidDate } from "./dateTimeUtils.js";
-import { useController } from "./useActionForm.js";
+import { isValidDate } from "../../dateTimeUtils.js";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
+import { useController } from "../../useActionForm.js";
+import { useFieldMetadata } from "./useFieldMetadata.js";
+import { assertFieldType } from "./utils.js";
 
 interface DateTimeFieldProps {
   field: string;
@@ -11,6 +13,13 @@ interface DateTimeFieldProps {
 
 export const useDateTimeField = (props: DateTimeFieldProps) => {
   const { path, metadata } = useFieldMetadata(props.field);
+
+  assertFieldType({
+    fieldApiIdentifier: props.field,
+    actualFieldType: metadata.fieldType,
+    expectedFieldType: GadgetFieldType.DateTime,
+  });
+
   const { field: fieldProps, fieldState } = useController({ name: path });
   const { onChange, value } = props;
 

--- a/packages/react/src/auto/hooks/useEnumInputController.tsx
+++ b/packages/react/src/auto/hooks/useEnumInputController.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useController, type Control } from "../../useActionForm.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
+import { assertFieldType } from "./utils.js";
 
 export const useEnumInputController = (props: {
   field: string; // The field API identifier
@@ -8,6 +10,11 @@ export const useEnumInputController = (props: {
 }) => {
   const { field: fieldApiIdentifier, control } = props;
   const { path, metadata } = useFieldMetadata(fieldApiIdentifier);
+  assertFieldType({
+    fieldApiIdentifier,
+    actualFieldType: metadata.fieldType,
+    expectedFieldType: GadgetFieldType.Enum,
+  });
 
   const config = metadata.configuration;
   if (config.__typename !== "GadgetEnumConfig") {

--- a/packages/react/src/auto/hooks/useFileInputController.tsx
+++ b/packages/react/src/auto/hooks/useFileInputController.tsx
@@ -2,10 +2,12 @@ import { filesize } from "filesize";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useApi } from "../../GadgetProvider.js";
 import type { GadgetOnlyImageFileFieldValidation, GadgetRangeFieldValidation } from "../../internal/gql/graphql.js";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useController, useFormContext, type Control } from "../../useActionForm.js";
 import type { AutoFileFieldValue } from "../../validationSchema.js";
 import { RequiredValidationSpecId, isAutoFileFieldValue } from "../../validationSchema.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
+import { assertFieldType } from "./utils.js";
 
 export const imageFileTypes = ["image/jpeg", "image/png", "image/svg+xml", "image/webp"];
 
@@ -17,6 +19,9 @@ export const useFileInputController = (props: {
   // For showing a preview of the file
   const [imageThumbnailURL, setImageThumbnailURL] = useState<string>();
   const { path, metadata } = useFieldMetadata(fieldApiIdentifier);
+
+  assertFieldType({ fieldApiIdentifier, actualFieldType: metadata.fieldType, expectedFieldType: GadgetFieldType.File });
+
   const api = useApi();
 
   const {

--- a/packages/react/src/auto/hooks/useHasManyController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyController.tsx
@@ -1,14 +1,21 @@
 import { useCallback, useMemo } from "react";
-import type { GadgetHasManyConfig } from "../../internal/gql/graphql.js";
+import { GadgetFieldType, type GadgetHasManyConfig } from "../../internal/gql/graphql.js";
 import { useFieldArray } from "../../useActionForm.js";
 import type { AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModel.js";
+import { assertFieldType } from "./utils.js";
 
 export const useHasManyController = (props: { field: string }) => {
   const { field } = props;
   const fieldMetadata = useFieldMetadata(field);
-  const { path } = fieldMetadata;
+  const { path, metadata } = fieldMetadata;
+
+  assertFieldType({
+    fieldApiIdentifier: field,
+    actualFieldType: metadata.fieldType,
+    expectedFieldType: GadgetFieldType.HasMany,
+  });
 
   const fieldArray = useFieldArray({ name: path, keyName: "_fieldArrayKey" });
 

--- a/packages/react/src/auto/hooks/useHasManyThroughController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyThroughController.tsx
@@ -1,10 +1,11 @@
 import { assert } from "@gadgetinc/api-client-core";
 import { useCallback, useMemo } from "react";
-import type { GadgetHasManyThroughConfig } from "src/internal/gql/graphql.js";
+import { GadgetFieldType, type GadgetHasManyThroughConfig } from "../../internal/gql/graphql.js";
 import { useFieldArray } from "../../useActionForm.js";
 import type { AutoRelationshipInputProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModel.js";
+import { assertFieldType } from "./utils.js";
 
 export const useHasManyThroughController = (props: {
   field: string;
@@ -14,6 +15,13 @@ export const useHasManyThroughController = (props: {
 }) => {
   const fieldMetadata = useFieldMetadata(props.field);
   const { path, metadata } = fieldMetadata;
+
+  assertFieldType({
+    fieldApiIdentifier: props.field,
+    actualFieldType: metadata.fieldType,
+    expectedFieldType: GadgetFieldType.HasManyThrough,
+  });
+
   const configuration = metadata.configuration as GadgetHasManyThroughConfig;
   const joinModelHasManyFieldApiIdentifier = assert(
     configuration.joinModelHasManyFieldApiIdentifier,

--- a/packages/react/src/auto/hooks/useHasOneController.tsx
+++ b/packages/react/src/auto/hooks/useHasOneController.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useMemo } from "react";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useController, useWatch } from "../../useActionForm.js";
 import type { AutoRelationshipInputProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModel.js";
+import { assertFieldType } from "./utils.js";
 
 export const useHasOneController = (props: {
   field: string;
@@ -12,7 +14,13 @@ export const useHasOneController = (props: {
 }) => {
   const { field, primaryLabel, secondaryLabel, tertiaryLabel } = props;
   const fieldMetadata = useFieldMetadata(field);
-  const { path } = fieldMetadata;
+  const { path, metadata } = fieldMetadata;
+
+  assertFieldType({
+    fieldApiIdentifier: field,
+    actualFieldType: metadata.fieldType,
+    expectedFieldType: GadgetFieldType.HasOne,
+  });
 
   const record: Record<string, any> | undefined = useWatch({ name: path });
 

--- a/packages/react/src/auto/hooks/useJSONInputController.tsx
+++ b/packages/react/src/auto/hooks/useJSONInputController.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import deepEqual from "react-fast-compare";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import type { UseControllerProps } from "../../useActionForm.js";
 import { isFailedJSONParse, type FailedJSONParse } from "../../validationSchema.js";
 import { useStringInputController } from "./useStringInputController.js";
+import { assertFieldType } from "./utils.js";
 
 export const useJSONInputController = (
   props: {
@@ -10,6 +12,12 @@ export const useJSONInputController = (
   } & Omit<UseControllerProps, "name">
 ) => {
   const stringInputController = useStringInputController(props);
+  assertFieldType({
+    fieldApiIdentifier: props.field,
+    actualFieldType: stringInputController.metadata.fieldType,
+    expectedFieldType: GadgetFieldType.Json,
+  });
+
   const jsonValue = stringInputController.value;
   const isParseError = isFailedJSONParse(jsonValue);
 

--- a/packages/react/src/auto/hooks/usePasswordController.tsx
+++ b/packages/react/src/auto/hooks/usePasswordController.tsx
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
+import { useController, type Control } from "../../useActionForm.js";
+import { useAutoFormMetadata } from "../AutoFormContext.js";
+import { useFieldMetadata } from "./useFieldMetadata.js";
+import { assertFieldType } from "./utils.js";
+
+export const usePasswordController = (props: { field: string; control?: Control<any> }) => {
+  const { findBy } = useAutoFormMetadata();
+  const { path, metadata } = useFieldMetadata(props.field);
+
+  assertFieldType({
+    fieldApiIdentifier: props.field,
+    actualFieldType: metadata.fieldType,
+    expectedFieldType: GadgetFieldType.Password,
+  });
+
+  const { field: fieldProps } = useController({ name: path });
+
+  const [isEditing, setIsEditing] = useState(!findBy);
+
+  const startEditing = useCallback(() => {
+    fieldProps.onChange(""); // Touch the field to mark it as dirty
+    setIsEditing(true);
+  }, [fieldProps]);
+
+  return {
+    isEditing,
+    startEditing,
+    fieldProps,
+  };
+};
+
+/**
+ * The salted password hash is not retrieved from the DB
+ * Regardless of the password is defined or not, this placeholder is shown as exposing an unset password is a security risk
+ */
+export const existingPasswordPlaceholder = "********";

--- a/packages/react/src/auto/hooks/useRoleInputController.tsx
+++ b/packages/react/src/auto/hooks/useRoleInputController.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useRolesMetadata } from "../../metadata.js";
 import type { Control } from "../../useActionForm.js";
 import { useController } from "../../useActionForm.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
+import { assertFieldType } from "./utils.js";
 
 export const useRoleInputController = (props: {
   field: string; // Field API identifier
@@ -10,6 +12,11 @@ export const useRoleInputController = (props: {
 }) => {
   const { field, control } = props;
   const { path, metadata } = useFieldMetadata(field);
+  assertFieldType({
+    fieldApiIdentifier: field,
+    actualFieldType: metadata.fieldType,
+    expectedFieldType: GadgetFieldType.RoleAssignments,
+  });
 
   const {
     field: fieldProps,

--- a/packages/react/src/auto/hooks/utils.ts
+++ b/packages/react/src/auto/hooks/utils.ts
@@ -1,3 +1,5 @@
+import { type GadgetFieldType } from "../../internal/gql/graphql.js";
+
 /** Allows the use of multiple refs with one component */
 export const multiref = <T>(...refs: (React.Ref<T> | null | undefined)[]) => {
   return (value: T) => {
@@ -11,4 +13,18 @@ export const multiref = <T>(...refs: (React.Ref<T> | null | undefined)[]) => {
       }
     }
   };
+};
+
+export const assertFieldType = (props: {
+  fieldApiIdentifier: string;
+  actualFieldType: GadgetFieldType;
+  expectedFieldType: GadgetFieldType;
+}) => {
+  const { fieldApiIdentifier, actualFieldType, expectedFieldType } = props;
+
+  if (actualFieldType !== expectedFieldType) {
+    throw new Error(
+      `Field "${fieldApiIdentifier}" is not a ${expectedFieldType} field. Only ${expectedFieldType} fields are supported for this input type`
+    );
+  }
 };

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoBooleanInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoBooleanInput.tsx
@@ -1,40 +1,16 @@
 import type { CheckboxProps } from "@shopify/polaris";
 import { Checkbox } from "@shopify/polaris";
-import React, { useEffect } from "react";
+import React from "react";
+import { useBooleanInputController } from "../../../auto/hooks/useBooleanInputController.js";
 import type { Control } from "../../../useActionForm.js";
-import { useController, useFormContext } from "../../../useActionForm.js";
-import { get } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
-import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 
 export const PolarisAutoBooleanInput = autoInput((props: { field: string; control?: Control<any> } & Partial<CheckboxProps>) => {
-  const { field: fieldApiIdentifier, control, ...rest } = props;
+  const { field: _field, control: _control, ...rest } = props;
+  const { error, fieldProps, metadata } = useBooleanInputController(props);
 
-  const { path, metadata } = useFieldMetadata(fieldApiIdentifier);
-
-  const {
-    field: fieldProps,
-    fieldState: { error },
-  } = useController({
-    control,
-    name: path,
-  });
-
-  const {
-    formState: { defaultValues },
-  } = useFormContext();
-
-  useEffect(() => {
-    if (metadata.requiredArgumentForInput) {
-      // when the field is required, this defaults to false to match the UI
-      // When not required, the field will have a null value unless it is touched by the user
-      const defaultValue = get(defaultValues ?? {}, path) ?? false;
-      fieldProps.onChange(defaultValue);
-    }
-  }, [metadata.requiredArgumentForInput, defaultValues]);
-
-  const label = props.label ?? metadata.name;
   const { value: _value, ...restFieldProps } = fieldProps;
+  const label = props.label ?? metadata.name;
 
   return <Checkbox {...restFieldProps} checked={!!fieldProps.value} error={error?.message} {...rest} label={label} />;
 });

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -11,8 +11,8 @@ import {
   zonedTimeToUtc,
 } from "../../../dateTimeUtils.js";
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
-import { useDateTimeField } from "../../../useDateTimeField.js";
 import { autoInput } from "../../AutoInput.js";
+import { useDateTimeField } from "../../hooks/useDateTimeField.js";
 import PolarisAutoTimePicker from "./PolarisAutoTimePicker.js";
 
 export const PolarisAutoDateTimePicker = autoInput(

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoPasswordInput.tsx
@@ -1,17 +1,11 @@
 import type { TextFieldProps } from "@shopify/polaris";
 import { Button } from "@shopify/polaris";
 import { EditIcon } from "@shopify/polaris-icons";
-import React, { useState } from "react";
-import { useController, type Control } from "../../../useActionForm.js";
-import { useAutoFormMetadata } from "../../AutoFormContext.js";
+import React from "react";
+import { existingPasswordPlaceholder, usePasswordController } from "../../../auto/hooks/usePasswordController.js";
+import { type Control } from "../../../useActionForm.js";
 import { autoInput } from "../../AutoInput.js";
-import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { PolarisAutoEncryptedStringInput } from "./PolarisAutoEncryptedStringInput.js";
-/**
- * The salted password hash is not retrieved from the DB
- * Regardless of the password is defined or not, this placeholder is shown as exposing an unset password is a security risk
- */
-const existingPasswordPlaceholder = "********";
 
 export const PolarisAutoPasswordInput = autoInput(
   (
@@ -20,16 +14,7 @@ export const PolarisAutoPasswordInput = autoInput(
       control?: Control<any>;
     } & Partial<TextFieldProps>
   ) => {
-    const { findBy } = useAutoFormMetadata();
-    const { path } = useFieldMetadata(props.field);
-    const { field: fieldProps } = useController({ name: path });
-
-    const [isEditing, setIsEditing] = useState(!findBy);
-
-    const startEditing = () => {
-      fieldProps.onChange(""); // Touch the field to mark it as dirty
-      setIsEditing(true);
-    };
+    const { isEditing, startEditing } = usePasswordController(props);
 
     const startEditingButton = (
       <div style={{ display: "flex" }}>

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoBooleanInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoBooleanInput.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect } from "react";
+import React from "react";
+import { useBooleanInputController } from "../../../auto/hooks/useBooleanInputController.js";
 import type { Control } from "../../../useActionForm.js";
-import { useController, useFormContext } from "../../../useActionForm.js";
-import { get } from "../../../utils.js";
 import { autoInput } from "../../AutoInput.js";
-import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import { ShadcnRequired } from "../ShadcnRequired.js";
 import type { CheckboxProps, ShadcnElements } from "../elements.js";
 
@@ -16,32 +14,11 @@ export const makeShadcnAutoBooleanInput = ({ Checkbox, Label }: Pick<ShadcnEleme
       label?: string;
     } & Partial<CheckboxProps>
   ) {
-    const { field: fieldApiIdentifier, control, ...rest } = props;
-    const { path, metadata } = useFieldMetadata(fieldApiIdentifier);
+    const { field: _field, control: _control, ...rest } = props;
+    const { path, error, fieldProps, metadata } = useBooleanInputController(props);
 
-    const {
-      field: fieldProps,
-      fieldState: { error },
-    } = useController({
-      control,
-      name: path,
-    });
-
-    const {
-      formState: { defaultValues },
-    } = useFormContext();
-
-    useEffect(() => {
-      if (metadata.requiredArgumentForInput) {
-        // when the field is required, this defaults to false to match the UI
-        // When not required, the field will have a null value unless it is touched by the user
-        const defaultValue = get(defaultValues ?? {}, path) ?? false;
-        fieldProps.onChange(defaultValue);
-      }
-    }, [metadata.requiredArgumentForInput, defaultValues]);
-
-    const label = props.label ?? metadata.name;
     const { value: _value, ...restFieldProps } = fieldProps;
+    const label = props.label ?? metadata.name;
 
     return (
       <div className="flex items-center space-x-2">

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
@@ -10,8 +10,8 @@ import {
   zonedTimeToUtc,
 } from "../../../dateTimeUtils.js";
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
-import { useDateTimeField } from "../../../useDateTimeField.js";
 import { autoInput } from "../../AutoInput.js";
+import { useDateTimeField } from "../../hooks/useDateTimeField.js";
 import { ShadcnRequired } from "../ShadcnRequired.js";
 import type { ShadcnElements } from "../elements.js";
 

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoPasswordInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoPasswordInput.tsx
@@ -1,33 +1,16 @@
 import { PencilIcon } from "lucide-react";
-import React, { useCallback, useState } from "react";
+import React from "react";
+import { existingPasswordPlaceholder, usePasswordController } from "../../../auto/hooks/usePasswordController.js";
 import type { Control } from "../../../useActionForm.js";
-import { useController } from "../../../useActionForm.js";
-import { useAutoFormMetadata } from "../../AutoFormContext.js";
 import { autoInput } from "../../AutoInput.js";
-import { useFieldMetadata } from "../../hooks/useFieldMetadata.js";
 import type { ShadcnElements } from "../elements.js";
 import { makeShadcnAutoEncryptedStringInput } from "./ShadcnAutoEncryptedStringInput.js";
-
-/**
- * The salted password hash is not retrieved from the DB.
- * Regardless of the password being defined or not, this placeholder is shown as exposing an unset password is a security risk.
- */
-const existingPasswordPlaceholder = "********";
 
 export function makeShadcnAutoPasswordInput({ Input, Label, Button }: Pick<ShadcnElements, "Input" | "Label" | "Button">) {
   const EncryptedInput = makeShadcnAutoEncryptedStringInput({ Input, Label, Button });
 
   function ShadcnAutoPasswordInput(props: { field: string; control?: Control<any>; className?: string }) {
-    const { findBy } = useAutoFormMetadata();
-    const { path } = useFieldMetadata(props.field);
-    const { field: fieldProps } = useController({ name: path });
-
-    const [isEditing, setIsEditing] = useState(!findBy);
-
-    const startEditing = useCallback(() => {
-      fieldProps.onChange(""); // Touch the field to mark it as dirty
-      setIsEditing(true);
-    }, [fieldProps]);
+    const { isEditing, startEditing } = usePasswordController(props);
 
     return (
       <EncryptedInput

--- a/packages/react/src/auto/shared/AutoRichTextInput.tsx
+++ b/packages/react/src/auto/shared/AutoRichTextInput.tsx
@@ -1,14 +1,14 @@
 import * as mdxModule from "@mdxeditor/editor";
 import "@mdxeditor/editor/style.css";
 import React, { useEffect, useRef } from "react";
+import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useFormContext } from "../../useActionForm.js";
 import { get } from "../../utils.js";
 import { autoInput } from "../AutoInput.js";
 import { useStringInputController } from "../hooks/useStringInputController.js";
-import { multiref } from "../hooks/utils.js";
+import { assertFieldType, multiref } from "../hooks/utils.js";
 import type { AutoRichTextInputProps, MDXEditorMethods } from "./AutoRichTextInputProps.js";
 import "./styles/rich-text.css";
-
 const {
   MDXEditor,
   BoldItalicUnderlineToggles,
@@ -33,6 +33,11 @@ const AutoRichTextInput = autoInput<AutoRichTextInputProps>((props) => {
   const { formState } = useFormContext();
   const { field, control, editorRef, ...rest } = props;
   const controller = useStringInputController({ field, control });
+  assertFieldType({
+    fieldApiIdentifier: field,
+    actualFieldType: controller.metadata.fieldType,
+    expectedFieldType: GadgetFieldType.RichText,
+  });
   const innerRef = useRef<MDXEditorMethods>(null);
 
   useEffect(() => {


### PR DESCRIPTION
- **UPDATE**
  - Previously, the only field based validation that was ran on AutoInputs was that the field existed in the metadata. There were no errors for when an existing field was put into an `AutoInput` of the wrong field type
  - Now, most field type specific AutoInputs have a new validator that ensures that a field API ID string corresponding to the correct field type is given. 
  - Why don't all field types have validators?
    - String based inputs did not get validators because it may be the case that someone wants to use one field's UI elements for a different field type
      - Eg. Someone wants to have a show/hide system for a `string` field and uses `AutoEncryptedInput`
    - Many of the string based inputs use the same base `AutoTextInput` component, exported under fieldType specific names. Making individual fieldType specific wrappers for this component to add fieldType specific validations feels unnecessary given that there are no functional changes
  -  Why is this a breaking change?
     - An app using field type specific inputs for a field with a different type will now throw an error due to the validator. I believe that this is a better case overall as the dev would now need to confront that issue instead of having potential controller issues hidden 