### PR TITLE
Loosen type of AutoForm `defaultValues` prop

### DIFF
--- a/packages/react/spec/auto/AutoComponentsApiClientTypeChecker.tsx
+++ b/packages/react/spec/auto/AutoComponentsApiClientTypeChecker.tsx
@@ -14,8 +14,26 @@ export const AutoComponentsApiClientTypeChecker = () => {
   return (
     <>
       {/* AutoForm - Create actions */}
-      <PolarisAutoForm action={testApi.widget.create} />
-      <ShadcnAutoForm action={testApi.widget.create} />
+      <PolarisAutoForm
+        action={testApi.widget.create}
+        defaultValues={{
+          widget: {
+            inventoryCount: 123,
+            gizmos: [{ name: "Gizmo 1" }],
+            section: { name: "Section 1" },
+          },
+        }}
+      />
+      <ShadcnAutoForm
+        action={testApi.widget.create}
+        defaultValues={{
+          widget: {
+            inventoryCount: 123,
+            gizmos: [{ name: "Gizmo 1" }],
+            section: { name: "Section 1" },
+          },
+        }}
+      />
 
       {/* AutoForm - Update actions */}
       <PolarisAutoForm action={testApi.widget.update} />

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -8,7 +8,7 @@ import { FieldType, buildAutoFormFieldList, isModelActionMetadata, useActionMeta
 import type { AnyActionWithId, RecordIdentifier, UseActionFormHookStateData, UseActionFormSubmit } from "../use-action-form/types.js";
 import { isPlainObject, processDefaultValues } from "../use-action-form/utils.js";
 import { isRelationshipField, pathListToSelection } from "../use-table/helpers.js";
-import type { FieldErrors, UseFormReturn } from "../useActionForm.js";
+import type { FieldErrors, FieldValues, UseFormReturn } from "../useActionForm.js";
 import { useActionForm } from "../useActionForm.js";
 import { get, getFlattenedObjectKeys, type ErrorWrapper, type OptionsType } from "../utils.js";
 import { validationSchema } from "../validationSchema.js";
@@ -43,7 +43,9 @@ type AutoFormPropsWithChildren = {
 export type AutoFormProps<
   GivenOptions extends OptionsType,
   SchemaT,
-  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>,
+  ExtraFormVariables extends FieldValues = Record<string, unknown>,
+  DefaultValues = ActionFunc["variablesType"] & ExtraFormVariables
 > = (AutoFormPropsWithChildren | AutoFormPropsWithoutChildren) & {
   /** Which action this fom will run on submit */
   action: ActionFunc;
@@ -54,7 +56,7 @@ export type AutoFormProps<
   /** A denylist of fields to render within the form. Every field except these fields will be rendered as inputs. */
   exclude?: string[];
   /** A set of field values to pre-populate the form with on load. Only applies to create forms. */
-  defaultValues?: ActionFunc["variablesType"];
+  defaultValues?: DefaultValues;
   /** What to show the user once the form has been submitted successfully */
   successContent?: ReactNode;
   /** Selection object to pass to the form to retrieve existing values. This will override the default selection based on included fields */


### PR DESCRIPTION
- Unfortunately when I first tried to tighten up the type in this PR, I did not realize that the types for relationship fields would be based on the GQL nested action types instead of JS types. 
  - https://github.com/gadget-inc/js-clients/pull/780
  - if you have `childModel.parentModel.name` in the defaultValues prop, you would get a type error saying `only "create", 'update', 'delete', '_link' are valid property names`. This is wrong because those would be treated like field names instead of nested actionss in useActionForm
- Reshaping the GQL nested action based type to be more like the JS type using only TS type operations is gonna be very hard. 
  - Fixing this type to reflect the JS expected type is probably gonna easier to implement and maintain as an `api-client-core` change