### PR TITLE
Add `inline-flex` to shadcn autotable checkboxes

### DIFF
--- a/packages/react/src/auto/shadcn/ShadcnAutoTable.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoTable.tsx
@@ -70,6 +70,7 @@ export const makeAutoTable = (elements: ShadcnElements) => {
               ? "indeterminate"
               : false
           }
+          className="inline-flex"
           onCheckedChange={(value) => selection.onSelectionChange(SelectionType.Page, !!value)}
           onClick={(e) => e.stopPropagation()}
         />
@@ -168,6 +169,7 @@ export const makeAutoTable = (elements: ShadcnElements) => {
     return (
       <TableCell className={`sticky left-0 ${getCellBackgroundColor({ isSelected, isHovered })} z-10`}>
         <Checkbox
+          className="inline-flex"
           id={`AutoTableSingleRowCheckbox-${row.id as string}`}
           checked={isSelected}
           onClick={(e) => {


### PR DESCRIPTION
This looked bad on Firefox without this added style. Now it looks better on all browsers 