### PR TITLE
Strengthen internal .deleteMany type to require being passed a filter

### DIFF
--- a/packages/api-client-core/src/InternalModelManager.ts
+++ b/packages/api-client-core/src/InternalModelManager.ts
@@ -22,7 +22,13 @@ import {
   namespacify,
   sortTypeName,
 } from "./support.js";
-import type { InternalFieldSelection, InternalFindListOptions, InternalFindManyOptions, InternalFindOneOptions } from "./types.js";
+import type {
+  AnyFilter,
+  InternalFieldSelection,
+  InternalFindListOptions,
+  InternalFindManyOptions,
+  InternalFindOneOptions,
+} from "./types.js";
 
 export const internalFindOneQuery = (apiIdentifier: string, id: string, namespace: string[], select?: InternalFieldSelection) => {
   const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
@@ -236,7 +242,7 @@ export const internalDeleteMutation = (apiIdentifier: string, namespace: string[
 export const internalDeleteManyMutation = (
   apiIdentifier: string,
   namespace: string[],
-  options?: { search?: string; filter?: Record<string, any>[] | Record<string, any> }
+  options?: { search?: string; filter?: AnyFilter }
 ) => {
   const capitalizedApiIdentifier = capitalizeIdentifier(apiIdentifier);
 
@@ -533,7 +539,7 @@ export class InternalModelManager<Shape extends RecordShape = RecordData> {
    *
    * @param options Search and filter options for the records to delete
    */
-  async deleteMany(options?: { search?: string; filter?: Record<string, any> | Record<string, any>[] }): Promise<void> {
+  async deleteMany(options: { search?: string; filter: AnyFilter }): Promise<void> {
     const plan = internalDeleteManyMutation(this.apiIdentifier, this.namespace, options);
     const response = await this.connection.currentClient.mutation(plan.query, plan.variables).toPromise();
     assertMutationSuccess(response, this.dataPath(`deleteMany${this.capitalizedApiIdentifier}`));


### PR DESCRIPTION
A user on discord invoked `api.thing.internal.deleteMany(["1", "2", "3"])` which is wrong -- the function accepts an options object with a filter and a sort, but the type had those properties marked as optional, which meant that the array actually passed the typecheck! The right invocation is `api.thing.internal.deleteMany({filter: { ...}})`. Since this is a really sensitive operation, I think we should be more annoying about the required inputs so that users are forced to pass a filter of some sort. They can still delete everything by doing `api.thing.internal.deleteMany({filter: {}})`, but I think we should make that done explicitly instead of by accident if you don't pass the right options.

This is a breaking types change which I am ok to just YOLO -- functionality is unaffected but I think we can consider it a bugfix.
