### PR TITLE
Added new `loadingSkeleton` prop to AutoTable

### DIFF
--- a/packages/react/.changeset/popular-lobsters-cheat.md
+++ b/packages/react/.changeset/popular-lobsters-cheat.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Added `loadingSkeleton` prop to AutoTable to override the default loading skeleton component

--- a/packages/react/src/auto/AutoTable.tsx
+++ b/packages/react/src/auto/AutoTable.tsx
@@ -117,4 +117,9 @@ export type AutoTableProps<
    * Indicates if pagination is enabled. Defaults to `true`.
    */
   paginate?: boolean;
+
+  /**
+   * The loading skeleton to display when the table is loading.
+   */
+  loadingSkeleton?: ReactNode;
 };

--- a/packages/react/src/auto/polaris/PolarisAutoTable.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoTable.tsx
@@ -179,7 +179,7 @@ const PolarisAutoTableComponent = <
   );
 
   if (!error && ((fetching && !rows) || !columns)) {
-    return <PolarisSkeletonTable columns={3} />;
+    return props.loadingSkeleton ?? <PolarisSkeletonTable columns={3} />;
   }
 
   return (

--- a/packages/react/src/auto/shadcn/ShadcnAutoTable.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoTable.tsx
@@ -282,7 +282,7 @@ export const makeAutoTable = (elements: ShadcnElements) => {
       );
     }
     if ((fetching && !rows) || !columns) {
-      return <Skeleton />;
+      return props.loadingSkeleton ?? <Skeleton />;
     }
 
     return (


### PR DESCRIPTION
- a new loading skeleton profits been added to auto table in order to allow people to override the default loading skeleton component
- this was suggested by people on discord here https://discord.com/channels/836317518595096598/1278488062158176338