### PR TITLE
add search  placeholder to Polaris AutoForm

### DIFF
--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -188,6 +188,7 @@ const PolarisAutoTableComponent = <
             queryValue={search.value}
             onQueryChange={search.set}
             onQueryClear={search.clear}
+            queryPlaceholder={"Search"}
           />
         )}
 


### PR DESCRIPTION
Previously there was no placeholder and the borderless searcher was hard to see when blurred. Now, a simple `Search` placeholder value is added 