### PR TITLE
Added new `recordFilter` prop to allow the related model options in the dropdown to be filtered

### DIFF
--- a/packages/react/.changeset/seven-bikes-refuse.md
+++ b/packages/react/.changeset/seven-bikes-refuse.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Added new `recordFilter` prop to `AutoHasManyInput` and `AutoBelongsToInput` to allow the related model options in the dropdown to be filtered

--- a/packages/react/cypress/component/auto/form/PolarisAutoHasManyInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/PolarisAutoHasManyInput.cy.tsx
@@ -107,7 +107,7 @@ describe("PolarisAutoHasManyInput", () => {
             },
           },
         });
-      },
+      }
     ).as("gizmos");
   };
 
@@ -120,8 +120,8 @@ describe("PolarisAutoHasManyInput", () => {
 
   it("can deselect exiting related records and select new records and submit it", () => {
     interceptGizmosOptionsQuery(5);
-
     cy.mountWithWrapper(<PolarisAutoForm action={api.widget.update} findBy="42" />, PolarisWrapper);
+    cy.wait("@gizmos");
 
     cy.get(`span[title="Gizmo 1"]`);
     cy.get(`span[title="Gizmo 2"]`);
@@ -159,8 +159,8 @@ describe("PolarisAutoHasManyInput", () => {
 
   it("does not change anything for hasMany fields when the input is untouched", () => {
     interceptGizmosOptionsQuery(5);
-
     cy.mountWithWrapper(<PolarisAutoForm action={api.widget.update} findBy="42" />, PolarisWrapper);
+    cy.wait("@gizmos");
 
     expectUpdateActionSubmissionVariables({
       id: "42",
@@ -176,15 +176,16 @@ describe("PolarisAutoHasManyInput", () => {
   describe("optionLabel", () => {
     it("should use the field api id of the string option label as the option display label", () => {
       interceptGizmosOptionsQuery(5);
-
       cy.mountWithWrapper(
         <PolarisAutoForm action={api.widget.update} findBy="42">
           <PolarisSubmitResultBanner />
           <PolarisAutoHasManyInput field="gizmos" optionLabel="otherField" />
           <PolarisAutoSubmit />
         </PolarisAutoForm>,
-        PolarisWrapper,
+        PolarisWrapper
       );
+      cy.wait("@gizmos");
+
       cy.get(`input[name="widget.gizmos"]`).click();
       cy.contains(`Gizmo 3 other field`).parent().parent().click();
       cy.get(`input[name="widget.gizmos"]`).focus();
@@ -208,15 +209,16 @@ describe("PolarisAutoHasManyInput", () => {
 
     it("should use call the option label function to generate the option labels", () => {
       interceptGizmosOptionsQuery(5);
-
       cy.mountWithWrapper(
         <PolarisAutoForm action={api.widget.update} findBy="42">
           <PolarisSubmitResultBanner />
           <PolarisAutoHasManyInput field="gizmos" optionLabel={({ record }) => `Custom label for ${record.id}`} />
           <PolarisAutoSubmit />
         </PolarisAutoForm>,
-        PolarisWrapper,
+        PolarisWrapper
       );
+      cy.wait("@gizmos");
+
       cy.get(`input[name="widget.gizmos"]`).click();
       cy.contains(`Custom label for 3`).parent().parent().click();
       cy.get(`input[name="widget.gizmos"]`).focus();
@@ -242,9 +244,7 @@ describe("PolarisAutoHasManyInput", () => {
   it("should filter out related record options based on a given filter", () => {
     interceptGizmosOptionsQuery(5, {
       first: 25,
-      filter: {
-        name: { equals: "gizmo 2" },
-      },
+      filter: { name: { equals: "gizmo 2" } },
     });
 
     cy.mountWithWrapper(
@@ -253,10 +253,10 @@ describe("PolarisAutoHasManyInput", () => {
         <PolarisAutoHasManyInput field="gizmos" recordFilter={{ name: { equals: "gizmo 2" } }} />
         <PolarisAutoSubmit />
       </PolarisAutoForm>,
-      PolarisWrapper,
+      PolarisWrapper
     );
 
-    cy.wait("@gizmos");
+    cy.wait("@gizmos"); // This asserts the filter is applied
   });
 });
 

--- a/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
@@ -4,11 +4,11 @@ import React, { useState } from "react";
 import { Provider } from "../../../src/GadgetProvider.tsx";
 import { PolarisAutoForm } from "../../../src/auto/polaris/PolarisAutoForm.tsx";
 import { PolarisAutoInput } from "../../../src/auto/polaris/inputs/PolarisAutoInput.tsx";
+import { PolarisAutoHasManyThroughInput } from "../../../src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughInput.tsx";
 import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoSubmit.tsx";
 import { FormProvider, useForm } from "../../../src/useActionForm.ts";
 import { testApi as api } from "../../apis.ts";
 import { StorybookErrorBoundary } from "../storybook/StorybookErrorBoundary.tsx";
-import { PolarisAutoHasManyInput } from "../../../src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
@@ -134,7 +134,6 @@ const ConditionalAppearingAutoInput = () => {
           <PolarisAutoInput field="isChecked" />
           <PolarisAutoInput field="section" />
           <PolarisAutoInput field="gizmos" />
-          <PolarisAutoHasManyInput field="gizmos" recordFilter={{ name: { equals: "gizmo 2" } }} />
           <PolarisAutoInput field="customStringParam" />
         </>
       )}
@@ -228,5 +227,12 @@ export const hasManyThrough = {
   name: "HasManyThrough fields",
   args: {
     action: api.hasManyThrough.baseModel.create,
+    children: (
+      <>
+        <PolarisAutoInput field="baseModelName" />
+        <PolarisAutoHasManyThroughInput field="baseModelHmtField" />
+        <PolarisAutoSubmit />
+      </>
+    ),
   },
 };

--- a/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/PolarisAutoForm.stories.jsx
@@ -8,6 +8,7 @@ import { PolarisAutoSubmit } from "../../../src/auto/polaris/submit/PolarisAutoS
 import { FormProvider, useForm } from "../../../src/useActionForm.ts";
 import { testApi as api } from "../../apis.ts";
 import { StorybookErrorBoundary } from "../storybook/StorybookErrorBoundary.tsx";
+import { PolarisAutoHasManyInput } from "../../../src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
@@ -133,6 +134,7 @@ const ConditionalAppearingAutoInput = () => {
           <PolarisAutoInput field="isChecked" />
           <PolarisAutoInput field="section" />
           <PolarisAutoInput field="gizmos" />
+          <PolarisAutoHasManyInput field="gizmos" recordFilter={{ name: { equals: "gizmo 2" } }} />
           <PolarisAutoInput field="customStringParam" />
         </>
       )}

--- a/packages/react/spec/auto/shadcn-defaults/ShadcnAutoForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/ShadcnAutoForm.stories.jsx
@@ -6,7 +6,7 @@ import { testApi as api } from "../../apis.ts";
 import { StorybookErrorBoundary } from "../storybook/StorybookErrorBoundary.tsx";
 import { elements } from "./index.tsx";
 
-const { AutoForm, AutoInput, AutoSubmit } = makeAutocomponents(elements);
+const { AutoForm, AutoInput, AutoSubmit, AutoHasManyThroughInput } = makeAutocomponents(elements);
 
 export default {
   title: "Shadcn/AutoForm",
@@ -213,5 +213,12 @@ export const hasManyThrough = {
   name: "HasManyThrough fields",
   args: {
     action: api.hasManyThrough.baseModel.create,
+    children: (
+      <>
+        <AutoInput field="baseModelName" />
+        <AutoHasManyThroughInput field="baseModelHmtField" />
+        <AutoSubmit />
+      </>
+    ),
   },
 };

--- a/packages/react/src/auto/hooks/useBelongsToController.tsx
+++ b/packages/react/src/auto/hooks/useBelongsToController.tsx
@@ -33,10 +33,11 @@ export const useBelongsToController = (props: Omit<AutoRelationshipFormProps, "c
 };
 
 export const useBelongsToInputController = (props: AutoRelationshipInputProps) => {
-  const { field, control, optionLabel } = props;
+  const { field, control, optionLabel, recordFilter } = props;
   const { fieldMetadata, relatedModelOptions, isLoading, errorMessage } = useBelongsToController({
     field,
     recordLabel: { primary: optionLabel },
+    recordFilter,
   });
   const { path } = fieldMetadata;
 

--- a/packages/react/src/auto/hooks/useHasManyController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyController.tsx
@@ -44,7 +44,11 @@ export const useHasManyInputController = (props: AutoRelationshipInputProps) => 
   }, [metadata.configuration]);
 
   const { remove, append, update } = fieldArray;
-  const relatedModelOptions = useRelatedModelOptions({ field, recordLabel: { primary: props.optionLabel } });
+  const relatedModelOptions = useRelatedModelOptions({
+    field,
+    recordLabel: { primary: props.optionLabel },
+    recordFilter: props.recordFilter,
+  });
 
   const { relatedModel } = relatedModelOptions;
 
@@ -72,7 +76,7 @@ export const useHasManyInputController = (props: AutoRelationshipInputProps) => 
         });
       }
     },
-    [inverseFieldApiIdentifier, records, remove, update]
+    [inverseFieldApiIdentifier, records, remove, update],
   );
 
   const onSelectRecord = useCallback(
@@ -94,7 +98,7 @@ export const useHasManyInputController = (props: AutoRelationshipInputProps) => 
         });
       }
     },
-    [records, onRemoveRecord, update, append]
+    [records, onRemoveRecord, update, append],
   );
 
   return {

--- a/packages/react/src/auto/hooks/useHasManyController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyController.tsx
@@ -76,7 +76,7 @@ export const useHasManyInputController = (props: AutoRelationshipInputProps) => 
         });
       }
     },
-    [inverseFieldApiIdentifier, records, remove, update],
+    [inverseFieldApiIdentifier, records, remove, update]
   );
 
   const onSelectRecord = useCallback(
@@ -98,7 +98,7 @@ export const useHasManyInputController = (props: AutoRelationshipInputProps) => 
         });
       }
     },
-    [records, onRemoveRecord, update, append],
+    [records, onRemoveRecord, update, append]
   );
 
   return {

--- a/packages/react/src/auto/hooks/useHasManyThroughController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyThroughController.tsx
@@ -56,6 +56,7 @@ export const useHasManyThroughInputController = (props: AutoRelationshipInputPro
   const { fieldMetadata, fieldArray, records, relatedModelOptions, inverseRelatedModelField } = useHasManyThroughController({
     field: props.field,
     recordLabel: props.optionLabel,
+    recordFilter: props.recordFilter,
   });
 
   const { relatedModel } = relatedModelOptions;

--- a/packages/react/src/auto/hooks/useHasOneController.tsx
+++ b/packages/react/src/auto/hooks/useHasOneController.tsx
@@ -34,7 +34,7 @@ export const useHasOneController = (props: Omit<AutoRelationshipFormProps, "chil
 };
 
 export const useHasOneInputController = (props: AutoRelationshipInputProps) => {
-  const { field, control } = props;
+  const { field, control, recordFilter } = props;
   const {
     record: value,
     fieldMetadata,
@@ -42,6 +42,7 @@ export const useHasOneInputController = (props: AutoRelationshipInputProps) => {
   } = useHasOneController({
     field,
     recordLabel: { primary: props.optionLabel },
+    recordFilter,
   });
 
   const { path } = fieldMetadata;

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -12,6 +12,7 @@ import {
   type DisplayedRecordOption,
   type OptionLabel,
   type RecordLabel,
+  type RecordFilter,
 } from "../interfaces/AutoRelationshipInputProps.js";
 import type { RelationshipFieldConfig } from "../interfaces/RelationshipFieldConfig.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
@@ -20,7 +21,7 @@ import { useModelManager } from "./useModelManager.js";
 export const optionRecordsToLoadCount = 25;
 export const selectedRecordsToLoadCount = 25;
 
-const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabel }) => {
+const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabel; recordFilter?: RecordFilter }) => {
   const { field } = props;
   const { metadata } = useFieldMetadata(field);
   const { findBy } = useAutoFormMetadata();
@@ -36,9 +37,11 @@ const useRelatedModelRecords = (props: { field: string; optionLabel?: OptionLabe
   const relatedModelRecords = useAllRelatedModelRecords({
     relatedModel: { apiIdentifier: relatedModelApiIdentifier!, namespace: relatedModelNamespace },
 
-    filter: isHasManyField
-      ? omitRelatedModelRecordsAssociatedWithOtherRecords({ enabled: false, relatedModelInverseFieldApiId, findBy })
-      : undefined,
+    filter:
+      props?.recordFilter ??
+      (isHasManyField
+        ? omitRelatedModelRecordsAssociatedWithOtherRecords({ enabled: false, relatedModelInverseFieldApiId, findBy })
+        : undefined),
   });
 
   return {
@@ -82,12 +85,15 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 
   return assert(
     optionLabel ?? relationshipFieldConfig.relatedModel?.defaultDisplayField.apiIdentifier,
-    "Option label is required for relationships"
+    "Option label is required for relationships",
   );
 };
 
 export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "children" | "label">) => {
   const { field } = props;
+
+  console.log("props :", props);
+
   const recordLabel = getRecordLabelObject(props.recordLabel);
 
   const optionLabel = useOptionLabelForField(field, recordLabel?.primary);
@@ -102,7 +108,7 @@ export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "c
         secondary: recordLabel?.secondary,
         tertiary: recordLabel?.tertiary,
       }),
-      "id"
+      "id",
     );
 
     return options as ReturnType<typeof getRecordsAsOptions>;
@@ -126,8 +132,8 @@ export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "c
         typeof option.primary === "string"
           ? option.primary.toLowerCase()
           : React.isValidElement(option.primary)
-          ? JSON.stringify(option.primary.props).toLowerCase()
-          : "";
+            ? JSON.stringify(option.primary.props).toLowerCase()
+            : "";
 
       return search.value ? optionAsString.includes(search.value.toLowerCase()) : true;
     }),
@@ -141,8 +147,8 @@ const getRecordLabel = (record: Record<string, any>, optionLabel: OptionLabel): 
   typeof optionLabel === "string"
     ? record[optionLabel] // Related model field API id
     : Array.isArray(optionLabel)
-    ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
-    : optionLabel({ record }); // Callback on the whole related model record
+      ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
+      : optionLabel({ record }); // Callback on the whole related model record
 
 const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: string }) => string) => string[] }) =>
   records
@@ -181,7 +187,7 @@ const useAllRelatedModelRecords = (props: {
         acc[fieldName] = true;
         return acc;
       },
-      { id: true } as FieldSelection
+      { id: true } as FieldSelection,
     );
   }
 

--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -11,8 +11,8 @@ import {
   type AutoRelationshipFormProps,
   type DisplayedRecordOption,
   type OptionLabel,
-  type RecordLabel,
   type RecordFilter,
+  type RecordLabel,
 } from "../interfaces/AutoRelationshipInputProps.js";
 import type { RelationshipFieldConfig } from "../interfaces/RelationshipFieldConfig.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
@@ -85,14 +85,12 @@ export const useOptionLabelForField = (field: string, optionLabel?: OptionLabel)
 
   return assert(
     optionLabel ?? relationshipFieldConfig.relatedModel?.defaultDisplayField.apiIdentifier,
-    "Option label is required for relationships",
+    "Option label is required for relationships"
   );
 };
 
 export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "children" | "label">) => {
   const { field } = props;
-
-  console.log("props :", props);
 
   const recordLabel = getRecordLabelObject(props.recordLabel);
 
@@ -108,7 +106,7 @@ export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "c
         secondary: recordLabel?.secondary,
         tertiary: recordLabel?.tertiary,
       }),
-      "id",
+      "id"
     );
 
     return options as ReturnType<typeof getRecordsAsOptions>;
@@ -132,8 +130,8 @@ export const useRelatedModelOptions = (props: Omit<AutoRelationshipFormProps, "c
         typeof option.primary === "string"
           ? option.primary.toLowerCase()
           : React.isValidElement(option.primary)
-            ? JSON.stringify(option.primary.props).toLowerCase()
-            : "";
+          ? JSON.stringify(option.primary.props).toLowerCase()
+          : "";
 
       return search.value ? optionAsString.includes(search.value.toLowerCase()) : true;
     }),
@@ -147,8 +145,8 @@ const getRecordLabel = (record: Record<string, any>, optionLabel: OptionLabel): 
   typeof optionLabel === "string"
     ? record[optionLabel] // Related model field API id
     : Array.isArray(optionLabel)
-      ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
-      : optionLabel({ record }); // Callback on the whole related model record
+    ? optionLabel.map((fieldName) => record[fieldName]).join(" ")
+    : optionLabel({ record }); // Callback on the whole related model record
 
 const getRecordIdsAsString = (records?: { map: (mapperFunction: (record: { id: string }) => string) => string[] }) =>
   records
@@ -187,7 +185,7 @@ const useAllRelatedModelRecords = (props: {
         acc[fieldName] = true;
         return acc;
       },
-      { id: true } as FieldSelection,
+      { id: true } as FieldSelection
     );
   }
 

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -1,6 +1,6 @@
+import type { FindManyOptions } from "@gadgetinc/api-client-core";
 import type { ReactNode } from "react";
 import type { Control } from "../../useActionForm.js";
-import type { FindManyOptions } from "@gadgetinc/api-client-core";
 
 export type RecordFilter = FindManyOptions["filter"];
 

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -1,11 +1,15 @@
 import type { ReactNode } from "react";
 import type { Control } from "../../useActionForm.js";
+import type { FindManyOptions } from "@gadgetinc/api-client-core";
+
+export type RecordFilter = FindManyOptions["filter"];
 
 export interface AutoRelationshipInputProps {
   field: string;
   control?: Control<any>;
   optionLabel?: OptionLabel;
   label?: string;
+  recordFilter?: RecordFilter;
 }
 
 export type DisplayedRecordOption = RecordLabel<ReactNode> & {
@@ -28,6 +32,7 @@ export type AutoRelationshipFormProps = {
   label?: ReactNode;
   children: ReactNode;
   recordLabel?: OptionLabel | RecordLabel;
+  recordFilter?: RecordFilter;
 };
 
 export const getRecordLabelObject = (recordLabel?: OptionLabel | RecordLabel): RecordLabel | undefined => {

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyForm.tsx
@@ -11,13 +11,15 @@ import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelation
 import { getRecordLabelObject } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { EditableOptionLabelButton } from "./EditableOptionLabelButton.js";
 
-export const useRecordLabelObjectFromProps = (props: AutoRelationshipFormProps) => {
+type HasManyFormProps = Omit<AutoRelationshipFormProps, "recordFilter">;
+
+const useRecordLabelObjectFromProps = (props: HasManyFormProps) => {
   const recordLabelObject = getRecordLabelObject(props.recordLabel);
   const primaryLabel = useOptionLabelForField(props.field, recordLabelObject?.primary);
   return { ...recordLabelObject, primary: primaryLabel };
 };
 
-export const PolarisAutoHasManyForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
+export const PolarisAutoHasManyForm = autoRelationshipForm((props: HasManyFormProps) => {
   useRequiredChildComponentsValidator(props, "AutoHasManyForm");
   const { metadata } = useAutoRelationship({ field: props.field });
   const { getValues } = useFormContext();

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneForm.tsx
@@ -8,7 +8,7 @@ import type { AutoRelationshipFormProps } from "../../../interfaces/AutoRelation
 import { EditableOptionLabelButton } from "./EditableOptionLabelButton.js";
 import { SearchableSingleRelatedModelRecordSelector } from "./SearchableSingleRelatedModelRecordSelector.js";
 
-export const PolarisAutoHasOneForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
+export const PolarisAutoHasOneForm = autoRelationshipForm((props: Omit<AutoRelationshipFormProps, "recordFilter">) => {
   const hasOneForm = useHasOneForm(props);
   const {
     isEditing,

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
@@ -21,7 +21,7 @@ export const makeShadcnAutoHasManyForm = ({
 }: Pick<ShadcnElements, "Accordion" | "AccordionContent" | "AccordionItem" | "AccordionTrigger" | "Badge" | "Button" | "Label">) => {
   const EditableOptionLabelButton = makeShadcnEditableOptionLabelButton({ Badge, Button, Label });
 
-  function ShadcnAutoHasManyForm(props: AutoRelationshipFormProps) {
+  function ShadcnAutoHasManyForm(props: Omit<AutoRelationshipFormProps, "recordFilter">) {
     useRequiredChildComponentsValidator(props, "AutoHasManyForm");
     const { metadata } = useAutoRelationship({ field: props.field });
     const { getValues } = useFormContext();

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
@@ -56,7 +56,7 @@ export const makeShadcnAutoHasOneForm = ({
   });
   const EditableOptionLabelButton = makeShadcnEditableOptionLabelButton({ Badge, Button, Label });
 
-  function ShadcnHasOneForm(props: AutoRelationshipFormProps) {
+  function ShadcnHasOneForm(props: Omit<AutoRelationshipFormProps, "recordFilter">) {
     const { field } = props;
     const form = useHasOneForm(props);
     const {

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnListMessages.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnListMessages.tsx
@@ -48,50 +48,46 @@ export const makeShadcnListMessages = ({
     const { label, id, selected, onSelect, allowMultiple, formatOptionText } = props;
     const className = selected ? "bg-muted" : "";
 
-    if (typeof label === "string") {
-      return (
-        <CommandItem
-          key={id}
-          id={id}
-          selected={selected}
-          className={className}
-          value={label}
-          onMouseDown={(e: React.MouseEvent) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onSelect={() => {
-            onSelect?.(id);
-          }}
-          onKeyDown={(e: React.KeyboardEvent) => {
-            if (e.key === "Enter") {
-              onSelect?.(id);
-            }
-          }}
-        >
-          {allowMultiple ? (
-            <>
-              <Checkbox
-                id={id}
-                checked={selected}
-                onCheckedChange={(_state) => {
-                  onSelect?.(id);
-                }}
-              />
-              <Label htmlFor={id} className={"flex-1 ml-2"}>
-                {formatOptionText ? formatOptionText(label) : label}
-              </Label>
-            </>
-          ) : formatOptionText ? (
-            formatOptionText(label)
-          ) : (
-            label
-          )}
-        </CommandItem>
-      );
-    }
+    const labelElement = formatOptionText && typeof label === "string" ? formatOptionText(label) : label;
 
-    return null;
+    return (
+      <CommandItem
+        key={id}
+        id={id}
+        selected={selected}
+        className={className}
+        value={label}
+        onMouseDown={(e: React.MouseEvent) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+        onSelect={() => {
+          onSelect?.(id);
+        }}
+        onKeyDown={(e: React.KeyboardEvent) => {
+          if (e.key === "Enter") {
+            onSelect?.(id);
+          }
+        }}
+      >
+        {allowMultiple ? (
+          <>
+            <Checkbox
+              id={id}
+              checked={selected}
+              onCheckedChange={(_state) => {
+                onSelect?.(id);
+              }}
+            />
+            <Label htmlFor={id} className={"flex-1 ml-2"}>
+              {labelElement}
+            </Label>
+          </>
+        ) : (
+          labelElement
+        )}
+      </CommandItem>
+    );
   }
 
   return {


### PR DESCRIPTION
- **UPDATE**
  - Added `recordFilter` prop
    - All relationship inputs receive this since they all get a related model record dropdown
    - belongsTo and hasManyThrough relationship forms get this since they have dropdown for existing record selection 
    - hasOne and hasMany relationship forms do NOT get this since they do not currently support existing record selection 
      - It is omitted from their input type 
  - Manually audited that the `recordFilter` prop works properly for all of the components that it is available on