### PR TITLE
fix bottom border radius on AutoRichTextInput toolbar

### DIFF
--- a/packages/react/src/auto/shared/styles/rich-text.css
+++ b/packages/react/src/auto/shared/styles/rich-text.css
@@ -1,5 +1,8 @@
 .mdxeditor-toolbar {
-  border-radius: var(--p-border-radius-200);
+  border-top-left-radius: var(--p-border-radius-200);
+  border-top-right-radius: var(--p-border-radius-200);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .Autoform-RichTextInput {


### PR DESCRIPTION
The border radius no longer applies to the bottom of the toolbar. 
