### PR TITLE
Remove bad extra bottom border in shadcn comboboxes

### DIFF
--- a/packages/react/spec/auto/shadcn-defaults/components/Command.tsx
+++ b/packages/react/spec/auto/shadcn-defaults/components/Command.tsx
@@ -21,7 +21,7 @@ const CommandInput = React.forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     /* eslint-disable-next-line react/no-unknown-property */
-    <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <div className="flex items-center px-3" cmdk-input-wrapper="">
       <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         ref={ref}

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoComboInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoComboInput.tsx
@@ -68,7 +68,7 @@ export const makeShadcnAutoComboInput = ({
             {inputLabel} {requiredIndicator}
           </Label>
         )}
-        <div className={`relative rounded-md ${open ? "ring-1 ring-ring border" : "border"}`}>
+        <div className={`relative rounded-md border ${open ? "ring-1 ring-ring" : ""}`}>
           {props.selectedRecordTag && <div className="py-2 px-2 pt-2 pb-1">{props.selectedRecordTag}</div>}
           <Command className="overflow-visible z-50">
             <CommandInput


### PR DESCRIPTION
There was a bad extra bottom border in shadcn comboboxes. Unfortunately this is not overridable in through passing in `className` to the shadcn provided component, so the base component has to be updated. I will update this on the Gadget side separately 

BEFORE
![CleanShot 2025-03-31 at 10 53 32@2x](https://github.com/user-attachments/assets/0325ea9e-bfdd-498c-810a-cd5dd542906c)

AFTER
![CleanShot 2025-03-31 at 10 53 49@2x](https://github.com/user-attachments/assets/77967035-ce21-4ded-9090-3ad619f2114a)
