### PR TITLE
Force `id` into given `select` prop in AutoForm

### DIFF
--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -348,36 +348,31 @@ export const DeepRelationshipChain = {
     // `id` fields must be selected at every step of the relationship field chain because they control if a nested action will become an update or a create.
     // If there is no ID, only creates nested actions will be used to create new nested records instead of updating existing ones.
     select: {
-      id: true,
       englishName: true,
       size: true,
       continents: {
         edges: {
           node: {
-            id: true,
             englishName: true,
             countries: {
               edges: {
                 node: {
-                  id: true,
                   englishName: true,
                   cities: {
                     edges: {
                       node: {
-                        id: true,
                         englishName: true,
                         localName: true,
                         citizens: {
                           edges: {
                             node: {
-                              id: true,
                               firstName: true,
                               lastName: true,
-                              cityOfMayorDuty: { id: true, englishName: true, localName: true },
+                              cityOfMayorDuty: { englishName: true, localName: true },
                             },
                           },
                         },
-                        mayor: { id: true, firstName: true, lastName: true },
+                        mayor: { firstName: true, lastName: true },
                       },
                     },
                   },

--- a/packages/react/src/use-table/helpers.tsx
+++ b/packages/react/src/use-table/helpers.tsx
@@ -311,7 +311,7 @@ const isBelongsToField = (field: { fieldType: GadgetFieldType }) => {
   return field.fieldType === GadgetFieldType.BelongsTo;
 };
 
-const isHasOneOrBelongsToField = (field: { fieldType: GadgetFieldType }) => {
+export const isHasOneOrBelongsToField = (field: { fieldType: GadgetFieldType }) => {
   return field.fieldType === GadgetFieldType.HasOne || isBelongsToField(field);
 };
 
@@ -323,7 +323,7 @@ const isHasManyThroughField = (field: { fieldType: GadgetFieldType }) => {
   return field.fieldType === GadgetFieldType.HasManyThrough;
 };
 
-const isHasManyOrHasManyThroughField = (field: { fieldType: GadgetFieldType }) => {
+export const isHasManyOrHasManyThroughField = (field: { fieldType: GadgetFieldType }) => {
   return isHasManyField(field) || isHasManyThroughField(field);
 };
 
@@ -385,11 +385,6 @@ export const fieldMetadataArrayToFieldMetadataTree = (fieldMetadataArray: FieldM
   depth += 1;
   const map: Record<string, any> = {};
 
-  const getRelatedModelFields = (field: FieldMetadata) => {
-    if (!("configuration" in field)) return [];
-    return (field as FieldMetadataWithRelationshipConfig).configuration.relatedModel?.fields ?? [];
-  };
-
   for (const field of fieldMetadataArray) {
     map[field.apiIdentifier] = {};
 
@@ -411,6 +406,13 @@ export const fieldMetadataArrayToFieldMetadataTree = (fieldMetadataArray: FieldM
   }
 
   return map;
+};
+
+export const getRelatedModelFields = (field: FieldMetadata) => {
+  if (!("configuration" in field) || !("relatedModel" in field.configuration)) {
+    return [];
+  }
+  return field.configuration.relatedModel?.fields ?? [];
 };
 
 const maybeGetFieldMetadataByColumnPath = (fieldMetadataTree: TableSpec["fieldMetadataTree"], columnPath: string) => {


### PR DESCRIPTION
- **UPDATE**
  - The `select` prop in `AutoForm` previously did a complete override of the existing field selection when using the `findBy` prop. If you did not include the `id:true` in the selection for every relationship field, the form would have really sneaky and wrong behaviour
    - Submitting when you have AutoRelationshipForms only be able to run with `create` nested actions instead of `update` nested actions. 
      - All children cloned instead of updated 💀 
      - We use the presence of an `id` field to determine which action to use.
    - AutoRealtionshipInput dropdowns fallback to showing the ID if there is nothing for the display field value. Without the id, there are empty options in the dropdown
  - FIX
    - The `id`s for relationship field values are now forced into the selection if you use the `select` prop