### PR TITLE
Fix `AutoHasManyThroughInput` usage of `optionLabel` in dropdown

### DIFF
--- a/packages/react/src/auto/hooks/useHasManyThroughController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyThroughController.tsx
@@ -53,7 +53,10 @@ export const useHasManyThroughController = (props: Omit<AutoRelationshipFormProp
 };
 
 export const useHasManyThroughInputController = (props: AutoRelationshipInputProps) => {
-  const { fieldMetadata, fieldArray, records, relatedModelOptions, inverseRelatedModelField } = useHasManyThroughController(props);
+  const { fieldMetadata, fieldArray, records, relatedModelOptions, inverseRelatedModelField } = useHasManyThroughController({
+    field: props.field,
+    recordLabel: props.optionLabel,
+  });
 
   const { relatedModel } = relatedModelOptions;
   const { remove, append } = fieldArray;


### PR DESCRIPTION
- UPDATE
  - Previously, the dropdown for HMT fields did not respect the given `optionLabel` prop at all. 
  - It simply needed to reshape the props such that the `input` controller was compatible with the `form` controller, which is responsible for making the related model options 