### PR TITLE
make shadcn dateTime picker use Lazyload to avoid SSR issues with css files

### DIFF
--- a/packages/react/cypress/component/auto/form/AutoFormDateTimePicker.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoFormDateTimePicker.cy.tsx
@@ -86,7 +86,7 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
       if (name === SUITE_NAMES.SHADCN) {
         cy.get("#test-date").contains("YYYY-MM-DD");
         cy.get("#test-date").click();
-        cy.get(".rdp-month_caption").contains(`${new Date().getFullYear()}`);
+        cy.get("button").contains(`${new Date().getFullYear()}`);
       }
     });
 
@@ -158,65 +158,42 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
           expect(onChangeSpy.getCalls()[0].args[0].toISOString()).equal(new Date("2021-03-17T11:23:00.000Z").toISOString());
         });
     });
+  });
+  describe("date and time", () => {
+    it("can show with a blank current value", () => {
+      mockMetadataResponse();
+      const onChangeSpy = cy.spy().as("onChangeSpy");
+      cy.mountWithWrapper(
+        <AutoForm action={api.widget.create}>
+          <AutoDateTimePicker suiteName={name} id="test" includeTime onChange={onChangeSpy} field="startsAt" />
+        </AutoForm>,
+        wrapper
+      );
+      cy.wait("@ModelCreateActionMetadata");
+      // Test is flaky without waiting for the DOM to load
+      cy.wait(100);
 
-    describe("date and time", () => {
-      it("can show with a blank current value", () => {
-        mockMetadataResponse();
-        const onChangeSpy = cy.spy().as("onChangeSpy");
+      if (name === SUITE_NAMES.POLARIS) {
+        cy.get("#test-date").should("have.value", "");
+        cy.get("#test-time").should("have.value", "");
+      }
+
+      if (name === SUITE_NAMES.SHADCN) {
+        cy.get("#test-date").contains("YYYY-MM-DD HH:mm");
+        cy.get("#test-date").click();
+        cy.get("#test-time").should("have.value", "");
+      }
+    });
+
+    it(
+      "can show the default field value from the metadata",
+      // eslint-disable-next-line
+      // @ts-ignore - This test passes in isolation but is flakey when run with the rest of the file
+      { retries: 2 },
+      () => {
+        mockMetadataResponse({ startsAt: "2024-07-10T04:00:00.000Z" });
         cy.mountWithWrapper(
           <AutoForm action={api.widget.create}>
-            <AutoDateTimePicker suiteName={name} id="test" includeTime onChange={onChangeSpy} field="startsAt" />
-          </AutoForm>,
-          wrapper
-        );
-        cy.wait("@ModelCreateActionMetadata");
-        // Test is flaky without waiting for the DOM to load
-        cy.wait(100);
-
-        if (name === SUITE_NAMES.POLARIS) {
-          cy.get("#test-date").should("have.value", "");
-          cy.get("#test-time").should("have.value", "");
-        }
-
-        if (name === SUITE_NAMES.SHADCN) {
-          cy.get("#test-date").contains("YYYY-MM-DD hh:mm aa");
-          cy.get("#test-date").click();
-          cy.get("#test-time").should("have.value", "");
-        }
-      });
-
-      it(
-        "can show the default field value from the metadata",
-        // eslint-disable-next-line
-        // @ts-ignore - This test passes in isolation but is flakey when run with the rest of the file
-        { retries: 2 },
-        () => {
-          mockMetadataResponse({ startsAt: "2024-07-10T04:00:00.000Z" });
-          cy.mountWithWrapper(
-            <AutoForm action={api.widget.create}>
-              <AutoDateTimePicker suiteName={name} id="test" includeTime field="startsAt" />
-            </AutoForm>,
-            wrapper
-          );
-          cy.wait("@ModelCreateActionMetadata");
-
-          if (name === SUITE_NAMES.POLARIS) {
-            cy.get("#test-date").should("have.value", "2024-07-10");
-            cy.get("#test-time").should("have.value", "4:00 AM");
-          }
-
-          if (name === SUITE_NAMES.SHADCN) {
-            cy.get("#test-date").contains("2024-07-10");
-            cy.get("#test-date").click();
-            cy.get("#test-time").should("have.value", "04:00");
-          }
-        }
-      );
-
-      it("can show the default field value from the defaultValues prop", () => {
-        mockMetadataResponse();
-        cy.mountWithWrapper(
-          <AutoForm action={api.widget.create} defaultValues={{ widget: { startsAt: "2024-07-10T04:00:00.000Z" } }}>
             <AutoDateTimePicker suiteName={name} id="test" includeTime field="startsAt" />
           </AutoForm>,
           wrapper
@@ -233,103 +210,125 @@ describeForEachAutoAdapter("AutoFormDateTimePicker", ({ name, adapter: { AutoFor
           cy.get("#test-date").click();
           cy.get("#test-time").should("have.value", "04:00");
         }
-      });
+      }
+    );
 
-      it("can show the current value", () => {
-        mockMetadataResponse();
-        const onChangeSpy = cy.spy().as("onChangeSpy");
-        cy.mountWithWrapper(
-          <AutoForm action={api.widget.create}>
-            <AutoDateTimePicker suiteName={name} id="test" includeTime value={baseDate} onChange={onChangeSpy} field="startsAt" />
-          </AutoForm>,
-          wrapper
-        );
-        cy.wait("@ModelCreateActionMetadata");
+    it("can show the default field value from the defaultValues prop", () => {
+      mockMetadataResponse();
+      cy.mountWithWrapper(
+        <AutoForm action={api.widget.create} defaultValues={{ widget: { startsAt: "2024-07-10T04:00:00.000Z" } }}>
+          <AutoDateTimePicker suiteName={name} id="test" includeTime field="startsAt" />
+        </AutoForm>,
+        wrapper
+      );
+      cy.wait("@ModelCreateActionMetadata");
 
-        if (name === SUITE_NAMES.POLARIS) {
-          cy.get("#test-date").should("have.value", format(dateInLocalTZ, "yyyy-MM-dd"));
-          cy.get("#test-time").should("have.value", format(dateInLocalTZ, "K:m aa"));
-        }
+      if (name === SUITE_NAMES.POLARIS) {
+        cy.get("#test-date").should("have.value", "2024-07-10");
+        cy.get("#test-time").should("have.value", "4:00 AM");
+      }
 
-        if (name === SUITE_NAMES.SHADCN) {
-          cy.get("#test-date").contains(format(dateInLocalTZ, "yyyy-MM-dd"));
-          cy.get("#test-date").click();
-          cy.get("#test-time").should("have.value", format(dateInLocalTZ, "HH:mm"));
-        }
-      });
-
-      it("can change the date", () => {
-        mockMetadataResponse();
-        const onChangeSpy = cy.spy().as("onChangeSpy");
-        cy.mountWithWrapper(
-          <AutoForm action={api.widget.create}>
-            <AutoDateTimePicker suiteName={name} id="test" includeTime value={baseDate} onChange={onChangeSpy} field="startsAt" />
-          </AutoForm>,
-          wrapper
-        );
-        cy.wait("@ModelCreateActionMetadata");
+      if (name === SUITE_NAMES.SHADCN) {
+        cy.get("#test-date").contains("2024-07-10");
         cy.get("#test-date").click();
+        cy.get("#test-time").should("have.value", "04:00");
+      }
+    });
 
-        if (name === SUITE_NAMES.POLARIS) {
-          cy.get(`[aria-label='Thursday March 4 2021']`).click();
-        }
+    it("can show the current value", () => {
+      mockMetadataResponse();
+      const onChangeSpy = cy.spy().as("onChangeSpy");
+      cy.mountWithWrapper(
+        <AutoForm action={api.widget.create}>
+          <AutoDateTimePicker suiteName={name} id="test" includeTime value={baseDate} onChange={onChangeSpy} field="startsAt" />
+        </AutoForm>,
+        wrapper
+      );
+      cy.wait("@ModelCreateActionMetadata");
 
-        if (name === SUITE_NAMES.SHADCN) {
-          cy.get(`[aria-label='Thursday, March 4th, 2021']`).click();
-        }
-        // eslint-disable-next-line jest/valid-expect-in-promise
-        cy.get("@onChangeSpy")
-          .should("have.been.called")
-          .then(() => {
-            expect(onChangeSpy.getCalls()[0].args[0].toISOString()).equal(new Date("2021-03-04T11:23:00.000Z").toISOString());
-          });
-      });
+      if (name === SUITE_NAMES.POLARIS) {
+        cy.get("#test-date").should("have.value", format(dateInLocalTZ, "yyyy-MM-dd"));
+        cy.get("#test-time").should("have.value", format(dateInLocalTZ, "K:m aa"));
+      }
 
-      it("can enter an invalid time and show an error", () => {
-        if (name === SUITE_NAMES.SHADCN) {
-          // In shadcn, the time input is a `<input type="time">` which prevents invalid times from being entered
-          return;
-        }
-
-        mockMetadataResponse();
-        const onChangeSpy = cy.spy().as("onChangeSpy");
-        cy.mountWithWrapper(
-          <AutoForm action={api.widget.create}>
-            <AutoDateTimePicker suiteName={name} id="test" includeTime value={baseDate} onChange={onChangeSpy} field="startsAt" />
-          </AutoForm>,
-          wrapper
-        );
-        cy.wait("@ModelCreateActionMetadata");
-
-        if (name === SUITE_NAMES.POLARIS) {
-          cy.get("#test-time").click().clear().type("foo");
-          cy.get("body").click();
-
-          cy.contains("Invalid time format");
-          cy.get("#test-time").click().clear().type("12:21 AM");
-          cy.contains("Invalid time format").should("not.exist");
-        }
-      });
-
-      it("can show the selected date", () => {
-        mockMetadataResponse();
-        cy.mountWithWrapper(<TestComponentWithCustomOnChange />, wrapper);
-        cy.wait("@ModelCreateActionMetadata");
+      if (name === SUITE_NAMES.SHADCN) {
+        cy.get("#test-date").contains(format(dateInLocalTZ, "yyyy-MM-dd"));
         cy.get("#test-date").click();
+        cy.get("#test-time").should("have.value", format(dateInLocalTZ, "HH:mm"));
+      }
+    });
 
-        if (name === SUITE_NAMES.POLARIS) {
-          cy.get(`[aria-label='Thursday March 4 2021']`).click();
-          cy.get("#test-date").click();
-          cy.get(`[aria-label='Thursday March 4 2021']`).should("have.attr", "aria-pressed", "true");
-        }
+    it("can change the date", () => {
+      mockMetadataResponse();
+      const onChangeSpy = cy.spy().as("onChangeSpy");
+      cy.mountWithWrapper(
+        <AutoForm action={api.widget.create}>
+          <AutoDateTimePicker suiteName={name} id="test" includeTime value={baseDate} onChange={onChangeSpy} field="startsAt" />
+        </AutoForm>,
+        wrapper
+      );
+      cy.wait("@ModelCreateActionMetadata");
+      cy.get("#test-date").click();
 
+      if (name === SUITE_NAMES.POLARIS) {
+        cy.get(`[aria-label='Thursday March 4 2021']`).click();
+      }
+
+      if (name === SUITE_NAMES.SHADCN) {
+        cy.get(`[aria-label='Thursday, March 4th, 2021']`).click();
+      }
+      // eslint-disable-next-line jest/valid-expect-in-promise
+      cy.get("@onChangeSpy")
+        .should("have.been.called")
+        .then(() => {
+          expect(onChangeSpy.getCalls()[0].args[0].toISOString()).equal(new Date("2021-03-04T11:23:00.000Z").toISOString());
+        });
+    });
+
+    it("can enter an invalid time and show an error", () => {
+      if (name === SUITE_NAMES.SHADCN) {
+        // In shadcn, the time input is a `<input type="time">` which prevents invalid times from being entered
+        return;
+      }
+
+      mockMetadataResponse();
+      const onChangeSpy = cy.spy().as("onChangeSpy");
+      cy.mountWithWrapper(
+        <AutoForm action={api.widget.create}>
+          <AutoDateTimePicker suiteName={name} id="test" includeTime value={baseDate} onChange={onChangeSpy} field="startsAt" />
+        </AutoForm>,
+        wrapper
+      );
+      cy.wait("@ModelCreateActionMetadata");
+
+      if (name === SUITE_NAMES.POLARIS) {
+        cy.get("#test-time").click().clear().type("foo");
+        cy.get("body").click();
+
+        cy.contains("Invalid time format");
+        cy.get("#test-time").click().clear().type("12:21 AM");
+        cy.contains("Invalid time format").should("not.exist");
+      }
+    });
+
+    it("can show the selected date", () => {
+      mockMetadataResponse();
+      cy.mountWithWrapper(<TestComponentWithCustomOnChange />, wrapper);
+      cy.wait("@ModelCreateActionMetadata");
+      cy.get("#test-date").click();
+
+      if (name === SUITE_NAMES.POLARIS) {
+        cy.get(`[aria-label='Thursday March 4 2021']`).click();
         cy.get("#test-date").click();
+        cy.get(`[aria-label='Thursday March 4 2021']`).should("have.attr", "aria-pressed", "true");
+      }
 
-        if (name === SUITE_NAMES.SHADCN) {
-          cy.get(`[aria-label='Thursday, March 4th, 2021']`).click();
-          cy.get(`[aria-label='Thursday, March 4th, 2021, selected']`).should("exist");
-        }
-      });
+      cy.get("#test-date").click();
+
+      if (name === SUITE_NAMES.SHADCN) {
+        cy.get(`[aria-label='Thursday, March 4th, 2021']`).click();
+        cy.get(`[aria-label='Thursday, March 4th, 2021, selected']`).should("exist");
+      }
     });
   });
 });

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoDateTimePicker.tsx
@@ -1,17 +1,11 @@
 import { CalendarIcon, X } from "lucide-react";
-import React, { useCallback, useState, type ReactNode } from "react";
+import React, { Suspense, useCallback, useState, type ReactNode } from "react";
 import { copyTime, formatDate, getDateTimeObjectFromDate, getTimeString, isValidDate, zonedTimeToUtc } from "../../../dateTimeUtils.js";
 import type { GadgetDateTimeConfig } from "../../../internal/gql/graphql.js";
 import { autoInput } from "../../AutoInput.js";
 import { useDateTimeField } from "../../hooks/useDateTimeField.js";
 import { ShadcnRequired } from "../ShadcnRequired.js";
 import type { ShadcnElements } from "../elements.js";
-import "./auto-date-time-input.css";
-
-export interface Range {
-  start: Date;
-  end: Date;
-}
 
 export interface DatePickerProps {
   onChange: (date: Date) => void;
@@ -27,8 +21,9 @@ export interface DatePickerProps {
   disableDatesBefore: Date;
   disableDatesAfter: Date;
   disableSpecificDates: Date[];
-  range: Range;
 }
+
+const ShadcnAutoTimeInput = React.lazy(() => import("./ShadcnAutoTimeInput.js"));
 
 export const makeShadcnAutoDateTimePicker = ({
   Button,
@@ -132,7 +127,7 @@ export const makeShadcnAutoDateTimePicker = ({
                 formatDate(localTime, props.includeTime ?? (config as GadgetDateTimeConfig).includeTime, true)
               ) : (
                 <span className="opacity-50">
-                  {props.includeTime ?? (config as GadgetDateTimeConfig).includeTime ? "YYYY-MM-DD hh:mm aa" : "YYYY-MM-DD"}
+                  {props.includeTime ?? (config as GadgetDateTimeConfig).includeTime ? "YYYY-MM-DD HH:mm" : "YYYY-MM-DD"}
                 </span>
               )}
               {localTime && !metadata.requiredArgumentForInput && <ClearButton onClear={handleClear} />}
@@ -145,33 +140,17 @@ export const makeShadcnAutoDateTimePicker = ({
         <PopoverContent className="w-auto p-0">
           <div className="flex flex-row flex-nowrap">
             <div className="relative bg-background">
-              <Calendar
-                mode="single"
-                defaultMonth={localTime}
-                selected={localTime}
-                onSelect={handleDateSelect}
-                initialFocus
-                classNames={{
-                  month_grid: "w-full",
-                  selected: "bg-primary text-primary-foreground",
-                  nav: "translate-y-3",
-                  day_button: "w-full",
-                }}
-              />
+              <Calendar mode="single" defaultMonth={localTime} selected={localTime} onSelect={handleDateSelect} initialFocus />
             </div>
             {(props.includeTime ?? (config as GadgetDateTimeConfig).includeTime) && (
               <div className="flex flex-col p-4 bg-white border-l">
                 <Label htmlFor={props.id ? `${props.id}-time` : undefined} data-testid={props.id ? `${props.id}-time` : undefined}>
                   {props.timePickerProps?.label ?? "Time"} (HH:MM)
                 </Label>
-                <input
-                  type="time"
-                  id={props.id ? `${props.id}-time` : undefined}
-                  data-testid={props.id ? `${props.id}-time` : undefined}
-                  className="shadcn-auto-form-time-input w-32 px-3 py-2 border rounded-md mt-2"
-                  value={timeString}
-                  onChange={(e) => handleTimeInput(e.target.value)}
-                />
+
+                <Suspense fallback={null}>
+                  <ShadcnAutoTimeInput id={props.id} timeString={timeString} handleTimeInput={handleTimeInput} />
+                </Suspense>
               </div>
             )}
           </div>

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoTimeInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoTimeInput.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import "./auto-date-time-input.css";
+
+const ShadcnAutoTimeInput = (props: { id?: string; timeString?: string; handleTimeInput: (time: string) => void }) => {
+  return (
+    <input
+      type="time"
+      id={props.id ? `${props.id}-time` : undefined}
+      data-testid={props.id ? `${props.id}-time` : undefined}
+      className="shadcn-auto-form-time-input w-32 px-3 py-2 border rounded-md mt-2"
+      value={props.timeString}
+      onChange={(e) => props.handleTimeInput(e.target.value)}
+    />
+  );
+};
+
+export default ShadcnAutoTimeInput;


### PR DESCRIPTION
- Update
  - `import "./something.css"` does not play nice with SSR in Gadget apps. 
  - This was affecting the DateTime picker because of the required css file to make the `input type="time"` dropdown not appear
  - The part that requires css has now been moved to a new file that will be lazy loaded. This was inspired from the `AutoRichTextInput`  system of getting in the custom css file