### PR TITLE
Update autoRelationship form field type to be object based for displaying related model records

### DIFF
--- a/packages/react/.changeset/rich-penguins-drive.md
+++ b/packages/react/.changeset/rich-penguins-drive.md
@@ -1,0 +1,14 @@
+---
+"@gadgetinc/react": patch
+---
+
+- BREAKING CHANGE - In AutoForm relationship input components, the callback signature of `optionLabel` has been changed
+  - Previously
+    - `(record: Record<string, any> ) => ReactNode`
+  - Now
+    - `(props: { record: Record<string, any> }) => ReactNode`
+  - Affected components:
+    - `AutoBelongsToInput`
+    - `AutoHasManyInput`
+  - How to migrate:
+    - Update your reference in the `optionLabel` callback argument to be `{ record }` instead of `record`

--- a/packages/react/cypress/component/auto/form/AutoBelongsToForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoBelongsToForm.cy.tsx
@@ -102,7 +102,13 @@ describeForEachAutoAdapter(
       cy.mountWithWrapper(
         <AutoForm action={api.widget.update} findBy="42">
           <SubmitResultBanner />
-          <AutoBelongsToForm field="section" primaryLabel="name" secondaryLabel="label">
+          <AutoBelongsToForm
+            field="section"
+            displayRecord={{
+              primary: "name",
+              secondary: "label",
+            }}
+          >
             <AutoInput field="name" />
             <AutoInput field="label" />
           </AutoBelongsToForm>
@@ -139,7 +145,13 @@ describeForEachAutoAdapter(
       cy.mountWithWrapper(
         <AutoForm action={api.widget.update} findBy="42">
           <SubmitResultBanner />
-          <AutoBelongsToForm field="section" primaryLabel="name" secondaryLabel="label">
+          <AutoBelongsToForm
+            field="section"
+            displayRecord={{
+              primary: "name",
+              secondary: "label",
+            }}
+          >
             <AutoInput field="name" />
             <AutoInput field="label" />
           </AutoBelongsToForm>

--- a/packages/react/cypress/component/auto/form/AutoBelongsToForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoBelongsToForm.cy.tsx
@@ -104,7 +104,7 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoBelongsToForm
             field="section"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: "label",
             }}
@@ -147,7 +147,7 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoBelongsToForm
             field="section"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: "label",
             }}

--- a/packages/react/cypress/component/auto/form/AutoBelongsToInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoBelongsToInput.cy.tsx
@@ -179,7 +179,7 @@ describeForEachAutoAdapter(
         cy.mountWithWrapper(
           <AutoForm action={api.widget.update} findBy="42">
             <SubmitResultBanner />
-            <AutoBelongsToInput field="section" optionLabel={(record: any) => `Custom label for ${record.id}`} />
+            <AutoBelongsToInput field="section" optionLabel={({ record }: { record: any }) => `Custom label for ${record.id}`} />
             <AutoSubmit />
           </AutoForm>,
           wrapper

--- a/packages/react/cypress/component/auto/form/AutoHasManyForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyForm.cy.tsx
@@ -111,7 +111,13 @@ describeForEachAutoAdapter(
       cy.mountWithWrapper(
         <AutoForm action={api.widget.update} findBy="42">
           <SubmitResultBanner />
-          <AutoHasManyForm field="gizmos" primaryLabel="name" secondaryLabel="orientation">
+          <AutoHasManyForm
+            field="gizmos"
+            displayRecord={{
+              primary: "name",
+              secondary: "orientation",
+            }}
+          >
             <AutoInput field="name" />
             <AutoInput field="orientation" />
             <AutoInput field="attachment" />

--- a/packages/react/cypress/component/auto/form/AutoHasManyForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyForm.cy.tsx
@@ -113,7 +113,7 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoHasManyForm
             field="gizmos"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: "orientation",
             }}

--- a/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
@@ -68,7 +68,6 @@ describeForEachAutoAdapter(
         <AutoForm action={api.university.course.update} findBy="3">
           <AutoHasManyThroughForm
             field="students"
-            selectPaths={["firstName", "lastName", "year", "department"]}
             displayRecord={{
               primary: ["firstName", "lastName"],
               secondary: (record: any) => `Year: ${record.year}`,
@@ -122,7 +121,6 @@ describeForEachAutoAdapter(
         <AutoForm action={api.university.course.update} findBy="3">
           <AutoHasManyThroughForm
             field="students"
-            selectPaths={["firstName", "lastName", "year", "department"]}
             primaryLabel={["firstName", "lastName"]}
             secondaryLabel={(record: any) => `Year: ${record.year}`}
             tertiaryLabel="department"

--- a/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
@@ -68,7 +68,7 @@ describeForEachAutoAdapter(
         <AutoForm action={api.university.course.update} findBy="3">
           <AutoHasManyThroughForm
             field="students"
-            displayRecord={{
+            recordLabel={{
               primary: ["firstName", "lastName"],
               secondary: (record: any) => `Year: ${record.year}`,
               tertiary: "department",

--- a/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
@@ -69,9 +69,11 @@ describeForEachAutoAdapter(
           <AutoHasManyThroughForm
             field="students"
             selectPaths={["firstName", "lastName", "year", "department"]}
-            primaryLabel={["firstName", "lastName"]}
-            secondaryLabel={(record: any) => `Year: ${record.year}`}
-            tertiaryLabel="department"
+            displayRecord={{
+              primary: ["firstName", "lastName"],
+              secondary: (record: any) => `Year: ${record.year}`,
+              tertiary: "department",
+            }}
           >
             <AutoInput field="registration.effectiveFrom" />
             <AutoInput field="registration.effectiveTo" />

--- a/packages/react/cypress/component/auto/form/AutoHasOneForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasOneForm.cy.tsx
@@ -105,7 +105,7 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoHasOneForm
             field="doodad"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
               tertiary: "size",
@@ -150,7 +150,7 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoHasOneForm
             field="doodad"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
               tertiary: "size",
@@ -192,7 +192,7 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoHasOneForm
             field="doodad"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
               tertiary: "size",

--- a/packages/react/cypress/component/auto/form/AutoHasOneForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasOneForm.cy.tsx
@@ -105,9 +105,11 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoHasOneForm
             field="doodad"
-            primaryLabel="name"
-            secondaryLabel={(record: any) => `Weight:${record.weight} (${record.active})`}
-            tertiaryLabel="size"
+            displayRecord={{
+              primary: "name",
+              secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
+              tertiary: "size",
+            }}
           >
             <AutoInput field="name" />
             <AutoInput field="weight" />
@@ -148,9 +150,11 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoHasOneForm
             field="doodad"
-            primaryLabel="name"
-            secondaryLabel={(record: any) => `Weight:${record.weight} (${record.active})`}
-            tertiaryLabel="size"
+            displayRecord={{
+              primary: "name",
+              secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
+              tertiary: "size",
+            }}
           >
             <AutoInput field="name" />
             <AutoInput field="weight" />
@@ -188,9 +192,11 @@ describeForEachAutoAdapter(
           <SubmitResultBanner />
           <AutoHasOneForm
             field="doodad"
-            primaryLabel="name"
-            secondaryLabel={(record: any) => `Weight:${record.weight} (${record.active})`}
-            tertiaryLabel="size"
+            displayRecord={{
+              primary: "name",
+              secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
+              tertiary: "size",
+            }}
           >
             <AutoInput field="name" />
             <AutoInput field="weight" />

--- a/packages/react/cypress/component/auto/form/AutoHasOneForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasOneForm.cy.tsx
@@ -107,7 +107,7 @@ describeForEachAutoAdapter(
             field="doodad"
             recordLabel={{
               primary: "name",
-              secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
+              secondary: ({ record }: { record: any }) => `Weight:${record.weight} (${record.active})`,
               tertiary: "size",
             }}
           >
@@ -152,7 +152,7 @@ describeForEachAutoAdapter(
             field="doodad"
             recordLabel={{
               primary: "name",
-              secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
+              secondary: ({ record }: { record: any }) => `Weight:${record.weight} (${record.active})`,
               tertiary: "size",
             }}
           >
@@ -194,7 +194,7 @@ describeForEachAutoAdapter(
             field="doodad"
             recordLabel={{
               primary: "name",
-              secondary: (record: any) => `Weight:${record.weight} (${record.active})`,
+              secondary: ({ record }: { record: any }) => `Weight:${record.weight} (${record.active})`,
               tertiary: "size",
             }}
           >

--- a/packages/react/cypress/component/auto/form/PolarisAutoHasManyInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoHasManyInput.cy.tsx
@@ -200,7 +200,7 @@ describe("PolarisAutoHasManyInput", () => {
       cy.mountWithWrapper(
         <PolarisAutoForm action={api.widget.update} findBy="42">
           <PolarisSubmitResultBanner />
-          <PolarisAutoHasManyInput field="gizmos" optionLabel={(record) => `Custom label for ${record.id}`} />
+          <PolarisAutoHasManyInput field="gizmos" optionLabel={({ record }) => `Custom label for ${record.id}`} />
           <PolarisAutoSubmit />
         </PolarisAutoForm>,
         PolarisWrapper

--- a/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
+++ b/packages/react/cypress/component/auto/table/AutoTableSort.cy.tsx
@@ -16,7 +16,6 @@ describe("AutoTable - Sort", () => {
         times: 1,
       },
       (req) => {
-        console.log("fetch metadata");
         req.reply(sortTestWidgetModelMetadata);
       }
     ).as("getModelMetadata");
@@ -30,7 +29,6 @@ describe("AutoTable - Sort", () => {
         times: 1,
       },
       (req) => {
-        console.log("fetch unsorted data");
         req.reply(mockUnsortedIdContent);
       }
     ).as("getWidgets");
@@ -44,7 +42,6 @@ describe("AutoTable - Sort", () => {
         times: 1,
       },
       (req) => {
-        console.log("fetch sorted data");
         req.reply(mockDescendingSortedIdContent);
       }
     ).as("getWidgetsWithDescendingSort");
@@ -58,7 +55,6 @@ describe("AutoTable - Sort", () => {
         times: 1,
       },
       (req) => {
-        console.log("fetch sorted data");
         req.reply(mockAscendingSortedIdContent);
       }
     ).as("getWidgetsWithAscendingSort");

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -30,7 +30,7 @@ const ExampleWidgetAutoRelatedForm = (props) => {
         <Card>
           <PolarisAutoBelongsToForm
             field="section"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: "name",
               tertiary: "id",
@@ -43,7 +43,7 @@ const ExampleWidgetAutoRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasOneForm
             field="doodad"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: (record) => `${record.weight} (${record.active})`,
               tertiary: "size",
@@ -60,7 +60,7 @@ const ExampleWidgetAutoRelatedForm = (props) => {
           <PolarisAutoHasManyForm
             label={<Text as="h2" variant="headingSm">{`Has Many Form -- Gizmos`}</Text>}
             field="gizmos"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: "orientation",
               tertiary: (record) => <Text>{record.id}</Text>,
@@ -71,7 +71,7 @@ const ExampleWidgetAutoRelatedForm = (props) => {
             <PolarisAutoInput field="attachment" />
             <PolarisAutoHasManyForm
               field="doodads"
-              displayRecord={{
+              recordLabel={{
                 primary: "name",
                 secondary: "weight",
               }}
@@ -190,7 +190,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasManyThroughForm
             field="students"
-            displayRecord={{
+            recordLabel={{
               primary: ["firstName", "lastName"],
               secondary: (record) => {
                 if (record.year <= 1) {
@@ -223,7 +223,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasManyThroughForm
             field="professors"
-            displayRecord={{
+            recordLabel={{
               primary: ["title", "firstName", "lastName"],
             }}
           />
@@ -268,7 +268,7 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasManyThroughForm
             field="followers"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
             }}
           >
@@ -282,7 +282,7 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasManyThroughForm
             field="followees"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
             }}
           >
@@ -321,7 +321,7 @@ export const DeepRelationshipChain = {
                   {/* level 2 hasMany */}
                   <PolarisAutoHasManyForm
                     field="cities"
-                    displayRecord={{
+                    recordLabel={{
                       primary: (record) => `${record.englishName} ${record.localName ? `(${record.localName})` : ""}`,
                     }}
                   >
@@ -402,18 +402,18 @@ const MayorOrCitizenSelect = () => {
       </Box>
       {showMayor ? (
         <Card>
-          <PolarisAutoHasOneForm field="mayor" displayRecord={{ primary: ["firstName", "lastName"] }}>
+          <PolarisAutoHasOneForm field="mayor" recordLabel={{ primary: ["firstName", "lastName"] }}>
             <PolarisAutoInput field="firstName" />
             <PolarisAutoInput field="lastName" />
           </PolarisAutoHasOneForm>
         </Card>
       ) : (
         <Card>
-          <PolarisAutoHasManyForm field="citizens" displayRecord={{ primary: ["firstName", "lastName"] }}>
+          <PolarisAutoHasManyForm field="citizens" recordLabel={{ primary: ["firstName", "lastName"] }}>
             <PolarisAutoInput field="firstName" />
             <PolarisAutoInput field="lastName" />
 
-            <PolarisAutoBelongsToForm field="cityOfMayorDuty" displayRecord={{ primary: ["englishName", "localName"] }}>
+            <PolarisAutoBelongsToForm field="cityOfMayorDuty" recordLabel={{ primary: ["englishName", "localName"] }}>
               <PolarisAutoInput field="englishName" />
               <PolarisAutoInput field="localName" />
             </PolarisAutoBelongsToForm>

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -60,7 +60,6 @@ const ExampleWidgetAutoRelatedForm = (props) => {
           <PolarisAutoHasManyForm
             label={<Text as="h2" variant="headingSm">{`Has Many Form -- Gizmos`}</Text>}
             field="gizmos"
-            selectPaths={["name", "orientation"]}
             displayRecord={{
               primary: "name",
               secondary: "orientation",
@@ -72,7 +71,6 @@ const ExampleWidgetAutoRelatedForm = (props) => {
             <PolarisAutoInput field="attachment" />
             <PolarisAutoHasManyForm
               field="doodads"
-              selectPaths={["name", "weight"]}
               displayRecord={{
                 primary: "name",
                 secondary: "weight",
@@ -192,7 +190,6 @@ const ExampleCourseCreateRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasManyThroughForm
             field="students"
-            selectPaths={["firstName", "lastName", "year", "department"]}
             displayRecord={{
               primary: ["firstName", "lastName"],
               secondary: (record) => {
@@ -226,7 +223,6 @@ const ExampleCourseCreateRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasManyThroughForm
             field="professors"
-            selectPaths={["title", "firstName", "lastName"]}
             displayRecord={{
               primary: ["title", "firstName", "lastName"],
             }}
@@ -272,7 +268,6 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasManyThroughForm
             field="followers"
-            selectPaths={["name"]}
             displayRecord={{
               primary: "name",
             }}
@@ -287,7 +282,6 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasManyThroughForm
             field="followees"
-            selectPaths={["name"]}
             displayRecord={{
               primary: "name",
             }}
@@ -325,7 +319,12 @@ export const DeepRelationshipChain = {
                   <PolarisAutoInput field="englishName" />
 
                   {/* level 2 hasMany */}
-                  <PolarisAutoHasManyForm field="cities">
+                  <PolarisAutoHasManyForm
+                    field="cities"
+                    displayRecord={{
+                      primary: (record) => `${record.englishName} ${record.localName ? `(${record.localName})` : ""}`,
+                    }}
+                  >
                     <PolarisAutoInput field="englishName" />
                     <PolarisAutoInput field="localName" />
 

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -1,4 +1,4 @@
-import { AppProvider, BlockStack, Box, Button, Card, FormLayout, InlineStack, Page, Text } from "@shopify/polaris";
+import { AppProvider, BlockStack, Box, Button, Card, FormLayout, InlineStack, Label, Page, Text } from "@shopify/polaris";
 import translations from "@shopify/polaris/locales/en.json";
 import React, { useState } from "react";
 import { Provider } from "../../../../src/GadgetProvider.tsx";
@@ -30,11 +30,11 @@ const ExampleWidgetAutoRelatedForm = (props) => {
         <Card>
           <PolarisAutoBelongsToForm
             field="section"
-            recordLabel={{
-              primary: "name",
-              secondary: "name",
-              tertiary: "id",
-            }}
+            recordLabel={({ record }) => (
+              <Label>
+                {record.name} (id:{record.id})
+              </Label>
+            )}
           >
             <PolarisAutoInput field="name" />
           </PolarisAutoBelongsToForm>
@@ -192,7 +192,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
             field="students"
             recordLabel={{
               primary: ["firstName", "lastName"],
-              secondary: (record) => {
+              secondary: ({ record }) => {
                 if (record.year <= 1) {
                   return "Freshman";
                 } else if (record.year <= 2) {
@@ -202,7 +202,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
                 } else if (record.year <= 4) {
                   return "Senior";
                 } else {
-                  return "Mature";
+                  return `Mature (${record.year})`;
                 }
               },
               tertiary: "department",

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -28,7 +28,14 @@ const ExampleWidgetAutoRelatedForm = (props) => {
         </Card>
 
         <Card>
-          <PolarisAutoBelongsToForm field="section" primaryLabel="name" secondaryLabel="name" tertiaryLabel="id">
+          <PolarisAutoBelongsToForm
+            field="section"
+            displayRecord={{
+              primary: "name",
+              secondary: "name",
+              tertiary: "id",
+            }}
+          >
             <PolarisAutoInput field="name" />
           </PolarisAutoBelongsToForm>
         </Card>
@@ -36,9 +43,11 @@ const ExampleWidgetAutoRelatedForm = (props) => {
         <Card>
           <PolarisAutoHasOneForm
             field="doodad"
-            primaryLabel="name"
-            secondaryLabel={(record) => `${record.weight} (${record.active})`}
-            tertiaryLabel="size"
+            displayRecord={{
+              primary: "name",
+              secondary: (record) => `${record.weight} (${record.active})`,
+              tertiary: "size",
+            }}
           >
             <PolarisAutoInput field="name" />
             <PolarisAutoInput field="weight" />
@@ -52,14 +61,23 @@ const ExampleWidgetAutoRelatedForm = (props) => {
             label={<Text as="h2" variant="headingSm">{`Has Many Form -- Gizmos`}</Text>}
             field="gizmos"
             selectPaths={["name", "orientation"]}
-            primaryLabel="name"
-            secondaryLabel="orientation"
-            tertiaryLabel={(record) => <Text>{record.id}</Text>}
+            displayRecord={{
+              primary: "name",
+              secondary: "orientation",
+              tertiary: (record) => <Text>{record.id}</Text>,
+            }}
           >
             <PolarisAutoInput field="name" />
             <PolarisAutoInput field="orientation" />
             <PolarisAutoInput field="attachment" />
-            <PolarisAutoHasManyForm field="doodads" selectPaths={["name", "weight"]} primaryLabel="name" secondaryLabel="weight">
+            <PolarisAutoHasManyForm
+              field="doodads"
+              selectPaths={["name", "weight"]}
+              displayRecord={{
+                primary: "name",
+                secondary: "weight",
+              }}
+            >
               <PolarisAutoInput field="name" />
               <PolarisAutoInput field="weight" />
             </PolarisAutoHasManyForm>
@@ -175,21 +193,23 @@ const ExampleCourseCreateRelatedForm = (props) => {
           <PolarisAutoHasManyThroughForm
             field="students"
             selectPaths={["firstName", "lastName", "year", "department"]}
-            primaryLabel={["firstName", "lastName"]}
-            secondaryLabel={(record) => {
-              if (record.year <= 1) {
-                return "Freshman";
-              } else if (record.year <= 2) {
-                return "Sophomore";
-              } else if (record.year <= 3) {
-                return "Junior";
-              } else if (record.year <= 4) {
-                return "Senior";
-              } else {
-                return "Mature";
-              }
+            displayRecord={{
+              primary: ["firstName", "lastName"],
+              secondary: (record) => {
+                if (record.year <= 1) {
+                  return "Freshman";
+                } else if (record.year <= 2) {
+                  return "Sophomore";
+                } else if (record.year <= 3) {
+                  return "Junior";
+                } else if (record.year <= 4) {
+                  return "Senior";
+                } else {
+                  return "Mature";
+                }
+              },
+              tertiary: "department",
             }}
-            tertiaryLabel="department"
           >
             <InlineStack>
               {/* Fields on the join model. The prefix is the model API id of the join model */}
@@ -207,7 +227,9 @@ const ExampleCourseCreateRelatedForm = (props) => {
           <PolarisAutoHasManyThroughForm
             field="professors"
             selectPaths={["title", "firstName", "lastName"]}
-            primaryLabel={["title", "firstName", "lastName"]}
+            displayRecord={{
+              primary: ["title", "firstName", "lastName"],
+            }}
           />
         </Card>
         <PolarisAutoSubmit />
@@ -248,7 +270,13 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         </Card>
 
         <Card>
-          <PolarisAutoHasManyThroughForm field="followers" selectPaths={["name"]} primaryLabel={"name"}>
+          <PolarisAutoHasManyThroughForm
+            field="followers"
+            selectPaths={["name"]}
+            displayRecord={{
+              primary: "name",
+            }}
+          >
             <InlineStack>
               <PolarisAutoInput field="friendship.started" />
               <PolarisAutoInput field="friendship.ended" />
@@ -257,7 +285,13 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         </Card>
 
         <Card>
-          <PolarisAutoHasManyThroughForm field="followees" selectPaths={["name"]} primaryLabel={"name"}>
+          <PolarisAutoHasManyThroughForm
+            field="followees"
+            selectPaths={["name"]}
+            displayRecord={{
+              primary: "name",
+            }}
+          >
             <InlineStack>
               <PolarisAutoInput field="friendship.started" />
               <PolarisAutoInput field="friendship.ended" />
@@ -369,18 +403,18 @@ const MayorOrCitizenSelect = () => {
       </Box>
       {showMayor ? (
         <Card>
-          <PolarisAutoHasOneForm field="mayor" primaryLabel={["firstName", "lastName"]}>
+          <PolarisAutoHasOneForm field="mayor" displayRecord={{ primary: ["firstName", "lastName"] }}>
             <PolarisAutoInput field="firstName" />
             <PolarisAutoInput field="lastName" />
           </PolarisAutoHasOneForm>
         </Card>
       ) : (
         <Card>
-          <PolarisAutoHasManyForm field="citizens" primaryLabel={["firstName", "lastName"]}>
+          <PolarisAutoHasManyForm field="citizens" displayRecord={{ primary: ["firstName", "lastName"] }}>
             <PolarisAutoInput field="firstName" />
             <PolarisAutoInput field="lastName" />
 
-            <PolarisAutoBelongsToForm field="cityOfMayorDuty" primaryLabel={["englishName", "localName"]}>
+            <PolarisAutoBelongsToForm field="cityOfMayorDuty" displayRecord={{ primary: ["englishName", "localName"] }}>
               <PolarisAutoInput field="englishName" />
               <PolarisAutoInput field="localName" />
             </PolarisAutoBelongsToForm>

--- a/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
@@ -23,10 +23,11 @@ const Component = (props) => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoBelongsToForm
             field="section"
-            recordLabel={{
-              primary: "name",
-            }}
-            renderSelectedRecord={(record) => <Label>this is a custom belongsTo render for {record.name}</Label>}
+            recordLabel={({ record }) => (
+              <Label>
+                {record.name} (id:{record.id})
+              </Label>
+            )}
           >
             <AutoInput field="name" />
           </AutoBelongsToForm>
@@ -266,7 +267,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
             field="students"
             recordLabel={{
               primary: ["firstName", "lastName"],
-              secondary: (record) => {
+              secondary: ({ record }) => {
                 if (record.year <= 1) {
                   return "Freshman";
                 } else if (record.year <= 2) {
@@ -276,7 +277,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
                 } else if (record.year <= 4) {
                   return "Senior";
                 } else {
-                  return "Mature";
+                  return `Mature (${record.year})`;
                 }
               },
               tertiary: "department",

--- a/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
@@ -8,32 +8,39 @@ import { elements } from "../../index.tsx";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 
-const { AutoForm, AutoHasOneForm, AutoInput, AutoSubmit, SubmitResultBanner, AutoBelongsToForm, AutoHasManyForm, AutoHasManyThroughForm } = makeAutocomponents(elements);
+const { AutoForm, AutoHasOneForm, AutoInput, AutoSubmit, SubmitResultBanner, AutoBelongsToForm, AutoHasManyForm, AutoHasManyThroughForm } =
+  makeAutocomponents(elements);
 const { Card, Label, Button } = elements;
 
 const Component = (props) => {
   return (
-    <AutoForm {...props} >
+    <AutoForm {...props}>
       <div className="flex flex-col gap-8">
         <div className="bg-white p-4 rounded-md">
           <SubmitResultBanner />
         </div>
 
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
-          <AutoBelongsToForm field="section" primaryLabel="name"
+          <AutoBelongsToForm
+            field="section"
+            displayRecord={{
+              primary: "name",
+            }}
             renderSelectedRecord={(record) => <Label>this is a custom belongsTo render for {record.name}</Label>}
           >
             <AutoInput field="name" />
           </AutoBelongsToForm>
         </Card>
 
-
-
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
-          <AutoHasOneForm field="doodad" primaryLabel="name"
-            secondaryLabel={(record) => `${record.weight ?? 'N/A'} (${record.active ?? 'N/A'})`} tertiaryLabel="size"
+          <AutoHasOneForm
+            field="doodad"
+            displayRecord={{
+              primary: "name",
+              secondary: (record) => `${record.weight ?? "N/A"} (${record.active ?? "N/A"})`,
+              tertiary: "size",
+            }}
           >
-
             <div className="flex flex-col gap-4">
               <AutoInput field="name" />
               <AutoInput field="weight" />
@@ -42,7 +49,6 @@ const Component = (props) => {
             </div>
           </AutoHasOneForm>
         </Card>
-
 
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoHasManyForm
@@ -53,14 +59,23 @@ const Component = (props) => {
             }
             field="gizmos"
             selectPaths={["name", "orientation"]}
-            primaryLabel="name"
-            secondaryLabel="orientation"
+            displayRecord={{
+              primary: "name",
+              secondary: "orientation",
+            }}
           >
             <div className="flex flex-col gap-4">
               <AutoInput field="name" />
               <AutoInput field="orientation" />
               <AutoInput field="attachment" />
-              <AutoHasManyForm field="doodads" selectPaths={["name", "weight"]} primaryLabel="name" secondaryLabel="weight">
+              <AutoHasManyForm
+                field="doodads"
+                selectPaths={["name", "weight"]}
+                displayRecord={{
+                  primary: "name",
+                  secondary: "weight",
+                }}
+              >
                 <div className="flex flex-col gap-4">
                   <AutoInput field="name" />
                   <AutoInput field="weight" />
@@ -74,7 +89,7 @@ const Component = (props) => {
           <AutoSubmit variant="default" className="w-full bg-white p-2 rounded-md" />
         </div>
       </div>
-    </AutoForm >
+    </AutoForm>
   );
 };
 
@@ -176,7 +191,13 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         </Card>
 
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
-          <AutoHasManyThroughForm field="followers" selectPaths={["name"]} primaryLabel={"name"}>
+          <AutoHasManyThroughForm
+            field="followers"
+            selectPaths={["name"]}
+            displayRecord={{
+              primary: "name",
+            }}
+          >
             <div className="flex flex-row gap-4">
               <AutoInput field="friendship.started" />
               <AutoInput field="friendship.ended" />
@@ -185,7 +206,13 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         </Card>
 
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
-          <AutoHasManyThroughForm field="followees" selectPaths={["name"]} primaryLabel={"name"}>
+          <AutoHasManyThroughForm
+            field="followees"
+            selectPaths={["name"]}
+            displayRecord={{
+              primary: "name",
+            }}
+          >
             <div className="flex flex-row gap-4">
               <AutoInput field="friendship.started" />
               <AutoInput field="friendship.ended" />
@@ -200,24 +227,19 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
   );
 };
 
-
 const ExampleSectionAutoRelatedForm = (props) => {
   return (
     <div className="flex flex-col gap-4">
       <AutoForm {...props}>
         <SubmitResultBanner />
         <Card>
-          <Label >
-            Top Level Form -- Section
-          </Label>
+          <Label>Top Level Form -- Section</Label>
           <AutoInput field="name" />
           <AutoInput field="label" />
         </Card>
 
         <Card>
-          <Label >
-            Has Many Form -- Widgets
-          </Label>
+          <Label>Has Many Form -- Widgets</Label>
           <AutoHasManyForm field="widgets" label="Widgets">
             <AutoInput field="name" />
             <AutoInput field="inventoryCount" />
@@ -229,7 +251,6 @@ const ExampleSectionAutoRelatedForm = (props) => {
   );
 };
 
-
 const ExampleCourseCreateRelatedForm = (props) => {
   return (
     <div className="flex flex-col gap-4  p-4 rounded-md">
@@ -238,35 +259,33 @@ const ExampleCourseCreateRelatedForm = (props) => {
           <SubmitResultBanner />
         </div>
         <Card className="p-4 flex flex-col gap-4 bg-white">
-          <Label >
-            Top Level Form -- Course
-          </Label>
+          <Label>Top Level Form -- Course</Label>
           <AutoInput field="title" />
           <AutoInput field="description" />
         </Card>
 
         <Card className="p-4 flex flex-col gap-4 bg-white">
-          <Label >
-            Has Many Through Form -- Students
-          </Label>
+          <Label>Has Many Through Form -- Students</Label>
           <AutoHasManyThroughForm
             field="students"
             selectPaths={["firstName", "lastName", "year", "department"]}
-            primaryLabel={["firstName", "lastName"]}
-            secondaryLabel={(record) => {
-              if (record.year <= 1) {
-                return "Freshman";
-              } else if (record.year <= 2) {
-                return "Sophomore";
-              } else if (record.year <= 3) {
-                return "Junior";
-              } else if (record.year <= 4) {
-                return "Senior";
-              } else {
-                return "Mature";
-              }
+            displayRecord={{
+              primary: ["firstName", "lastName"],
+              secondary: (record) => {
+                if (record.year <= 1) {
+                  return "Freshman";
+                } else if (record.year <= 2) {
+                  return "Sophomore";
+                } else if (record.year <= 3) {
+                  return "Junior";
+                } else if (record.year <= 4) {
+                  return "Senior";
+                } else {
+                  return "Mature";
+                }
+              },
+              tertiary: "department",
             }}
-            tertiaryLabel="department"
           >
             <div className="flex flex-col gap-4">
               <AutoInput field="registration.effectiveFrom" />
@@ -276,13 +295,13 @@ const ExampleCourseCreateRelatedForm = (props) => {
         </Card>
 
         <Card className="p-4 flex flex-col gap-4 bg-white">
-          <Label >
-            Has Many Through Form -- Professors
-          </Label>
+          <Label>Has Many Through Form -- Professors</Label>
           <AutoHasManyThroughForm
             field="professors"
             selectPaths={["title", "firstName", "lastName"]}
-            primaryLabel={["title", "firstName", "lastName"]}
+            displayRecord={{
+              primary: ["title", "firstName", "lastName"],
+            }}
           />
         </Card>
         <AutoSubmit className="w-full bg-white p-2 rounded-md" />
@@ -390,22 +409,39 @@ const MayorOrCitizenSelect = () => {
     <>
       <div className="flex flex-row gap-4">
         <Label>Showing {showMayor ? "Mayor" : "Citizens"}</Label>
-        <Button type="button" onClick={() => setShowMayor(!showMayor)}>Toggle</Button>
+        <Button type="button" onClick={() => setShowMayor(!showMayor)}>
+          Toggle
+        </Button>
       </div>
       {showMayor ? (
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
-          <AutoHasOneForm field="mayor" primaryLabel={["firstName", "lastName"]}>
+          <AutoHasOneForm
+            field="mayor"
+            displayRecord={{
+              primary: ["firstName", "lastName"],
+            }}
+          >
             <AutoInput field="firstName" />
             <AutoInput field="lastName" />
           </AutoHasOneForm>
         </Card>
       ) : (
-        <Card className="p-6 w-full bg-white shadow-lg rounded-lg"  >
-          <AutoHasManyForm field="citizens" primaryLabel={["firstName", "lastName"]}>
+        <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
+          <AutoHasManyForm
+            field="citizens"
+            displayRecord={{
+              primary: ["firstName", "lastName"],
+            }}
+          >
             <AutoInput field="firstName" />
             <AutoInput field="lastName" />
 
-            <AutoBelongsToForm field="cityOfMayorDuty" primaryLabel={["englishName", "localName"]}>
+            <AutoBelongsToForm
+              field="cityOfMayorDuty"
+              displayRecord={{
+                primary: ["englishName", "localName"],
+              }}
+            >
               <AutoInput field="englishName" />
               <AutoInput field="localName" />
             </AutoBelongsToForm>

--- a/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
@@ -23,7 +23,7 @@ const Component = (props) => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoBelongsToForm
             field="section"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
             }}
             renderSelectedRecord={(record) => <Label>this is a custom belongsTo render for {record.name}</Label>}
@@ -35,7 +35,7 @@ const Component = (props) => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoHasOneForm
             field="doodad"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: (record) => `${record.weight ?? "N/A"} (${record.active ?? "N/A"})`,
               tertiary: "size",
@@ -58,7 +58,7 @@ const Component = (props) => {
               </Label>
             }
             field="gizmos"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
               secondary: "orientation",
             }}
@@ -69,7 +69,7 @@ const Component = (props) => {
               <AutoInput field="attachment" />
               <AutoHasManyForm
                 field="doodads"
-                displayRecord={{
+                recordLabel={{
                   primary: "name",
                   secondary: "weight",
                 }}
@@ -191,7 +191,7 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoHasManyThroughForm
             field="followers"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
             }}
           >
@@ -205,7 +205,7 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoHasManyThroughForm
             field="followees"
-            displayRecord={{
+            recordLabel={{
               primary: "name",
             }}
           >
@@ -264,7 +264,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
           <Label>Has Many Through Form -- Students</Label>
           <AutoHasManyThroughForm
             field="students"
-            displayRecord={{
+            recordLabel={{
               primary: ["firstName", "lastName"],
               secondary: (record) => {
                 if (record.year <= 1) {
@@ -293,7 +293,7 @@ const ExampleCourseCreateRelatedForm = (props) => {
           <Label>Has Many Through Form -- Professors</Label>
           <AutoHasManyThroughForm
             field="professors"
-            displayRecord={{
+            recordLabel={{
               primary: ["title", "firstName", "lastName"],
             }}
           />
@@ -411,7 +411,7 @@ const MayorOrCitizenSelect = () => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoHasOneForm
             field="mayor"
-            displayRecord={{
+            recordLabel={{
               primary: ["firstName", "lastName"],
             }}
           >
@@ -423,7 +423,7 @@ const MayorOrCitizenSelect = () => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoHasManyForm
             field="citizens"
-            displayRecord={{
+            recordLabel={{
               primary: ["firstName", "lastName"],
             }}
           >
@@ -432,7 +432,7 @@ const MayorOrCitizenSelect = () => {
 
             <AutoBelongsToForm
               field="cityOfMayorDuty"
-              displayRecord={{
+              recordLabel={{
                 primary: ["englishName", "localName"],
               }}
             >

--- a/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
@@ -58,7 +58,6 @@ const Component = (props) => {
               </Label>
             }
             field="gizmos"
-            selectPaths={["name", "orientation"]}
             displayRecord={{
               primary: "name",
               secondary: "orientation",
@@ -70,7 +69,6 @@ const Component = (props) => {
               <AutoInput field="attachment" />
               <AutoHasManyForm
                 field="doodads"
-                selectPaths={["name", "weight"]}
                 displayRecord={{
                   primary: "name",
                   secondary: "weight",
@@ -193,7 +191,6 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoHasManyThroughForm
             field="followers"
-            selectPaths={["name"]}
             displayRecord={{
               primary: "name",
             }}
@@ -208,7 +205,6 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
         <Card className="p-6 w-full bg-white shadow-lg rounded-lg">
           <AutoHasManyThroughForm
             field="followees"
-            selectPaths={["name"]}
             displayRecord={{
               primary: "name",
             }}
@@ -268,7 +264,6 @@ const ExampleCourseCreateRelatedForm = (props) => {
           <Label>Has Many Through Form -- Students</Label>
           <AutoHasManyThroughForm
             field="students"
-            selectPaths={["firstName", "lastName", "year", "department"]}
             displayRecord={{
               primary: ["firstName", "lastName"],
               secondary: (record) => {
@@ -298,7 +293,6 @@ const ExampleCourseCreateRelatedForm = (props) => {
           <Label>Has Many Through Form -- Professors</Label>
           <AutoHasManyThroughForm
             field="professors"
-            selectPaths={["title", "firstName", "lastName"]}
             displayRecord={{
               primary: ["title", "firstName", "lastName"],
             }}

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -21,7 +21,7 @@ import {
 import { useFieldsFromChildComponents } from "./AutoFormContext.js";
 import { isAutoInput } from "./AutoInput.js";
 import { getSelectedPathsFromOptionLabel } from "./hooks/useSelectedPathsFromRecordLabel.js";
-import { type RecordLabel } from "./interfaces/AutoRelationshipInputProps.js";
+import { getOptionLabelsFromRecordLabel, type RecordLabel } from "./interfaces/AutoRelationshipInputProps.js";
 
 /** When the AutoForm does not have children, these properties are available to control the rendering of the form */
 type AutoFormPropsWithoutChildren = {
@@ -250,6 +250,7 @@ export const useAutoForm = <
     registerFields(registeredFieldsFromChildren);
   }, [registeredFieldsFromChildren.join(","), registerFields]);
 
+  console.log("registeredFieldsFromChildren :", registeredFieldsFromChildren);
   if (hasRegisteredFieldsFromChildren) {
     include = Array.from(fieldSet);
     exclude = undefined;
@@ -554,7 +555,7 @@ const extractPathsFromChildren = (props: {
 const aggregatePathsFromRecordLabel = (recordLabel: RecordLabel, getFieldsToSelectOnRecordLabelCallback: () => string[]) => {
   const selectedPaths = new Set<string>();
 
-  [recordLabel.primary, recordLabel.secondary, recordLabel.tertiary]
+  getOptionLabelsFromRecordLabel(recordLabel)
     .flatMap((optionLabel) => getSelectedPathsFromOptionLabel(optionLabel, getFieldsToSelectOnRecordLabelCallback))
     .forEach((path) => selectedPaths.add(path));
 

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -250,7 +250,6 @@ export const useAutoForm = <
     registerFields(registeredFieldsFromChildren);
   }, [registeredFieldsFromChildren.join(","), registerFields]);
 
-  console.log("registeredFieldsFromChildren :", registeredFieldsFromChildren);
   if (hasRegisteredFieldsFromChildren) {
     include = Array.from(fieldSet);
     exclude = undefined;

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -7,7 +7,7 @@ import type { FieldMetadata, GlobalActionMetadata, ModelWithOneActionMetadata } 
 import { FieldType, buildAutoFormFieldList, isModelActionMetadata, useActionMetadata } from "../metadata.js";
 import type { AnyActionWithId, RecordIdentifier, UseActionFormHookStateData, UseActionFormSubmit } from "../use-action-form/types.js";
 import { isPlainObject, processDefaultValues } from "../use-action-form/utils.js";
-import { pathListToSelection } from "../use-table/helpers.js";
+import { isRelationshipField, pathListToSelection } from "../use-table/helpers.js";
 import type { FieldErrors, UseFormReturn } from "../useActionForm.js";
 import { useActionForm } from "../useActionForm.js";
 import { get, getFlattenedObjectKeys, type ErrorWrapper, type OptionsType } from "../utils.js";
@@ -20,6 +20,8 @@ import {
 } from "./AutoFormActionValidators.js";
 import { useFieldsFromChildComponents } from "./AutoFormContext.js";
 import { isAutoInput } from "./AutoInput.js";
+import { getSelectedPathsFromOptionLabel } from "./hooks/useSelectedPathsFromDisplayRecord.js";
+import { type DisplayRecord } from "./interfaces/AutoRelationshipInputProps.js";
 
 /** When the AutoForm does not have children, these properties are available to control the rendering of the form */
 type AutoFormPropsWithoutChildren = {
@@ -224,13 +226,24 @@ export const useAutoForm = <
   originalFormMethods: UseFormReturn<any, any>;
 } => {
   const { action, record, onSuccess, onFailure, findBy, select } = props;
+  validateNonBulkAction(action);
+  validateTriggersFromApiClient(action);
+
   let include = props.include;
   let exclude = props.exclude;
+
+  const { metadata, fetching: fetchingMetadata, error: metadataError } = useActionMetadata(props.action);
+
+  validateTriggersFromMetadata(metadata);
 
   const { hasCustomFormChildren, fieldSet, registerFields } = useFieldsFromChildComponents();
   const hasRegisteredFieldsFromChildren = hasCustomFormChildren && fieldSet.size > 0;
   const registeredFieldsFromChildren = hasCustomFormChildren
-    ? extractPathsFromChildren("children" in props ? props.children : undefined)
+    ? extractPathsFromChildren({
+        children: "children" in props ? props.children : undefined,
+        getFieldsToSelectOnDisplayRecordCallback: (path) =>
+          getAllRelatedModelFieldApiIdentifiers({ path, rootFieldsMetadata: getRootFieldsFromMetadata(metadata) }),
+      })
     : [];
 
   useEffect(() => {
@@ -241,13 +254,6 @@ export const useAutoForm = <
     include = Array.from(fieldSet);
     exclude = undefined;
   }
-
-  validateNonBulkAction(action);
-  validateTriggersFromApiClient(action);
-
-  const { metadata, fetching: fetchingMetadata, error: metadataError } = useActionMetadata(props.action);
-
-  validateTriggersFromMetadata(metadata);
 
   // filter down the fields to render only what we want to render for this form
   const fields = useFormFields(metadata, { include, exclude });
@@ -495,7 +501,13 @@ const resetValuesForDefaultValues = (modelApiIdentifier: string, defaultValues: 
   };
 };
 
-export const extractPathsFromChildren = (children: React.ReactNode) => {
+const extractPathsFromChildren = (props: {
+  children: React.ReactNode;
+  currentPath?: string;
+  getFieldsToSelectOnDisplayRecordCallback?: (path: string) => string[];
+}) => {
+  const { children, currentPath, getFieldsToSelectOnDisplayRecordCallback } = props;
+
   const paths = new Set<string>();
 
   React.Children.forEach(children, (child) => {
@@ -503,22 +515,29 @@ export const extractPathsFromChildren = (children: React.ReactNode) => {
       const grandChildren = child.props.children as React.ReactNode | undefined;
       let childPaths: string[] = [];
 
+      const newCurrentPath = currentPath && child.props.field ? currentPath + "." + child.props.field : child.props.field;
+
       if (grandChildren) {
-        childPaths = extractPathsFromChildren(grandChildren);
+        childPaths = extractPathsFromChildren({
+          children: grandChildren,
+          currentPath: newCurrentPath,
+          getFieldsToSelectOnDisplayRecordCallback,
+        });
       }
 
       let field: string | undefined = undefined;
 
       if (isAutoInput(child)) {
-        const props = child.props as { field: string; selectPaths?: string[]; children?: React.ReactNode };
+        const props = child.props as { field: string; displayRecord?: DisplayRecord; children?: React.ReactNode };
         field = props.field;
 
         paths.add(field);
 
-        if (props.selectPaths && Array.isArray(props.selectPaths)) {
-          props.selectPaths.forEach((selectPath) => {
-            paths.add(`${field}.${selectPath}`);
-          });
+        if (props.displayRecord) {
+          aggregatePathsFromDisplayRecord(
+            props.displayRecord,
+            () => getFieldsToSelectOnDisplayRecordCallback?.(newCurrentPath) ?? []
+          ).forEach((path) => paths.add(`${field}.${path}`));
         }
       }
 
@@ -531,6 +550,16 @@ export const extractPathsFromChildren = (children: React.ReactNode) => {
   });
 
   return Array.from(paths);
+};
+
+const aggregatePathsFromDisplayRecord = (displayRecord: DisplayRecord, getFieldsToSelectOnDisplayRecordCallback: () => string[]) => {
+  const selectedPaths = new Set<string>();
+
+  [displayRecord.primary, displayRecord.secondary, displayRecord.tertiary]
+    .flatMap((optionLabel) => getSelectedPathsFromOptionLabel(optionLabel, getFieldsToSelectOnDisplayRecordCallback))
+    .forEach((path) => selectedPaths.add(path));
+
+  return Array.from(selectedPaths);
 };
 
 const removeIdFieldsUnlessUpsertWithoutFindBy = (isUpsertWithFindBy?: boolean) => {
@@ -551,4 +580,38 @@ const validateFindBy = (params: { operatesWithRecordId: boolean; hasFindBy: bool
   } else if (!operatesWithRecordId && hasFindBy) {
     throw new Error("The 'findBy' prop is only allowed for actions that operate with a record identity.");
   }
+};
+
+const getRootFieldsFromMetadata = (metadata: ModelWithOneActionMetadata | GlobalActionMetadata | undefined | null) => {
+  return metadata && "fields" in metadata ? (metadata?.fields as FieldMetadata[]) ?? [] : [];
+};
+
+const getAllRelatedModelFieldApiIdentifiers = (props: {
+  rootFieldsMetadata: FieldMetadata[];
+  path: string;
+  includeRelationshipFields?: boolean;
+}) => {
+  const { rootFieldsMetadata, path, includeRelationshipFields = false } = props;
+
+  const pathSegments = path.split(".");
+
+  let currentFieldsToSearch = rootFieldsMetadata;
+  for (const pathSegment of pathSegments) {
+    const currentField = currentFieldsToSearch.find((field) => field.apiIdentifier === pathSegment);
+
+    if (
+      !currentField ||
+      !isRelationshipField(currentField) ||
+      !("relatedModel" in currentField.configuration) ||
+      !currentField.configuration.relatedModel
+    ) {
+      return [];
+    }
+
+    currentFieldsToSearch = currentField.configuration.relatedModel.fields;
+  }
+
+  return includeRelationshipFields
+    ? currentFieldsToSearch.map((field) => field.apiIdentifier)
+    : currentFieldsToSearch.filter((field) => !isRelationshipField(field)).map((field) => field.apiIdentifier);
 };

--- a/packages/react/src/auto/AutoInput.tsx
+++ b/packages/react/src/auto/AutoInput.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import { useFieldsFromChildComponents } from "./AutoFormContext.js";
 import { useRelationshipContext } from "./hooks/useAutoRelationship.js";
 import { useFieldApiIdentifier, useRelationshipTransformedMetaDataPaths } from "./hooks/useFieldMetadata.js";
-import { useSelectedPathsFromDisplayRecord } from "./hooks/useSelectedPathsFromDisplayRecord.js";
+import { useSelectedPathsFromRecordLabel } from "./hooks/useSelectedPathsFromRecordLabel.js";
 import type { AutoRelationshipFormProps } from "./interfaces/AutoRelationshipInputProps.js";
 
 export interface AutoInputComponent<P> extends React.FC<P> {
@@ -47,7 +47,7 @@ export function autoRelationshipForm<P extends AutoRelationshipFormProps>(Compon
   const WrappedComponent: React.FC<P> = (props) => {
     const { hasCustomFormChildren, registerFields, fieldSet } = useFieldsFromChildComponents();
 
-    const displayedRecordPaths = useSelectedPathsFromDisplayRecord(props);
+    const displayedRecordPaths = useSelectedPathsFromRecordLabel(props);
 
     const relationshipTransformedPaths = useRelationshipTransformedMetaDataPaths(props.field);
     const displayedRecordPathsToRegister = useMemo(

--- a/packages/react/src/auto/hooks/useBelongsToController.tsx
+++ b/packages/react/src/auto/hooks/useBelongsToController.tsx
@@ -36,7 +36,7 @@ export const useBelongsToInputController = (props: AutoRelationshipInputProps) =
   const { field, control, optionLabel } = props;
   const { fieldMetadata, relatedModelOptions, isLoading, errorMessage } = useBelongsToController({
     field,
-    displayRecord: { primary: optionLabel },
+    recordLabel: { primary: optionLabel },
   });
   const { path } = fieldMetadata;
 

--- a/packages/react/src/auto/hooks/useBelongsToController.tsx
+++ b/packages/react/src/auto/hooks/useBelongsToController.tsx
@@ -1,18 +1,13 @@
 import { useCallback } from "react";
 import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useController, useFormContext, useWatch, type Control } from "../../useActionForm.js";
-import type { AutoRelationshipInputProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps, AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModel.js";
 import { assertFieldType } from "./utils.js";
 
-export const useBelongsToController = (props: {
-  field: string;
-  primaryLabel?: OptionLabel;
-  secondaryLabel?: OptionLabel;
-  tertiaryLabel?: OptionLabel;
-}) => {
-  const { field, primaryLabel, secondaryLabel, tertiaryLabel } = props;
+export const useBelongsToController = (props: Omit<AutoRelationshipFormProps, "children" | "label">) => {
+  const { field } = props;
   const fieldMetadata = useFieldMetadata(field);
   const { path, metadata } = fieldMetadata;
   assertFieldType({
@@ -23,7 +18,7 @@ export const useBelongsToController = (props: {
 
   const record = useWatch({ name: path });
 
-  const relatedModelOptions = useRelatedModelOptions({ field, optionLabel: primaryLabel, secondaryLabel, tertiaryLabel });
+  const relatedModelOptions = useRelatedModelOptions(props);
 
   const isLoading = relatedModelOptions.relatedModel.fetching;
   const errorMessage = relatedModelOptions.relatedModel.error?.message;
@@ -39,7 +34,10 @@ export const useBelongsToController = (props: {
 
 export const useBelongsToInputController = (props: AutoRelationshipInputProps) => {
   const { field, control, optionLabel } = props;
-  const { fieldMetadata, relatedModelOptions, isLoading, errorMessage } = useBelongsToController({ field, primaryLabel: optionLabel });
+  const { fieldMetadata, relatedModelOptions, isLoading, errorMessage } = useBelongsToController({
+    field,
+    displayRecord: { primary: optionLabel },
+  });
   const { path } = fieldMetadata;
 
   const {

--- a/packages/react/src/auto/hooks/useHasManyController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyController.tsx
@@ -44,7 +44,7 @@ export const useHasManyInputController = (props: AutoRelationshipInputProps) => 
   }, [metadata.configuration]);
 
   const { remove, append, update } = fieldArray;
-  const relatedModelOptions = useRelatedModelOptions({ field, displayRecord: { primary: props.optionLabel } });
+  const relatedModelOptions = useRelatedModelOptions({ field, recordLabel: { primary: props.optionLabel } });
 
   const { relatedModel } = relatedModelOptions;
 

--- a/packages/react/src/auto/hooks/useHasManyController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyController.tsx
@@ -44,7 +44,7 @@ export const useHasManyInputController = (props: AutoRelationshipInputProps) => 
   }, [metadata.configuration]);
 
   const { remove, append, update } = fieldArray;
-  const relatedModelOptions = useRelatedModelOptions(props);
+  const relatedModelOptions = useRelatedModelOptions({ field, displayRecord: { primary: props.optionLabel } });
 
   const { relatedModel } = relatedModelOptions;
 

--- a/packages/react/src/auto/hooks/useHasManyThroughController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyThroughController.tsx
@@ -2,17 +2,12 @@ import { assert } from "@gadgetinc/api-client-core";
 import { useCallback, useMemo } from "react";
 import { GadgetFieldType, type GadgetHasManyThroughConfig } from "../../internal/gql/graphql.js";
 import { useFieldArray } from "../../useActionForm.js";
-import type { AutoRelationshipInputProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps, AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModel.js";
 import { assertFieldType } from "./utils.js";
 
-export const useHasManyThroughController = (props: {
-  field: string;
-  primaryLabel?: OptionLabel;
-  secondaryLabel?: OptionLabel;
-  tertiaryLabel?: OptionLabel;
-}) => {
+export const useHasManyThroughController = (props: Omit<AutoRelationshipFormProps, "children" | "label">) => {
   const fieldMetadata = useFieldMetadata(props.field);
   const { path, metadata } = fieldMetadata;
 
@@ -28,12 +23,7 @@ export const useHasManyThroughController = (props: {
     "joinModelHasManyFieldApiIdentifier is required for hasManyThrough fields"
   );
 
-  const relatedModelOptions = useRelatedModelOptions({
-    field: props.field,
-    optionLabel: props.primaryLabel,
-    secondaryLabel: props.secondaryLabel,
-    tertiaryLabel: props.tertiaryLabel,
-  });
+  const relatedModelOptions = useRelatedModelOptions(props);
 
   const fieldArrayPath = path.replace(metadata.apiIdentifier, joinModelHasManyFieldApiIdentifier);
 

--- a/packages/react/src/auto/hooks/useHasOneController.tsx
+++ b/packages/react/src/auto/hooks/useHasOneController.tsx
@@ -41,7 +41,7 @@ export const useHasOneInputController = (props: AutoRelationshipInputProps) => {
     relatedModelOptions,
   } = useHasOneController({
     field,
-    displayRecord: { primary: props.optionLabel },
+    recordLabel: { primary: props.optionLabel },
   });
 
   const { path } = fieldMetadata;

--- a/packages/react/src/auto/hooks/useHasOneController.tsx
+++ b/packages/react/src/auto/hooks/useHasOneController.tsx
@@ -1,18 +1,13 @@
 import { useCallback, useMemo } from "react";
 import { GadgetFieldType } from "../../internal/gql/graphql.js";
 import { useController, useWatch } from "../../useActionForm.js";
-import type { AutoRelationshipInputProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps, AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModel.js";
 import { assertFieldType } from "./utils.js";
 
-export const useHasOneController = (props: {
-  field: string;
-  primaryLabel?: OptionLabel;
-  secondaryLabel?: OptionLabel;
-  tertiaryLabel?: OptionLabel;
-}) => {
-  const { field, primaryLabel, secondaryLabel, tertiaryLabel } = props;
+export const useHasOneController = (props: Omit<AutoRelationshipFormProps, "children" | "label">) => {
+  const { field } = props;
   const fieldMetadata = useFieldMetadata(field);
   const { path, metadata } = fieldMetadata;
 
@@ -24,7 +19,7 @@ export const useHasOneController = (props: {
 
   const record: Record<string, any> | undefined = useWatch({ name: path });
 
-  const relatedModelOptions = useRelatedModelOptions({ field, optionLabel: primaryLabel, secondaryLabel, tertiaryLabel });
+  const relatedModelOptions = useRelatedModelOptions(props);
 
   const errorMessage = relatedModelOptions.relatedModel.error?.message;
   const isLoading = relatedModelOptions.relatedModel.fetching;
@@ -40,7 +35,14 @@ export const useHasOneController = (props: {
 
 export const useHasOneInputController = (props: AutoRelationshipInputProps) => {
   const { field, control } = props;
-  const { record: value, fieldMetadata, relatedModelOptions } = useHasOneController({ field, primaryLabel: props.optionLabel });
+  const {
+    record: value,
+    fieldMetadata,
+    relatedModelOptions,
+  } = useHasOneController({
+    field,
+    displayRecord: { primary: props.optionLabel },
+  });
 
   const { path } = fieldMetadata;
 

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -7,7 +7,12 @@ import { useDebouncedSearch } from "../../useDebouncedSearch.js";
 import { useFindMany } from "../../useFindMany.js";
 import { sortByProperty, uniqByProperty } from "../../utils.js";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
-import type { Option, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
+import type {
+  AutoRelationshipFormProps,
+  DisplayRecord,
+  DisplayedRecordOption,
+  OptionLabel,
+} from "../interfaces/AutoRelationshipInputProps.js";
 import type { RelationshipFieldConfig } from "../interfaces/RelationshipFieldConfig.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useModelManager } from "./useModelManager.js";
@@ -75,21 +80,23 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
   );
 };
 
-export const useRelatedModelOptions = (props: {
-  field: string; // Field API identifier
-  optionLabel?: OptionLabel; // The label to display for each related model record
-  secondaryLabel?: OptionLabel;
-  tertiaryLabel?: OptionLabel;
-}) => {
-  const { field } = props;
+export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "children" | "label">) => {
+  const { field, displayRecord } = props;
 
-  const optionLabel = useOptionLabelForField(field, props.optionLabel);
+  const optionLabel = useOptionLabelForField(field, displayRecord?.primary);
   const { relatedModelRecords } = useRelatedModelRecords(props);
 
   const { relatedModel, pagination, search } = relatedModelRecords;
 
   const getOptions = () => {
-    const options = uniqByProperty(getRecordsAsOptions(relatedModel.records, optionLabel, props.secondaryLabel, props.tertiaryLabel), "id");
+    const options = uniqByProperty(
+      getRecordsAsOptions(relatedModel.records, {
+        primary: optionLabel,
+        secondary: displayRecord?.secondary,
+        tertiary: displayRecord?.tertiary,
+      }),
+      "id"
+    );
 
     return options as ReturnType<typeof getRecordsAsOptions>;
   };
@@ -108,7 +115,7 @@ export const useRelatedModelOptions = (props: {
   return {
     options,
     searchFilterOptions: options.filter((option) => {
-      return search.value ? `${option.label}`.toLowerCase().includes(search.value.toLowerCase()) : true;
+      return search.value ? `${option.primary}`.toLowerCase().includes(search.value.toLowerCase()) : true;
     }),
     relatedModel,
     pagination,
@@ -129,27 +136,18 @@ const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: s
     .sort()
     .join(",");
 
-export const getRecordAsOption = (
-  record: Record<string, any>,
-  optionLabel: OptionLabel,
-  secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel
-): Option => {
+export const getRecordAsOption = (record: Record<string, any>, displayRecord: DisplayRecord): DisplayedRecordOption => {
+  const { primary, secondary, tertiary } = displayRecord;
   return {
     id: record.id as string,
-    label: getRecordLabel(record, optionLabel),
-    secondaryLabel: secondaryLabel ? getRecordLabel(record, secondaryLabel) : undefined,
-    tertiaryLabel: tertiaryLabel ? getRecordLabel(record, tertiaryLabel) : undefined,
+    primary: getRecordLabel(record, primary ?? "id"),
+    secondary: secondary ? getRecordLabel(record, secondary) : undefined,
+    tertiary: tertiary ? getRecordLabel(record, tertiary) : undefined,
   };
 };
 
-export const getRecordsAsOptions = (
-  records: Record<string, any>[],
-  optionLabel: OptionLabel,
-  secondaryLabel?: OptionLabel,
-  tertiaryLabel?: OptionLabel
-) => {
-  return records?.map((record: Record<string, any>) => getRecordAsOption(record, optionLabel, secondaryLabel, tertiaryLabel)) ?? [];
+export const getRecordsAsOptions = (records: Record<string, any>[], displayRecord: DisplayRecord) => {
+  return records?.map((record: Record<string, any>) => getRecordAsOption(record, displayRecord)) ?? [];
 };
 
 const useAllRelatedModelRecords = (props: {

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -9,9 +9,9 @@ import { sortByProperty, uniqByProperty } from "../../utils.js";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
 import type {
   AutoRelationshipFormProps,
-  DisplayRecord,
   DisplayedRecordOption,
   OptionLabel,
+  RecordLabel,
 } from "../interfaces/AutoRelationshipInputProps.js";
 import type { RelationshipFieldConfig } from "../interfaces/RelationshipFieldConfig.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
@@ -81,9 +81,9 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 };
 
 export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "children" | "label">) => {
-  const { field, displayRecord } = props;
+  const { field, recordLabel } = props;
 
-  const optionLabel = useOptionLabelForField(field, displayRecord?.primary);
+  const optionLabel = useOptionLabelForField(field, recordLabel?.primary);
   const { relatedModelRecords } = useRelatedModelRecords(props);
 
   const { relatedModel, pagination, search } = relatedModelRecords;
@@ -92,8 +92,8 @@ export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "c
     const options = uniqByProperty(
       getRecordsAsOptions(relatedModel.records, {
         primary: optionLabel,
-        secondary: displayRecord?.secondary,
-        tertiary: displayRecord?.tertiary,
+        secondary: recordLabel?.secondary,
+        tertiary: recordLabel?.tertiary,
       }),
       "id"
     );
@@ -136,8 +136,8 @@ const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: s
     .sort()
     .join(",");
 
-export const getRecordAsOption = (record: Record<string, any>, displayRecord: DisplayRecord): DisplayedRecordOption => {
-  const { primary, secondary, tertiary } = displayRecord;
+export const getRecordAsOption = (record: Record<string, any>, recordLabel: RecordLabel): DisplayedRecordOption => {
+  const { primary, secondary, tertiary } = recordLabel;
   return {
     id: record.id as string,
     primary: getRecordLabel(record, primary ?? "id"),
@@ -146,8 +146,8 @@ export const getRecordAsOption = (record: Record<string, any>, displayRecord: Di
   };
 };
 
-export const getRecordsAsOptions = (records: Record<string, any>[], displayRecord: DisplayRecord) => {
-  return records?.map((record: Record<string, any>) => getRecordAsOption(record, displayRecord)) ?? [];
+export const getRecordsAsOptions = (records: Record<string, any>[], recordLabel: RecordLabel) => {
+  return records?.map((record: Record<string, any>) => getRecordAsOption(record, recordLabel)) ?? [];
 };
 
 const useAllRelatedModelRecords = (props: {

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -7,11 +7,12 @@ import { useDebouncedSearch } from "../../useDebouncedSearch.js";
 import { useFindMany } from "../../useFindMany.js";
 import { sortByProperty, uniqByProperty } from "../../utils.js";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
-import type {
-  AutoRelationshipFormProps,
-  DisplayedRecordOption,
-  OptionLabel,
-  RecordLabel,
+import {
+  getRecordLabelObject,
+  type AutoRelationshipFormProps,
+  type DisplayedRecordOption,
+  type OptionLabel,
+  type RecordLabel,
 } from "../interfaces/AutoRelationshipInputProps.js";
 import type { RelationshipFieldConfig } from "../interfaces/RelationshipFieldConfig.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
@@ -70,6 +71,12 @@ const omitRelatedModelRecordsAssociatedWithOtherRecords = (props: {
   };
 };
 
+export const useRecordLabelObjectFromProps = (props: AutoRelationshipFormProps) => {
+  const recordLabelObject = getRecordLabelObject(props.recordLabel);
+  const primaryLabel = useOptionLabelForField(props.field, recordLabelObject?.primary);
+  return { ...recordLabelObject, primary: primaryLabel };
+};
+
 export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel): OptionLabel => {
   const { metadata } = useFieldMetadata(field);
   const relationshipFieldConfig = metadata.configuration as RelationshipFieldConfig;
@@ -81,7 +88,8 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 };
 
 export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "children" | "label">) => {
-  const { field, recordLabel } = props;
+  const { field } = props;
+  const recordLabel = getRecordLabelObject(props.recordLabel);
 
   const optionLabel = useOptionLabelForField(field, recordLabel?.primary);
   const { relatedModelRecords } = useRelatedModelRecords(props);
@@ -128,7 +136,7 @@ const getRecordLabel = (record: Record<string, any>, optionLabel: OptionLabel): 
     ? record[optionLabel] // Related model field API id
     : Array.isArray(optionLabel)
     ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
-    : optionLabel(record); // Callback on the whole related model record
+    : optionLabel({ record }); // Callback on the whole related model record
 
 const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: string }) => string) => string[] }) =>
   records

--- a/packages/react/src/auto/hooks/useSelectedPathsFromDisplayRecord.tsx
+++ b/packages/react/src/auto/hooks/useSelectedPathsFromDisplayRecord.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import {
+  GadgetFieldType,
+  type GadgetBelongsToConfig,
+  type GadgetHasManyConfig,
+  type GadgetHasManyThroughConfig,
+  type GadgetHasOneConfig,
+} from "../../internal/gql/graphql.js";
+import { isRelationshipField } from "../../use-table/helpers.js";
+import type { AutoRelationshipFormProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
+import { useMaybeFieldMetadata } from "./useFieldMetadata.js";
+
+export const useSelectedPathsFromDisplayRecord = (props: AutoRelationshipFormProps) => {
+  const { field, displayRecord } = props;
+  const { metadata } = useMaybeFieldMetadata(field);
+
+  const selectedPaths = useMemo(() => {
+    if (!displayRecord || !metadata || !isRelationshipField(metadata)) {
+      return [];
+    }
+    const fieldConfig = metadata.configuration as
+      | GadgetHasManyConfig
+      | GadgetHasManyThroughConfig
+      | GadgetHasOneConfig
+      | GadgetBelongsToConfig;
+
+    const selectedPaths = new Set<string>();
+
+    const defaultFieldsToSelect =
+      fieldConfig.relatedModel?.fields
+        .filter((field) => !isRelationshipField(field) && field.fieldType !== GadgetFieldType.Password)
+        .map((field) => field.apiIdentifier) ?? [];
+
+    [displayRecord.primary, displayRecord.secondary, displayRecord.tertiary]
+      .flatMap((optionLabel) => getSelectedPathsFromOptionLabel(optionLabel, () => defaultFieldsToSelect))
+      .forEach((path) => selectedPaths.add(path));
+
+    return Array.from(selectedPaths);
+  }, [displayRecord, metadata]);
+
+  return selectedPaths;
+};
+
+export const getSelectedPathsFromOptionLabel = (optionLabel?: OptionLabel, getFieldsToSelectOnDisplayRecordCallback?: () => string[]) => {
+  if (!optionLabel) {
+    return [];
+  }
+
+  if (Array.isArray(optionLabel)) {
+    return optionLabel;
+  }
+
+  if (typeof optionLabel === "string") {
+    return [optionLabel];
+  }
+
+  // Callback instead of explicit selection
+  return getFieldsToSelectOnDisplayRecordCallback?.().filter((field) => !displayRecordCallbackOmittedFields.includes(field)) ?? [];
+};
+
+const displayRecordCallbackOmittedFields = ["createdAt", "updatedAt"];

--- a/packages/react/src/auto/hooks/useSelectedPathsFromRecordLabel.tsx
+++ b/packages/react/src/auto/hooks/useSelectedPathsFromRecordLabel.tsx
@@ -10,12 +10,12 @@ import { isRelationshipField } from "../../use-table/helpers.js";
 import type { AutoRelationshipFormProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
 import { useMaybeFieldMetadata } from "./useFieldMetadata.js";
 
-export const useSelectedPathsFromDisplayRecord = (props: AutoRelationshipFormProps) => {
-  const { field, displayRecord } = props;
+export const useSelectedPathsFromRecordLabel = (props: AutoRelationshipFormProps) => {
+  const { field, recordLabel } = props;
   const { metadata } = useMaybeFieldMetadata(field);
 
   const selectedPaths = useMemo(() => {
-    if (!displayRecord || !metadata || !isRelationshipField(metadata)) {
+    if (!recordLabel || !metadata || !isRelationshipField(metadata)) {
       return [];
     }
     const fieldConfig = metadata.configuration as
@@ -31,17 +31,17 @@ export const useSelectedPathsFromDisplayRecord = (props: AutoRelationshipFormPro
         .filter((field) => !isRelationshipField(field) && field.fieldType !== GadgetFieldType.Password)
         .map((field) => field.apiIdentifier) ?? [];
 
-    [displayRecord.primary, displayRecord.secondary, displayRecord.tertiary]
+    [recordLabel.primary, recordLabel.secondary, recordLabel.tertiary]
       .flatMap((optionLabel) => getSelectedPathsFromOptionLabel(optionLabel, () => defaultFieldsToSelect))
       .forEach((path) => selectedPaths.add(path));
 
     return Array.from(selectedPaths);
-  }, [displayRecord, metadata]);
+  }, [recordLabel, metadata]);
 
   return selectedPaths;
 };
 
-export const getSelectedPathsFromOptionLabel = (optionLabel?: OptionLabel, getFieldsToSelectOnDisplayRecordCallback?: () => string[]) => {
+export const getSelectedPathsFromOptionLabel = (optionLabel?: OptionLabel, getFieldsToSelectOnRecordLabelCallback?: () => string[]) => {
   if (!optionLabel) {
     return [];
   }
@@ -55,7 +55,7 @@ export const getSelectedPathsFromOptionLabel = (optionLabel?: OptionLabel, getFi
   }
 
   // Callback instead of explicit selection
-  return getFieldsToSelectOnDisplayRecordCallback?.().filter((field) => !displayRecordCallbackOmittedFields.includes(field)) ?? [];
+  return getFieldsToSelectOnRecordLabelCallback?.().filter((field) => !recordLabelCallbackOmittedFields.includes(field)) ?? [];
 };
 
-const displayRecordCallbackOmittedFields = ["createdAt", "updatedAt"];
+const recordLabelCallbackOmittedFields = ["createdAt", "updatedAt"];

--- a/packages/react/src/auto/hooks/useSelectedPathsFromRecordLabel.tsx
+++ b/packages/react/src/auto/hooks/useSelectedPathsFromRecordLabel.tsx
@@ -7,7 +7,11 @@ import {
   type GadgetHasOneConfig,
 } from "../../internal/gql/graphql.js";
 import { isRelationshipField } from "../../use-table/helpers.js";
-import type { AutoRelationshipFormProps, OptionLabel } from "../interfaces/AutoRelationshipInputProps.js";
+import {
+  getOptionLabelsFromRecordLabel,
+  type AutoRelationshipFormProps,
+  type OptionLabel,
+} from "../interfaces/AutoRelationshipInputProps.js";
 import { useMaybeFieldMetadata } from "./useFieldMetadata.js";
 
 export const useSelectedPathsFromRecordLabel = (props: AutoRelationshipFormProps) => {
@@ -31,7 +35,7 @@ export const useSelectedPathsFromRecordLabel = (props: AutoRelationshipFormProps
         .filter((field) => !isRelationshipField(field) && field.fieldType !== GadgetFieldType.Password)
         .map((field) => field.apiIdentifier) ?? [];
 
-    [recordLabel.primary, recordLabel.secondary, recordLabel.tertiary]
+    getOptionLabelsFromRecordLabel(recordLabel)
       .flatMap((optionLabel) => getSelectedPathsFromOptionLabel(optionLabel, () => defaultFieldsToSelect))
       .forEach((path) => selectedPaths.add(path));
 

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -8,14 +8,14 @@ export interface AutoRelationshipInputProps {
   label?: string;
 }
 
-export interface DisplayedRecordOption extends RecordLabel<ReactNode> {
+export type DisplayedRecordOption = RecordLabel<ReactNode> & {
   id: string;
-}
+};
 
 /**
  * Type for the option label when displaying a list of records from a related model
  */
-export type OptionLabel = string | string[] | ((record: Record<string, any>) => ReactNode);
+export type OptionLabel = string | string[] | ((props: { record: Record<string, any> }) => ReactNode);
 
 export type RecordLabel<T = OptionLabel> = {
   primary?: T;
@@ -27,5 +27,25 @@ export type AutoRelationshipFormProps = {
   field: string;
   label?: ReactNode;
   children: ReactNode;
-  recordLabel?: RecordLabel;
+  recordLabel?: OptionLabel | RecordLabel;
+};
+
+export const getRecordLabelObject = (recordLabel?: OptionLabel | RecordLabel): RecordLabel | undefined => {
+  if (!recordLabel) {
+    return undefined;
+  }
+
+  if (typeof recordLabel === "object" && !Array.isArray(recordLabel)) {
+    return recordLabel;
+  }
+
+  return { primary: recordLabel };
+};
+
+export const getOptionLabelsFromRecordLabel = (recordLabel: OptionLabel | RecordLabel): (OptionLabel | undefined)[] => {
+  const recordLabelObject = getRecordLabelObject(recordLabel);
+  if (!recordLabelObject) {
+    return [];
+  }
+  return [recordLabelObject.primary, recordLabelObject.secondary, recordLabelObject.tertiary];
 };

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -8,14 +8,24 @@ export interface AutoRelationshipInputProps {
   label?: string;
 }
 
-export interface Option {
+export interface DisplayedRecordOption extends DisplayRecord<ReactNode> {
   id: string;
-  label: ReactNode;
-  secondaryLabel?: ReactNode;
-  tertiaryLabel?: ReactNode;
 }
 
 /**
  * Type for the option label when displaying a list of records from a related model
  */
 export type OptionLabel = string | string[] | ((record: Record<string, any>) => ReactNode);
+
+export type DisplayRecord<T = OptionLabel> = {
+  primary?: T;
+  secondary?: T;
+  tertiary?: T;
+};
+
+export type AutoRelationshipFormProps = {
+  field: string;
+  label?: ReactNode;
+  children: ReactNode;
+  displayRecord?: DisplayRecord;
+};

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -8,7 +8,7 @@ export interface AutoRelationshipInputProps {
   label?: string;
 }
 
-export interface DisplayedRecordOption extends DisplayRecord<ReactNode> {
+export interface DisplayedRecordOption extends RecordLabel<ReactNode> {
   id: string;
 }
 
@@ -17,7 +17,7 @@ export interface DisplayedRecordOption extends DisplayRecord<ReactNode> {
  */
 export type OptionLabel = string | string[] | ((record: Record<string, any>) => ReactNode);
 
-export type DisplayRecord<T = OptionLabel> = {
+export type RecordLabel<T = OptionLabel> = {
   primary?: T;
   secondary?: T;
   tertiary?: T;
@@ -27,5 +27,5 @@ export type AutoRelationshipFormProps = {
   field: string;
   label?: ReactNode;
   children: ReactNode;
-  displayRecord?: DisplayRecord;
+  recordLabel?: RecordLabel;
 };

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToForm.tsx
@@ -4,124 +4,115 @@ import React from "react";
 import { useBelongsToForm } from "../../../../useBelongsToForm.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
-import type { OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { SearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
 import { renderOptionLabel } from "./utils.js";
 
-export const PolarisAutoBelongsToForm = autoRelationshipForm(
-  (props: {
-    field: string;
-    children: React.ReactNode;
-    label?: React.ReactNode;
-    primaryLabel?: OptionLabel;
-    secondaryLabel?: OptionLabel;
-    tertiaryLabel?: OptionLabel;
-  }) => {
-    const belongsToForm = useBelongsToForm(props);
+export const PolarisAutoBelongsToForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
+  const belongsToForm = useBelongsToForm(props);
 
-    const {
-      record,
-      actionsOpen,
-      isEditing,
-      setActionsOpen,
-      setIsEditing,
-      pathPrefix,
-      hasRecord,
-      recordOption,
-      relatedModelName: parentName,
-      path,
-      setValue,
-      getValues,
-      metaDataPathPrefix,
-    } = belongsToForm;
+  const {
+    record,
+    actionsOpen,
+    isEditing,
+    setActionsOpen,
+    setIsEditing,
+    pathPrefix,
+    hasRecord,
+    recordOption,
+    relatedModelName: parentName,
+    path,
+    setValue,
+    getValues,
+    metaDataPathPrefix,
+  } = belongsToForm;
 
-    return (
-      <>
-        <BlockStack gap="300">
-          <InlineGrid columns="1fr auto">
-            {props.label ?? (
-              <Text as="h2" variant="headingSm">
-                {parentName}
-              </Text>
-            )}
-            {hasRecord && (
-              <Popover
-                active={actionsOpen}
-                activator={<Button onClick={() => setActionsOpen((prev) => !prev)} icon={MenuHorizontalIcon} />}
-                onClose={() => setActionsOpen(false)}
-              >
-                <ActionList
-                  actionRole="menuitem"
-                  items={[
-                    {
-                      content: `Edit ${parentName.toLocaleLowerCase()}`,
-                      onAction: () => {
-                        setIsEditing(true);
-                        setActionsOpen(false);
-                      },
-                    },
-                    {
-                      content: `Remove ${parentName.toLocaleLowerCase()}`,
-                      onAction: () => {
-                        const { __typename, ...rest } = record;
-                        const nulledValues = Object.fromEntries(Object.keys(rest).map((key) => [key, null]));
-                        setValue(path, { ...nulledValues, __typename, _unlink: true });
-                        setActionsOpen(false);
-                      },
-                      destructive: true,
-                    },
-                  ]}
-                />
-              </Popover>
-            )}
-          </InlineGrid>
-          {hasRecord ? (
-            <>
-              <Divider />
-              <InlineStack align="space-between">
-                <BlockStack gap="200">
-                  {renderOptionLabel(recordOption!.label, "primary")}
-                  {recordOption!.secondaryLabel && renderOptionLabel(recordOption!.secondaryLabel, "secondary")}
-                </BlockStack>
-                {recordOption!.tertiaryLabel && renderOptionLabel(recordOption!.tertiaryLabel, "tertiary")}
-              </InlineStack>
-            </>
-          ) : (
-            <SearchableSingleRelatedModelRecordSelector form={belongsToForm} />
+  return (
+    <>
+      <BlockStack gap="300">
+        <InlineGrid columns="1fr auto">
+          {props.label ?? (
+            <Text as="h2" variant="headingSm">
+              {parentName}
+            </Text>
           )}
-        </BlockStack>
-        <Modal open={isEditing} onClose={() => setIsEditing(false)} title={`Add ${parentName}`}>
-          <RelationshipContext.Provider
-            value={{ transformPath: (path) => pathPrefix + "." + path, transformMetadataPath: (path) => metaDataPathPrefix + "." + path }}
-          >
-            <Modal.Section>{props.children}</Modal.Section>
-            <Modal.Section>
-              <div style={{ float: "right", paddingBottom: "16px" }}>
-                <ButtonGroup>
-                  <Button variant="secondary" onClick={() => setIsEditing(false)}>
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="primary"
-                    onClick={() => {
-                      const { _unlink, _link, id: recordId, ...rest } = getValues(path);
+          {hasRecord && (
+            <Popover
+              active={actionsOpen}
+              activator={<Button onClick={() => setActionsOpen((prev) => !prev)} icon={MenuHorizontalIcon} />}
+              onClose={() => setActionsOpen(false)}
+            >
+              <ActionList
+                actionRole="menuitem"
+                items={[
+                  {
+                    content: `Edit ${parentName.toLocaleLowerCase()}`,
+                    onAction: () => {
+                      setIsEditing(true);
+                      setActionsOpen(false);
+                    },
+                  },
+                  {
+                    content: `Remove ${parentName.toLocaleLowerCase()}`,
+                    onAction: () => {
+                      const { __typename, ...rest } = record;
+                      const nulledValues = Object.fromEntries(Object.keys(rest).map((key) => [key, null]));
+                      setValue(path, { ...nulledValues, __typename, _unlink: true });
+                      setActionsOpen(false);
+                    },
+                    destructive: true,
+                  },
+                ]}
+              />
+            </Popover>
+          )}
+        </InlineGrid>
+        {hasRecord ? (
+          <>
+            <Divider />
+            <InlineStack align="space-between">
+              <BlockStack gap="200">
+                {renderOptionLabel(recordOption!.primary, "primary")}
+                {recordOption!.secondary && renderOptionLabel(recordOption!.secondary, "secondary")}
+              </BlockStack>
+              {recordOption!.tertiary && renderOptionLabel(recordOption!.tertiary, "tertiary")}
+            </InlineStack>
+          </>
+        ) : (
+          <SearchableSingleRelatedModelRecordSelector form={belongsToForm} />
+        )}
+      </BlockStack>
+      <Modal open={isEditing} onClose={() => setIsEditing(false)} title={`Add ${parentName}`}>
+        <RelationshipContext.Provider
+          value={{ transformPath: (path) => pathPrefix + "." + path, transformMetadataPath: (path) => metaDataPathPrefix + "." + path }}
+        >
+          <Modal.Section>{props.children}</Modal.Section>
+          <Modal.Section>
+            <div style={{ float: "right", paddingBottom: "16px" }}>
+              <ButtonGroup>
+                <Button variant="secondary" onClick={() => setIsEditing(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={() => {
+                    const { _unlink, _link, id: recordId, ...rest } = getValues(path);
 
-                      if (recordId) {
-                        setValue(path, { ...rest, id: recordId });
-                      } else {
-                        setValue(path, rest);
-                      }
-                      setIsEditing(false);
-                    }}
-                  >
-                    Save
-                  </Button>
-                </ButtonGroup>
-              </div>
-            </Modal.Section>
-          </RelationshipContext.Provider>
-        </Modal>
-      </>
-    );
-  }
-);
+                    if (recordId) {
+                      setValue(path, { ...rest, id: recordId });
+                    } else {
+                      setValue(path, rest);
+                    }
+                    setIsEditing(false);
+                  }}
+                >
+                  Save
+                </Button>
+              </ButtonGroup>
+            </div>
+          </Modal.Section>
+        </RelationshipContext.Provider>
+      </Modal>
+    </>
+  );
+});

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
@@ -19,12 +19,12 @@ export const PolarisAutoBelongsToInput = autoInput((props: AutoRelationshipInput
   } = useBelongsToInputController(props);
 
   const optionLabel = useOptionLabelForField(props.field, props.optionLabel);
-  const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, optionLabel) : null;
+  const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, { primary: optionLabel }) : null;
 
   const selectedRecordTag =
     selectedOption && selectedOption.id ? (
       <Tag onRemove={onRemoveRecord} key={`selectedRecordTag_${selectedOption.id}`}>
-        <p id={`${selectedOption.id}_${selectedOption.label}`}>{selectedOption.label}</p>
+        <p id={`${selectedOption.id}_${selectedOption.primary}`}>{selectedOption.primary}</p>
       </Tag>
     ) : danglingSelectedRecordId ? (
       <Tag onRemove={onRemoveRecord} key={`selectedRecordTag_${danglingSelectedRecordId}`}>

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
@@ -25,7 +25,7 @@ export const PolarisAutoHasManyForm = autoRelationshipForm((props: AutoRelations
 
   const modelName = metadata.configuration.relatedModel?.name;
 
-  const primaryLabel = useOptionLabelForField(props.field, props.displayRecord?.primary);
+  const primaryLabel = useOptionLabelForField(props.field, props.recordLabel?.primary);
 
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
@@ -51,8 +51,8 @@ export const PolarisAutoHasManyForm = autoRelationshipForm((props: AutoRelations
 
             const option = getRecordAsOption(record, {
               primary: primaryLabel,
-              secondary: props.displayRecord?.secondary,
-              tertiary: props.displayRecord?.tertiary,
+              secondary: props.recordLabel?.secondary,
+              tertiary: props.recordLabel?.tertiary,
             });
 
             const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
@@ -7,129 +7,124 @@ import { RelationshipContext, useAutoRelationship, useRelationshipContext } from
 import { useHasManyController } from "../../../hooks/useHasManyController.js";
 import { getRecordAsOption, useOptionLabelForField } from "../../../hooks/useRelatedModel.js";
 import { useRequiredChildComponentsValidator } from "../../../hooks/useRequiredChildComponentsValidator.js";
-import type { OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { renderOptionLabel } from "./utils.js";
 
-export const PolarisAutoHasManyForm = autoRelationshipForm(
-  (props: {
-    field: string;
-    label?: React.ReactNode;
-    children: React.ReactNode;
-    primaryLabel?: OptionLabel;
-    secondaryLabel?: OptionLabel;
-    tertiaryLabel?: OptionLabel;
-  }) => {
-    useRequiredChildComponentsValidator(props, "AutoHasManyForm");
-    const { metadata } = useAutoRelationship({ field: props.field });
-    const { getValues } = useFormContext();
+export const PolarisAutoHasManyForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
+  useRequiredChildComponentsValidator(props, "AutoHasManyForm");
+  const { metadata } = useAutoRelationship({ field: props.field });
+  const { getValues } = useFormContext();
 
-    const { fieldArray, fieldArrayPath } = useHasManyController({ field: props.field });
-    const { fields, append, remove } = fieldArray;
-    const relationshipContext = useRelationshipContext();
+  const { fieldArray, fieldArrayPath } = useHasManyController({ field: props.field });
+  const { fields, append, remove } = fieldArray;
+  const relationshipContext = useRelationshipContext();
 
-    if (metadata.configuration.__typename !== "GadgetHasManyConfig") {
-      throw new Error("PolarisAutoHasManyForm can only be used for HasMany fields");
-    }
-
-    const modelName = metadata.configuration.relatedModel?.name;
-
-    const primaryLabel = useOptionLabelForField(props.field, props.primaryLabel);
-
-    const [editingIndex, setEditingIndex] = useState<number | null>(null);
-
-    return (
-      <>
-        <div style={{ marginBottom: "8px" }}>
-          {props.label ?? (
-            <Text as="h2" variant="headingSm">
-              {metadata.name}
-            </Text>
-          )}
-        </div>
-        <Box borderColor="border" borderWidth="025" borderRadius="200">
-          <BlockStack as="ul">
-            {fields.flatMap((field, idx) => {
-              // since we don't put full data in the field array when we append, we need to
-              // get the value directly from the form state
-              const record = getValues(`${fieldArrayPath}.${idx}`);
-
-              if (!record) {
-                return [];
-              }
-
-              const option = getRecordAsOption(record, primaryLabel, props.secondaryLabel, props.tertiaryLabel);
-
-              const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;
-              const metadataPathPrefix = relationshipContext?.transformMetadataPath
-                ? relationshipContext.transformMetadataPath(props.field)
-                : props.field;
-
-              return (
-                <Box key={field._fieldArrayKey} borderColor="border" borderBlockEndWidth="025" id={`${pathPrefix}.${idx}`}>
-                  {editingIndex == idx ? (
-                    <Box padding="300">
-                      <BlockStack gap="300">
-                        <RelationshipContext.Provider
-                          value={{
-                            transformPath: (path) => `${pathPrefix}.${idx}.${path}`,
-                            transformMetadataPath: (path) => `${metadataPathPrefix}.${path}`,
-                            fieldArray,
-                          }}
-                        >
-                          {props.children}
-                        </RelationshipContext.Provider>
-                        <InlineStack align="space-between">
-                          <Button tone="critical" onClick={() => remove(idx)} id={`deleteButton_${metadataPathPrefix}.${idx}`}>
-                            Delete
-                          </Button>
-                          <Button variant="primary" onClick={() => setEditingIndex(null)} id={`confirmButton_${metadataPathPrefix}.${idx}`}>
-                            Confirm
-                          </Button>
-                        </InlineStack>
-                      </BlockStack>
-                    </Box>
-                  ) : (
-                    <ResourceItem id={option.id} name={option.label?.toString() ?? option.id} onClick={() => setEditingIndex(idx)}>
-                      {option.label ? (
-                        <InlineStack align="space-between">
-                          <BlockStack gap="200">
-                            {renderOptionLabel(option.label, "primary")}
-                            {option.secondaryLabel && renderOptionLabel(option.secondaryLabel, "secondary")}
-                          </BlockStack>
-                          {option.tertiaryLabel && renderOptionLabel(option.tertiaryLabel, "tertiary")}
-                        </InlineStack>
-                      ) : (
-                        <Text variant="bodyMd" as="h3" tone="subdued">
-                          Click to edit...
-                        </Text>
-                      )}
-                    </ResourceItem>
-                  )}
-                </Box>
-              );
-            })}
-            <Box>
-              <ResourceItem
-                id="add"
-                name="Add"
-                onClick={() => {
-                  append({});
-                  setEditingIndex(fields.length);
-                }}
-              >
-                <InlineStack align="start" gap="200">
-                  <Box>
-                    <Icon source={PlusCircleIcon} />
-                  </Box>
-                  <Text as="p" variant="bodyMd" fontWeight="semibold">
-                    Add {modelName}
-                  </Text>
-                </InlineStack>
-              </ResourceItem>
-            </Box>
-          </BlockStack>
-        </Box>
-      </>
-    );
+  if (metadata.configuration.__typename !== "GadgetHasManyConfig") {
+    throw new Error("PolarisAutoHasManyForm can only be used for HasMany fields");
   }
-);
+
+  const modelName = metadata.configuration.relatedModel?.name;
+
+  const primaryLabel = useOptionLabelForField(props.field, props.displayRecord?.primary);
+
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  return (
+    <>
+      <div style={{ marginBottom: "8px" }}>
+        {props.label ?? (
+          <Text as="h2" variant="headingSm">
+            {metadata.name}
+          </Text>
+        )}
+      </div>
+      <Box borderColor="border" borderWidth="025" borderRadius="200">
+        <BlockStack as="ul">
+          {fields.flatMap((field, idx) => {
+            // since we don't put full data in the field array when we append, we need to
+            // get the value directly from the form state
+            const record = getValues(`${fieldArrayPath}.${idx}`);
+
+            if (!record) {
+              return [];
+            }
+
+            const option = getRecordAsOption(record, {
+              primary: primaryLabel,
+              secondary: props.displayRecord?.secondary,
+              tertiary: props.displayRecord?.tertiary,
+            });
+
+            const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;
+            const metadataPathPrefix = relationshipContext?.transformMetadataPath
+              ? relationshipContext.transformMetadataPath(props.field)
+              : props.field;
+
+            return (
+              <Box key={field._fieldArrayKey} borderColor="border" borderBlockEndWidth="025" id={`${pathPrefix}.${idx}`}>
+                {editingIndex == idx ? (
+                  <Box padding="300">
+                    <BlockStack gap="300">
+                      <RelationshipContext.Provider
+                        value={{
+                          transformPath: (path) => `${pathPrefix}.${idx}.${path}`,
+                          transformMetadataPath: (path) => `${metadataPathPrefix}.${path}`,
+                          fieldArray,
+                        }}
+                      >
+                        {props.children}
+                      </RelationshipContext.Provider>
+                      <InlineStack align="space-between">
+                        <Button tone="critical" onClick={() => remove(idx)} id={`deleteButton_${metadataPathPrefix}.${idx}`}>
+                          Delete
+                        </Button>
+                        <Button variant="primary" onClick={() => setEditingIndex(null)} id={`confirmButton_${metadataPathPrefix}.${idx}`}>
+                          Confirm
+                        </Button>
+                      </InlineStack>
+                    </BlockStack>
+                  </Box>
+                ) : (
+                  <ResourceItem id={option.id} name={option.primary?.toString() ?? option.id} onClick={() => setEditingIndex(idx)}>
+                    {option.primary ? (
+                      <InlineStack align="space-between">
+                        <BlockStack gap="200">
+                          {renderOptionLabel(option.primary, "primary")}
+                          {option.secondary && renderOptionLabel(option.secondary, "secondary")}
+                        </BlockStack>
+                        {option.tertiary && renderOptionLabel(option.tertiary, "tertiary")}
+                      </InlineStack>
+                    ) : (
+                      <Text variant="bodyMd" as="h3" tone="subdued">
+                        Click to edit...
+                      </Text>
+                    )}
+                  </ResourceItem>
+                )}
+              </Box>
+            );
+          })}
+          <Box>
+            <ResourceItem
+              id="add"
+              name="Add"
+              onClick={() => {
+                append({});
+                setEditingIndex(fields.length);
+              }}
+            >
+              <InlineStack align="start" gap="200">
+                <Box>
+                  <Icon source={PlusCircleIcon} />
+                </Box>
+                <Text as="p" variant="bodyMd" fontWeight="semibold">
+                  Add {modelName}
+                </Text>
+              </InlineStack>
+            </ResourceItem>
+          </Box>
+        </BlockStack>
+      </Box>
+    </>
+  );
+});

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
@@ -8,7 +8,14 @@ import { useHasManyController } from "../../../hooks/useHasManyController.js";
 import { getRecordAsOption, useOptionLabelForField } from "../../../hooks/useRelatedModel.js";
 import { useRequiredChildComponentsValidator } from "../../../hooks/useRequiredChildComponentsValidator.js";
 import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
+import { getRecordLabelObject } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { renderOptionLabel } from "./utils.js";
+
+export const useRecordLabelObjectFromProps = (props: AutoRelationshipFormProps) => {
+  const recordLabelObject = getRecordLabelObject(props.recordLabel);
+  const primaryLabel = useOptionLabelForField(props.field, recordLabelObject?.primary);
+  return { ...recordLabelObject, primary: primaryLabel };
+};
 
 export const PolarisAutoHasManyForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
   useRequiredChildComponentsValidator(props, "AutoHasManyForm");
@@ -25,7 +32,7 @@ export const PolarisAutoHasManyForm = autoRelationshipForm((props: AutoRelations
 
   const modelName = metadata.configuration.relatedModel?.name;
 
-  const primaryLabel = useOptionLabelForField(props.field, props.recordLabel?.primary);
+  const recordLabel = useRecordLabelObjectFromProps(props);
 
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
@@ -49,11 +56,7 @@ export const PolarisAutoHasManyForm = autoRelationshipForm((props: AutoRelations
               return [];
             }
 
-            const option = getRecordAsOption(record, {
-              primary: primaryLabel,
-              secondary: props.recordLabel?.secondary,
-              tertiary: props.recordLabel?.tertiary,
-            });
+            const option = getRecordAsOption(record, recordLabel);
 
             const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;
             const metadataPathPrefix = relationshipContext?.transformMetadataPath

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
@@ -23,7 +23,6 @@ export const PolarisAutoHasManyInput = autoInput((props: AutoRelationshipInputPr
   } = useHasManyInputController(props);
 
   const optionLabel = useOptionLabelForField(field, props.optionLabel);
-  console.log("optionLabel :", optionLabel);
 
   const selectedRecordIds = useMemo(() => {
     return selectedRecords.map((record) => record.id).filter((id) => !!id) as string[];

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
@@ -23,6 +23,7 @@ export const PolarisAutoHasManyInput = autoInput((props: AutoRelationshipInputPr
   } = useHasManyInputController(props);
 
   const optionLabel = useOptionLabelForField(field, props.optionLabel);
+  console.log("optionLabel :", optionLabel);
 
   const selectedRecordIds = useMemo(() => {
     return selectedRecords.map((record) => record.id).filter((id) => !!id) as string[];

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -16,7 +16,6 @@ export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoRe
     remove,
     joinRecords,
     primaryLabel,
-    hasChildForm,
     listboxId,
     pathPrefix,
     metaDataPathPrefix,
@@ -95,7 +94,7 @@ export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoRe
                         />
                       </div>
                     </div>
-                    {hasChildForm && (
+                    {props.children && (
                       <Box borderColor="border" borderBlockStartWidth="025">
                         <Box padding="200">
                           <RelationshipContext.Provider

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -15,10 +15,10 @@ export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoRe
     append,
     remove,
     joinRecords,
-    primaryLabel,
     listboxId,
     pathPrefix,
     metaDataPathPrefix,
+    recordLabel,
     siblingModelName,
     siblingRecordsLoading,
     siblingRecords,
@@ -68,9 +68,9 @@ export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoRe
             const siblingRecord = inverseRelatedModelField && record[inverseRelatedModelField];
 
             const siblingOption = getRecordAsOption(siblingRecord, {
-              primary: primaryLabel,
-              secondary: props.recordLabel?.secondary,
-              tertiary: props.recordLabel?.tertiary,
+              primary: recordLabel.primary,
+              secondary: recordLabel.secondary,
+              tertiary: recordLabel.tertiary,
             });
 
             return (

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -5,147 +5,142 @@ import { useHasManyThroughForm } from "../../../../useHasManyThroughForm.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
 import { getRecordAsOption } from "../../../hooks/useRelatedModel.js";
-import type { Option, OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps, DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { RelatedModelOptionsPopover, RelatedModelOptionsSearch } from "./RelatedModelOptions.js";
 import { renderOptionLabel } from "./utils.js";
 
-export const PolarisAutoHasManyThroughForm = autoRelationshipForm(
-  (props: {
-    field: string;
-    label?: React.ReactNode;
-    children: React.ReactNode;
-    primaryLabel?: OptionLabel;
-    secondaryLabel?: OptionLabel;
-    tertiaryLabel?: OptionLabel;
-  }) => {
-    const [addingSibling, setAddingSibling] = useState(false);
-    const {
-      append,
-      remove,
-      joinRecords,
-      primaryLabel,
-      hasChildForm,
-      listboxId,
-      pathPrefix,
-      metaDataPathPrefix,
-      siblingModelName,
-      siblingRecordsLoading,
-      siblingRecords,
-      siblingPagination,
-      search,
-      joinModelField,
-      joinModelApiIdentifier,
-      siblingModelOptions,
-      inverseRelatedModelField,
-      fieldArray,
-    } = useHasManyThroughForm(props);
+export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
+  const [addingSibling, setAddingSibling] = useState(false);
+  const {
+    append,
+    remove,
+    joinRecords,
+    primaryLabel,
+    hasChildForm,
+    listboxId,
+    pathPrefix,
+    metaDataPathPrefix,
+    siblingModelName,
+    siblingRecordsLoading,
+    siblingRecords,
+    siblingPagination,
+    search,
+    joinModelField,
+    joinModelApiIdentifier,
+    siblingModelOptions,
+    inverseRelatedModelField,
+    fieldArray,
+  } = useHasManyThroughForm(props);
 
-    return (
-      <BlockStack gap="200">
-        <InlineGrid columns="1fr auto">
-          {props.label ?? (
-            <Text as="h2" variant="headingSm">
-              {siblingModelName}
-            </Text>
-          )}
-          <RelatedModelOptionsPopover
-            active={addingSibling}
-            activator={
-              <Button onClick={() => setAddingSibling((prev) => !prev)} disclosure>
-                Add {siblingModelName ?? "related model"}
-              </Button>
-            }
-            onClose={() => setAddingSibling(false)}
-            onScrolledToBottom={siblingPagination.loadNextPage}
-            search={
-              <RelatedModelOptionsSearch modelName={siblingModelName} value={search.value} onChange={search.set} ariaControls={listboxId} />
-            }
-            options={siblingModelOptions}
-            records={siblingRecords}
-            onSelect={(record) => {
-              inverseRelatedModelField && append({ [inverseRelatedModelField]: { ...record, _link: record.id } });
-            }}
-            isLoading={siblingRecordsLoading}
-            autoSelection={AutoSelection.None}
-            renderOption={(option) => <SiblingOption option={option} />}
-          />
-        </InlineGrid>
-
-        {joinRecords.length > 0 ? (
-          <BlockStack as="ul">
-            {joinRecords.map(([fieldKey, idx, record]) => {
-              const siblingRecord = inverseRelatedModelField && record[inverseRelatedModelField];
-
-              const siblingOption = getRecordAsOption(siblingRecord, primaryLabel, props.secondaryLabel, props.tertiaryLabel);
-
-              return (
-                <Box key={fieldKey} padding="300">
-                  <InlineGrid columns="1fr auto" gap="200" alignItems="center">
-                    <Box borderColor="border" borderWidth="025" borderRadius="200">
-                      <div style={{ display: "flex", padding: "8px" }}>
-                        <Box>
-                          <InlineStack gap="200">
-                            {renderOptionLabel(siblingOption.label, "primary")}
-                            {siblingOption?.tertiaryLabel && renderOptionLabel(siblingOption.tertiaryLabel, "tertiary")}
-                          </InlineStack>
-                          {siblingOption?.secondaryLabel && renderOptionLabel(siblingOption.secondaryLabel, "secondary")}
-                        </Box>
-                        <div style={{ marginLeft: "auto", alignSelf: "center" }}>
-                          <Button
-                            id={`deleteButton_${pathPrefix}.${idx}`}
-                            variant="tertiary"
-                            icon={XCircleIcon}
-                            onClick={() => remove(idx)}
-                          />
-                        </div>
-                      </div>
-                      {hasChildForm && (
-                        <Box borderColor="border" borderBlockStartWidth="025">
-                          <Box padding="200">
-                            <RelationshipContext.Provider
-                              value={{
-                                transformPath: (path) => `${joinModelField}.${idx}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
-                                transformMetadataPath: (path) => `${metaDataPathPrefix}.${path}`,
-                                fieldArray,
-                                hasManyThrough: { joinModelApiIdentifier, inverseRelatedModelField },
-                              }}
-                            >
-                              {props.children}
-                            </RelationshipContext.Provider>
-                          </Box>
-                        </Box>
-                      )}
-                    </Box>
-                  </InlineGrid>
-                </Box>
-              );
-            })}
-          </BlockStack>
-        ) : (
-          <Box borderColor="border" borderWidth="025" borderRadius="200">
-            <Box padding="300">
-              <InlineStack align="center">
-                <Text as="p" variant="bodyMd" tone="subdued">
-                  No {siblingModelName} yet
-                </Text>
-              </InlineStack>
-            </Box>
-          </Box>
+  return (
+    <BlockStack gap="200">
+      <InlineGrid columns="1fr auto">
+        {props.label ?? (
+          <Text as="h2" variant="headingSm">
+            {siblingModelName}
+          </Text>
         )}
-      </BlockStack>
-    );
-  }
-);
+        <RelatedModelOptionsPopover
+          active={addingSibling}
+          activator={
+            <Button onClick={() => setAddingSibling((prev) => !prev)} disclosure>
+              Add {siblingModelName ?? "related model"}
+            </Button>
+          }
+          onClose={() => setAddingSibling(false)}
+          onScrolledToBottom={siblingPagination.loadNextPage}
+          search={
+            <RelatedModelOptionsSearch modelName={siblingModelName} value={search.value} onChange={search.set} ariaControls={listboxId} />
+          }
+          options={siblingModelOptions}
+          records={siblingRecords}
+          onSelect={(record) => {
+            inverseRelatedModelField && append({ [inverseRelatedModelField]: { ...record, _link: record.id } });
+          }}
+          isLoading={siblingRecordsLoading}
+          autoSelection={AutoSelection.None}
+          renderOption={(option) => <SiblingOption option={option} />}
+        />
+      </InlineGrid>
 
-const SiblingOption = (props: { option: Option }) => {
+      {joinRecords.length > 0 ? (
+        <BlockStack as="ul">
+          {joinRecords.map(([fieldKey, idx, record]) => {
+            const siblingRecord = inverseRelatedModelField && record[inverseRelatedModelField];
+
+            const siblingOption = getRecordAsOption(siblingRecord, {
+              primary: primaryLabel,
+              secondary: props.displayRecord?.secondary,
+              tertiary: props.displayRecord?.tertiary,
+            });
+
+            return (
+              <Box key={fieldKey} padding="300">
+                <InlineGrid columns="1fr auto" gap="200" alignItems="center">
+                  <Box borderColor="border" borderWidth="025" borderRadius="200">
+                    <div style={{ display: "flex", padding: "8px" }}>
+                      <Box>
+                        <InlineStack gap="200">
+                          {renderOptionLabel(siblingOption.primary, "primary")}
+                          {siblingOption?.tertiary && renderOptionLabel(siblingOption.tertiary, "tertiary")}
+                        </InlineStack>
+                        {siblingOption?.secondary && renderOptionLabel(siblingOption.secondary, "secondary")}
+                      </Box>
+                      <div style={{ marginLeft: "auto", alignSelf: "center" }}>
+                        <Button
+                          id={`deleteButton_${pathPrefix}.${idx}`}
+                          variant="tertiary"
+                          icon={XCircleIcon}
+                          onClick={() => remove(idx)}
+                        />
+                      </div>
+                    </div>
+                    {hasChildForm && (
+                      <Box borderColor="border" borderBlockStartWidth="025">
+                        <Box padding="200">
+                          <RelationshipContext.Provider
+                            value={{
+                              transformPath: (path) => `${joinModelField}.${idx}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
+                              transformMetadataPath: (path) => `${metaDataPathPrefix}.${path}`,
+                              fieldArray,
+                              hasManyThrough: { joinModelApiIdentifier, inverseRelatedModelField },
+                            }}
+                          >
+                            {props.children}
+                          </RelationshipContext.Provider>
+                        </Box>
+                      </Box>
+                    )}
+                  </Box>
+                </InlineGrid>
+              </Box>
+            );
+          })}
+        </BlockStack>
+      ) : (
+        <Box borderColor="border" borderWidth="025" borderRadius="200">
+          <Box padding="300">
+            <InlineStack align="center">
+              <Text as="p" variant="bodyMd" tone="subdued">
+                No {siblingModelName} yet
+              </Text>
+            </InlineStack>
+          </Box>
+        </Box>
+      )}
+    </BlockStack>
+  );
+});
+
+const SiblingOption = (props: { option: DisplayedRecordOption }) => {
   const { option } = props;
 
   return (
     <Listbox.Action key={option.id} value={option.id}>
       <div style={{ display: "flex", gap: "200", width: "100%" }}>
         <BlockStack gap="050">
-          {renderOptionLabel(option.label, "primary")}
-          {option.secondaryLabel && renderOptionLabel(option.secondaryLabel, "secondary")}
+          {renderOptionLabel(option.primary, "primary")}
+          {option.secondary && renderOptionLabel(option.secondary, "secondary")}
         </BlockStack>
         <div style={{ marginLeft: "auto", alignSelf: "center" }}>
           <Icon source={PlusIcon} />

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -69,8 +69,8 @@ export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoRe
 
             const siblingOption = getRecordAsOption(siblingRecord, {
               primary: primaryLabel,
-              secondary: props.displayRecord?.secondary,
-              tertiary: props.displayRecord?.tertiary,
+              secondary: props.recordLabel?.secondary,
+              tertiary: props.recordLabel?.tertiary,
             });
 
             return (

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.tsx
@@ -4,90 +4,81 @@ import React from "react";
 import { useHasOneForm } from "../../../../useHasOneForm.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
-import type { OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { SearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
 import { renderOptionLabel } from "./utils.js";
 
-export const PolarisAutoHasOneForm = autoRelationshipForm(
-  (props: {
-    field: string;
-    children: React.ReactNode;
-    label?: React.ReactNode;
-    primaryLabel?: OptionLabel;
-    secondaryLabel?: OptionLabel;
-    tertiaryLabel?: OptionLabel;
-  }) => {
-    const hasOneForm = useHasOneForm(props);
-    const {
-      isEditing,
-      setIsEditing,
-      isCreatingRecord,
-      pathPrefix,
-      metaDataPathPrefix,
-      hasRecord,
-      recordOption,
-      relatedModelName,
-      confirmEdit,
-      removeRecord,
-    } = hasOneForm;
+export const PolarisAutoHasOneForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
+  const hasOneForm = useHasOneForm(props);
+  const {
+    isEditing,
+    setIsEditing,
+    isCreatingRecord,
+    pathPrefix,
+    metaDataPathPrefix,
+    hasRecord,
+    recordOption,
+    relatedModelName,
+    confirmEdit,
+    removeRecord,
+  } = hasOneForm;
 
-    return (
-      <>
-        <RelationshipContext.Provider
-          value={{ transformPath: (path) => pathPrefix + "." + path, transformMetadataPath: (path) => metaDataPathPrefix + "." + path }}
-        >
-          <BlockStack gap="300">
-            <InlineGrid columns="1fr auto">
-              {props.label ?? (
-                <Text as="h2" variant="headingSm">
-                  {relatedModelName}
-                </Text>
-              )}
-            </InlineGrid>
-
-            {hasRecord || isCreatingRecord ? (
-              <>
-                <Box borderColor="border" borderWidth="025" borderRadius="200">
-                  {!isEditing ? (
-                    <BlockStack as="ul">
-                      <ResourceItem id={recordOption!.id} onClick={() => setIsEditing(true)}>
-                        <InlineStack align="space-between">
-                          <BlockStack gap="200">
-                            {renderOptionLabel(recordOption!.label, "primary")}
-                            {recordOption!.secondaryLabel && renderOptionLabel(recordOption!.secondaryLabel, "secondary")}
-                          </BlockStack>
-                          {recordOption!.tertiaryLabel && renderOptionLabel(recordOption!.tertiaryLabel, "tertiary")}
-                        </InlineStack>
-                      </ResourceItem>
-                    </BlockStack>
-                  ) : (
-                    <>
-                      <Box padding="300">
-                        <BlockStack gap="300">
-                          {props.children}
-                          <InlineStack align="space-between">
-                            <Button tone="critical" onClick={removeRecord}>
-                              Remove
-                            </Button>
-                            <Button variant="primary" onClick={confirmEdit}>
-                              Confirm
-                            </Button>
-                          </InlineStack>
-                        </BlockStack>
-                      </Box>
-                    </>
-                  )}
-                </Box>
-              </>
-            ) : (
-              <EmptyFormComponent form={hasOneForm} />
+  return (
+    <>
+      <RelationshipContext.Provider
+        value={{ transformPath: (path) => pathPrefix + "." + path, transformMetadataPath: (path) => metaDataPathPrefix + "." + path }}
+      >
+        <BlockStack gap="300">
+          <InlineGrid columns="1fr auto">
+            {props.label ?? (
+              <Text as="h2" variant="headingSm">
+                {relatedModelName}
+              </Text>
             )}
-          </BlockStack>
-        </RelationshipContext.Provider>
-      </>
-    );
-  }
-);
+          </InlineGrid>
+
+          {hasRecord || isCreatingRecord ? (
+            <>
+              <Box borderColor="border" borderWidth="025" borderRadius="200">
+                {!isEditing ? (
+                  <BlockStack as="ul">
+                    <ResourceItem id={recordOption!.id} onClick={() => setIsEditing(true)}>
+                      <InlineStack align="space-between">
+                        <BlockStack gap="200">
+                          {renderOptionLabel(recordOption!.primary, "primary")}
+                          {recordOption!.secondary && renderOptionLabel(recordOption!.secondary, "secondary")}
+                        </BlockStack>
+                        {recordOption!.tertiary && renderOptionLabel(recordOption!.tertiary, "tertiary")}
+                      </InlineStack>
+                    </ResourceItem>
+                  </BlockStack>
+                ) : (
+                  <>
+                    <Box padding="300">
+                      <BlockStack gap="300">
+                        {props.children}
+                        <InlineStack align="space-between">
+                          <Button tone="critical" onClick={removeRecord}>
+                            Remove
+                          </Button>
+                          <Button variant="primary" onClick={confirmEdit}>
+                            Confirm
+                          </Button>
+                        </InlineStack>
+                      </BlockStack>
+                    </Box>
+                  </>
+                )}
+              </Box>
+            </>
+          ) : (
+            <EmptyFormComponent form={hasOneForm} />
+          )}
+        </BlockStack>
+      </RelationshipContext.Provider>
+    </>
+  );
+});
 
 /**
  * TODO - If this gets enabled fix this:

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
@@ -20,11 +20,11 @@ export const PolarisAutoHasOneInput = autoInput((props: AutoRelationshipInputPro
 
   const optionLabel = useOptionLabelForField(field, props.optionLabel);
 
-  const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, optionLabel) : null;
+  const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, { primary: optionLabel }) : null;
 
   const selectedRecordTag = selectedOption ? (
     <Tag onRemove={() => selectedRecord && onRemoveRecord(selectedRecord)} key={`selectedRecordTag_${selectedOption.id}`}>
-      <p id={`${selectedOption.id}_${selectedOption.label}`}>{selectedOption.label ?? `id: ${selectedOption.id}`}</p>
+      <p id={`${selectedOption.id}_${selectedOption.primary}`}>{selectedOption.primary ?? `id: ${selectedOption.id}`}</p>
     </Tag>
   ) : null;
 

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisListMessages.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisListMessages.tsx
@@ -1,16 +1,21 @@
 import { Listbox, Text } from "@shopify/polaris";
 import React from "react";
 import { getErrorMessage } from "../../../../utils.js";
-export const SelectableOption = (props: { label: React.ReactNode; id: string; selected: boolean }) => {
-  const { label, id, selected } = props;
 
-  return typeof label === "string" ? (
+export const SelectableOption = (props: { primary?: React.ReactNode; id: string; selected: boolean }) => {
+  const { primary, id, selected } = props;
+
+  return !primary ? (
     <Listbox.Option key={id} value={id} selected={selected}>
-      {label}
+      id: {id}
+    </Listbox.Option>
+  ) : typeof primary === "string" ? (
+    <Listbox.Option key={id} value={id} selected={selected}>
+      {primary}
     </Listbox.Option>
   ) : (
     <Listbox.Action key={id} value={id} selected={selected}>
-      {label}
+      {primary}
     </Listbox.Action>
   );
 };

--- a/packages/react/src/auto/polaris/inputs/relationships/RelatedModelOptions.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/RelatedModelOptions.tsx
@@ -2,11 +2,11 @@ import type { AutoSelection, TextFieldProps } from "@shopify/polaris";
 import { Icon, Listbox, Popover, Scrollable, TextField } from "@shopify/polaris";
 import { SearchIcon } from "@shopify/polaris-icons";
 import React from "react";
-import type { Option } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { ListMessage, NoRecordsMessage, SelectableOption, getErrorMessage } from "./PolarisListMessages.js";
 
 type RelatedModelOptionsProps = {
-  options: Option[];
+  options: DisplayedRecordOption[];
   records?: Record<string, any>[];
   isLoading?: boolean;
   errorMessage?: string;
@@ -14,7 +14,7 @@ type RelatedModelOptionsProps = {
   onSelect: (record: Record<string, any>) => void;
   autoSelection?: AutoSelection;
   actions?: React.ReactNode[];
-  renderOption?: (option: Option) => React.ReactNode;
+  renderOption?: (option: DisplayedRecordOption) => React.ReactNode;
 };
 
 export const RelatedModelOptions = (props: RelatedModelOptionsProps) => {

--- a/packages/react/src/auto/polaris/inputs/relationships/SelectedRelatedRecordTags.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/SelectedRelatedRecordTags.tsx
@@ -22,7 +22,7 @@ export const SelectedRelatedRecordTags = (props: {
 }) => {
   const { selectedRecords, optionLabel, onRemoveRecord } = props;
 
-  const options = getRecordsAsOptions(selectedRecords, optionLabel);
+  const options = getRecordsAsOptions(selectedRecords, { primary: optionLabel });
 
   return options.length
     ? options.map((option) => {
@@ -34,7 +34,7 @@ export const SelectedRelatedRecordTags = (props: {
               onRemoveRecord(record ?? { id: option.id });
             }}
           >
-            {option.label ?? `id: ${option.id}`}
+            {option.primary ?? `id: ${option.id}`}
           </Tag>
         );
       })

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoComboInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoComboInput.tsx
@@ -76,6 +76,7 @@ export const makeShadcnAutoComboInput = ({
 
     const requiredIndicator = props.metadata.requiredArgumentForInput ? <ShadcnRequired>*</ShadcnRequired> : null;
 
+    console.log("props :", props);
     useClickOutside(outsideBoxRef, () => {
       if (open) {
         setOpen(false);

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoComboInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoComboInput.tsx
@@ -76,7 +76,6 @@ export const makeShadcnAutoComboInput = ({
 
     const requiredIndicator = props.metadata.requiredArgumentForInput ? <ShadcnRequired>*</ShadcnRequired> : null;
 
-    console.log("props :", props);
     useClickOutside(outsideBoxRef, () => {
       if (open) {
         setOpen(false);

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoEnumInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoEnumInput.tsx
@@ -115,7 +115,7 @@ export const makeShadcnAutoEnumInput = ({
     return (
       <ShadcnComboInput
         {...props}
-        options={filteredOptions.map((option) => ({ id: option, label: option }))}
+        options={filteredOptions.map((option) => ({ id: option, primary: option }))}
         path={labelProp ?? label}
         metadata={metadata}
         label={labelProp ?? label}

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoJSONInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoJSONInput.tsx
@@ -31,7 +31,6 @@ export const makeShadcnAutoJSONInput = ({ Label, Textarea }: Pick<ShadcnElements
           {...getPropsWithoutRef(focusProps)}
           {...restOfProps}
           onChange={(e) => {
-            console.log(e.currentTarget.value);
             controller.onChange(e.currentTarget.value);
           }}
           id={id}

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoRolesInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoRolesInput.tsx
@@ -70,7 +70,6 @@ export const makeShadcnAutoRolesInput = ({
   });
 
   function AutoRolesInput(props: AutoRolesInputProps) {
-    const { field } = props;
     const { options, loading, rolesError, fieldError, selectedRoleKeys, fieldProps, metadata } = useRoleInputController(props);
 
     const callOnChange = useCallback(
@@ -98,7 +97,7 @@ export const makeShadcnAutoRolesInput = ({
       () =>
         options?.map((option) => ({
           id: option.value,
-          label: option.label,
+          primary: option.label,
         })) ?? [],
       [options]
     );
@@ -107,7 +106,7 @@ export const makeShadcnAutoRolesInput = ({
       () =>
         options?.map((option) => ({
           id: option.value,
-          label: option.label,
+          primary: option.label,
           value: option.value,
         })) ?? [],
       [options]

--- a/packages/react/src/auto/shadcn/inputs/relationships/RelatedModelOption.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/RelatedModelOption.tsx
@@ -40,7 +40,6 @@ export const makeRelatedModelOption = (
       () => [
         ...(actions ?? []),
         ...options.map((option) => {
-          console.log("option :", option);
           return props.renderOption ? (
             props.renderOption(option)
           ) : (

--- a/packages/react/src/auto/shadcn/inputs/relationships/RelatedModelOption.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/RelatedModelOption.tsx
@@ -1,18 +1,18 @@
 import { LoaderIcon } from "lucide-react";
 import React, { useMemo } from "react";
-import type { Option } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
 import { makeShadcnListMessages } from "./ShadcnListMessages.js";
 
 export type RelatedModelOptionsProps = {
-  options: Option[];
+  options: DisplayedRecordOption[];
   records?: Record<string, any>[];
   isLoading?: boolean;
   errorMessage?: string;
   checkSelected?: (id: string) => boolean;
   onSelect: (record: Record<string, any>) => void;
   actions?: React.ReactNode[];
-  renderOption?: (option: Option) => React.ReactNode;
+  renderOption?: (option: DisplayedRecordOption) => React.ReactNode;
   allowMultiple?: boolean;
   allowOther?: boolean;
   searchValue?: string;
@@ -40,11 +40,13 @@ export const makeRelatedModelOption = (
       () => [
         ...(actions ?? []),
         ...options.map((option) => {
+          console.log("option :", option);
           return props.renderOption ? (
             props.renderOption(option)
           ) : (
             <ShadcnSelectableOption
               {...option}
+              label={option.primary}
               selected={checkSelected?.(option.id) ?? false}
               allowMultiple={props.allowMultiple}
               onSelect={(id) => {

--- a/packages/react/src/auto/shadcn/inputs/relationships/SelectedRelatedRecordTags.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/SelectedRelatedRecordTags.tsx
@@ -12,7 +12,7 @@ export const makeSelectedRecordTags = ({ Badge, Button }: Pick<ShadcnElements, "
   }) {
     const { selectedRecords, optionLabel, onRemoveRecord } = props;
 
-    const options = getRecordsAsOptions(selectedRecords, optionLabel);
+    const options = getRecordsAsOptions(selectedRecords, { primary: optionLabel });
 
     if (!options.length) {
       return null;
@@ -24,7 +24,7 @@ export const makeSelectedRecordTags = ({ Badge, Button }: Pick<ShadcnElements, "
         {options.map((option, index) => {
           return (
             <Badge key={`option-${option.id || index}`} variant={"outline"}>
-              {option.label}
+              {option.primary}
               <Button
                 onClick={() => {
                   const record = selectedRecords.find((record) => record.id === option.id);

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToForm.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useBelongsToForm } from "../../../../useBelongsToForm.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
-import type { OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
 import { makeShadcnRenderOptionLabel } from "../../utils.js";
 import { makeSearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
@@ -71,14 +71,7 @@ export const makeShadcnAutoBelongsToForm = ({
     ScrollArea,
   });
 
-  function ShadcnAutoBelongsToForm(props: {
-    field: string;
-    children: React.ReactNode;
-
-    primaryLabel?: OptionLabel;
-    secondaryLabel?: OptionLabel;
-    tertiaryLabel?: OptionLabel;
-  }) {
+  function ShadcnAutoBelongsToForm(props: AutoRelationshipFormProps) {
     const { field } = props;
     const form = useBelongsToForm(props);
     const {
@@ -137,10 +130,10 @@ export const makeShadcnAutoBelongsToForm = ({
           {hasRecord ? (
             <div className="flex flex-col gap-2">
               <div className="flex flex-row justify-between gap-2 mt-2">
-                {renderOptionLabel(recordOption!.label, "primary")}
-                {recordOption!.tertiaryLabel && renderOptionLabel(recordOption!.tertiaryLabel, "tertiary")}
+                {renderOptionLabel(recordOption!.primary, "primary")}
+                {recordOption!.tertiary && renderOptionLabel(recordOption!.tertiary, "tertiary")}
               </div>
-              {recordOption!.secondaryLabel && renderOptionLabel(recordOption!.secondaryLabel, "secondary")}
+              {recordOption!.secondary && renderOptionLabel(recordOption!.secondary, "secondary")}
             </div>
           ) : (
             <SearchableSingleRelatedModelRecordSelector form={form} field={field} />

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToInput.tsx
@@ -62,12 +62,12 @@ export const makeShadcnAutoBelongsToInput = ({
     } = useBelongsToInputController(props);
 
     const optionLabel = useOptionLabelForField(props.field, props.optionLabel);
-    const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, optionLabel) : null;
+    const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, { primary: optionLabel }) : null;
 
     const selectedRecordTag =
       selectedOption && selectedOption.id ? (
         <Badge key={`selectedRecordTag_${selectedOption.id}`} variant={"outline"}>
-          {selectedOption.label}
+          {selectedOption.primary}
           <Button
             aria-label={`Remove`}
             onClick={(e) => {

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
@@ -36,7 +36,7 @@ export const makeShadcnAutoHasManyForm = ({
 
     const modelName = metadata.configuration.relatedModel?.name;
 
-    const primaryLabel = useOptionLabelForField(props.field, props.displayRecord?.primary);
+    const primaryLabel = useOptionLabelForField(props.field, props.recordLabel?.primary);
 
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
@@ -61,8 +61,8 @@ export const makeShadcnAutoHasManyForm = ({
 
               const option = getRecordAsOption(record, {
                 primary: primaryLabel,
-                secondary: props.displayRecord?.secondary,
-                tertiary: props.displayRecord?.tertiary,
+                secondary: props.recordLabel?.secondary,
+                tertiary: props.recordLabel?.tertiary,
               });
 
               const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
@@ -6,7 +6,7 @@ import { RelationshipContext, useAutoRelationship, useRelationshipContext } from
 import { useHasManyController } from "../../../hooks/useHasManyController.js";
 import { getRecordAsOption, useOptionLabelForField } from "../../../hooks/useRelatedModel.js";
 import { useRequiredChildComponentsValidator } from "../../../hooks/useRequiredChildComponentsValidator.js";
-import type { OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
 import { makeShadcnRenderOptionLabel } from "../../utils.js";
 
@@ -21,14 +21,7 @@ export const makeShadcnAutoHasManyForm = ({
 }: Pick<ShadcnElements, "Accordion" | "AccordionContent" | "AccordionItem" | "AccordionTrigger" | "Badge" | "Button" | "Label">) => {
   const renderOptionLabel = makeShadcnRenderOptionLabel({ Label, Badge, Button });
 
-  function ShadcnAutoHasManyForm(props: {
-    field: string;
-    label?: React.ReactNode;
-    children: React.ReactNode;
-    primaryLabel?: OptionLabel;
-    secondaryLabel?: OptionLabel;
-    tertiaryLabel?: OptionLabel;
-  }) {
+  function ShadcnAutoHasManyForm(props: AutoRelationshipFormProps) {
     useRequiredChildComponentsValidator(props, "AutoHasManyForm");
     const { metadata } = useAutoRelationship({ field: props.field });
     const { getValues } = useFormContext();
@@ -43,7 +36,7 @@ export const makeShadcnAutoHasManyForm = ({
 
     const modelName = metadata.configuration.relatedModel?.name;
 
-    const primaryLabel = useOptionLabelForField(props.field, props.primaryLabel);
+    const primaryLabel = useOptionLabelForField(props.field, props.displayRecord?.primary);
 
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
@@ -66,7 +59,11 @@ export const makeShadcnAutoHasManyForm = ({
                 return [];
               }
 
-              const option = getRecordAsOption(record, primaryLabel, props.secondaryLabel, props.tertiaryLabel);
+              const option = getRecordAsOption(record, {
+                primary: primaryLabel,
+                secondary: props.displayRecord?.secondary,
+                tertiary: props.displayRecord?.tertiary,
+              });
 
               const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;
               const metadataPathPrefix = relationshipContext?.transformMetadataPath
@@ -119,16 +116,14 @@ export const makeShadcnAutoHasManyForm = ({
                   className=""
                 >
                   <AccordionTrigger onClick={(e) => e.preventDefault()}>
-                    {option.label ? (
+                    {option.primary ? (
                       <div className="flex justify-between w-full items-center">
                         <div className="flex flex-col gap-1 items-start">
-                          {option.label && renderOptionLabel(option.label, "primary")}
-                          {option.secondaryLabel && renderOptionLabel(option.secondaryLabel, "secondary")}
+                          {renderOptionLabel(option.primary, "primary")}
+                          {option.secondary && renderOptionLabel(option.secondary, "secondary")}
                         </div>
 
-                        {option.tertiaryLabel && (
-                          <div className="flex items-center">{renderOptionLabel(option.tertiaryLabel, "tertiary")}</div>
-                        )}
+                        {option.tertiary && <div className="flex items-center">{renderOptionLabel(option.tertiary, "tertiary")}</div>}
                       </div>
                     ) : (
                       <Label>Click to edit...</Label>

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
@@ -4,7 +4,7 @@ import { useFormContext } from "../../../../useActionForm.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext, useAutoRelationship, useRelationshipContext } from "../../../hooks/useAutoRelationship.js";
 import { useHasManyController } from "../../../hooks/useHasManyController.js";
-import { getRecordAsOption, useOptionLabelForField } from "../../../hooks/useRelatedModel.js";
+import { getRecordAsOption, useRecordLabelObjectFromProps } from "../../../hooks/useRelatedModel.js";
 import { useRequiredChildComponentsValidator } from "../../../hooks/useRequiredChildComponentsValidator.js";
 import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
@@ -36,7 +36,7 @@ export const makeShadcnAutoHasManyForm = ({
 
     const modelName = metadata.configuration.relatedModel?.name;
 
-    const primaryLabel = useOptionLabelForField(props.field, props.recordLabel?.primary);
+    const recordLabel = useRecordLabelObjectFromProps(props);
 
     const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
@@ -59,11 +59,7 @@ export const makeShadcnAutoHasManyForm = ({
                 return [];
               }
 
-              const option = getRecordAsOption(record, {
-                primary: primaryLabel,
-                secondary: props.recordLabel?.secondary,
-                tertiary: props.recordLabel?.tertiary,
-              });
+              const option = getRecordAsOption(record, recordLabel);
 
               const pathPrefix = relationshipContext?.transformPath ? relationshipContext.transformPath(props.field) : props.field;
               const metadataPathPrefix = relationshipContext?.transformMetadataPath

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -87,10 +87,10 @@ export const makeShadcnAutoHasManyThroughForm = ({
       remove,
       joinRecords,
       metadata,
-      primaryLabel,
       listboxId,
       pathPrefix,
       metaDataPathPrefix,
+      recordLabel,
       siblingModelName,
       siblingRecordsLoading,
       siblingRecords,
@@ -168,9 +168,9 @@ export const makeShadcnAutoHasManyThroughForm = ({
               const siblingRecord = inverseRelatedModelField && record[inverseRelatedModelField];
 
               const siblingOption = getRecordAsOption(siblingRecord, {
-                primary: primaryLabel,
-                secondary: props.recordLabel?.secondary,
-                tertiary: props.recordLabel?.tertiary,
+                primary: recordLabel.primary,
+                secondary: recordLabel.secondary,
+                tertiary: recordLabel.tertiary,
               });
 
               return (

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -169,8 +169,8 @@ export const makeShadcnAutoHasManyThroughForm = ({
 
               const siblingOption = getRecordAsOption(siblingRecord, {
                 primary: primaryLabel,
-                secondary: props.displayRecord?.secondary,
-                tertiary: props.displayRecord?.tertiary,
+                secondary: props.recordLabel?.secondary,
+                tertiary: props.recordLabel?.tertiary,
               });
 
               return (

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -88,7 +88,6 @@ export const makeShadcnAutoHasManyThroughForm = ({
       joinRecords,
       metadata,
       primaryLabel,
-      hasChildForm,
       listboxId,
       pathPrefix,
       metaDataPathPrefix,
@@ -198,7 +197,7 @@ export const makeShadcnAutoHasManyThroughForm = ({
                         </Button>
                       </div>
                     </div>
-                    {hasChildForm && (
+                    {props.children && (
                       <div
                         className="flex-1 p-2 border-t border-gray-300"
                         onClick={(e) => {

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -5,7 +5,7 @@ import { debounce } from "../../../../utils.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
 import { getRecordAsOption } from "../../../hooks/useRelatedModel.js";
-import type { Option, OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps, DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
 import { makeShadcnRenderOptionLabel } from "../../utils.js";
 import { makeShadcnAutoComboInput } from "../ShadcnAutoComboInput.js";
@@ -59,7 +59,7 @@ export const makeShadcnAutoHasManyThroughForm = ({
 
   const renderOptionLabel = makeShadcnRenderOptionLabel({ Label, Badge, Button });
 
-  const SiblingOption = (props: { option: Option; onSelect: (option: Option) => void }) => {
+  const SiblingOption = (props: { option: DisplayedRecordOption; onSelect: (option: DisplayedRecordOption) => void }) => {
     const { option, onSelect } = props;
 
     return (
@@ -70,8 +70,8 @@ export const makeShadcnAutoHasManyThroughForm = ({
       >
         <div className="flex justify-between items-center w-full">
           <div className="flex flex-row items-center gap-2">
-            {renderOptionLabel(option.label, "primary")}
-            {option.secondaryLabel && renderOptionLabel(option.secondaryLabel, "secondary")}
+            {renderOptionLabel(option.primary, "primary")}
+            {option.secondary && renderOptionLabel(option.secondary, "secondary")}
           </div>
           <PlusIcon className="w-4 h-4 shrink-0" />
         </div>
@@ -79,14 +79,7 @@ export const makeShadcnAutoHasManyThroughForm = ({
     );
   };
 
-  function ShadcnAutoHasManyThroughForm(props: {
-    field: string;
-    label?: React.ReactNode;
-    children: React.ReactNode;
-    primaryLabel?: OptionLabel;
-    secondaryLabel?: OptionLabel;
-    tertiaryLabel?: OptionLabel;
-  }) {
+  function ShadcnAutoHasManyThroughForm(props: AutoRelationshipFormProps) {
     const [open, setOpen] = useState(false);
     const {
       field,
@@ -175,7 +168,11 @@ export const makeShadcnAutoHasManyThroughForm = ({
             {joinRecords.map(([fieldKey, idx, record]) => {
               const siblingRecord = inverseRelatedModelField && record[inverseRelatedModelField];
 
-              const siblingOption = getRecordAsOption(siblingRecord, primaryLabel, props.secondaryLabel, props.tertiaryLabel);
+              const siblingOption = getRecordAsOption(siblingRecord, {
+                primary: primaryLabel,
+                secondary: props.displayRecord?.secondary,
+                tertiary: props.displayRecord?.tertiary,
+              });
 
               return (
                 <div className="flex items-center w-full border border-gray-300 rounded-md " key={fieldKey}>
@@ -184,10 +181,10 @@ export const makeShadcnAutoHasManyThroughForm = ({
                       <div className="flex justify-between items-center w-full">
                         <div className="flex flex-col gap-1">
                           <div className="flex items-center gap-2">
-                            {renderOptionLabel(siblingOption.label, "primary")}
-                            {siblingOption?.tertiaryLabel && renderOptionLabel(siblingOption.tertiaryLabel, "tertiary")}
+                            {renderOptionLabel(siblingOption.primary, "primary")}
+                            {siblingOption?.tertiary && renderOptionLabel(siblingOption.tertiary, "tertiary")}
                           </div>
-                          {siblingOption?.secondaryLabel && renderOptionLabel(siblingOption.secondaryLabel, "secondary")}
+                          {siblingOption?.secondary && renderOptionLabel(siblingOption.secondary, "secondary")}
                         </div>
                         <Button
                           id={`deleteButton_${pathPrefix}.${idx}`}

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from "react";
 import { useHasOneForm } from "../../../../useHasOneForm.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
-import type { OptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
 import { makeShadcnRenderOptionLabel } from "../../utils.js";
 import { makeSearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
@@ -57,13 +57,7 @@ export const makeShadcnAutoHasOneForm = ({
     ScrollArea,
   });
 
-  function ShadcnHasOneForm(props: {
-    field: string;
-    children: React.ReactNode;
-    primaryLabel?: OptionLabel;
-    secondaryLabel?: OptionLabel;
-    tertiaryLabel?: OptionLabel;
-  }) {
+  function ShadcnHasOneForm(props: AutoRelationshipFormProps) {
     const { field } = props;
     const form = useHasOneForm(props);
     const {
@@ -118,12 +112,12 @@ export const makeShadcnAutoHasOneForm = ({
                   >
                     <div className="flex justify-between w-full items-center">
                       <div className="flex flex-col gap-1 items-start">
-                        {recordOption?.label && renderOptionLabel(recordOption?.label, "primary")}
-                        {recordOption?.secondaryLabel && renderOptionLabel(recordOption?.secondaryLabel, "secondary")}
+                        {recordOption?.primary && renderOptionLabel(recordOption?.primary, "primary")}
+                        {recordOption?.secondary && renderOptionLabel(recordOption?.secondary, "secondary")}
                       </div>
 
-                      {recordOption?.tertiaryLabel && (
-                        <div className="flex items-center">{renderOptionLabel(recordOption?.tertiaryLabel, "tertiary")}</div>
+                      {recordOption?.tertiary && (
+                        <div className="flex items-center">{renderOptionLabel(recordOption?.tertiary, "tertiary")}</div>
                       )}
                     </div>
                   </AccordionTrigger>

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneInput.tsx
@@ -63,11 +63,11 @@ export const makeShadcnAutoHasOneInput = ({
 
     const optionLabel = useOptionLabelForField(field, props.optionLabel);
 
-    const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, optionLabel) : null;
+    const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, { primary: optionLabel }) : null;
 
     const selectedRecordTag = selectedOption ? (
       <Badge variant={"outline"} key={`selectedRecordTag_${selectedOption.id}`}>
-        <p id={`${selectedOption.id}_${selectedOption.label}`}>{selectedOption.label ?? `id: ${selectedOption.id}`}</p>
+        <p id={`${selectedOption.id}_${selectedOption.primary}`}>{selectedOption.primary ?? `id: ${selectedOption.id}`}</p>
         <Button
           aria-label={`Remove`}
           onClick={(e) => {

--- a/packages/react/src/use-table/helpers.tsx
+++ b/packages/react/src/use-table/helpers.tsx
@@ -327,7 +327,7 @@ const isHasManyOrHasManyThroughField = (field: { fieldType: GadgetFieldType }) =
   return isHasManyField(field) || isHasManyThroughField(field);
 };
 
-const isRelationshipField = (field: { fieldType: GadgetFieldType }) => {
+export const isRelationshipField = (field: { fieldType: GadgetFieldType }) => {
   return isHasOneOrBelongsToField(field) || isHasManyOrHasManyThroughField(field);
 };
 

--- a/packages/react/src/useBelongsToForm.ts
+++ b/packages/react/src/useBelongsToForm.ts
@@ -1,15 +1,9 @@
 import { useBelongsToController } from "./auto/hooks/useBelongsToController.js";
 import { useRequiredChildComponentsValidator } from "./auto/hooks/useRequiredChildComponentsValidator.js";
-import type { OptionLabel } from "./auto/interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "./auto/interfaces/AutoRelationshipInputProps.js";
 import { useSingleRelatedRecordRelationshipForm } from "./useSingleRelatedRecordRelationshipForm.js";
 
-export const useBelongsToForm = (props: {
-  field: string;
-  children: React.ReactNode;
-  primaryLabel?: OptionLabel;
-  secondaryLabel?: OptionLabel;
-  tertiaryLabel?: OptionLabel;
-}) => {
+export const useBelongsToForm = (props: AutoRelationshipFormProps) => {
   useRequiredChildComponentsValidator(props, "AutoBelongsToForm");
   const { record, relatedModelOptions } = useBelongsToController(props);
 

--- a/packages/react/src/useHasManyThroughForm.ts
+++ b/packages/react/src/useHasManyThroughForm.ts
@@ -4,17 +4,10 @@ import { extractPathsFromChildren } from "./auto/AutoForm.js";
 import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
 import { useHasManyThroughController } from "./auto/hooks/useHasManyThroughController.js";
 import { useOptionLabelForField } from "./auto/hooks/useRelatedModel.js";
-import type { OptionLabel } from "./auto/interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "./auto/interfaces/AutoRelationshipInputProps.js";
 import { useFormContext } from "./useActionForm.js";
 
-export const useHasManyThroughForm = (props: {
-  field: string;
-  label?: React.ReactNode;
-  children: React.ReactNode;
-  primaryLabel?: OptionLabel;
-  secondaryLabel?: OptionLabel;
-  tertiaryLabel?: OptionLabel;
-}) => {
+export const useHasManyThroughForm = (props: AutoRelationshipFormProps) => {
   const { field, children } = props;
   const { metadata } = useAutoRelationship({ field });
   const { setValue } = useFormContext();
@@ -71,7 +64,7 @@ export const useHasManyThroughForm = (props: {
     });
   }, [fields, records]);
 
-  const primaryLabel = useOptionLabelForField(field, props.primaryLabel);
+  const primaryLabel = useOptionLabelForField(field, props.displayRecord?.primary);
 
   return {
     fields,

--- a/packages/react/src/useHasManyThroughForm.ts
+++ b/packages/react/src/useHasManyThroughForm.ts
@@ -1,6 +1,5 @@
 import { assert } from "@gadgetinc/api-client-core";
 import { useEffect, useMemo } from "react";
-import { extractPathsFromChildren } from "./auto/AutoForm.js";
 import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
 import { useHasManyThroughController } from "./auto/hooks/useHasManyThroughController.js";
 import { useOptionLabelForField } from "./auto/hooks/useRelatedModel.js";
@@ -11,8 +10,6 @@ export const useHasManyThroughForm = (props: AutoRelationshipFormProps) => {
   const { field, children } = props;
   const { metadata } = useAutoRelationship({ field });
   const { setValue } = useFormContext();
-  const childPaths = children && extractPathsFromChildren(children);
-  const hasChildForm = childPaths && childPaths.length > 0;
 
   const { fieldArrayPath, fieldArray, records, relatedModelOptions, inverseRelatedModelField, joinModelField, joinModelApiIdentifier } =
     useHasManyThroughController(props);
@@ -72,8 +69,6 @@ export const useHasManyThroughForm = (props: AutoRelationshipFormProps) => {
     remove,
     joinRecords,
     primaryLabel,
-    hasChildForm,
-    childPaths,
     listboxId,
     pathPrefix,
     metaDataPathPrefix,

--- a/packages/react/src/useHasManyThroughForm.ts
+++ b/packages/react/src/useHasManyThroughForm.ts
@@ -2,7 +2,7 @@ import { assert } from "@gadgetinc/api-client-core";
 import { useEffect, useMemo } from "react";
 import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
 import { useHasManyThroughController } from "./auto/hooks/useHasManyThroughController.js";
-import { useOptionLabelForField } from "./auto/hooks/useRelatedModel.js";
+import { useRecordLabelObjectFromProps } from "./auto/hooks/useRelatedModel.js";
 import type { AutoRelationshipFormProps } from "./auto/interfaces/AutoRelationshipInputProps.js";
 import { useFormContext } from "./useActionForm.js";
 
@@ -61,17 +61,17 @@ export const useHasManyThroughForm = (props: AutoRelationshipFormProps) => {
     });
   }, [fields, records]);
 
-  const primaryLabel = useOptionLabelForField(field, props.recordLabel?.primary);
+  const recordLabel = useRecordLabelObjectFromProps(props);
 
   return {
     fields,
     append,
     remove,
     joinRecords,
-    primaryLabel,
     listboxId,
     pathPrefix,
     metaDataPathPrefix,
+    recordLabel,
     siblingModelName,
     siblingRecordsLoading,
     siblingRecords,

--- a/packages/react/src/useHasManyThroughForm.ts
+++ b/packages/react/src/useHasManyThroughForm.ts
@@ -61,7 +61,7 @@ export const useHasManyThroughForm = (props: AutoRelationshipFormProps) => {
     });
   }, [fields, records]);
 
-  const primaryLabel = useOptionLabelForField(field, props.displayRecord?.primary);
+  const primaryLabel = useOptionLabelForField(field, props.recordLabel?.primary);
 
   return {
     fields,

--- a/packages/react/src/useHasOneForm.ts
+++ b/packages/react/src/useHasOneForm.ts
@@ -2,16 +2,10 @@ import { useCallback, useMemo } from "react";
 import { useAutoFormMetadata } from "./auto/AutoFormContext.js";
 import { useHasOneController } from "./auto/hooks/useHasOneController.js";
 import { useRequiredChildComponentsValidator } from "./auto/hooks/useRequiredChildComponentsValidator.js";
-import type { OptionLabel } from "./auto/interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "./auto/interfaces/AutoRelationshipInputProps.js";
 import { useSingleRelatedRecordRelationshipForm } from "./useSingleRelatedRecordRelationshipForm.js";
 
-export const useHasOneForm = (props: {
-  field: string;
-  children: React.ReactNode;
-  primaryLabel?: OptionLabel;
-  secondaryLabel?: OptionLabel;
-  tertiaryLabel?: OptionLabel;
-}) => {
+export const useHasOneForm = (props: AutoRelationshipFormProps) => {
   useRequiredChildComponentsValidator(props, "AutoHasOneForm");
   const { record, relatedModelOptions } = useHasOneController(props);
 

--- a/packages/react/src/useSingleRelatedRecordRelationshipForm.ts
+++ b/packages/react/src/useSingleRelatedRecordRelationshipForm.ts
@@ -52,13 +52,13 @@ export const useSingleRelatedRecordRelationshipForm = (
     }
   }, [record, defaultRecordId, path, setValue, submitCount, isSubmitSuccessful]);
 
-  const primaryLabel = useOptionLabelForField(props.field, props.displayRecord?.primary);
+  const primaryLabel = useOptionLabelForField(props.field, props.recordLabel?.primary);
 
   const recordOption = record
     ? getRecordAsOption(record, {
         primary: primaryLabel,
-        secondary: props.displayRecord?.secondary,
-        tertiary: props.displayRecord?.tertiary,
+        secondary: props.recordLabel?.secondary,
+        tertiary: props.recordLabel?.tertiary,
       })
     : null;
   const relatedModelName = metadata.name ?? "Unknown";

--- a/packages/react/src/useSingleRelatedRecordRelationshipForm.ts
+++ b/packages/react/src/useSingleRelatedRecordRelationshipForm.ts
@@ -1,21 +1,18 @@
 import { useEffect, useState } from "react";
 import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
 import { getRecordAsOption, useOptionLabelForField, type useRelatedModelOptions } from "./auto/hooks/useRelatedModel.js";
-import type { OptionLabel } from "./auto/interfaces/AutoRelationshipInputProps.js";
+import type { AutoRelationshipFormProps } from "./auto/interfaces/AutoRelationshipInputProps.js";
 import { useFormContext } from "./useActionForm.js";
 import { get } from "./utils.js";
 
-export const useSingleRelatedRecordRelationshipForm = (props: {
-  field: string;
-  children: React.ReactNode;
-  primaryLabel?: OptionLabel;
-  secondaryLabel?: OptionLabel;
-  tertiaryLabel?: OptionLabel;
-  relationshipController: {
-    record: Record<string, any> | undefined;
-    relatedModelOptions: ReturnType<typeof useRelatedModelOptions>;
-  };
-}) => {
+export const useSingleRelatedRecordRelationshipForm = (
+  props: AutoRelationshipFormProps & {
+    relationshipController: {
+      record: Record<string, any> | undefined;
+      relatedModelOptions: ReturnType<typeof useRelatedModelOptions>;
+    };
+  }
+) => {
   const {
     field,
     relationshipController: { record, relatedModelOptions },
@@ -55,9 +52,15 @@ export const useSingleRelatedRecordRelationshipForm = (props: {
     }
   }, [record, defaultRecordId, path, setValue, submitCount, isSubmitSuccessful]);
 
-  const primaryLabel = useOptionLabelForField(props.field, props.primaryLabel);
+  const primaryLabel = useOptionLabelForField(props.field, props.displayRecord?.primary);
 
-  const recordOption = record ? getRecordAsOption(record, primaryLabel, props.secondaryLabel, props.tertiaryLabel) : null;
+  const recordOption = record
+    ? getRecordAsOption(record, {
+        primary: primaryLabel,
+        secondary: props.displayRecord?.secondary,
+        tertiary: props.displayRecord?.tertiary,
+      })
+    : null;
   const relatedModelName = metadata.name ?? "Unknown";
 
   return {
@@ -71,7 +74,6 @@ export const useSingleRelatedRecordRelationshipForm = (props: {
     pagination,
     path,
     pathPrefix,
-    primaryLabel,
     record,
     recordOption,
     records,
@@ -80,11 +82,9 @@ export const useSingleRelatedRecordRelationshipForm = (props: {
     search,
     searchFilterOptions,
     searchOpen,
-    secondaryLabel: props.secondaryLabel,
     setActionsOpen,
     setIsEditing,
     setSearchOpen,
     setValue,
-    tertiaryLabel: props.tertiaryLabel,
   };
 };

--- a/packages/react/src/useSingleRelatedRecordRelationshipForm.ts
+++ b/packages/react/src/useSingleRelatedRecordRelationshipForm.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
-import { getRecordAsOption, useOptionLabelForField, type useRelatedModelOptions } from "./auto/hooks/useRelatedModel.js";
+import { getRecordAsOption, useRecordLabelObjectFromProps, type useRelatedModelOptions } from "./auto/hooks/useRelatedModel.js";
 import type { AutoRelationshipFormProps } from "./auto/interfaces/AutoRelationshipInputProps.js";
 import { useFormContext } from "./useActionForm.js";
 import { get } from "./utils.js";
@@ -52,15 +52,9 @@ export const useSingleRelatedRecordRelationshipForm = (
     }
   }, [record, defaultRecordId, path, setValue, submitCount, isSubmitSuccessful]);
 
-  const primaryLabel = useOptionLabelForField(props.field, props.recordLabel?.primary);
+  const recordLabel = useRecordLabelObjectFromProps(props);
+  const recordOption = record ? getRecordAsOption(record, recordLabel) : null;
 
-  const recordOption = record
-    ? getRecordAsOption(record, {
-        primary: primaryLabel,
-        secondary: props.recordLabel?.secondary,
-        tertiary: props.recordLabel?.tertiary,
-      })
-    : null;
   const relatedModelName = metadata.name ?? "Unknown";
 
   return {


### PR DESCRIPTION
 - UPDATE
   - After consulting design, we will replace the old `primaryLabel`, `secondaryLabel`, and `ternaryLabel` with a new prop called `displayRecord:{primary, secondary, ternary}`
   - The `selectPaths` prop has been removed in favour of inferring the used fields directly from the field name strings used in the `displayRecord` object. 
     - If a callback function is used, we will then try to smartly select fields on the related model
       - This matches the behaviour of `AutoTable` when we have a custom column configuration. If the given columns are based on field names, we use those directly. If a single callback for a custom cell renderer is detected, then we expand the selection to include all non-relationship fields 