### PR TITLE
Background action upsert responses

### DIFF
--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/api-client-core",
-  "version": "0.15.40",
+  "version": "0.15.41",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/packages/api-client-core/spec/mockActions.ts
+++ b/packages/api-client-core/spec/mockActions.ts
@@ -56,6 +56,36 @@ export const MockWidgetUpdateAction = {
   { id: true; name: true }
 >;
 
+export const MockUpsertWidgetAction = {
+  type: "action",
+  isBulk: false,
+  defaultSelection: {
+    id: true,
+    name: true,
+  },
+  operationName: "upsertWidget",
+  operationReturnType: "UpsertWidget",
+  modelApiIdentifier: "widget",
+  operatesWithRecordIdentity: false,
+  acceptsModelInput: true,
+  modelSelectionField: "widget",
+  variables: {
+    on: { required: false, type: "[String!]" },
+    widget: { required: true, type: "UpsertWidgetInput" },
+  },
+  paramOnlyVariables: ["on"],
+  hasReturnType: {
+    "... on CreateWidgetResult": { hasReturnType: false },
+    "... on UpdateWidgetResult": { hasReturnType: false },
+  },
+} as unknown as ActionFunction<
+  { select?: { id?: boolean; name?: boolean } },
+  any,
+  { id?: boolean; name?: boolean },
+  { id: string; name: string },
+  { id: true; name: true }
+>;
+
 export const MockBulkCreateWidgetAction = {
   type: "action",
   operationName: "bulkCreateWidgets",
@@ -76,11 +106,12 @@ export const MockBulkCreateWidgetAction = {
   variables: {
     inputs: {
       required: true,
-      type: "[BulkCreateeWidgetsInput!]",
+      type: "[BulkCreateWidgetsInput!]",
     },
   },
   acceptsModelInput: true,
   hasReturnType: false,
+  singleAction: MockWidgetCreateAction,
 } as unknown as BulkActionFunction<any, any, any, any, any>;
 
 export const MockBulkUpdateWidgetAction = {
@@ -108,6 +139,30 @@ export const MockBulkUpdateWidgetAction = {
   },
   acceptsModelInput: true,
   hasReturnType: false,
+  singleAction: MockWidgetUpdateAction,
+} as unknown as BulkActionFunction<any, any, any, any, any>;
+
+export const MockBulkUpsertWidgetAction = {
+  type: "action",
+  operationName: "bulkUpsertWidgets",
+  namespace: null,
+  modelApiIdentifier: "widget",
+  operatesWithRecordIdentity: false,
+  modelSelectionField: "widgets",
+  isBulk: true,
+  defaultSelection: {
+    id: true,
+    name: true,
+  },
+  variables: {
+    inputs: {
+      required: true,
+      type: "[BulkUpsertWidgetsInput!]",
+    },
+  },
+  acceptsModelInput: true,
+  hasReturnType: false,
+  singleAction: MockUpsertWidgetAction,
 } as unknown as BulkActionFunction<any, any, any, any, any>;
 
 export const MockBulkFlipDownWidgetsAction = {

--- a/packages/api-client-core/spec/operationBuilders.spec.ts
+++ b/packages/api-client-core/spec/operationBuilders.spec.ts
@@ -7,7 +7,13 @@ import {
   findOneOperation,
   globalActionOperation,
 } from "../src/index.js";
-import { MockBulkUpdateWidgetAction, MockGlobalAction, MockWidgetCreateAction } from "./mockActions.js";
+import {
+  MockBulkUpdateWidgetAction,
+  MockBulkUpsertWidgetAction,
+  MockGlobalAction,
+  MockUpsertWidgetAction,
+  MockWidgetCreateAction,
+} from "./mockActions.js";
 
 describe("operation builders", () => {
   describe("findOneOperation", () => {
@@ -1365,6 +1371,54 @@ describe("operation builders", () => {
       `);
     });
 
+    test("builds query for upsert action", async () => {
+      expect(backgroundActionResultOperation("app-job-1234567", MockUpsertWidgetAction, { select: { id: true } })).toMatchInlineSnapshot(`
+        {
+          "query": "subscription UpsertWidgetBackgroundResult($id: String!) {
+          backgroundAction(id: $id) {
+            id
+            outcome
+            result {
+              ... on UpsertWidgetResult {
+                success
+                errors {
+                  message
+                  code
+                  ... on InvalidRecordError {
+                    model {
+                      apiIdentifier
+                    }
+                    validationErrors {
+                      message
+                      apiIdentifier
+                    }
+                  }
+                }
+                ... on CreateWidgetResult {
+                  __typename
+                  widget {
+                    id
+                    __typename
+                  }
+                }
+                ... on UpdateWidgetResult {
+                  __typename
+                  widget {
+                    id
+                    __typename
+                  }
+                }
+              }
+            }
+          }
+        }",
+          "variables": {
+            "id": "app-job-1234567",
+          },
+        }
+      `);
+    });
+
     test("builds query for one result of a bulk action", async () => {
       expect(backgroundActionResultOperation("app-job-1234567", MockBulkUpdateWidgetAction, { select: { id: true } }))
         .toMatchInlineSnapshot(`
@@ -1392,6 +1446,55 @@ describe("operation builders", () => {
                 widget {
                   id
                   __typename
+                }
+              }
+            }
+          }
+        }",
+          "variables": {
+            "id": "app-job-1234567",
+          },
+        }
+      `);
+    });
+
+    test("builds query for one result of a bulk upsert action", async () => {
+      expect(backgroundActionResultOperation("app-job-1234567", MockBulkUpsertWidgetAction, { select: { id: true } }))
+        .toMatchInlineSnapshot(`
+        {
+          "query": "subscription UpsertWidgetBackgroundResult($id: String!) {
+          backgroundAction(id: $id) {
+            id
+            outcome
+            result {
+              ... on UpsertWidgetResult {
+                success
+                errors {
+                  message
+                  code
+                  ... on InvalidRecordError {
+                    model {
+                      apiIdentifier
+                    }
+                    validationErrors {
+                      message
+                      apiIdentifier
+                    }
+                  }
+                }
+                ... on CreateWidgetResult {
+                  __typename
+                  widget {
+                    id
+                    __typename
+                  }
+                }
+                ... on UpdateWidgetResult {
+                  __typename
+                  widget {
+                    id
+                    __typename
+                  }
                 }
               }
             }

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -131,6 +131,7 @@ export interface ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, Schema
   paramOnlyVariables?: readonly string[];
   hasReturnType?: HasReturnType;
   singleActionFunctionName?: string;
+  singleAction?: IsBulk extends true ? ActionFunctionMetadata<OptionsT, VariablesT, SelectionT, SchemaT, DefaultsT, false> : never;
   plan?: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
   /** @deprecated */
   hasCreateOrUpdateEffect?: boolean;
@@ -204,5 +205,8 @@ export interface GlobalActionFunction<VariablesT> {
   plan?: (variables?: VariablesOptions) => GQLBuilderResult;
 }
 
-export type AnyActionFunction = ActionFunctionMetadata<any, any, any, any, any, any> | GlobalActionFunction<any>;
+export type AnyActionFunction =
+  | ActionFunctionMetadata<any, any, any, any, any, true>
+  | ActionFunctionMetadata<any, any, any, any, any, false | undefined>
+  | GlobalActionFunction<any>;
 export type AnyBulkActionFunction = ActionFunctionMetadata<any, any, any, any, any, true>;

--- a/packages/api-client-core/src/operationBuilders.ts
+++ b/packages/api-client-core/src/operationBuilders.ts
@@ -206,25 +206,32 @@ export const backgroundActionResultOperation = <Action extends AnyActionFunction
   options?: Options
 ) => {
   let fields: FieldSelection = {};
-  let operationName = action.operationName;
   let resultType: string;
 
-  if (action.isBulk) {
-    operationName = action.operationName.replace(/^bulk/, "").replace(/s$/, "");
+  const backgroundAction = action.isBulk && action.singleAction ? action.singleAction : action;
+
+  let operationName = backgroundAction.operationName;
+  if (backgroundAction.isBulk) {
+    operationName = backgroundAction.operationName.replace(/^bulk/, "").replace(/s$/, "");
   }
 
-  if (!action.operationReturnType) {
+  if (!backgroundAction.operationReturnType) {
     resultType = `${camelize(operationName)}Result`;
   } else {
-    resultType = `${action.operationReturnType}Result`;
+    resultType = `${backgroundAction.operationReturnType}Result`;
   }
 
-  switch (action.type) {
+  switch (backgroundAction.type) {
     case "action": {
-      const selection = options?.select || action.defaultSelection;
+      const selection = options?.select || backgroundAction.defaultSelection;
 
       fields = {
-        [`... on ${resultType}`]: actionResultFieldSelection(action.modelApiIdentifier, selection, action.isBulk, action.hasReturnType),
+        [`... on ${resultType}`]: actionResultFieldSelection(
+          backgroundAction.modelApiIdentifier,
+          selection,
+          backgroundAction.isBulk,
+          backgroundAction.hasReturnType
+        ),
       };
       break;
     }

--- a/packages/api-client-core/src/operationRunners.ts
+++ b/packages/api-client-core/src/operationRunners.ts
@@ -403,7 +403,7 @@ export async function enqueueActionRunner<SchemaT, Action extends AnyActionFunct
   options: EnqueueBackgroundActionOptions<Action> = {}
 ): Promise<Result | Result[]> {
   const normalizedVariableValues = action.isBulk
-    ? disambiguateBulkActionVariables(action as ActionFunctionMetadata<any, any, any, any, any, true>, variables)
+    ? disambiguateBulkActionVariables(action, variables)
     : disambiguateActionVariables(action, variables);
   const variableOptions = setVariableOptionValues(action.variables, normalizedVariableValues);
 

--- a/packages/react/src/useEnqueue.ts
+++ b/packages/react/src/useEnqueue.ts
@@ -1,9 +1,4 @@
-import type {
-  ActionFunctionMetadata,
-  AnyActionFunction,
-  EnqueueBackgroundActionOptions,
-  GadgetConnection,
-} from "@gadgetinc/api-client-core";
+import type { AnyActionFunction, EnqueueBackgroundActionOptions, GadgetConnection } from "@gadgetinc/api-client-core";
 import {
   BackgroundActionHandle,
   disambiguateActionVariables,
@@ -69,9 +64,7 @@ export const useEnqueue = <SchemaT, Action extends AnyActionFunction>(
     state,
     useCallback(
       async (input: Action["variablesType"], options?: EnqueueBackgroundActionOptions<Action>) => {
-        const variables = action.isBulk
-          ? disambiguateBulkActionVariables(action as ActionFunctionMetadata<any, any, any, any, any, true>, input)
-          : disambiguateActionVariables(action, input);
+        const variables = action.isBulk ? disambiguateBulkActionVariables(action, input) : disambiguateActionVariables(action, input);
 
         const fullContext = { ...baseBackgroundOptions, ...options };
         variables.backgroundOptions = graphqlizeBackgroundOptions(fullContext);


### PR DESCRIPTION
Right now this code breaks in a gadget app:

```
const handles = await api.enqueue(api.todo.bulkUpsert, input)

return await Promise.all(handles.map((handle) => handle.result()))
```

This is because we are not correctly building the graphql query in cases where the `hasReturnType` between an action and its bulkAction are different.

This PR changes this so that if a bulkAction has a reference to its `singleAction` we will use that to generate the query for background action results; things will continue to work for existing clients and non-upsert actions

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
