### PR TITLE
Reworked Shadcn AutoComponents DateTime picker

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoFormDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormDateTimePicker.cy.tsx
@@ -208,7 +208,7 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
           if (name === SUITE_NAMES.SHADCN) {
             cy.get("#test-date").contains("2024-07-10");
             cy.get("#test-date").click();
-            cy.get("#test-time").should("have.value", "4:00 AM");
+            cy.get("#test-time").should("have.value", "04:00");
           }
         }
       );
@@ -231,7 +231,7 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
         if (name === SUITE_NAMES.SHADCN) {
           cy.get("#test-date").contains("2024-07-10");
           cy.get("#test-date").click();
-          cy.get("#test-time").should("have.value", "4:00 AM");
+          cy.get("#test-time").should("have.value", "04:00");
         }
       });
 
@@ -254,7 +254,7 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
         if (name === SUITE_NAMES.SHADCN) {
           cy.get("#test-date").contains(format(dateInLocalTZ, "yyyy-MM-dd"));
           cy.get("#test-date").click();
-          cy.get("#test-time").should("have.value", format(dateInLocalTZ, "K:m aa"));
+          cy.get("#test-time").should("have.value", format(dateInLocalTZ, "HH:mm"));
         }
       });
 
@@ -286,6 +286,11 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
       });
 
       it("can enter an invalid time and show an error", () => {
+        if (name === SUITE_NAMES.SHADCN) {
+          // In shadcn, the time input is a `<input type="time">` which prevents invalid times from being entered
+          return;
+        }
+
         mockMetadataResponse();
         const onChangeSpy = cy.spy().as("onChangeSpy");
         cy.mountWithWrapper(
@@ -303,14 +308,6 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
           cy.contains("Invalid time format");
           cy.get("#test-time").click().clear().type("12:21 AM");
           cy.contains("Invalid time format").should("not.exist");
-        }
-
-        if (name === SUITE_NAMES.SHADCN) {
-          cy.get("#test-date").click();
-          cy.get("#test-time").click().clear().type("foo");
-          cy.contains("Please use format: 12:00 PM");
-          cy.get("#test-time").click().clear().type("12:21 AM");
-          cy.contains("Please use format: 12:00 PM").should("not.exist");
         }
       });
 

--- a/packages/react/spec/auto/shadcn-defaults/components/Calendar.tsx
+++ b/packages/react/spec/auto/shadcn-defaults/components/Calendar.tsx
@@ -1,50 +1,408 @@
+/**
+ * From https://date-picker.luca-felix.com/
+ * The default component provided by react-day-picker
+ * They mention that the default component in the Shadcn docs is outdated and suggests this as an alternative
+ *
+ */
+
+import { differenceInCalendarDays } from "date-fns";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import * as React from "react";
-import { DayPicker } from "react-day-picker";
+import { DayPicker, labelNext, labelPrevious, useDayPicker, type DayPickerProps } from "react-day-picker";
 import { cn } from "../utils.js";
-import { buttonVariants } from "./Button.js";
+import { Button, buttonVariants } from "./Button.js";
 
-export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+export type CalendarProps = DayPickerProps & {
+  /**
+   * In the year view, the number of years to display at once.
+   * @default 12
+   */
+  yearRange?: number;
 
-function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+  /**
+   * Wether to show the year switcher in the caption.
+   * @default true
+   */
+  showYearSwitcher?: boolean;
+
+  monthsClassName?: string;
+  monthCaptionClassName?: string;
+  weekdaysClassName?: string;
+  weekdayClassName?: string;
+  monthClassName?: string;
+  captionClassName?: string;
+  captionLabelClassName?: string;
+  buttonNextClassName?: string;
+  buttonPreviousClassName?: string;
+  navClassName?: string;
+  monthGridClassName?: string;
+  weekClassName?: string;
+  dayClassName?: string;
+  dayButtonClassName?: string;
+  rangeStartClassName?: string;
+  rangeEndClassName?: string;
+  selectedClassName?: string;
+  todayClassName?: string;
+  outsideClassName?: string;
+  disabledClassName?: string;
+  rangeMiddleClassName?: string;
+  hiddenClassName?: string;
+};
+
+type NavView = "days" | "years";
+
+/**
+ * A custom calendar component built on top of react-day-picker.
+ * @param props The props for the calendar.
+ * @default yearRange 12
+ * @returns
+ */
+function Calendar({ className, showOutsideDays = true, showYearSwitcher = true, yearRange = 12, numberOfMonths, ...props }: CalendarProps) {
+  const [navView, setNavView] = React.useState<NavView>("days");
+  const [displayYears, setDisplayYears] = React.useState<{
+    from: number;
+    to: number;
+  }>(
+    React.useMemo(() => {
+      const currentYear = new Date().getFullYear();
+      return {
+        from: currentYear - Math.floor(yearRange / 2 - 1),
+        to: currentYear + Math.ceil(yearRange / 2),
+      };
+    }, [yearRange])
+  );
+
+  const { onNextClick, onPrevClick, startMonth, endMonth } = props;
+
+  const columnsDisplayed = navView === "years" ? 1 : numberOfMonths;
+
+  const _monthsClassName = cn("relative flex", props.monthsClassName);
+  const _monthCaptionClassName = cn("relative mx-10 flex h-7 items-center justify-center", props.monthCaptionClassName);
+  const _weekdaysClassName = cn("flex flex-row", props.weekdaysClassName);
+  const _weekdayClassName = cn("w-8 text-sm font-normal text-muted-foreground", props.weekdayClassName);
+  const _monthClassName = cn("w-full", props.monthClassName);
+  const _captionClassName = cn("relative flex items-center justify-center pt-1", props.captionClassName);
+  const _captionLabelClassName = cn("truncate text-sm font-medium", props.captionLabelClassName);
+  const buttonNavClassName = buttonVariants({
+    variant: "outline",
+    className: "absolute h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+  });
+  const _buttonNextClassName = cn(buttonNavClassName, "right-0", props.buttonNextClassName);
+  const _buttonPreviousClassName = cn(buttonNavClassName, "left-0", props.buttonPreviousClassName);
+  const _navClassName = cn("flex items-start", props.navClassName);
+  const _monthGridClassName = cn("mx-auto mt-4", props.monthGridClassName);
+  const _weekClassName = cn("mt-2 flex w-max items-start", props.weekClassName);
+  const _dayClassName = cn("flex size-8 flex-1 items-center justify-center p-0 text-sm", props.dayClassName);
+  const _dayButtonClassName = cn(
+    buttonVariants({ variant: "ghost" }),
+    "size-8 rounded-md p-0 font-normal transition-none aria-selected:opacity-100",
+    props.dayButtonClassName
+  );
+  const buttonRangeClassName =
+    "bg-accent [&>button]:bg-primary [&>button]:text-primary-foreground [&>button]:hover:bg-primary [&>button]:hover:text-primary-foreground";
+  const _rangeStartClassName = cn(buttonRangeClassName, "day-range-start rounded-s-md", props.rangeStartClassName);
+  const _rangeEndClassName = cn(buttonRangeClassName, "day-range-end rounded-e-md", props.rangeEndClassName);
+  const _rangeMiddleClassName = cn(
+    "bg-accent !text-foreground [&>button]:bg-transparent [&>button]:!text-foreground [&>button]:hover:bg-transparent [&>button]:hover:!text-foreground",
+    props.rangeMiddleClassName
+  );
+  const _selectedClassName = cn(
+    "[&>button]:bg-primary [&>button]:text-primary-foreground [&>button]:hover:bg-primary [&>button]:hover:text-primary-foreground",
+    props.selectedClassName
+  );
+  const _todayClassName = cn("[&>button]:bg-accent [&>button]:text-accent-foreground", props.todayClassName);
+  const _outsideClassName = cn(
+    "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
+    props.outsideClassName
+  );
+  const _disabledClassName = cn("text-muted-foreground opacity-50", props.disabledClassName);
+  const _hiddenClassName = cn("invisible flex-1", props.hiddenClassName);
+
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
-      classNames={{
-        root: "bg-white",
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
-        nav_button: cn(buttonVariants({ variant: "outline" }), "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-y-1",
-        head_row: "flex",
-        head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center  text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-        day: cn("hover:bg-gray-100", "h-9 w-9 p-0 font-normal aria-selected:opacity-100 text-center"),
-        day_range_end: "day-range-end",
-        day_today: "bg-accent text-accent-foreground",
-        day_outside: "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
-        day_disabled: "text-muted-foreground opacity-50",
-        day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
-        day_hidden: "invisible",
-        ...classNames,
+      style={{
+        width: 248.8 * (columnsDisplayed ?? 1) + "px",
       }}
-      components={
-        {
-          IconLeft: ({ className, ...props }: any) => <ChevronLeft className={cn("h-4 w-4", className)} {...props} />,
-          IconRight: ({ className, ...props }: any) => <ChevronRight className={cn("h-4 w-4", className)} {...props} />,
-        } as any
-      }
+      classNames={{
+        months: _monthsClassName,
+        month_caption: _monthCaptionClassName,
+        weekdays: _weekdaysClassName,
+        weekday: _weekdayClassName,
+        month: _monthClassName,
+        caption: _captionClassName,
+        caption_label: _captionLabelClassName,
+        button_next: _buttonNextClassName,
+        button_previous: _buttonPreviousClassName,
+        nav: _navClassName,
+        month_grid: _monthGridClassName,
+        week: _weekClassName,
+        day: _dayClassName,
+        day_button: _dayButtonClassName,
+        range_start: _rangeStartClassName,
+        range_middle: _rangeMiddleClassName,
+        range_end: _rangeEndClassName,
+        selected: _selectedClassName,
+        today: _todayClassName,
+        outside: _outsideClassName,
+        disabled: _disabledClassName,
+        hidden: _hiddenClassName,
+      }}
+      components={{
+        Chevron: ({ orientation }) => {
+          const Icon = orientation === "left" ? ChevronLeft : ChevronRight;
+          return <Icon className="h-4 w-4" />;
+        },
+        Nav: ({ className }) => (
+          <Nav
+            className={className}
+            displayYears={displayYears}
+            navView={navView}
+            setDisplayYears={setDisplayYears}
+            startMonth={startMonth}
+            endMonth={endMonth}
+            onPrevClick={onPrevClick}
+          />
+        ),
+        CaptionLabel: (props) => (
+          <CaptionLabel
+            showYearSwitcher={showYearSwitcher}
+            navView={navView}
+            setNavView={setNavView}
+            displayYears={displayYears}
+            {...props}
+          />
+        ),
+        MonthGrid: ({ className, children, ...props }) => (
+          <MonthGrid
+            children={children}
+            className={className}
+            displayYears={displayYears}
+            startMonth={startMonth}
+            endMonth={endMonth}
+            navView={navView}
+            setNavView={setNavView}
+            {...props}
+          />
+        ),
+      }}
+      numberOfMonths={columnsDisplayed}
       {...props}
     />
   );
 }
 Calendar.displayName = "Calendar";
+
+function Nav({
+  className,
+  navView,
+  startMonth,
+  endMonth,
+  displayYears,
+  setDisplayYears,
+  onPrevClick,
+  onNextClick,
+}: {
+  className?: string;
+  navView: NavView;
+  startMonth?: Date;
+  endMonth?: Date;
+  displayYears: { from: number; to: number };
+  setDisplayYears: React.Dispatch<React.SetStateAction<{ from: number; to: number }>>;
+  onPrevClick?: (date: Date) => void;
+  onNextClick?: (date: Date) => void;
+}) {
+  const { nextMonth, previousMonth, goToMonth } = useDayPicker();
+
+  const isPreviousDisabled = (() => {
+    if (navView === "years") {
+      return (
+        (startMonth && differenceInCalendarDays(new Date(displayYears.from - 1, 0, 1), startMonth) < 0) ||
+        (endMonth && differenceInCalendarDays(new Date(displayYears.from - 1, 0, 1), endMonth) > 0)
+      );
+    }
+    return !previousMonth;
+  })();
+
+  const isNextDisabled = (() => {
+    if (navView === "years") {
+      return (
+        (startMonth && differenceInCalendarDays(new Date(displayYears.to + 1, 0, 1), startMonth) < 0) ||
+        (endMonth && differenceInCalendarDays(new Date(displayYears.to + 1, 0, 1), endMonth) > 0)
+      );
+    }
+    return !nextMonth;
+  })();
+
+  const handlePreviousClick = React.useCallback(() => {
+    if (!previousMonth) return;
+    if (navView === "years") {
+      setDisplayYears((prev) => ({
+        from: prev.from - (prev.to - prev.from + 1),
+        to: prev.to - (prev.to - prev.from + 1),
+      }));
+      onPrevClick?.(new Date(displayYears.from - (displayYears.to - displayYears.from), 0, 1));
+      return;
+    }
+    goToMonth(previousMonth);
+    onPrevClick?.(previousMonth);
+  }, [previousMonth, goToMonth]);
+
+  const handleNextClick = React.useCallback(() => {
+    if (!nextMonth) return;
+    if (navView === "years") {
+      setDisplayYears((prev) => ({
+        from: prev.from + (prev.to - prev.from + 1),
+        to: prev.to + (prev.to - prev.from + 1),
+      }));
+      onNextClick?.(new Date(displayYears.from + (displayYears.to - displayYears.from), 0, 1));
+      return;
+    }
+    goToMonth(nextMonth);
+    onNextClick?.(nextMonth);
+  }, [goToMonth, nextMonth]);
+  return (
+    <nav className={cn("flex items-center", className)}>
+      <Button
+        variant="outline"
+        className="absolute left-0 h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100"
+        type="button"
+        tabIndex={isPreviousDisabled ? undefined : -1}
+        disabled={isPreviousDisabled}
+        aria-label={
+          navView === "years" ? `Go to the previous ${displayYears.to - displayYears.from + 1} years` : labelPrevious(previousMonth)
+        }
+        onClick={handlePreviousClick}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      <Button
+        variant="outline"
+        className="absolute right-0 h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100"
+        type="button"
+        tabIndex={isNextDisabled ? undefined : -1}
+        disabled={isNextDisabled}
+        aria-label={navView === "years" ? `Go to the next ${displayYears.to - displayYears.from + 1} years` : labelNext(nextMonth)}
+        onClick={handleNextClick}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </nav>
+  );
+}
+
+function CaptionLabel({
+  children,
+  showYearSwitcher,
+  navView,
+  setNavView,
+  displayYears,
+  ...props
+}: {
+  showYearSwitcher?: boolean;
+  navView: NavView;
+  setNavView: React.Dispatch<React.SetStateAction<NavView>>;
+  displayYears: { from: number; to: number };
+} & React.HTMLAttributes<HTMLSpanElement>) {
+  if (!showYearSwitcher) return <span {...props}>{children}</span>;
+  return (
+    <Button
+      className="h-7 w-full truncate text-sm font-medium"
+      variant="ghost"
+      size="sm"
+      onClick={() => setNavView((prev) => (prev === "days" ? "years" : "days"))}
+    >
+      {navView === "days" ? children : displayYears.from + " - " + displayYears.to}
+    </Button>
+  );
+}
+
+function MonthGrid({
+  className,
+  children,
+  displayYears,
+  startMonth,
+  endMonth,
+  navView,
+  setNavView,
+  ...props
+}: {
+  className?: string;
+  children: React.ReactNode;
+  displayYears: { from: number; to: number };
+  startMonth?: Date;
+  endMonth?: Date;
+  navView: NavView;
+  setNavView: React.Dispatch<React.SetStateAction<NavView>>;
+} & React.TableHTMLAttributes<HTMLTableElement>) {
+  if (navView === "years") {
+    return (
+      <YearGrid
+        displayYears={displayYears}
+        startMonth={startMonth}
+        endMonth={endMonth}
+        setNavView={setNavView}
+        navView={navView}
+        className={className}
+        {...props}
+      />
+    );
+  }
+  return (
+    <table className={className} {...props}>
+      {children}
+    </table>
+  );
+}
+
+function YearGrid({
+  className,
+  displayYears,
+  startMonth,
+  endMonth,
+  setNavView,
+  navView,
+  ...props
+}: {
+  className?: string;
+  displayYears: { from: number; to: number };
+  startMonth?: Date;
+  endMonth?: Date;
+  setNavView: React.Dispatch<React.SetStateAction<NavView>>;
+  navView: NavView;
+} & React.HTMLAttributes<HTMLDivElement>) {
+  const { goToMonth, selected } = useDayPicker();
+
+  return (
+    <div className={cn("grid grid-cols-4 gap-y-2", className)} {...props}>
+      {Array.from({ length: displayYears.to - displayYears.from + 1 }, (_, i) => {
+        const isBefore = differenceInCalendarDays(new Date(displayYears.from + i, 11, 31), startMonth!) < 0;
+
+        const isAfter = differenceInCalendarDays(new Date(displayYears.from + i, 0, 0), endMonth!) > 0;
+
+        const isDisabled = isBefore || isAfter;
+        return (
+          <Button
+            key={i}
+            className={cn(
+              "h-7 w-full text-sm font-normal text-foreground",
+              displayYears.from + i === new Date().getFullYear() && "bg-accent font-medium text-accent-foreground"
+            )}
+            variant="ghost"
+            onClick={() => {
+              setNavView("days");
+              goToMonth(new Date(displayYears.from + i, (selected as Date | undefined)?.getMonth() ?? 0));
+            }}
+            disabled={navView === "years" ? isDisabled : undefined}
+          >
+            {displayYears.from + i}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
 
 export { Calendar };

--- a/packages/react/spec/auto/shadcn-defaults/components/Calendar.tsx
+++ b/packages/react/spec/auto/shadcn-defaults/components/Calendar.tsx
@@ -176,7 +176,6 @@ function Calendar({ className, showOutsideDays = true, showYearSwitcher = true, 
         ),
         MonthGrid: ({ className, children, ...props }) => (
           <MonthGrid
-            children={children}
             className={className}
             displayYears={displayYears}
             startMonth={startMonth}
@@ -184,7 +183,9 @@ function Calendar({ className, showOutsideDays = true, showYearSwitcher = true, 
             navView={navView}
             setNavView={setNavView}
             {...props}
-          />
+          >
+            {children}
+          </MonthGrid>
         ),
       }}
       numberOfMonths={columnsDisplayed}

--- a/packages/react/src/auto/hooks/useDateTimeField.ts
+++ b/packages/react/src/auto/hooks/useDateTimeField.ts
@@ -8,7 +8,7 @@ import { assertFieldType } from "./utils.js";
 interface DateTimeFieldProps {
   field: string;
   value?: Date;
-  onChange?: (value: Date) => void;
+  onChange?: (value?: Date) => void;
 }
 
 export const useDateTimeField = (props: DateTimeFieldProps) => {

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoDateTimePicker.tsx
@@ -21,7 +21,7 @@ export const PolarisAutoDateTimePicker = autoInput(
     field: string;
     id?: string;
     value?: Date;
-    onChange?: (value: Date) => void;
+    onChange?: (value?: Date) => void;
     error?: string;
     includeTime?: boolean;
     hideTimePopover?: boolean;

--- a/packages/react/src/auto/shadcn/inputs/auto-date-time-input.css
+++ b/packages/react/src/auto/shadcn/inputs/auto-date-time-input.css
@@ -1,0 +1,5 @@
+/* This conceals the dropdown hour/minute selector. It is bright blue and cannot be styled to match the rest of an app */
+.shadcn-auto-form-time-input::-webkit-calendar-picker-indicator {
+  display: none;
+  -webkit-appearance: none;
+}

--- a/packages/react/src/dateTimeUtils.ts
+++ b/packages/react/src/dateTimeUtils.ts
@@ -403,12 +403,16 @@ export const copyTime = (to: Date, input: Date) => {
  * @param dateTime
  * @returns
  */
-export const getDateTimeObjectFromDate = (dateTime: Date) => {
+export const getDateTimeObjectFromDate = (dateTime: Date, use24Hour = false) => {
   return {
     month: dateTime.getMonth(),
     year: dateTime.getFullYear(),
     day: dateTime.getDay(),
-    hour: dateTime.getHours() > 12 ? (dateTime.getHours() - 12).toString() : dateTime.getHours().toString(),
+    hour: use24Hour
+      ? dateTime.getHours().toString()
+      : dateTime.getHours() > 12
+      ? (dateTime.getHours() - 12).toString()
+      : dateTime.getHours().toString(),
     minute: dateTime.getMinutes().toString().padStart(2, "0"),
     ampm: dateTime.getHours() >= 12 ? "PM" : "AM",
   };
@@ -431,7 +435,7 @@ export const getDateFromDateTimeObject = (dateTime: DateTimeState) => {
   return date;
 };
 
-export const formatDate = (date: Date, includeTime: boolean): string => {
+export const formatDate = (date: Date, includeTime: boolean, use24Hour = false): string => {
   // Extract year, month, and day
   const year = date.getFullYear();
 
@@ -441,26 +445,34 @@ export const formatDate = (date: Date, includeTime: boolean): string => {
   // Get the day of the month and pad with leading zero if necessary
   const day = String(date.getDate()).padStart(2, "0");
 
+  if (!includeTime) {
+    return `${year}-${month}-${day}`;
+  }
+
   // Extract hours in 24-hour format
   let hours = date.getHours();
+  let hoursStr: string;
+  let timeStr: string;
 
-  // Determine AM or PM
-  const ampm = hours >= 12 ? "PM" : "AM";
+  if (use24Hour) {
+    // Use 24 hour format
+    hoursStr = String(hours).padStart(2, "0");
+    // Extract minutes and pad with leading zero if necessary
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    timeStr = `${hoursStr}:${minutes}`;
+  } else {
+    // Use 12 hour format
+    const ampm = hours >= 12 ? "PM" : "AM";
+    // Convert to 12-hour format
+    hours = hours % 12;
+    hours = hours ? hours : 12; // If hours is 0, set to 12
+    hoursStr = String(hours).padStart(2, "0");
+    // Extract minutes and pad with leading zero if necessary
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    timeStr = `${hoursStr}:${minutes} ${ampm}`;
+  }
 
-  // Convert to 12-hour format
-  hours = hours % 12;
-  hours = hours ? hours : 12; // If hours is 0, set to 12
-
-  // Pad hours with leading zero if necessary
-  const hoursStr = String(hours).padStart(2, "0");
-
-  // Extract minutes and pad with leading zero if necessary
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-
-  // Construct the formatted date string
-  const formattedDate = includeTime ? `${year}-${month}-${day} ${hoursStr}:${minutes} ${ampm}` : `${year}-${month}-${day}`;
-
-  return formattedDate;
+  return `${year}-${month}-${day} ${timeStr}`;
 };
 
 /**
@@ -468,7 +480,13 @@ export const formatDate = (date: Date, includeTime: boolean): string => {
  * @param dateTime
  * @returns
  */
-export const getTimeString = (dateTime: DateTimeState) => {
+export const getTimeString = (dateTime: DateTimeState, use24Hour = false) => {
+  if (use24Hour) {
+    const hour24 = parseInt(dateTime.hour, 10);
+    const hour24Str = String(hour24).padStart(2, "0");
+    return `${hour24Str}:${dateTime.minute.padStart(2, "0")}`;
+  }
+
   if (parseInt(dateTime.hour, 10) === 0) {
     return `12:${dateTime.minute.padStart(2, "0")} AM`;
   }


### PR DESCRIPTION
![CleanShot 2025-03-11 at 17 40 18](https://github.com/user-attachments/assets/e30fc127-ab73-4dde-b6f4-31048d170424)

- **UPDATE**
  - Changed the default `Calendar` component file to be based on the more recent version of `react-day-picker`. 
    - Shadcn uses an outdated version of this component in their docs and this is called out by the `react-day-picker` docs that they point out. The version provided by the Shadcn docs did not have year selection, and it also had a lot of style issues that would need a lot of advanced styling out of the box to look reasonable. 
    - https://date-picker.luca-felix.com/
  - Made the state of the date and time pickers completely dependent on the form state
    - There were previously some `useStates` that were used to track the time and date independently of the form state. Those had the possibility of getting out of sync
  - Replaced the previous `input with time validation` approach with a `input type="time"` approach
    - This input won't even let you enter bad time values
    - This has a consequence of making the clock 24h instead of 12h
    - This avoids a lot of oddities that occurred with the validation when bad times were entered. It's also a bit of friction for the user  to clear out a bad value
  - Added a `clear` button to the input
    - Previously, there was no way to clear the value
    - There still is no way to clear the value on the polaris side. It is a bigger design challenge over there