### PR TITLE
Prevent AutoForm validations when there are no registered autoInput children

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoForm.cy.tsx
@@ -227,21 +227,7 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     submit("Widget");
   });
 
-  it("can render a form to update a model without making changes and submit it", async () => {
-    const name = `test record ${new Date()}`;
-
-    cy.wrap(null)
-      .then(async () => await api.widget.create({ name, inventoryCount: 42, anything: "hello" }))
-      .then((record) => {
-        cy.mountWithWrapper(<AutoForm action={api.widget.update} record={record.id} exclude={["gizmos"]} />, wrapper);
-        cy.get(`input[name="widget.name"]`).should("have.value", name);
-        cy.get(`input[name="widget.inventoryCount"]`).should("have.value", 42);
-
-        submit("Widget");
-      });
-  });
-
-  it("can render a rich text editor for markdown content", async () => {
+  it("can render a rich text editor for markdown content", () => {
     cy.mountWithWrapper(<AutoForm action={api.widget.create} include={["description"]} />, wrapper);
 
     cy.clickAndType(`[aria-label="editable markdown"] > p`, "# foobar\n## foobaz");
@@ -266,7 +252,7 @@ describeForEachAutoAdapter("AutoForm", ({ name, adapter: { AutoForm }, wrapper }
     });
   });
 
-  it("can submit a form with custom children even if the action has required fields", async () => {
+  it("can submit a form with custom children even if the action has required fields", () => {
     cy.mountWithWrapper(
       <AutoForm action={api.widget.create}>
         {/* Note that widget has name and inventoryCount as required fields that are not included here */}

--- a/packages/react/cypress/component/auto/form/AutoFormDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormDateTimePicker.cy.tsx
@@ -110,7 +110,7 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
       }
     });
 
-    it("can change the date", async () => {
+    it("can change the date", () => {
       mockMetadataResponse();
       const onChangeSpy = cy.spy().as("onChangeSpy");
       cy.mountWithWrapper(
@@ -121,16 +121,20 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
       );
       cy.wait("@ModelCreateActionMetadata");
       cy.get("#test-date").click();
-      cy.get(`[aria-label='Thursday March 4 2021']`).click();
+      if (name === SUITE_NAMES.POLARIS) {
+        cy.get(`[aria-label='Thursday March 4 2021']`).click();
+      } else if (name === SUITE_NAMES.SHADCN) {
+        cy.get(`[data-day="2021-03-04"]`).click();
+      }
       // eslint-disable-next-line jest/valid-expect-in-promise
       cy.get("@onChangeSpy")
         .should("have.been.called")
         .then(() => {
-          expect(onChangeSpy.getCalls()[0].args[0].toISOString()).equal(new Date("2021-03-04T11:23:10.000Z").toISOString());
+          expect(onChangeSpy.getCalls()[0].args[0].toISOString()).equal(new Date("2021-03-04T11:23:00.000Z").toISOString());
         });
     });
 
-    it("can change the date across a DST boundary", async () => {
+    it("can change the date across a DST boundary", () => {
       mockMetadataResponse();
       const onChangeSpy = cy.spy().as("onChangeSpy");
       cy.mountWithWrapper(
@@ -141,12 +145,17 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
       );
       cy.wait("@ModelCreateActionMetadata");
       cy.get("#test-date").click();
-      cy.get(`[aria-label='Wednesday March 17 2021']`).click();
+
+      if (name === SUITE_NAMES.POLARIS) {
+        cy.get(`[aria-label='Wednesday March 17 2021']`).click();
+      } else if (name === SUITE_NAMES.SHADCN) {
+        cy.get(`[data-day="2021-03-17"]`).click();
+      }
       // eslint-disable-next-line jest/valid-expect-in-promise
       cy.get("@onChangeSpy")
         .should("have.been.called")
         .then(() => {
-          expect(onChangeSpy.getCalls()[0].args[0].toISOString()).equal(new Date("2021-03-17T10:23:10.000Z").toISOString());
+          expect(onChangeSpy.getCalls()[0].args[0].toISOString()).equal(new Date("2021-03-17T11:23:00.000Z").toISOString());
         });
     });
 

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -252,7 +252,7 @@ export const useAutoForm = <
     registerFields(registeredFieldsFromChildren);
   }, [registeredFieldsFromChildren.join(","), registerFields]);
 
-  if (hasRegisteredFieldsFromChildren) {
+  if (hasCustomFormChildren) {
     include = Array.from(fieldSet);
     exclude = undefined;
   }


### PR DESCRIPTION
- UPDATE
  - Cypress tests would never fail if they were defined in async functions. Terrifying degree of false positives 💀 
  - One of the now sync test exposed an issue with the field registration system where we would still run validations if there were no registered autoInputs. 