### PR TITLE
Prevent default in Shadcn button in AutoForms

### DIFF
--- a/packages/react/cypress/support/auto.tsx
+++ b/packages/react/cypress/support/auto.tsx
@@ -42,6 +42,7 @@ const ONLY_RUN_SUITES = {
     "AutoRoleInput",
     "AutoEnumInput",
     "AutoBelongsToInput",
+    "AutoHasManyInput",
     // Table
     "AutoTable - Bulk actions",
   ],

--- a/packages/react/src/auto/index.tsx
+++ b/packages/react/src/auto/index.tsx
@@ -11,10 +11,12 @@ export interface AutoAdapter<T = any, F = any, B = any> {
   AutoJSONInput: React.ComponentType<any>;
   AutoSubmit: React.ComponentType<any>;
   SubmitResultBanner: React.ComponentType<any>;
+
   AutoHasOneForm: React.ComponentType<any>;
   AutoBelongsToForm: React.ComponentType<any>;
   AutoHasManyForm: React.ComponentType<any>;
   AutoHasManyThroughForm: React.ComponentType<any>;
+
   AutoDateTimePicker: React.ComponentType<{
     suiteName?: string;
     field: string;
@@ -25,5 +27,6 @@ export interface AutoAdapter<T = any, F = any, B = any> {
     includeTime?: boolean;
   }>;
   AutoBelongsToInput: React.ComponentType<any>;
+  AutoHasManyInput: React.ComponentType<any>;
   AutoEnumInput: React.ComponentType<any>;
 }

--- a/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
@@ -8,6 +8,7 @@ import { useAutoForm } from "../AutoForm.js";
 import { validateAutoFormProps } from "../AutoFormActionValidators.js";
 import { AutoFormFieldsFromChildComponentsProvider, AutoFormMetadataContext } from "../AutoFormContext.js";
 import { AutoHasManyThroughJoinModelForm } from "../hooks/useHasManyThroughController.js";
+import { makeDefaultPreventedButton } from "./ShadcnDefaultPreventedButton.js";
 import type { ShadcnElements } from "./elements.js";
 import { makeShadcnAutoInput } from "./inputs/ShadcnAutoInput.js";
 import { makeShadcnAutoBelongsToForm } from "./inputs/relationships/ShadcnAutoBelongsToForm.js";
@@ -30,6 +31,9 @@ export type ShadcnAutoFormProps<
  */
 export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements) => {
   const { Skeleton, cn } = elements;
+
+  const DefaultPreventedButton = makeDefaultPreventedButton(elements);
+  const allElements = { ...elements, Button: DefaultPreventedButton };
 
   const {
     AutoInput,
@@ -54,14 +58,15 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
     AutoHasManyInput,
     AutoHasManyThroughInput,
     AutoHasOneInput,
-  } = makeShadcnAutoInput(elements);
+  } = makeShadcnAutoInput(allElements);
 
-  const AutoSubmit = makeShadcnAutoSubmit(elements);
-  const { SubmitSuccessfulBanner, SubmitErrorBanner, SubmitResultBanner } = makeSubmitResultBanner(elements);
-  const AutoHasOneForm = makeShadcnAutoHasOneForm(elements);
-  const AutoBelongsToForm = makeShadcnAutoBelongsToForm(elements);
-  const AutoHasManyForm = makeShadcnAutoHasManyForm(elements);
-  const AutoHasManyThroughForm = makeShadcnAutoHasManyThroughForm(elements);
+  const AutoSubmit = makeShadcnAutoSubmit(allElements);
+  const { SubmitSuccessfulBanner, SubmitErrorBanner, SubmitResultBanner } = makeSubmitResultBanner(allElements);
+
+  const AutoHasOneForm = makeShadcnAutoHasOneForm(allElements);
+  const AutoBelongsToForm = makeShadcnAutoBelongsToForm(allElements);
+  const AutoHasManyForm = makeShadcnAutoHasManyForm(allElements);
+  const AutoHasManyThroughForm = makeShadcnAutoHasManyThroughForm(allElements);
 
   const FormContainer = forwardRef<HTMLFormElement, React.FormHTMLAttributes<HTMLFormElement>>(({ className, ...props }, ref) => {
     return <form ref={ref} noValidate className={cn("space-y-6", className)} {...props} />;

--- a/packages/react/src/auto/shadcn/ShadcnAutoTable.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoTable.tsx
@@ -9,6 +9,7 @@ import { type AutoTableProps } from "../AutoTable.js";
 import { validateAutoTableProps } from "../AutoTableValidators.js";
 import { useHover } from "../hooks/useHover.js";
 import { useTableBulkActions } from "../hooks/useTableBulkActions.js";
+import { makeDefaultPreventedButton } from "./ShadcnDefaultPreventedButton.js";
 import type { ShadcnElements } from "./elements.js";
 import { makeShadcnAutoLoadingIndicator } from "./table/ShadcnAutoLoadingIndicator.js";
 import { makeShadcnAutoTableBulkActionModal } from "./table/ShadcnAutoTableBulkActionModal.js";
@@ -31,13 +32,16 @@ export type ShadcnAutoTableProps<
 export const makeAutoTable = (elements: ShadcnElements) => {
   const { Alert, Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Label, Checkbox, Button } = elements;
 
-  const ShadcnAutoTableCellRenderer = makeShadcnAutoTableCellRenderer(elements);
-  const ShadcnAutoTablePagination = makeShadcnAutoTablePagination(elements);
-  const ShadcnAutoTableSearch = makeShadcnAutoTableSearch(elements);
-  const ShadcnAutoTableColumnSortIndicator = makeShadcnAutoTableColumnSortIndicator(elements);
-  const ShadcnAutoTableBulkActionSelector = makeShadcnAutoTableBulkActionSelector(elements);
-  const ShadcnAutoTableBulkActionModal = makeShadcnAutoTableBulkActionModal(elements);
-  const ShadcnAutoLoadingIndicator = makeShadcnAutoLoadingIndicator(elements);
+  const DefaultPreventedButton = makeDefaultPreventedButton(elements);
+  const allElements = { ...elements, Button: DefaultPreventedButton };
+
+  const ShadcnAutoTableCellRenderer = makeShadcnAutoTableCellRenderer(allElements);
+  const ShadcnAutoTablePagination = makeShadcnAutoTablePagination(allElements);
+  const ShadcnAutoTableSearch = makeShadcnAutoTableSearch(allElements);
+  const ShadcnAutoTableColumnSortIndicator = makeShadcnAutoTableColumnSortIndicator(allElements);
+  const ShadcnAutoTableBulkActionSelector = makeShadcnAutoTableBulkActionSelector(allElements);
+  const ShadcnAutoTableBulkActionModal = makeShadcnAutoTableBulkActionModal(allElements);
+  const ShadcnAutoLoadingIndicator = makeShadcnAutoLoadingIndicator(allElements);
 
   function AutoTableSelectAllCheckbox(props: { selection: RecordSelection; rows: TableRow[] }) {
     const { selection, rows } = props;

--- a/packages/react/src/auto/shadcn/ShadcnDefaultPreventedButton.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnDefaultPreventedButton.tsx
@@ -1,0 +1,34 @@
+import type { ActionFunction, GlobalActionFunction } from "@gadgetinc/api-client-core";
+import type { ComponentProps } from "react";
+import React from "react";
+import type { OptionsType } from "../../utils.js";
+import type { AutoFormProps } from "../AutoForm.js";
+import type { ButtonProps, ShadcnElements } from "./elements.js";
+
+type FormContainerT = React.ForwardRefExoticComponent<React.FormHTMLAttributes<HTMLFormElement> & React.RefAttributes<HTMLFormElement>>;
+
+export type ShadcnAutoFormProps<
+  GivenOptions extends OptionsType,
+  SchemaT,
+  ActionFunc extends ActionFunction<GivenOptions, any, any, SchemaT, any> | GlobalActionFunction<any>
+> = AutoFormProps<GivenOptions, SchemaT, ActionFunc> & Omit<ComponentProps<FormContainerT>, "action" | "defaultValue">;
+
+export const makeDefaultPreventedButton = <Elements extends Pick<ShadcnElements, "Button">>(elements: Elements) => {
+  const { Button } = elements;
+
+  const DefaultPreventedButton = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+    return (
+      <Button
+        ref={ref}
+        {...props}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          props.onClick?.(e);
+        }}
+      />
+    );
+  });
+  DefaultPreventedButton.displayName = "DefaultPreventedButton";
+  return DefaultPreventedButton;
+};

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
@@ -38,7 +38,6 @@ export const makeShadcnAutoDateTimePicker = ({
       <div
         className="ml-auto h-4 w-4 bg-transparent hover:opacity-30"
         onClick={(e) => {
-          e.stopPropagation();
           props.onClear();
         }}
       >
@@ -110,7 +109,7 @@ export const makeShadcnAutoDateTimePicker = ({
 
     return (
       <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <PopoverTrigger asChild onClick={(e: React.MouseEvent<HTMLButtonElement>) => e.stopPropagation()}>
+        <PopoverTrigger asChild>
           <div>
             <Label htmlFor={props.id ? `${props.id}-date` : undefined}>
               {props.label ?? metadata.name ?? "Date"}
@@ -118,6 +117,7 @@ export const makeShadcnAutoDateTimePicker = ({
             </Label>
             <Button
               id={props.id ? `${props.id}-date` : undefined}
+              onClick={() => setIsOpen(!isOpen)}
               variant="outline"
               type="button"
               className={`w-full justify-start text-left font-normal ${!localTime ? "text-muted-foreground" : ""} ${

--- a/packages/react/src/auto/shadcn/inputs/relationships/SelectedRelatedRecordTags.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/SelectedRelatedRecordTags.tsx
@@ -22,7 +22,7 @@ export const makeSelectedRecordTags = ({ Badge, Button }: Pick<ShadcnElements, "
       <>
         {options.map((option, index) => {
           return (
-            <Badge key={`option-${option.id || index}`} variant={"outline"}>
+            <Badge key={`option-${option.id || index}`} variant={"outline"} id={`selected-option-${option.primary}`}>
               {option.primary}
               <Button
                 onClick={(e) => {
@@ -31,7 +31,7 @@ export const makeSelectedRecordTags = ({ Badge, Button }: Pick<ShadcnElements, "
                   onRemoveRecord(record ?? { id: option.id });
                 }}
                 variant="ghost"
-                aria-label={`Remove`}
+                aria-label={`Remove ${option.primary}`}
                 size="icon"
               >
                 <XIcon />

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToForm.tsx
@@ -91,8 +91,11 @@ export const makeShadcnAutoBelongsToForm = ({
             {label ?? <h2 className="text-lg font-medium h-9">{relatedModelName}</h2>}
             {hasRecord && (
               <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
-                <DropdownMenuTrigger data-testid={`${path}-dropdown-menu-trigger`} asChild>
-                  <Button variant="ghost" className="w-4">
+                <DropdownMenuTrigger
+                  data-testid={`${path}-dropdown-menu-trigger`}
+                  className="focus-visible:outline-none focus-visible:ring-0"
+                >
+                  <Button variant="ghost" className="w-4" onClick={() => setActionsOpen(!actionsOpen)}>
                     <EllipsisVerticalIcon className="w-4 h-2" />
                   </Button>
                 </DropdownMenuTrigger>

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToInput.tsx
@@ -54,15 +54,7 @@ export const makeShadcnAutoBelongsToInput = ({
       selectedOption && selectedOption.id ? (
         <Badge key={`selectedRecordTag_${selectedOption.id}`} variant={"outline"}>
           {selectedOption.primary}
-          <Button
-            aria-label={`Remove`}
-            onClick={(e) => {
-              e.preventDefault();
-              onRemoveRecord();
-            }}
-            variant="ghost"
-            size="icon"
-          >
+          <Button aria-label={`Remove`} onClick={(e) => onRemoveRecord()} variant="ghost" size="icon">
             <XIcon />
           </Button>
         </Badge>
@@ -71,15 +63,7 @@ export const makeShadcnAutoBelongsToInput = ({
           <p id={`${danglingSelectedRecordId}`} style={{ color: "red" }}>
             id: {danglingSelectedRecordId}
           </p>
-          <Button
-            aria-label={`Remove`}
-            onClick={(e) => {
-              e.preventDefault();
-              onRemoveRecord();
-            }}
-            variant="ghost"
-            size="icon"
-          >
+          <Button aria-label={`Remove`} onClick={() => onRemoveRecord()} variant="ghost" size="icon">
             <XIcon />
           </Button>
         </Badge>

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyForm.tsx
@@ -89,11 +89,7 @@ export const makeShadcnAutoHasManyForm = ({
                           variant="default"
                           type="button"
                           id={`confirmButton_${metadataPathPrefix}.${idx}`}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            setEditingIndex(null);
-                          }}
+                          onClick={() => setEditingIndex(null)}
                         >
                           Confirm
                         </Button>
@@ -104,13 +100,8 @@ export const makeShadcnAutoHasManyForm = ({
               }
 
               return (
-                <AccordionItem
-                  key={field._fieldArrayKey}
-                  value={`${fieldArrayPath}.${idx}`}
-                  id={`${pathPrefix}.${idx}`}
-                  onClick={() => setEditingIndex(idx)}
-                >
-                  <AccordionSection position={position}>
+                <AccordionItem key={field._fieldArrayKey} value={`${fieldArrayPath}.${idx}`} id={`${pathPrefix}.${idx}`}>
+                  <AccordionSection position={position} onClick={() => setEditingIndex(idx)}>
                     <EditableOptionLabelButton option={option} />
                   </AccordionSection>
                 </AccordionItem>
@@ -141,7 +132,6 @@ export const makeShadcnAutoHasManyForm = ({
         variant="outline"
         className={`flex w-full h-fit justify-start gap-2 px-4 py-3 cursor-pointer ${position ? `${positionalBorder[position]}` : ""}`}
         onClick={(e) => {
-          e.preventDefault();
           onClick?.();
         }}
       >

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -113,17 +113,20 @@ export const makeShadcnAutoHasManyThroughForm = ({
           <div>
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  variant="outline"
-                  role="combobox"
-                  aria-expanded={open}
-                  aria-controls={listboxId}
-                  className={`w-[300px] flex flex-row items-center justify-between cursor-pointer ${open ? "bg-accent" : ""}`}
-                >
-                  <Label className="truncate flex-grow text-left cursor-pointer">Add {siblingModelName ?? "related model"}</Label>
-                  <ChevronsUpDown className="opacity-50 w-5 h-5 flex-shrink-0" />
-                </Button>
+                <div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    onClick={() => setOpen(!open)}
+                    aria-expanded={open}
+                    aria-controls={listboxId}
+                    className={`w-[300px] flex flex-row items-center justify-between cursor-pointer ${open ? "bg-accent" : ""}`}
+                  >
+                    <Label className="truncate flex-grow text-left cursor-pointer">Add {siblingModelName ?? "related model"}</Label>
+                    <ChevronsUpDown className="opacity-50 w-5 h-5 flex-shrink-0" />
+                  </Button>
+                </div>
               </PopoverTrigger>
               <PopoverContent className="w-[300px] bg-background p-0">
                 <div className="p-2">

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneForm.tsx
@@ -51,23 +51,8 @@ export const makeShadcnAutoHasOneForm = ({
       removeRecord,
     } = form;
 
-    const clickConfirmEdit = useCallback(
-      (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-        confirmEdit();
-      },
-      [confirmEdit]
-    );
-
-    const clickRemoveRecord = useCallback(
-      (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-        removeRecord();
-      },
-      [removeRecord]
-    );
+    const clickConfirmEdit = useCallback(() => confirmEdit(), [confirmEdit]);
+    const clickRemoveRecord = useCallback(() => removeRecord(), [removeRecord]);
 
     return (
       <RelationshipContext.Provider

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneInput.tsx
@@ -53,15 +53,7 @@ export const makeShadcnAutoHasOneInput = ({
     const selectedRecordTag = selectedOption ? (
       <Badge variant={"outline"} key={`selectedRecordTag_${selectedOption.id}`}>
         <p id={`${selectedOption.id}_${selectedOption.primary}`}>{selectedOption.primary ?? `id: ${selectedOption.id}`}</p>
-        <Button
-          aria-label={`Remove`}
-          onClick={(e) => {
-            e.preventDefault();
-            selectedRecord && onRemoveRecord(selectedRecord);
-          }}
-          variant="ghost"
-          size="icon"
-        >
+        <Button aria-label={`Remove`} onClick={() => selectedRecord && onRemoveRecord(selectedRecord)} variant="ghost" size="icon">
           <XIcon />
         </Button>
       </Badge>

--- a/packages/react/src/auto/shadcn/submit/ShadcnAutoSubmit.tsx
+++ b/packages/react/src/auto/shadcn/submit/ShadcnAutoSubmit.tsx
@@ -14,11 +14,21 @@ export const makeShadcnAutoSubmit = ({ Button }: Pick<ShadcnElements, "Button">)
    * Auto form submit button button for use within <AutoForm/>
    */
   function ShadcnAutoSubmit(props: { children?: ReactNode; isSubmitting?: boolean; className?: string } & ButtonProps) {
-    const { submitResult } = useAutoFormMetadata();
+    const { submitResult, submit } = useAutoFormMetadata();
     const isSubmitting = props.isSubmitting ?? submitResult.isSubmitting;
 
     return (
-      <Button type="submit" disabled={isSubmitting} {...props}>
+      <Button
+        type="submit"
+        disabled={isSubmitting}
+        {...props}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void submit();
+          props.onClick?.(e);
+        }}
+      >
         {isSubmitting ? <LoaderIcon className="h-4 w-4 animate-spin" /> : props.children ?? "Submit"}
       </Button>
     );

--- a/packages/react/src/auto/shadcn/table/ShadcnAutoTableBulkActionSelector.tsx
+++ b/packages/react/src/auto/shadcn/table/ShadcnAutoTableBulkActionSelector.tsx
@@ -24,7 +24,14 @@ export const makeShadcnAutoTableBulkActionSelector = (elements: ShadcnElements) 
     return (
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button variant="outline" role="combobox" aria-expanded={open} className="w-[200px] justify-between" aria-label="More actions">
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-[200px] justify-between"
+            aria-label="More actions"
+            onClick={() => setOpen(!open)}
+          >
             {"Actions..."}
             <ChevronsUpDown className="opacity-50" />
           </Button>


### PR DESCRIPTION
- UPDATE
  - Normally, you'd never want to submit a form unless you're explicitly hitting a submit button, and it'd be quite painful to manually add a default prevention system to every single button.
  - Now, instead of using the given button directly. we use a button with a modified onClick that prevents the default behaviour of submitting 👍 