### PR TITLE
Remove PolarisAutoTable `F` keyboard shortcut

### DIFF
--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -185,10 +185,12 @@ const PolarisAutoTableComponent = <
             cancelAction={{ onAction: () => search.clear() }}
             disabled={!!error}
             // Search
+            disableKeyboardShortcuts
             queryValue={search.value}
             onQueryChange={search.set}
             onQueryClear={search.clear}
             queryPlaceholder={"Search"}
+            filteringAccessibilityTooltip={"Search"}
           />
         )}
 


### PR DESCRIPTION
This `F` keyboard shortcut applies to the whole page and would hijack focus, even in other textboxes. I've simply removed this keyboard shortcut as always clicking to search seems a lot less bad than focus highjacking 