### PR TITLE
Add error for nesting AutoForm inside another AutoForm

### DIFF
--- a/packages/react/spec/auto/polaris/form/PolarisAutoFormErrors.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoFormErrors.stories.jsx
@@ -57,3 +57,10 @@ export const GlobalActionWithoutApiTrigger = {
     action: api.noTriggerGlobalAction,
   },
 };
+
+export const NestedAutoForm = {
+  args: {
+    action: api.autoTableTest.create,
+    children: <PolarisAutoForm action={api.autoTableTest.create} />,
+  },
+};

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -18,7 +18,7 @@ import {
   validateTriggersFromApiClient,
   validateTriggersFromMetadata,
 } from "./AutoFormActionValidators.js";
-import { useFieldsFromChildComponents } from "./AutoFormContext.js";
+import { useAssertNotNestedInAnotherAutoForm, useFieldsFromChildComponents } from "./AutoFormContext.js";
 import { isAutoInput } from "./AutoInput.js";
 import { getSelectedPathsFromOptionLabel } from "./hooks/useSelectedPathsFromRecordLabel.js";
 import { getOptionLabelsFromRecordLabel, type RecordLabel } from "./interfaces/AutoRelationshipInputProps.js";
@@ -273,6 +273,7 @@ export const useAutoForm = <
   originalFormMethods: UseFormReturn<any, any>;
 } => {
   const { action, record, onSuccess, onFailure, findBy, select } = props;
+  useAssertNotNestedInAnotherAutoForm();
   validateNonBulkAction(action);
   validateTriggersFromApiClient(action);
 

--- a/packages/react/src/auto/AutoFormContext.tsx
+++ b/packages/react/src/auto/AutoFormContext.tsx
@@ -47,6 +47,14 @@ export const useAutoFormMetadata = () => {
   return autoFormContext;
 };
 
+export const useAssertNotNestedInAnotherAutoForm = () => {
+  const autoFormContext = useContext(AutoFormMetadataContext);
+
+  if (autoFormContext) {
+    throw new Error(`<AutoForm/> cannot be nested within another <AutoForm/> component.`);
+  }
+};
+
 export const useFieldsFromChildComponents = () => {
   const autoFormContext = useContext(AutoFormFieldsFromChildComponentsContext);
   if (!autoFormContext) {

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -77,7 +77,6 @@ const PolarisAutoFormComponent = <
     formError,
     isSubmitting,
     isSubmitSuccessful,
-    pauseExistingRecordLookup,
     originalFormMethods,
   } = useAutoForm(props);
 


### PR DESCRIPTION
Nesting an autoForm within another AutoForm causes the submission to break completely. This should be an error case in the first place