### PR TITLE
Make `children` optional in `AutoHasManyThrough` form

### DIFF
--- a/packages/react/src/auto/hooks/useRelatedModel.tsx
+++ b/packages/react/src/auto/hooks/useRelatedModel.tsx
@@ -73,7 +73,7 @@ const omitRelatedModelRecordsAssociatedWithOtherRecords = (props: {
   };
 };
 
-export const useRecordLabelObjectFromProps = (props: AutoRelationshipFormProps) => {
+export const useRecordLabelObjectFromProps = (props: Pick<AutoRelationshipFormProps, "field" | "recordLabel">) => {
   const recordLabelObject = getRecordLabelObject(props.recordLabel);
   const primaryLabel = useOptionLabelForField(props.field, recordLabelObject?.primary);
   return { ...recordLabelObject, primary: primaryLabel };

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -88,6 +88,8 @@ export type AutoRelationshipFormProps = {
   recordFilter?: RecordFilter;
 };
 
+export type AutoHasManyThroughFormProps = Omit<AutoRelationshipFormProps, "children"> & { children?: ReactNode };
+
 export const getRecordLabelObject = (recordLabel?: OptionLabel | RecordLabel): RecordLabel | undefined => {
   if (!recordLabel) {
     return undefined;

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -5,11 +5,11 @@ import { useHasManyThroughForm } from "../../../../useHasManyThroughForm.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
 import { getRecordAsOption } from "../../../hooks/useRelatedModel.js";
-import type { AutoRelationshipFormProps, DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoHasManyThroughFormProps, DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
 import { RelatedModelOptionsPopover, RelatedModelOptionsSearch } from "./RelatedModelOptions.js";
 import { renderOptionLabel } from "./utils.js";
 
-export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoRelationshipFormProps) => {
+export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoHasManyThroughFormProps) => {
   const [addingSibling, setAddingSibling] = useState(false);
   const {
     append,

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -5,7 +5,7 @@ import { debounce } from "../../../../utils.js";
 import { autoRelationshipForm } from "../../../AutoInput.js";
 import { RelationshipContext } from "../../../hooks/useAutoRelationship.js";
 import { getRecordAsOption } from "../../../hooks/useRelatedModel.js";
-import type { AutoRelationshipFormProps, DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
+import type { AutoHasManyThroughFormProps, DisplayedRecordOption } from "../../../interfaces/AutoRelationshipInputProps.js";
 import type { ShadcnElements } from "../../elements.js";
 import { makeShadcnRenderOptionLabel } from "../../utils.js";
 import { makeShadcnAutoComboInput } from "../ShadcnAutoComboInput.js";
@@ -79,7 +79,7 @@ export const makeShadcnAutoHasManyThroughForm = ({
     );
   };
 
-  function ShadcnAutoHasManyThroughForm(props: AutoRelationshipFormProps) {
+  function ShadcnAutoHasManyThroughForm(props: AutoHasManyThroughFormProps) {
     const [open, setOpen] = useState(false);
     const {
       field,

--- a/packages/react/src/useHasManyThroughForm.ts
+++ b/packages/react/src/useHasManyThroughForm.ts
@@ -3,10 +3,10 @@ import { useEffect, useMemo } from "react";
 import { useAutoRelationship, useRelationshipContext } from "./auto/hooks/useAutoRelationship.js";
 import { useHasManyThroughController } from "./auto/hooks/useHasManyThroughController.js";
 import { useRecordLabelObjectFromProps } from "./auto/hooks/useRelatedModel.js";
-import type { AutoRelationshipFormProps } from "./auto/interfaces/AutoRelationshipInputProps.js";
+import type { AutoHasManyThroughFormProps } from "./auto/interfaces/AutoRelationshipInputProps.js";
 import { useFormContext } from "./useActionForm.js";
 
-export const useHasManyThroughForm = (props: AutoRelationshipFormProps) => {
+export const useHasManyThroughForm = (props: AutoHasManyThroughFormProps) => {
   const { field, children } = props;
   const { metadata } = useAutoRelationship({ field });
   const { setValue } = useFormContext();


### PR DESCRIPTION
in `AutoHasManyThrough`, not having any react children did not impede the usage of the component, but this was a top error. Now, this is no longer a type error