### PR TITLE
Update shadcn auto file input

### DIFF
--- a/packages/react/src/auto/hooks/useFileInputController.tsx
+++ b/packages/react/src/auto/hooks/useFileInputController.tsx
@@ -124,6 +124,32 @@ export const useFileInputController = (props: {
     [api, fieldProps, fileSizeValidation, path, setError]
   );
 
+  const validations = {
+    fileSize: fileSizeValidation,
+    onlyImages: onlyImagesValidation,
+  };
+
+  const actionHintParts = useMemo(() => {
+    if (fieldProps.value) return null;
+
+    const actionHintParts = ["Accepts"];
+    if (validations.onlyImages) {
+      actionHintParts.push(`.jpg, .webp, .svg${validations.onlyImages.allowAnimatedImages ? ", .gif" : ""}, and .png`);
+    }
+
+    if (validations.fileSize) {
+      const validation = validations.fileSize;
+      const message = getFileSizeValidationMessage(validation, {
+        inRange: (min, max) => `between ${filesize(min)} and ${filesize(max)}`,
+        max: (max) => `smaller than ${filesize(max)}`,
+        min: (min) => `larger than ${filesize(min)}`,
+      });
+      if (message) actionHintParts.push(message);
+    }
+
+    return actionHintParts;
+  }, [fieldProps.value, validations.fileSize, validations.onlyImages?.allowAnimatedImages]);
+
   return {
     fieldProps,
     isError: !!errorFromValidator,
@@ -131,12 +157,10 @@ export const useFileInputController = (props: {
     imageThumbnailURL,
     onFileUpload,
     clearFileValue,
-    validations: {
-      fileSize: fileSizeValidation,
-      onlyImages: onlyImagesValidation,
-    },
+    validations,
     metadata,
     canClearFileValue,
+    actionHintParts,
   };
 };
 

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoFileInput.tsx
@@ -1,41 +1,37 @@
 import type { DropZoneProps } from "@shopify/polaris";
 import { Box, Button, DropZone, InlineError, InlineStack, Thumbnail } from "@shopify/polaris";
 import { DeleteIcon, NoteIcon } from "@shopify/polaris-icons";
-import { filesize } from "filesize";
 import React, { useMemo } from "react";
 import type { Control } from "../../../useActionForm.js";
 import { isAutoFileFieldValue } from "../../../validationSchema.js";
 import { autoInput } from "../../AutoInput.js";
-import { getFileSizeValidationMessage, imageFileTypes, useFileInputController } from "../../hooks/useFileInputController.js";
+import { imageFileTypes, useFileInputController } from "../../hooks/useFileInputController.js";
 
 export const PolarisAutoFileInput = autoInput((props: { field: string; control?: Control<any> } & Omit<DropZoneProps, "allowMultiple">) => {
   const { field: fieldApiIdentifier, control, ...rest } = props;
-  const { fieldProps, errorMessage, imageThumbnailURL, onFileUpload, clearFileValue, canClearFileValue, validations, metadata } =
-    useFileInputController({
-      field: fieldApiIdentifier,
-      control,
-    });
+
+  const {
+    fieldProps,
+    errorMessage,
+    imageThumbnailURL,
+    onFileUpload,
+    clearFileValue,
+    canClearFileValue,
+    validations,
+    metadata,
+    actionHintParts,
+  } = useFileInputController({
+    field: fieldApiIdentifier,
+    control,
+  });
 
   const fileUploadContainer = useMemo(() => {
-    if (fieldProps.value) return null;
-
-    const actionHintParts = ["Accepts"];
-    if (validations.onlyImages) {
-      actionHintParts.push(`.jpg, .webp, .svg${validations.onlyImages.allowAnimatedImages ? ", .gif" : ""}, and .png`);
-    }
-
-    if (validations.fileSize) {
-      const validation = validations.fileSize;
-      const message = getFileSizeValidationMessage(validation, {
-        inRange: (min, max) => `between ${filesize(min)} and ${filesize(max)}`,
-        max: (max) => `smaller than ${filesize(max)}`,
-        min: (min) => `larger than ${filesize(min)}`,
-      });
-      if (message) actionHintParts.push(message);
+    if (!actionHintParts) {
+      return null;
     }
 
     return <DropZone.FileUpload actionTitle="Add file" actionHint={actionHintParts.length === 1 ? "" : actionHintParts.join(" ")} />;
-  }, [fieldProps.value, validations.fileSize, validations.onlyImages]);
+  }, [actionHintParts]);
 
   const filePreview = useMemo(() => {
     const value = fieldProps.value;

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoFileInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoFileInput.tsx
@@ -1,11 +1,19 @@
-import { filesize } from "filesize";
+import { DeleteIcon, File } from "lucide-react";
 import React, { HtmlHTMLAttributes, useMemo, type ReactNode } from "react";
 import type { Control } from "../../../useActionForm.js";
+import { isAutoFileFieldValue } from "../../../validationSchema.js";
 import { autoInput } from "../../AutoInput.js";
-import { getFileSizeValidationMessage, useFileInputController } from "../../hooks/useFileInputController.js";
+import { useFileInputController } from "../../hooks/useFileInputController.js";
 import { ShadcnElements } from "../elements.js";
 
-export const makeShadcnAutoFileInput = ({ Input, Label }: Pick<ShadcnElements, "Input" | "Label">) => {
+export const makeShadcnAutoFileInput = ({
+  Input,
+  Label,
+  Button,
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+}: Pick<ShadcnElements, "Input" | "Label" | "Button" | "Avatar" | "AvatarImage" | "AvatarFallback">) => {
   function ShadcnAutoFileInput(
     props: {
       field: string;
@@ -14,34 +22,31 @@ export const makeShadcnAutoFileInput = ({ Input, Label }: Pick<ShadcnElements, "
     } & HtmlHTMLAttributes<HTMLDivElement>
   ) {
     const { field: fieldApiIdentifier, control, ...rest } = props;
-    const { fieldProps, errorMessage, imageThumbnailURL, onFileUpload, clearFileValue, canClearFileValue, validations, metadata } =
-      useFileInputController({
-        field: fieldApiIdentifier,
-        control,
-      });
+
+    const {
+      fieldProps,
+      errorMessage,
+      imageThumbnailURL,
+      onFileUpload,
+      clearFileValue,
+      canClearFileValue,
+      validations,
+      metadata,
+      actionHintParts,
+    } = useFileInputController({
+      field: fieldApiIdentifier,
+      control,
+    });
 
     const fileUploadContainer = useMemo(() => {
-      if (fieldProps.value) return null;
-
-      const actionHintParts = ["Accepts"];
-      if (validations.onlyImages) {
-        actionHintParts.push(`.jpg, .webp, .svg${validations.onlyImages.allowAnimatedImages ? ", .gif" : ""}, and .png`);
-      }
-
-      if (validations.fileSize) {
-        const validation = validations.fileSize;
-        const message = getFileSizeValidationMessage(validation, {
-          inRange: (min, max) => `between ${filesize(min)} and ${filesize(max)}`,
-          max: (max) => `smaller than ${filesize(max)}`,
-          min: (min) => `larger than ${filesize(min)}`,
-        });
-        if (message) actionHintParts.push(message);
+      if (!actionHintParts) {
+        return null;
       }
 
       return (
         <div>
-          <Label>
-            {actionHintParts.length > 0 && (
+          {actionHintParts.length > 1 && (
+            <Label>
               <span className="block text-sm text-gray-500 mb-2">
                 {actionHintParts.map((part, index) => (
                   <span key={index} className="mr-1">
@@ -49,14 +54,76 @@ export const makeShadcnAutoFileInput = ({ Input, Label }: Pick<ShadcnElements, "
                   </span>
                 ))}
               </span>
-            )}
-          </Label>
-          <Input type="file" {...props} />
+            </Label>
+          )}
+
+          <Input
+            type="file"
+            {...props}
+            accept={validations.onlyImages?.acceptedTypes?.join(",")}
+            onChange={(e) => {
+              if (e.target.files) {
+                void onFileUpload(Array.from(e.target.files));
+              }
+            }}
+          />
         </div>
       );
-    }, [fieldProps.value, validations.fileSize, validations.onlyImages]);
+    }, [actionHintParts, validations.onlyImages?.acceptedTypes, props, onFileUpload]);
 
-    return <div>{fileUploadContainer}</div>;
+    const inputLabel = props.label ?? (
+      <div style={{ display: "flex", gap: "4px" }}>
+        {metadata.name}
+        {metadata.requiredArgumentForInput ? <span style={{ color: "var(--p-color-text-critical)" }}>{"*"}</span> : null}
+      </div>
+    );
+
+    const filePreview = useMemo(() => {
+      const value = fieldProps.value;
+      if (!value || !isAutoFileFieldValue(value)) return null;
+
+      return (
+        <div className="p-8 pr-16">
+          <div className="flex justify-between items-center gap-8">
+            <div className="flex items-center gap-4">
+              <Avatar>
+                <AvatarImage src={imageThumbnailURL} />
+                <AvatarFallback>
+                  <File />
+                </AvatarFallback>
+              </Avatar>
+
+              <div className="text-sm">
+                {value.$uploading ? "(Uploading) " : ""}
+                {value.fileName}
+              </div>
+            </div>
+
+            {/* Delete Button */}
+            {canClearFileValue && (
+              <Button variant="ghost" size="sm" onClick={() => clearFileValue()} id={`clear-file-${fieldApiIdentifier}`}>
+                <DeleteIcon className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      );
+    }, [canClearFileValue, clearFileValue, fieldApiIdentifier, fieldProps.value, imageThumbnailURL]);
+
+    return (
+      <div>
+        {inputLabel}
+        {fileUploadContainer}
+        {filePreview}
+        <div>
+          {errorMessage && (
+            <div style={{ marginTop: "4px" }}>
+              <Label className="text-red-500">{errorMessage}</Label>
+            </div>
+          )}
+        </div>
+      </div>
+    );
   }
 
   return autoInput(ShadcnAutoFileInput);

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoInput.tsx
@@ -44,6 +44,9 @@ export const makeShadcnAutoInput = (
     | "ScrollArea"
     | "ScrollBar"
     | "Textarea"
+    | "Avatar"
+    | "AvatarImage"
+    | "AvatarFallback"
   >
 ) => {
   const AutoIdInput = makeShadcnAutoIdInput(elements);


### PR DESCRIPTION
- **UPDATE**
  - ShadcnAutoFileInput 
    - Some shared behaviour with Polaris AutoFilInput has been refactored to the shared controller
    - Removed bad `accepts` label when there are no file type validations 
    - Added a placeholder file icon for non image files 