### PR TITLE
Fix type error for global actions in AutoForm

### DIFF
--- a/packages/react/spec/auto/AutoComponentsApiClientTypeChecker.tsx
+++ b/packages/react/spec/auto/AutoComponentsApiClientTypeChecker.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { PolarisAutoForm } from "../../src/auto/polaris/PolarisAutoForm.js";
+import { PolarisAutoTable } from "../../src/auto/polaris/PolarisAutoTable.js";
+import { makeAutocomponents } from "../../src/auto/shadcn/unreleasedIndex.js";
+import { testApi } from "../apis.js";
+import { elements } from "./shadcn-defaults/index.js";
+
+const { AutoForm: ShadcnAutoForm, AutoTable: ShadcnAutoTable } = makeAutocomponents(elements);
+
+/**
+ * If the api client breaks the expected types of the auto components, this file will fail in CI on `pnpm typecheck`
+ */
+export const AutoComponentsApiClientTypeChecker = () => {
+  return (
+    <>
+      {/* AutoForm - Create actions */}
+      <PolarisAutoForm action={testApi.widget.create} />
+      <ShadcnAutoForm action={testApi.widget.create} />
+
+      {/* AutoForm - Update actions */}
+      <PolarisAutoForm action={testApi.widget.update} />
+      <ShadcnAutoForm action={testApi.widget.update} />
+
+      {/* AutoForm - Upsert actions */}
+      <PolarisAutoForm action={testApi.widget.upsert} />
+      <ShadcnAutoForm action={testApi.widget.upsert} />
+
+      {/* AutoForm - Delete actions */}
+      <PolarisAutoForm action={testApi.widget.delete} />
+      <ShadcnAutoForm action={testApi.widget.delete} />
+
+      {/* AutoForm - Custom actions */}
+      <PolarisAutoForm action={testApi.widget.addInventory} />
+      <ShadcnAutoForm action={testApi.widget.addInventory} />
+
+      {/* AutoForm - Global actions */}
+      <ShadcnAutoForm action={testApi.flipAll} defaultValues={{ inventoryCount: 123 }} />
+      <PolarisAutoForm action={testApi.flipAll} defaultValues={{ inventoryCount: 123 }} />
+
+      {/* AutoTable */}
+      <PolarisAutoTable model={testApi.widget} />
+      <ShadcnAutoTable model={testApi.widget} />
+    </>
+  );
+};

--- a/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
@@ -194,6 +194,7 @@ export const Namespaced = {
 export const GlobalAction = {
   args: {
     action: api.flipAll,
+    defaultValues: { title: "From defaultValue prop" },
   },
 };
 

--- a/packages/react/spec/auto/shadcn-defaults/ShadcnAutoForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/ShadcnAutoForm.stories.jsx
@@ -187,6 +187,7 @@ export const Namespaced = {
 export const GlobalAction = {
   args: {
     action: api.flipAll,
+    defaultValues: { title: "From defaultValue prop" },
   },
 };
 

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -8,7 +8,7 @@ import { FieldType, buildAutoFormFieldList, isModelActionMetadata, useActionMeta
 import type { AnyActionWithId, RecordIdentifier, UseActionFormHookStateData, UseActionFormSubmit } from "../use-action-form/types.js";
 import { isPlainObject, processDefaultValues } from "../use-action-form/utils.js";
 import { pathListToSelection } from "../use-table/helpers.js";
-import type { FieldErrors, FieldValues, UseFormReturn } from "../useActionForm.js";
+import type { FieldErrors, UseFormReturn } from "../useActionForm.js";
 import { useActionForm } from "../useActionForm.js";
 import { get, getFlattenedObjectKeys, type ErrorWrapper, type OptionsType } from "../utils.js";
 import { validationSchema } from "../validationSchema.js";
@@ -41,9 +41,7 @@ type AutoFormPropsWithChildren = {
 export type AutoFormProps<
   GivenOptions extends OptionsType,
   SchemaT,
-  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>,
-  ExtraFormVariables extends FieldValues = Record<string, unknown>,
-  DefaultValues = ActionFunc["variablesType"] & ExtraFormVariables
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
 > = (AutoFormPropsWithChildren | AutoFormPropsWithoutChildren) & {
   /** Which action this fom will run on submit */
   action: ActionFunc;
@@ -54,7 +52,7 @@ export type AutoFormProps<
   /** A denylist of fields to render within the form. Every field except these fields will be rendered as inputs. */
   exclude?: string[];
   /** A set of field values to pre-populate the form with on load. Only applies to create forms. */
-  defaultValues?: DefaultValues;
+  defaultValues?: ActionFunc["variablesType"];
   /** What to show the user once the form has been submitted successfully */
   successContent?: ReactNode;
   /** Selection object to pass to the form to retrieve existing values. This will override the default selection based on included fields */
@@ -210,7 +208,7 @@ export const useAutoForm = <
   SchemaT,
   ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
 >(
-  props: AutoFormProps<GivenOptions, SchemaT, ActionFunc, any, any>
+  props: AutoFormProps<GivenOptions, SchemaT, ActionFunc>
 ): {
   select?: GivenOptions["select"];
   metadata: ModelWithOneActionMetadata | GlobalActionMetadata | undefined;

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -1,4 +1,4 @@
-import type { ActionFunction } from "@gadgetinc/api-client-core";
+import type { ActionFunction, GlobalActionFunction } from "@gadgetinc/api-client-core";
 import type { FormProps } from "@shopify/polaris";
 import { BlockStack, Form, FormLayout, SkeletonBodyText, SkeletonDisplayText, Text } from "@shopify/polaris";
 import React from "react";
@@ -27,7 +27,7 @@ export const PolarisAutoFormSkeleton = () => (
 export const PolarisAutoForm = <
   GivenOptions extends OptionsType,
   SchemaT,
-  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
 >(
   props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> &
     // polaris form props also take an 'action' property, which we override with the Gadget form action
@@ -38,7 +38,9 @@ export const PolarisAutoForm = <
   validateAutoFormProps(props);
 
   // Component key to force re-render when the action or findBy changes
-  const componentKey = `${action.modelApiIdentifier ?? ""}.${action.operationName}.${JSON.stringify(findBy)}`;
+  const componentKey = `${"modelApiIdentifier" in action ? `${action.modelApiIdentifier}.` : ""}${action.operationName}.${JSON.stringify(
+    findBy
+  )}`;
 
   return (
     <AutoFormFieldsFromChildComponentsProvider hasCustomFormChildren={React.Children.count(props.children) > 0}>
@@ -53,7 +55,7 @@ export const PolarisAutoForm = <
 const PolarisAutoFormComponent = <
   GivenOptions extends OptionsType,
   SchemaT,
-  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
 >(
   //polaris form props also take an 'action' property, which we need to omit here.
   props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<Partial<FormProps>, "action">
@@ -95,7 +97,7 @@ const PolarisAutoFormComponent = <
       isSubmitting,
     },
     model: {
-      apiIdentifier: action.modelApiIdentifier,
+      apiIdentifier: "modelApiIdentifier" in action ? action.modelApiIdentifier : undefined,
       namespace: action.namespace,
     },
     fields,

--- a/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
@@ -1,4 +1,4 @@
-import type { ActionFunction } from "@gadgetinc/api-client-core";
+import type { ActionFunction, GlobalActionFunction } from "@gadgetinc/api-client-core";
 import type { ComponentProps } from "react";
 import React, { forwardRef } from "react";
 import { FormProvider } from "../../useActionForm.js";
@@ -50,14 +50,18 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
     return <form ref={ref} noValidate className={cn("space-y-6", className)} {...props} />;
   });
 
-  function AutoForm<GivenOptions extends OptionsType, SchemaT, ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>>(
-    props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<ComponentProps<typeof FormContainer>, "action">
-  ) {
+  function AutoForm<
+    GivenOptions extends OptionsType,
+    SchemaT,
+    ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
+  >(props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<ComponentProps<typeof FormContainer>, "action">) {
     const { action, findBy } = props;
     validateAutoFormProps(props);
 
     // Component key to force re-render when the action or findBy changes
-    const componentKey = `${action.modelApiIdentifier ?? ""}.${action.operationName}.${JSON.stringify(findBy)}`;
+    const componentKey = `${"modelApiIdentifier" in action ? `${action.modelApiIdentifier}.` : ""}${action.operationName}.${JSON.stringify(
+      findBy
+    )}`;
 
     return (
       <AutoFormFieldsFromChildComponentsProvider hasCustomFormChildren={React.Children.count(props.children) > 0}>
@@ -69,7 +73,7 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
   function AutoFormInner<
     GivenOptions extends OptionsType,
     SchemaT,
-    ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any>
+    ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
   >(props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<ComponentProps<typeof FormContainer>, "action">) {
     const { record: _record, action, findBy, ...rest } = props;
 
@@ -110,7 +114,7 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
         isSubmitting,
       },
       model: {
-        apiIdentifier: action.modelApiIdentifier,
+        apiIdentifier: "modelApiIdentifier" in action ? action.modelApiIdentifier : undefined,
         namespace: action.namespace,
       },
       fields,

--- a/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
@@ -54,7 +54,7 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
     GivenOptions extends OptionsType,
     SchemaT,
     ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
-  >(props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<ComponentProps<typeof FormContainer>, "action">) {
+  >(props: AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<ComponentProps<typeof FormContainer>, "action" | "defaultValue">) {
     const { action, findBy } = props;
     validateAutoFormProps(props);
 


### PR DESCRIPTION
- UPDATE
  - Global actions caused type errors when used in `AutoForm`. This was not a problem in older versions, and I'm not certain what caused this.
  - The types for `AutoForm` components have been updated to account for Global actions.
  - The `AutoFormProps` type has been simplified to remove the last 2 type arguments. 
    - They did not contribute anything that could not be inferred from the other type args
    - They resulted in the `defaultValues` type being `Record<string, unknown>` instead of the real type from the API client