### PR TITLE
fix minor z-index issue with autoTable select all chceckbox

### DIFF
--- a/packages/react/src/auto/shadcn/ShadcnAutoTable.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoTable.tsx
@@ -89,9 +89,9 @@ export const makeAutoTable = (elements: ShadcnElements) => {
     const [isHovered, hoverProps] = useHover();
     return (
       <>
-        <TableRow {...hoverProps} className="bg-background hover:bg-muted z-50">
+        <TableRow {...hoverProps} className="bg-background hover:bg-muted ">
           {canSelectRecords && (
-            <TableHead className={`sticky left-0 bg-${isHovered ? "muted" : "background"}`}>
+            <TableHead className={`sticky left-0 z-50 bg-${isHovered ? "muted" : "background"}`}>
               <AutoTableSelectAllCheckbox selection={selection} rows={rows} />
             </TableHead>
           )}


### PR DESCRIPTION
- Update
  - The column sort icons were appearing over the checkbox. The fix was to simply change where the z-index was applied