### PR TITLE
Error for relationship fields in `AutoHasManyThrough` form + New join model AutoInput system

### DIFF
--- a/packages/react/.changeset/rotten-news-rule.md
+++ b/packages/react/.changeset/rotten-news-rule.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+BEAKING CHANGE - Added error for using dot.path.fields in the `field` prop of AutoInputs to traverse record relationships. This functionality was inconsistent and is now better handled by the new relationship form components

--- a/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-
-import { describeForEachAutoAdapter } from "../../../support/auto.js";
-
+import { AutoHasManyThroughJoinModelForm } from "../../../../src/auto/hooks/useHasManyThroughController.js";
 import { api } from "../../../support/api.js";
+import { describeForEachAutoAdapter } from "../../../support/auto.js";
 
 describeForEachAutoAdapter(
   "AutoHasManyForm",
@@ -74,8 +73,10 @@ describeForEachAutoAdapter(
               tertiary: "department",
             }}
           >
-            <AutoInput field="registration.effectiveFrom" />
-            <AutoInput field="registration.effectiveTo" />
+            <AutoHasManyThroughJoinModelForm>
+              <AutoInput field="effectiveFrom" />
+              <AutoInput field="effectiveTo" />
+            </AutoHasManyThroughJoinModelForm>
           </AutoHasManyThroughForm>
           <AutoSubmit id="submit" />
         </AutoForm>,

--- a/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/polaris/form/PolarisAutoRelationshipForm.stories.jsx
@@ -2,6 +2,7 @@ import { AppProvider, BlockStack, Box, Button, Card, FormLayout, InlineStack, La
 import translations from "@shopify/polaris/locales/en.json";
 import React, { useState } from "react";
 import { Provider } from "../../../../src/GadgetProvider.tsx";
+import { AutoHasManyThroughJoinModelForm } from "../../../../src/auto/hooks/useHasManyThroughController.tsx";
 import { PolarisAutoForm } from "../../../../src/auto/polaris/PolarisAutoForm.tsx";
 import { PolarisAutoInput } from "../../../../src/auto/polaris/inputs/PolarisAutoInput.tsx";
 import { PolarisAutoBelongsToForm } from "../../../../src/auto/polaris/inputs/relationships/PolarisAutoBelongsToForm.tsx";
@@ -210,8 +211,11 @@ const ExampleCourseCreateRelatedForm = (props) => {
           >
             <InlineStack gap="300">
               {/* Fields on the join model. The prefix is the model API id of the join model */}
-              <PolarisAutoInput field="registration.effectiveFrom" />
-              <PolarisAutoInput field="registration.effectiveTo" />
+
+              <AutoHasManyThroughJoinModelForm>
+                <PolarisAutoInput field="effectiveTo" />
+                <PolarisAutoInput field="effectiveFrom" />
+              </AutoHasManyThroughJoinModelForm>
 
               {/* Fields on the sibling model. No prefix */}
               <PolarisAutoInput field="firstName" />
@@ -273,8 +277,10 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
             }}
           >
             <InlineStack>
-              <PolarisAutoInput field="friendship.started" />
-              <PolarisAutoInput field="friendship.ended" />
+              <AutoHasManyThroughJoinModelForm>
+                <PolarisAutoInput field="started" />
+                <PolarisAutoInput field="ended" />
+              </AutoHasManyThroughJoinModelForm>
             </InlineStack>
           </PolarisAutoHasManyThroughForm>
         </Card>
@@ -287,8 +293,10 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
             }}
           >
             <InlineStack>
-              <PolarisAutoInput field="friendship.started" />
-              <PolarisAutoInput field="friendship.ended" />
+              <AutoHasManyThroughJoinModelForm>
+                <PolarisAutoInput field="started" />
+                <PolarisAutoInput field="ended" />
+              </AutoHasManyThroughJoinModelForm>
             </InlineStack>
           </PolarisAutoHasManyThroughForm>
         </Card>

--- a/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
+++ b/packages/react/spec/auto/shadcn-defaults/inputs/form/ShadcnAutoRelationshipForm.stories.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Provider } from "../../../../../src/GadgetProvider.tsx";
+import { AutoHasManyThroughJoinModelForm } from "../../../../../src/auto/hooks/useHasManyThroughController.tsx";
 import { makeAutocomponents } from "../../../../../src/auto/shadcn/index.ts";
 import { FormProvider, useForm } from "../../../../../src/useActionForm.ts";
 import { testApi as api } from "../../../../apis.ts";
@@ -197,8 +198,10 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
             }}
           >
             <div className="flex flex-row gap-4">
-              <AutoInput field="friendship.started" />
-              <AutoInput field="friendship.ended" />
+              <AutoHasManyThroughJoinModelForm>
+                <AutoInput field="started" />
+                <AutoInput field="ended" />
+              </AutoHasManyThroughJoinModelForm>
             </div>
           </AutoHasManyThroughForm>
         </Card>
@@ -211,8 +214,10 @@ const ExampleTweeterFollowerCreateRelatedForm = (props) => {
             }}
           >
             <div className="flex flex-row gap-4">
-              <AutoInput field="friendship.started" />
-              <AutoInput field="friendship.ended" />
+              <AutoHasManyThroughJoinModelForm>
+                <AutoInput field="started" />
+                <AutoInput field="ended" />
+              </AutoHasManyThroughJoinModelForm>
             </div>
           </AutoHasManyThroughForm>
         </Card>
@@ -284,8 +289,10 @@ const ExampleCourseCreateRelatedForm = (props) => {
             }}
           >
             <div className="flex flex-col gap-4">
-              <AutoInput field="registration.effectiveFrom" />
-              <AutoInput field="registration.effectiveTo" />
+              <AutoHasManyThroughJoinModelForm>
+                <AutoInput field="effectiveFrom" />
+                <AutoInput field="effectiveTo" />
+              </AutoHasManyThroughJoinModelForm>
             </div>
           </AutoHasManyThroughForm>
         </Card>

--- a/packages/react/src/auto/hooks/useFieldMetadata.tsx
+++ b/packages/react/src/auto/hooks/useFieldMetadata.tsx
@@ -1,4 +1,5 @@
 import { type FieldMetadata } from "../../metadata.js";
+import { isRelationshipField } from "../../use-table/helpers.js";
 import { useAutoFormMetadata } from "../AutoFormContext.js";
 import { useRelationshipContext } from "../hooks/useAutoRelationship.js";
 
@@ -22,7 +23,17 @@ export const useFieldMetadata = (fieldApiIdentifier: string) => {
     throw new Error(`Field "${fieldApiIdentifier}" not found in metadata`);
   }
 
+  useValidateNoRelationshipFieldsInHasManyThroughForm(metadata);
+
   return { path, metadata };
+};
+
+const useValidateNoRelationshipFieldsInHasManyThroughForm = (metadata: FieldMetadata) => {
+  const relationshipContext = useRelationshipContext();
+
+  if (isRelationshipField(metadata) && relationshipContext && relationshipContext.hasManyThrough) {
+    throw new Error(`"${metadata.apiIdentifier}" is not allowed in a AutoHasManyThroughForm`);
+  }
 };
 
 const useGetPaths = (fieldApiIdentifier: string) => {

--- a/packages/react/src/auto/hooks/useHasManyThroughController.tsx
+++ b/packages/react/src/auto/hooks/useHasManyThroughController.tsx
@@ -1,8 +1,9 @@
 import { assert } from "@gadgetinc/api-client-core";
-import { useCallback, useMemo } from "react";
+import React, { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
 import { GadgetFieldType, type GadgetHasManyThroughConfig } from "../../internal/gql/graphql.js";
 import { useFieldArray } from "../../useActionForm.js";
 import type { AutoRelationshipFormProps, AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
+import { useRelationshipContext } from "./useAutoRelationship.js";
 import { useFieldMetadata } from "./useFieldMetadata.js";
 import { useRelatedModelOptions } from "./useRelatedModel.js";
 import { assertFieldType } from "./utils.js";
@@ -115,4 +116,28 @@ export const useHasManyThroughInputController = (props: AutoRelationshipInputPro
     onSelectRecord,
     onRemoveRecord,
   };
+};
+
+export const AutoHasManyThroughJoinModelForm = (props: {
+  /** The React children containing inputs on the join model in an AutoHasManyThroughForm component */
+  children?: ReactNode;
+}) => {
+  useEnsureInHasManyThroughForm();
+
+  return <HasManyThroughJoinModelContext.Provider value={true}>{props.children}</HasManyThroughJoinModelContext.Provider>;
+};
+
+export const HasManyThroughJoinModelContext = createContext<null | true>(null);
+
+// Export a hook that just checks if we're inside the component
+export const useIsInHasManyThroughJoinModelInput = () => {
+  return useContext(HasManyThroughJoinModelContext) !== null;
+};
+
+export const useEnsureInHasManyThroughForm = () => {
+  const relationshipContext = useRelationshipContext();
+
+  if (!relationshipContext || !relationshipContext.hasManyThrough) {
+    throw new Error(`'AutoJoinModelInput' can only be used within a 'AutoHasManyThroughForm' component`);
+  }
 };

--- a/packages/react/src/auto/polaris/index.ts
+++ b/packages/react/src/auto/polaris/index.ts
@@ -1,4 +1,5 @@
 export { useAutoFormMetadata } from "../AutoFormContext.js";
+export { AutoHasManyThroughJoinModelForm } from "../hooks/useHasManyThroughController.js";
 export { PolarisAutoButton as AutoButton } from "./PolarisAutoButton.js";
 export { PolarisAutoForm as AutoForm, PolarisAutoFormSkeleton as AutoFormSkeleton } from "./PolarisAutoForm.js";
 export { PolarisAutoTable as AutoTable } from "./PolarisAutoTable.js";


### PR DESCRIPTION
- UPDATES
  - Banning Relationships in HMT forms
    - The resulting GQL request is completely incorrect when relationship fields are used within `AutoHasManyThrough` forms. 
      - It seems that the form state does not get updated properly for relationships.
      - This is a problem on both the join model relationships and sibling model relationships
    - For now, an error will prevent users from thinking that this is supported. In the future, it is feasible to add support for this smoothly without breaking change
    - No changes for non-relationship fields being used in a `AutoHasManyThroughForm`. Access to sibling and join model fields is still good
  - New HMT form join record input system
    - previously, we relied on having `field="joinModelName.joinModelField"` inside of AutoInputs inside of HMT form components to refer to join model inputs. This system suggests that it is OK to have `dot.separated.paths` to traverse relationships in autoform, but this does not work well outside of this context.
    - Now, I have added a validation that assures that "." is not included inside in the `field` prop string. I think it is bad to give users the idea that this notation will work consistently.
    -  I added two new components to give an alternate way to use inputs on the join model without dot.separated.paths
        - `<AutoHasManyThroughJoinModelForm> ` - wrapper  component around regular AutoForm inputs to ensure that they are applied to the join model
