### PR TITLE
Fix relationship form searching with custom rendered labels, and added `Click to edit...` placeholder to AutoHasOneForm

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
@@ -70,7 +70,7 @@ describeForEachAutoAdapter(
             field="students"
             recordLabel={{
               primary: ["firstName", "lastName"],
-              secondary: (record: any) => `Year: ${record.year}`,
+              secondary: ({ record }: any) => `Year: ${record.year}`,
               tertiary: "department",
             }}
           >

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -45,7 +45,7 @@ const ExampleWidgetAutoRelatedForm = (props) => {
             field="doodad"
             recordLabel={{
               primary: "name",
-              secondary: (record) => `${record.weight} (${record.active})`,
+              secondary: ({ record }) => `${record.weight} (${record.active})`,
               tertiary: "size",
             }}
           >
@@ -63,7 +63,7 @@ const ExampleWidgetAutoRelatedForm = (props) => {
             recordLabel={{
               primary: "name",
               secondary: "orientation",
-              tertiary: (record) => <Text>{record.id}</Text>,
+              tertiary: ({ record }) => <Text>{record.name}</Text>,
             }}
           >
             <PolarisAutoInput field="name" />
@@ -322,7 +322,7 @@ export const DeepRelationshipChain = {
                   <PolarisAutoHasManyForm
                     field="cities"
                     recordLabel={{
-                      primary: (record) => `${record.englishName} ${record.localName ? `(${record.localName})` : ""}`,
+                      primary: ({ record }) => `${record.englishName} ${record.localName ? `(${record.localName})` : ""}`,
                     }}
                   >
                     <PolarisAutoInput field="englishName" />

--- a/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
@@ -38,7 +38,7 @@ const Component = (props) => {
             field="doodad"
             recordLabel={{
               primary: "name",
-              secondary: (record) => `${record.weight ?? "N/A"} (${record.active ?? "N/A"})`,
+              secondary: ({ record }) => `${record.weight ?? "N/A"} (${record.active ?? "N/A"})`,
               tertiary: "size",
             }}
           >

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -1,6 +1,5 @@
 import { assert, type FieldSelection } from "@gadgetinc/api-client-core";
-import type React from "react";
-import { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { FieldType } from "../../metadata.js";
 import { type RecordIdentifier } from "../../use-action-form/types.js";
 import { useDebouncedSearch } from "../../useDebouncedSearch.js";
@@ -123,7 +122,14 @@ export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "c
   return {
     options,
     searchFilterOptions: options.filter((option) => {
-      return search.value ? `${option.primary}`.toLowerCase().includes(search.value.toLowerCase()) : true;
+      const optionAsString =
+        typeof option.primary === "string"
+          ? option.primary.toLowerCase()
+          : React.isValidElement(option.primary)
+          ? JSON.stringify(option.primary.props).toLowerCase()
+          : "";
+
+      return search.value ? optionAsString.includes(search.value.toLowerCase()) : true;
     }),
     relatedModel,
     pagination,

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -49,3 +49,29 @@ export const getOptionLabelsFromRecordLabel = (recordLabel: OptionLabel | Record
   }
   return [recordLabelObject.primary, recordLabelObject.secondary, recordLabelObject.tertiary];
 };
+
+export const shouldShowOptionLabel = (option?: DisplayedRecordOption | null) => {
+  return option ? [option.primary, option.secondary, option.tertiary].some(canLabelBeShown) : false;
+};
+
+const canLabelBeShown = (option?: React.ReactNode) => {
+  if (!option) {
+    return false;
+  }
+
+  if (typeof option === "string") {
+    return true;
+  }
+
+  if (
+    typeof option === "object" &&
+    "props" in option &&
+    typeof option.props === "object" &&
+    option.props &&
+    "children" in option.props &&
+    option.props.children
+  ) {
+    return true;
+  }
+  return false;
+};

--- a/packages/react/src/auto/polaris/inputs/relationships/EditableOptionLabelButton.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/EditableOptionLabelButton.tsx
@@ -1,0 +1,27 @@
+import { BlockStack, InlineStack, Text } from "@shopify/polaris";
+import React, { useMemo } from "react";
+import type { DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
+import { shouldShowOptionLabel } from "../../../interfaces/AutoRelationshipInputProps.js";
+import { renderOptionLabel } from "./utils.js";
+
+export const EditableOptionLabelButton = ({ option }: { option?: DisplayedRecordOption }) => {
+  const showOptionLabel = useMemo(() => shouldShowOptionLabel(option), [option]);
+
+  return (
+    <>
+      {showOptionLabel && option ? (
+        <InlineStack align="space-between">
+          <BlockStack gap="200">
+            {renderOptionLabel(option.primary, "primary")}
+            {option.secondary && renderOptionLabel(option.secondary, "secondary")}
+          </BlockStack>
+          {option.tertiary && renderOptionLabel(option.tertiary, "tertiary")}
+        </InlineStack>
+      ) : (
+        <Text variant="bodyMd" as="h3" tone="subdued">
+          Click to edit...
+        </Text>
+      )}
+    </>
+  );
+};

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
@@ -9,7 +9,7 @@ import { getRecordAsOption, useOptionLabelForField } from "../../../hooks/useRel
 import { useRequiredChildComponentsValidator } from "../../../hooks/useRequiredChildComponentsValidator.js";
 import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { getRecordLabelObject } from "../../../interfaces/AutoRelationshipInputProps.js";
-import { renderOptionLabel } from "./utils.js";
+import { EditableOptionLabelButton } from "./EditableOptionLabelButton.js";
 
 export const useRecordLabelObjectFromProps = (props: AutoRelationshipFormProps) => {
   const recordLabelObject = getRecordLabelObject(props.recordLabel);
@@ -89,19 +89,7 @@ export const PolarisAutoHasManyForm = autoRelationshipForm((props: AutoRelations
                   </Box>
                 ) : (
                   <ResourceItem id={option.id} name={option.primary?.toString() ?? option.id} onClick={() => setEditingIndex(idx)}>
-                    {option.primary ? (
-                      <InlineStack align="space-between">
-                        <BlockStack gap="200">
-                          {renderOptionLabel(option.primary, "primary")}
-                          {option.secondary && renderOptionLabel(option.secondary, "secondary")}
-                        </BlockStack>
-                        {option.tertiary && renderOptionLabel(option.tertiary, "tertiary")}
-                      </InlineStack>
-                    ) : (
-                      <Text variant="bodyMd" as="h3" tone="subdued">
-                        Click to edit...
-                      </Text>
-                    )}
+                    <EditableOptionLabelButton option={option} />
                   </ResourceItem>
                 )}
               </Box>

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.tsx
@@ -5,8 +5,8 @@ import { useHasOneForm } from "../../../../useHasOneForm.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
 import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
+import { EditableOptionLabelButton } from "./EditableOptionLabelButton.js";
 import { SearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
-import { renderOptionLabel } from "./utils.js";
 
 export const PolarisAutoHasOneForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
   const hasOneForm = useHasOneForm(props);
@@ -40,16 +40,10 @@ export const PolarisAutoHasOneForm = autoRelationshipForm((props: AutoRelationsh
           {hasRecord || isCreatingRecord ? (
             <>
               <Box borderColor="border" borderWidth="025" borderRadius="200">
-                {!isEditing ? (
+                {!isEditing && recordOption ? (
                   <BlockStack as="ul">
-                    <ResourceItem id={recordOption!.id} onClick={() => setIsEditing(true)}>
-                      <InlineStack align="space-between">
-                        <BlockStack gap="200">
-                          {renderOptionLabel(recordOption!.primary, "primary")}
-                          {recordOption!.secondary && renderOptionLabel(recordOption!.secondary, "secondary")}
-                        </BlockStack>
-                        {recordOption!.tertiary && renderOptionLabel(recordOption!.tertiary, "tertiary")}
-                      </InlineStack>
+                    <ResourceItem id={recordOption.id} onClick={() => setIsEditing(true)}>
+                      <EditableOptionLabelButton option={recordOption} />
                     </ResourceItem>
                   </BlockStack>
                 ) : (

--- a/packages/react/src/auto/polaris/inputs/relationships/RelatedModelOptions.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/RelatedModelOptions.tsx
@@ -40,14 +40,15 @@ export const RelatedModelOptions = (props: RelatedModelOptionsProps) => {
         onSelect(recordWithoutTimestamps);
       }}
     >
-      {listBoxOptions.length ? (
-        listBoxOptions
-      ) : errorMessage ? (
+      {errorMessage ? (
         <ListMessage message={getErrorMessage(errorMessage)} />
-      ) : !isLoading ? (
-        <NoRecordsMessage />
-      ) : null}
-      {isLoading && <Listbox.Loading accessibilityLabel="Loading" />}
+      ) : (
+        <>
+          {listBoxOptions}
+          {!isLoading && options.length === 0 && <NoRecordsMessage />}
+          {isLoading && <Listbox.Loading accessibilityLabel="Loading" />}
+        </>
+      )}
     </Listbox>
   );
 };
@@ -86,7 +87,7 @@ export const RelatedModelOptionsPopover = (
         >
           {props.search}
           <Scrollable
-            shadow
+            shadow={props.options.length > numberOfOptionsThatCanBeShownWithoutScrolling}
             style={{
               position: "relative",
               width: "310px",
@@ -112,6 +113,8 @@ export const RelatedModelOptionsPopover = (
     </Popover>
   );
 };
+
+const numberOfOptionsThatCanBeShownWithoutScrolling = 8;
 
 export const RelatedModelOptionsSearch = (
   props: { modelName: string; label?: TextFieldProps["label"]; autoComplete?: TextFieldProps["autoComplete"] } & Omit<

--- a/packages/react/src/auto/shadcn/inputs/relationships/EditableOptionLabelButton.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/EditableOptionLabelButton.tsx
@@ -1,0 +1,28 @@
+import React, { useMemo } from "react";
+import { shouldShowOptionLabel, type DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { ShadcnElements } from "../../elements.js";
+import { makeShadcnRenderOptionLabel } from "../../utils.js";
+
+export const makeShadcnEditableOptionLabelButton = ({ Badge, Button, Label }: Pick<ShadcnElements, "Badge" | "Button" | "Label">) => {
+  const renderOptionLabel = makeShadcnRenderOptionLabel({ Label, Badge, Button });
+
+  return function ({ option }: { option?: DisplayedRecordOption | null }) {
+    const showOptionLabel = useMemo(() => shouldShowOptionLabel(option), [option]);
+    return (
+      <>
+        {showOptionLabel && option ? (
+          <div className="flex justify-between w-full items-center">
+            <div className="flex flex-col gap-1 items-start">
+              {renderOptionLabel(option.primary, "primary")}
+              {option.secondary && renderOptionLabel(option.secondary, "secondary")}
+            </div>
+
+            {option.tertiary && <div className="flex items-center">{renderOptionLabel(option.tertiary, "tertiary")}</div>}
+          </div>
+        ) : (
+          <Label>Click to edit...</Label>
+        )}
+      </>
+    );
+  };
+};

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
@@ -6,9 +6,9 @@ import { RelationshipContext, useAutoRelationship, useRelationshipContext } from
 import { useHasManyController } from "../../../hooks/useHasManyController.js";
 import { getRecordAsOption, useRecordLabelObjectFromProps } from "../../../hooks/useRelatedModel.js";
 import { useRequiredChildComponentsValidator } from "../../../hooks/useRequiredChildComponentsValidator.js";
-import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
+import { type AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
-import { makeShadcnRenderOptionLabel } from "../../utils.js";
+import { makeShadcnEditableOptionLabelButton } from "./EditableOptionLabelButton.js";
 
 export const makeShadcnAutoHasManyForm = ({
   Accordion,
@@ -19,7 +19,7 @@ export const makeShadcnAutoHasManyForm = ({
   Button,
   Label,
 }: Pick<ShadcnElements, "Accordion" | "AccordionContent" | "AccordionItem" | "AccordionTrigger" | "Badge" | "Button" | "Label">) => {
-  const renderOptionLabel = makeShadcnRenderOptionLabel({ Label, Badge, Button });
+  const EditableOptionLabelButton = makeShadcnEditableOptionLabelButton({ Badge, Button, Label });
 
   function ShadcnAutoHasManyForm(props: AutoRelationshipFormProps) {
     useRequiredChildComponentsValidator(props, "AutoHasManyForm");
@@ -112,18 +112,7 @@ export const makeShadcnAutoHasManyForm = ({
                   className=""
                 >
                   <AccordionTrigger onClick={(e) => e.preventDefault()}>
-                    {option.primary ? (
-                      <div className="flex justify-between w-full items-center">
-                        <div className="flex flex-col gap-1 items-start">
-                          {renderOptionLabel(option.primary, "primary")}
-                          {option.secondary && renderOptionLabel(option.secondary, "secondary")}
-                        </div>
-
-                        {option.tertiary && <div className="flex items-center">{renderOptionLabel(option.tertiary, "tertiary")}</div>}
-                      </div>
-                    ) : (
-                      <Label>Click to edit...</Label>
-                    )}
+                    <EditableOptionLabelButton option={option} />
                   </AccordionTrigger>
                   <AccordionContent className="border border-gray-300 rounded-md p-3">
                     <RelationshipContext.Provider

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
@@ -5,7 +5,7 @@ import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
 import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
-import { makeShadcnRenderOptionLabel } from "../../utils.js";
+import { makeShadcnEditableOptionLabelButton } from "./EditableOptionLabelButton.js";
 import { makeSearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
 
 export const makeShadcnAutoHasOneForm = ({
@@ -42,8 +42,6 @@ export const makeShadcnAutoHasOneForm = ({
   | "AccordionItem"
   | "AccordionTrigger"
 >) => {
-  const renderOptionLabel = makeShadcnRenderOptionLabel({ Label, Badge, Button });
-
   const SearchableSingleRelatedModelRecordSelector = makeSearchableSingleRelatedModelRecordSelector({
     Command,
     CommandItem,
@@ -56,6 +54,7 @@ export const makeShadcnAutoHasOneForm = ({
     Checkbox,
     ScrollArea,
   });
+  const EditableOptionLabelButton = makeShadcnEditableOptionLabelButton({ Badge, Button, Label });
 
   function ShadcnHasOneForm(props: AutoRelationshipFormProps) {
     const { field } = props;
@@ -110,16 +109,7 @@ export const makeShadcnAutoHasOneForm = ({
                       setIsEditing(true);
                     }}
                   >
-                    <div className="flex justify-between w-full items-center">
-                      <div className="flex flex-col gap-1 items-start">
-                        {recordOption?.primary && renderOptionLabel(recordOption?.primary, "primary")}
-                        {recordOption?.secondary && renderOptionLabel(recordOption?.secondary, "secondary")}
-                      </div>
-
-                      {recordOption?.tertiary && (
-                        <div className="flex items-center">{renderOptionLabel(recordOption?.tertiary, "tertiary")}</div>
-                      )}
-                    </div>
+                    <EditableOptionLabelButton option={recordOption} />
                   </AccordionTrigger>
                 </AccordionItem>
               ) : (


### PR DESCRIPTION
- **UPDATES**
  - Related model record searching with custom renderer callbacks 
    - The `search` system that we use for related model records relies on the fullText search that we use in the API. Since the fullText match can result in records with labels that disagree with the user provided search value, there is also a client side filter that ensures we only see options from the API that contain the user's search value. 
      - This client side filter worked well when the record labels were strings, but the filter removed EVERYTHING when the labels were ReactNodes from a callback function. 
        - `[object Object` as a string does not contain the user's search query
    - Now, the client side filter serializes react nodes before checking if they contain the user's search value. Searching now works with custom renderer callbacks 😎 
  - `Click to edit...` placeholder
    - Updated such that the placeholder only shows if there is nothing available across all the `primary, secondary, ternary` 
      - It was weird if you put a valid value into an input corresponding to the secondary label, but were still unable to see that value after confirming the value
    - Added the same placeholder to `AutoHasOneForm` to be consistent
      - Previously, there was no placeholder and there would simply be a completely empty button 
