### PR TITLE
Add computed view hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.511.0-development.2409",
+    "@gadget-client/js-clients-test": "1.512.0-development.2586",
     "@gadget-client/kitchen-sink": "1.9.0-development.206",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -83,6 +83,28 @@ export interface MaybeFindFirstFunction<OptionsT, SelectionT, SchemaT, DefaultsT
   plan?: <Options extends OptionsT>(options?: LimitToKnownKeys<Options, OptionsT>) => GQLBuilderResult;
 }
 
+export interface ViewFunctionWithoutVariables<ResultT> {
+  (): Promise<ResultT>;
+  type: "computedView";
+  operationName: string;
+  namespace?: string | string[] | null;
+  resultType: ResultT;
+  plan(): GQLBuilderResult;
+}
+
+export interface ViewFunctionWithVariables<VariablesT, ResultT> {
+  (variables: VariablesT): Promise<ResultT>;
+  type: "computedView";
+  operationName: string;
+  namespace?: string | string[] | null;
+  variables: VariablesOptions;
+  variablesType: VariablesT;
+  resultType: ResultT;
+  plan(variables: VariablesT): GQLBuilderResult;
+}
+
+export type ViewFunction<VariablesT, ResultT> = ViewFunctionWithoutVariables<ResultT> | ViewFunctionWithVariables<VariablesT, ResultT>;
+
 export interface ActionWithIdAndVariables<OptionsT, VariablesT> {
   <Options extends OptionsT>(id: string, variables: VariablesT, options?: LimitToKnownKeys<Options, OptionsT>):
     | AsyncRecord<any>

--- a/packages/api-client-core/src/types.ts
+++ b/packages/api-client-core/src/types.ts
@@ -1,7 +1,15 @@
 import type { OperationContext } from "@urql/core";
 import type { VariableOptions } from "tiny-graphql-query-compiler";
 import type { FieldSelection } from "./FieldSelection.js";
-import type { ActionFunction, AnyActionFunction, BulkActionFunction, GlobalActionFunction } from "./GadgetFunctions.js";
+import type {
+  ActionFunction,
+  AnyActionFunction,
+  BulkActionFunction,
+  GlobalActionFunction,
+  ViewFunction,
+  ViewFunctionWithoutVariables,
+  ViewFunctionWithVariables,
+} from "./GadgetFunctions.js";
 
 /**
  * Limit the keys in T to only those that also exist in U. AKA Subset or Intersection.
@@ -879,3 +887,8 @@ export type ActionFunctionOptions<Action extends AnyActionFunction> = Action ext
   : Action extends GlobalActionFunction<any>
   ? Record<string, never>
   : never;
+
+/** Get the result type of executing a view function */
+export type ViewResult<F extends ViewFunction<any, any>> = Awaited<
+  F extends ViewFunctionWithVariables<any, infer Result> ? Result : F extends ViewFunctionWithoutVariables<infer Result> ? Result : never
+>;

--- a/packages/react/spec/useView.spec.tsx
+++ b/packages/react/spec/useView.spec.tsx
@@ -1,0 +1,243 @@
+import { renderHook } from "@testing-library/react";
+import type { IsExact } from "conditional-type-checks";
+import { assert } from "conditional-type-checks";
+import { useView } from "../src/useView.js";
+import type { ErrorWrapper } from "../src/utils.js";
+import { testApi } from "./apis.js";
+import { MockClientWrapper, createMockUrqlClient, mockUrqlClient } from "./testWrappers.js";
+
+describe("useView", () => {
+  // all these functions are typechecked but never run to avoid actually making API calls
+  const _TestUseViewNoVariablesReturnsTypedData = () => {
+    const [{ data, fetching, error }, refresh] = useView(testApi.totalInStock);
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+    assert<IsExact<typeof data, undefined | { totalInStock: number | null }>>(true);
+    assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+
+    if (data) {
+      data.totalInStock;
+    }
+
+    refresh();
+  };
+
+  const _TestUseViewVariablesReturnsTypedData = () => {
+    const [{ data, fetching, error }, refresh] = useView(testApi.echo, { value: "test" });
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+    assert<IsExact<typeof data, undefined | { value: string | null }>>(true);
+    assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+
+    if (data) {
+      data.value;
+    }
+
+    refresh();
+  };
+
+  const _TestUseViewOptions = () => {
+    const [{ data, fetching, error }, refresh] = useView(testApi.echo, { value: "test" }, { pause: true });
+
+    assert<IsExact<typeof fetching, boolean>>(true);
+    assert<IsExact<typeof data, undefined | { value: string | null }>>(true);
+    assert<IsExact<typeof error, ErrorWrapper | undefined>>(true);
+
+    if (data) {
+      data.value;
+    }
+
+    refresh();
+  };
+
+  const _TestUseNamespacedView = () => {
+    const [{ data }] = useView(testApi.game.echo, { value: 123 });
+
+    assert<IsExact<typeof data, undefined | { value: number | null }>>(true);
+
+    if (data) {
+      data.value;
+    }
+  };
+
+  test("can fetch a view with no variables", async () => {
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
+    const { result } = renderHook(() => useView(testApi.totalInStock), { wrapper: MockClientWrapper(testApi, client) });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(client.executeQuery).toHaveBeenCalledTimes(1);
+
+    expect(query).toMatchInlineSnapshot(`
+      "query totalInStock {
+        totalInStock
+      }"
+    `);
+
+    client.executeQuery.pushResponse("totalInStock", {
+      data: {
+        totalInStock: 100,
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current[0].data!).toEqual(100);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("can fetch a view with variables", async () => {
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
+    const { result } = renderHook(() => useView(testApi.echo, { value: "test" }), { wrapper: MockClientWrapper(testApi, client) });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(client.executeQuery).toHaveBeenCalledTimes(1);
+
+    expect(query).toMatchInlineSnapshot(`
+      "query echo($value: undefined) {
+        echo(value: $value)
+      }"
+    `);
+
+    client.executeQuery.pushResponse("echo", {
+      data: {
+        echo: {
+          value: "test",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current[0].data!.value).toEqual("test");
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("can find namespaced view", async () => {
+    let query: string | undefined;
+    const client = createMockUrqlClient({
+      queryAssertions: (request) => {
+        query = request.query.loc?.source.body;
+      },
+    });
+
+    const { result } = renderHook(() => useView(testApi.game.echo, { value: 123 }), { wrapper: MockClientWrapper(testApi, client) });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(client.executeQuery).toHaveBeenCalledTimes(1);
+
+    expect(query).toMatchInlineSnapshot(`
+      "query echo($value: undefined) {
+        game {
+          echo(value: $value)
+        }
+      }"
+    `);
+
+    client.executeQuery.pushResponse("echo", {
+      data: {
+        game: {
+          echo: {
+            value: 123,
+          },
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    expect(result.current[0].data!.value).toEqual(123);
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+  });
+
+  test("returns the same data object on rerender if nothing changes about the result", async () => {
+    const { result, rerender } = renderHook(() => useView(testApi.echo, { value: "test" }), { wrapper: MockClientWrapper(testApi) });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(true);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toHaveBeenCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("echo", {
+      data: {
+        echo: {
+          value: "test",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    const beforeObject = result.current[0];
+
+    rerender();
+
+    expect(result.current[0]).toBe(beforeObject);
+  });
+
+  test("suspends when loading data", async () => {
+    const { result, rerender } = renderHook(() => useView(testApi.echo, { value: "test" }, { suspense: true }), {
+      wrapper: MockClientWrapper(testApi),
+    });
+
+    // first render never completes as the component suspends
+    expect(result.current).toBeFalsy();
+    expect(mockUrqlClient.executeQuery).toHaveBeenCalledTimes(1);
+
+    mockUrqlClient.executeQuery.pushResponse("echo", {
+      data: {
+        echo: {
+          value: "test",
+        },
+      },
+      stale: false,
+      hasNext: false,
+    });
+
+    // rerender as react would do when the suspense promise resolves
+    rerender();
+    expect(result.current).toBeTruthy();
+    expect(result.current[0].data!.value).toEqual("test");
+    expect(result.current[0].error).toBeFalsy();
+
+    const beforeObject = result.current[0];
+    rerender();
+    expect(result.current[0]).toBe(beforeObject);
+  });
+
+  test("doesn't issue a request if paused", async () => {
+    const { result } = renderHook(() => useView(testApi.echo, { value: "test" }, { pause: true }), {
+      wrapper: MockClientWrapper(testApi),
+    });
+
+    expect(result.current[0].data).toBeFalsy();
+    expect(result.current[0].fetching).toBe(false);
+    expect(result.current[0].error).toBeFalsy();
+
+    expect(mockUrqlClient.executeQuery).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -25,3 +25,4 @@ export * from "./useList.js";
 export * from "./useMaybeFindFirst.js";
 export * from "./useMaybeFindOne.js";
 export * from "./useTable.js";
+export * from "./useView.js";

--- a/packages/react/src/useView.ts
+++ b/packages/react/src/useView.ts
@@ -1,0 +1,91 @@
+import type { ViewFunction, ViewFunctionWithoutVariables, ViewFunctionWithVariables, ViewResult } from "@gadgetinc/api-client-core";
+import { get, namespaceDataPath } from "@gadgetinc/api-client-core";
+import { useMemo } from "react";
+import { useGadgetQuery } from "./useGadgetQuery.js";
+import { useStructuralMemo } from "./useStructuralMemo.js";
+import type { ReadHookResult, ReadOperationOptions } from "./utils.js";
+import { ErrorWrapper, useQueryArgs } from "./utils.js";
+
+/**
+ * React hook to fetch the result of a computed view from the backend. Returns a standard hook result set with a tuple of the result object with `data`, `fetching`, and `error` keys, and a `refetch` function. `data` will be the shape of the computed view's result.
+ *
+ * @param manager Gadget view function to run
+ * @param options options for controlling client side execution
+ *
+ * @example
+ *
+ * ```
+ * export function Leaderboard() {
+ *   const [result, refresh] = useView(api.leaderboard);
+ *
+ *   if (result.error) return <>Error: {result.error.toString()}</>;
+ *   if (result.fetching && !result.data) return <>Fetching...</>;
+ *   if (!result.data) return <>No data found</>;
+ *
+ *   return <>{result.data.map((leaderboard) => <div>{leaderboard.name}: {leaderboard.score}</div>)}</>;
+ * }
+ * ```
+ */
+export function useView<F extends ViewFunctionWithoutVariables<any>>(
+  view: F,
+  options?: Omit<ReadOperationOptions, "live">
+): ReadHookResult<ViewResult<F>>;
+/**
+ * React hook to fetch the result of a computed view with variables from the backend. Returns a standard hook result set with a tuple of the result object with `data`, `fetching`, and `error` keys, and a `refetch` function. `data` will be the shape of the computed view's result.
+ *
+ * @param manager Gadget view function to run
+ * @param variables variables to pass to the backend view
+ * @param options options for controlling client side execution
+ *
+ * @example
+ *
+ * ```
+ * export function Leaderboard() {
+ *   const [result, refresh] = useView(api.leaderboard, {
+ *     first: 10,
+ *   });
+ *
+ *   if (result.error) return <>Error: {result.error.toString()}</>;
+ *   if (result.fetching && !result.data) return <>Fetching...</>;
+ *   if (!result.data) return <>No data found</>;
+ *
+ *   return <>{result.data.map((leaderboard) => <div>{leaderboard.name}: {leaderboard.score}</div>)}</>;
+ * }
+ * ```
+ */
+export function useView<F extends ViewFunctionWithVariables<any, any>>(
+  view: F,
+  variables: F["variablesType"],
+  options?: Omit<ReadOperationOptions, "live">
+): ReadHookResult<ViewResult<F>>;
+export function useView<VariablesT, F extends ViewFunction<VariablesT, any>>(
+  view: F,
+  variablesOrOptions?: VariablesT | Omit<ReadOperationOptions, "live">,
+  maybeOptions?: Omit<ReadOperationOptions, "live">
+): ReadHookResult<ViewResult<F>> {
+  let variables: VariablesT | undefined;
+  let options: Omit<ReadOperationOptions, "live"> | undefined;
+
+  if ("variables" in view) {
+    variables = variablesOrOptions as VariablesT;
+    options = maybeOptions;
+  } else if (variablesOrOptions) {
+    options = variablesOrOptions as Omit<ReadOperationOptions, "live">;
+  }
+
+  const memoizedVariables = useStructuralMemo(variables);
+  const memoizedOptions = useStructuralMemo(options);
+  const plan = useMemo(() => view.plan((memoizedVariables ?? {}) as unknown as VariablesT), [view, memoizedVariables]);
+
+  const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, memoizedOptions));
+
+  const result = useMemo(() => {
+    const dataPath = namespaceDataPath([view.operationName], view.namespace);
+    const data = get(rawResult.data, dataPath);
+    const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath, options?.pause);
+
+    return { ...rawResult, data, error };
+  }, [view, options?.pause, rawResult]);
+
+  return [result, refresh];
+}

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -74,10 +74,6 @@ export declare type ReadOperationOptions = {
   suspense?: boolean;
   /**
    * Marks this query as a live query that will subscribe to changes from the backend and re-render when backend data changes with the newest data.
-   *
-   * This option is currently only available for Gadget apps in the Realtime Queries beta!
-   * Please contact Gadget for access to this beta in order to use Realtime queries.
-   * @experimental
    */
   live?: boolean;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.511.0-development.2409
-        version: 1.511.0-development.2409
+        specifier: 1.512.0-development.2586
+        version: 1.512.0-development.2586
       '@gadget-client/kitchen-sink':
         specifier: 1.9.0-development.206
         version: 1.9.0-development.206
@@ -2919,8 +2919,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.511.0-development.2409:
-    resolution: {integrity: sha1-1orSp+ftWNsgurc7a43+D8XolJA=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/12688}
+  /@gadget-client/js-clients-test@1.512.0-development.2586:
+    resolution: {integrity: sha1-nLi3pJ97Ss19lRp0TMiKS42Xoxs=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/15653}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
       tiny-graphql-query-compiler: link:packages/tiny-graphql-query-compiler


### PR DESCRIPTION
This adds a react `useView` hook to accompany the imperative computed view functions we're already generating in fv1.4 . `useView` works pretty similarly to a finder in that we grab the function off the api client and run half of it to get the operation plan, and then execute the actual thing using the urql hook. Computed views have no built in support for pagination so its simpler than a findMany or what have you, but they are typed so we do the ole fish-out-the-type-from-a-fake-property-on-the-function-thing.

The plan for releasing this is to stick it in the next react version but not announce support for a while yet while we dogfood and do an internal alpha methinks.

[no-changelog-required]
