### PR TITLE
Fix jumpiness in AutoRelationshipInput related model records dropdowns when paginating

### DIFF
--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -232,7 +232,7 @@ const useAllRelatedModelRecords = (props: {
     ];
 
     const updatedUniqueOptions = uniqByProperty(allOptions, "id");
-    const sortedUniqueOptions = sortByProperty(updatedUniqueOptions, "id");
+    const sortedUniqueOptions = sortByProperty(updatedUniqueOptions, "id", { transform: (value: any) => parseInt(value) });
 
     setLoadedRecords(sortedUniqueOptions);
   }, [paginationPage, searchValue, fetching]);

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisListMessages.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisListMessages.tsx
@@ -7,7 +7,7 @@ export const SelectableOption = (props: { primary?: React.ReactNode; id: string;
 
   return !primary ? (
     <Listbox.Option key={id} value={id} selected={selected}>
-      id: {id}
+      {`id: ${id}`}
     </Listbox.Option>
   ) : typeof primary === "string" ? (
     <Listbox.Option key={id} value={id} selected={selected}>

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -479,12 +479,17 @@ export const getModelManager = (
 };
 
 type SortOrder = "asc" | "desc";
-export const sortByProperty = <T>(arr: T[], property: keyof T, order: SortOrder = "asc"): T[] => {
+export const sortByProperty = <T>(arr: T[], property: keyof T, options?: { order?: SortOrder; transform?: (value: any) => any }): T[] => {
+  const { order = "asc", transform } = options ?? {};
+
   return arr.sort((a, b) => {
-    if (a[property] < b[property]) {
+    const aValue = transform ? transform(a[property]) : a[property];
+    const bValue = transform ? transform(b[property]) : b[property];
+
+    if (aValue < bValue) {
       return order === "asc" ? -1 : 1;
     }
-    if (a[property] > b[property]) {
+    if (aValue > bValue) {
       return order === "asc" ? 1 : -1;
     }
     return 0;


### PR DESCRIPTION
- **UPDATE**
  - Previously, scrolling in the related model record drop down was jumpy. It did not always feel like a smooth scroll like it did in the gizmo hasMany records drop down in storybook
  - this issue was caused by the fact that the records are sorted by ID, however, they are sorted by ID as strings instead of as numbers. 
    - eg. `1,10,11,12,13,14,15,16,17,18,19,   2,20,21,22.....`
    - this was probably never noticed because this behaviour was generally tested in the gizmos has many field on the widget model, and all records in the gizmo model have IDs greater than 1000. This is an issue that is more appearance when the model records start at 1
  - Now, the ID strings are converted to number before they are sorted. You can now observe smooth scrolling in all of the auto relationship input components when paginating