### PR TITLE
Export all autocomponent types explicitly in Shadcn package to prevent portability issues

### DIFF
--- a/packages/react/src/auto/shadcn/ShadcnAutoButton.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoButton.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import type { OptionsType } from "../../utils.js";
 import type { AutoButtonProps } from "../hooks/useAutoButtonController.js";
 import { useAutoButtonController } from "../hooks/useAutoButtonController.js";
-import { ButtonProps, type ShadcnElements } from "./elements.js";
+import type { ButtonProps, ShadcnElements } from "./elements.js";
 
 /**
  * Render a button that invokes an action when clicked, and shows a toast notification when the action succeeds or encounters an error by default.

--- a/packages/react/src/auto/shadcn/unreleasedIndex.ts
+++ b/packages/react/src/auto/shadcn/unreleasedIndex.ts
@@ -1,11 +1,33 @@
+export type { OptionsType } from "../../utils.js";
+export { type AutoInputComponent } from "../AutoInput.js";
+export type { AutoButtonProps } from "../hooks/useAutoButtonController.js";
+export type { AutoRelationshipFormProps, AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
+export type {
+  AutoBooleanInputProps,
+  AutoDateTimeInputProps,
+  AutoEncryptedStringInputProps,
+  AutoEnumInputProps,
+  AutoFileInputProps,
+  AutoHiddenInputProps,
+  AutoIdInputProps,
+  AutoInputProps,
+  AutoJSONInputProps,
+  AutoNumberInputProps,
+  AutoPasswordInputProps,
+  AutoRolesInputProps,
+  AutoTextInputProps,
+} from "../shared/AutoInputTypes.js";
+export type { AutoRichTextInputProps } from "../shared/AutoRichTextInputProps.js";
 export { GadgetShadcnTailwindSafelist } from "./GadgetShadcnTailwindSafelist.js";
 export type { ShadcnAutoFormProps as AutoFormProps } from "./ShadcnAutoForm.js";
 export type { ShadcnAutoTableProps as AutoTableProps } from "./ShadcnAutoTable.js";
 export * from "./elements.js";
+export type { DatePickerProps } from "./inputs/ShadcnAutoDateTimePicker.js";
 import { makeAutoButton } from "./ShadcnAutoButton.js";
 import { makeAutoForm } from "./ShadcnAutoForm.js";
 import { makeAutoTable } from "./ShadcnAutoTable.js";
 import type { ShadcnElements } from "./elements.js";
+
 /**
  * Build the Autocomponents library for your shadcn presentation components.
  * Autocomponents will render these given components, so they need to take the same base props that mainline shadcn components do.


### PR DESCRIPTION
- UPDATE
  - Previously, the types for many AutoComponents was not included in the `index` file, which made it a type error to re-export those imported components
    - ex > `export {makeAutoComponents} from '@gadgetinc/react/auto/shadcn'; ` would have a TS error when imported in other local files in a project 
  - The fix is to simply include all of the types explicitly in the index file. 