### PR TITLE
Add a ping to live queries to ensure socket is active

### DIFF
--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -521,14 +521,14 @@ export class GadgetConnection {
           if (!received) {
             timedOut = setTimeout(() => {
               if (activeSocket.readyState === WebSocket.OPEN) {
-                activeSocket.close(4408, 'Request Timeout')
+                activeSocket.close(4408, "Request Timeout");
               }
-            }, 2_000)
+            }, 2_000);
           }
         },
         pong: (received) => {
           if (received) clearTimeout(timedOut);
-        }
+        },
       },
       ...this.subscriptionClientOptions,
       ...overrides,

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -474,7 +474,7 @@ export class GadgetConnection {
     return this.createSubscriptionClient({
       url,
       webSocketImpl: this.websocketImplementation,
-      keepAlive: 5_000,
+      keepAlive: 7_000,
       connectionParams: async () => {
         // In the browser, we can't set arbitrary headers on the websocket request, so we don't use the same auth mechanism that we use for normal HTTP requests. Instead we use graphql-ws' connectionParams to send the auth information in the connection setup message to the server.
         const connectionParams: Record<string, any> = { environment: this.environment, auth: { type: this.authenticationMode } };
@@ -523,7 +523,7 @@ export class GadgetConnection {
               if (activeSocket.readyState === WebSocket.OPEN) {
                 activeSocket.close(4408, "Request Timeout");
               }
-            }, 2_000);
+            }, 3_000);
           }
         },
         pong: (received) => {


### PR DESCRIPTION
Without the `keepAlive` option the websocket used for live queries does not send out ping messages. This is a problem as after the initial connection and subscription messages no more messages are sent to the server. This means that the connection could no longer be active without realising it.

Following the example in:

[ttps://github.com/enisdenjo/graphql-ws/blob/5161bd91388677893badb8dbaca5c6587095199b/src/client.ts#L266-L303](https://github.com/enisdenjo/graphql-ws/blob/5161bd91388677893badb8dbaca5c6587095199b/src/client.ts#L266-L303)

I have set the `keepAlive` parameter with a 5 second interval and waiting at most 2 seconds to get a response from the server. This is slightly lower than the example which uses 10 second intervals, and a 5 second timeout as I expect live queries to be more real time than this. 

## Testing

I have tested this locally by:

* Make a page use a live query and print results
* Use the network developer tools to set to offline
* Make an update to some data displayed by the live query
* Then disable the offline mode again

Previously the websocket would continue to appear active however receive no further messages. With this change you see a new websocket connection is established after the timeout.


## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
