### PR TITLE
Added placeholder prop to searchable autoInputs and fixed polaris string based autoInputs so that they get the underlying polaris text input props types

### DIFF
--- a/packages/react/.changeset/dull-owls-work.md
+++ b/packages/react/.changeset/dull-owls-work.md
@@ -1,0 +1,13 @@
+---
+"@gadgetinc/react": patch
+---
+
+- Added optional `placeholder` prop to override the now blank default. Previously, the placeholder was always "Search"
+  - Affected components
+    - `AutoBelongsToInput`
+    - `AutoHasOneInput`
+    - `AutoHasManyInput`
+    - `AutoHasManyThroughInput`
+    - `AutoEnumInput`
+    - `AutoRolesInput`
+- Fixed issue with Polaris `AutoEmailInput`, `AutoStringInput`, and `AutoUrlInput` prop types where the props of the underlying components were not re-exported

--- a/packages/react/cypress/component/auto/form/AutoEnumInput.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoEnumInput.cy.tsx
@@ -265,13 +265,13 @@ describeForEachAutoAdapter("AutoEnumInput", ({ name, adapter: { AutoForm }, wrap
       cy.mountWithWrapper(<AutoForm action={api.game.stadium.create} />, wrapper);
       cy.get(getInputSelector("type")).type("hello");
       cy.contains(`Add "hello"`).should("not.exist");
-      cy.contains(`No options found matching "hello"`).should("exist");
+      cy.contains(`No results`).should("exist");
 
       blurComboboxes();
 
       cy.get(getInputSelector("tags")).type("nope");
       cy.contains(`Add "nope"`).should("not.exist");
-      cy.contains(`No options found matching "nope"`).should("exist");
+      cy.contains(`No results`).should("exist");
     });
   });
 

--- a/packages/react/spec/auto/shadcn-defaults/components/TextArea.tsx
+++ b/packages/react/spec/auto/shadcn-defaults/components/TextArea.tsx
@@ -6,7 +6,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
+++ b/packages/react/src/auto/interfaces/AutoRelationshipInputProps.tsx
@@ -30,6 +30,11 @@ export interface AutoRelationshipInputProps extends ControllableWithReactHookFor
    * Optional filter for the related model options.
    */
   recordFilter?: RecordFilter;
+
+  /**
+   * Optional placeholder for the input
+   */
+  placeholder?: string;
 }
 
 export type DisplayedRecordOption = RecordLabel<ReactNode> & {

--- a/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
+++ b/packages/react/src/auto/polaris/PolarisFixedOptionsCombobox.tsx
@@ -24,6 +24,11 @@ type BaseComboboxProps = Omit<AutocompleteProps, "selected" | "onSelect" | "text
    * Selectable options in the combobox.
    */
   options: EnumOption[];
+
+  /**
+   * Placeholder for the combobox.
+   */
+  placeholder?: string;
 };
 
 /** Props for a single-selection combobox. */
@@ -61,7 +66,7 @@ export type PolarisFixedOptionsMultiComboboxProps = BaseComboboxProps & {
 export type PolarisFixedOptionsComboboxProps = PolarisFixedOptionsSingleComboboxProps | PolarisFixedOptionsMultiComboboxProps;
 
 export const PolarisFixedOptionsCombobox = (props: PolarisFixedOptionsComboboxProps) => {
-  const { label, options: allOptions, value, onChange, allowMultiple, ...rest } = props;
+  const { label, options: allOptions, value, onChange, allowMultiple, placeholder, ...rest } = props;
   const selectedValues = useMemo(() => (value ? (allowMultiple ? value : [value]) : []), [allowMultiple, value]);
   const selectedOptions = allOptions.filter((option) => selectedValues.includes(option.value));
 
@@ -136,7 +141,7 @@ export const PolarisFixedOptionsCombobox = (props: PolarisFixedOptionsComboboxPr
       label={label}
       value={inputValue}
       verticalContent={verticalContentMarkup}
-      placeholder="Search"
+      placeholder={placeholder}
       autoComplete="off"
       id={`${label}_Autocomplete_Textfield`}
     />

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoEnumInput.tsx
@@ -20,7 +20,7 @@ export type PolarisAutoEnumInputProps = AutoEnumInputProps & Partial<Omit<Combob
  * @returns The AutoEnumInput component.
  */
 export const PolarisAutoEnumInput = autoInput((props: PolarisAutoEnumInputProps) => {
-  const { field: fieldApiIdentifier, control, label: labelProp, ...comboboxProps } = props;
+  const { field: fieldApiIdentifier, control, label: labelProp, placeholder, ...comboboxProps } = props;
   const {
     allowMultiple,
     allowOther,
@@ -93,7 +93,7 @@ export const PolarisAutoEnumInput = autoInput((props: PolarisAutoEnumInputProps)
   if (!allowOther && (!optionItemElement || optionItemElement.length === 0) && searchValue) {
     emptyStateElement = (
       <Box padding="100">
-        <Text as="span" alignment="center" tone="subdued">{`No options found matching "${searchValue}"`}</Text>
+        <Text as="span" alignment="center" tone="subdued">{`No results`}</Text>
       </Box>
     );
   }
@@ -131,11 +131,11 @@ export const PolarisAutoEnumInput = autoInput((props: PolarisAutoEnumInputProps)
           autoComplete="off"
           label={inputLabel}
           value={searchValue}
-          placeholder="Search"
           verticalContent={selectedTagsElement}
           onChange={setSearchValue}
           id={`${props.field}-combobox-textfield`}
           error={errorMessage}
+          placeholder={placeholder}
         />
       }
       {...comboboxProps}

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoRolesInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoRolesInput.tsx
@@ -43,6 +43,7 @@ export const PolarisAutoRolesInput = autoInput((props: PolarisAutoRolesInputProp
       label={props.label ?? metadata.name}
       {...getPropsWithoutRef(fieldProps)}
       value={selectedRoleKeys}
+      placeholder={props.placeholder}
     />
   );
 });

--- a/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/PolarisAutoTextInput.tsx
@@ -47,7 +47,7 @@ export const PolarisAutoTextInput = autoInput((props: PolarisAutoTextInputProps)
  * @param props.label - Label of the email input.
  * @returns The AutoEmailInput component
  */
-export const PolarisAutoEmailInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;
+export const PolarisAutoEmailInput = (props: PolarisAutoTextInputProps) => <PolarisAutoTextInput {...props} />;
 
 /**
  * A string input within AutoForm.
@@ -61,7 +61,7 @@ export const PolarisAutoEmailInput = (props: AutoTextInputProps) => <PolarisAuto
  * @param props.label - Label of the string input.
  * @returns The AutoStringInput component
  */
-export const PolarisAutoStringInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;
+export const PolarisAutoStringInput = (props: PolarisAutoTextInputProps) => <PolarisAutoTextInput {...props} />;
 
 /**
  * A url input within AutoForm.
@@ -75,4 +75,4 @@ export const PolarisAutoStringInput = (props: AutoTextInputProps) => <PolarisAut
  * @param props.label - Label of the url input.
  * @returns The AutoUrlInput component
  */
-export const PolarisAutoUrlInput = (props: AutoTextInputProps) => <PolarisAutoTextInput {...props} />;
+export const PolarisAutoUrlInput = (props: PolarisAutoTextInputProps) => <PolarisAutoTextInput {...props} />;

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoBelongsToInput.tsx
@@ -23,6 +23,7 @@ import { RelatedModelOptions } from "./RelatedModelOptions.js";
  * @returns The belongsTo field input component
  */
 export const PolarisAutoBelongsToInput = autoInput((props: AutoRelationshipInputProps) => {
+  const { field, label, placeholder } = props;
   const {
     fieldMetadata: { path, metadata },
     relatedModelOptions: { options, searchFilterOptions, pagination, search, relatedModel },
@@ -34,7 +35,7 @@ export const PolarisAutoBelongsToInput = autoInput((props: AutoRelationshipInput
     onRemoveRecord,
   } = useBelongsToInputController(props);
 
-  const optionLabel = useOptionLabelForField(props.field, props.optionLabel);
+  const optionLabel = useOptionLabelForField(field, props.optionLabel);
   const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, { primary: optionLabel }) : null;
 
   const selectedRecordTag =
@@ -68,8 +69,8 @@ export const PolarisAutoBelongsToInput = autoInput((props: AutoRelationshipInput
             onChange={search.set}
             value={search.value}
             name={path}
-            label={props.label ?? metadata.name}
-            placeholder="Search"
+            label={label ?? metadata.name}
+            placeholder={placeholder}
             autoComplete="off"
             verticalContent={selectedRecordTag}
           />

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyInput.tsx
@@ -24,7 +24,7 @@ import { getSelectedRelatedRecordTags } from "./SelectedRelatedRecordTags.js";
  * @returns The hasMany field input component
  */
 export const PolarisAutoHasManyInput = autoInput((props: AutoRelationshipInputProps) => {
-  const { field } = props;
+  const { field, label, placeholder } = props;
 
   const {
     fieldMetadata: { path, metadata },
@@ -51,9 +51,9 @@ export const PolarisAutoHasManyInput = autoInput((props: AutoRelationshipInputPr
           <Combobox.TextField
             onChange={search.set}
             value={search.value}
-            label={props.label ?? metadata.name}
+            label={label ?? metadata.name}
+            placeholder={placeholder}
             name={path}
-            placeholder="Search"
             autoComplete="off"
             verticalContent={getSelectedRelatedRecordTags({
               selectedRecords,

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughInput.tsx
@@ -24,7 +24,7 @@ import { getSelectedRelatedRecordTags } from "./SelectedRelatedRecordTags.js";
  * @returns The hasManyThrough field input component
  */
 export const PolarisAutoHasManyThroughInput = autoInput((props: AutoRelationshipInputProps) => {
-  const { field } = props;
+  const { field, label, placeholder } = props;
   const {
     fieldMetadata: { path, metadata },
     relatedModelOptions: { options, searchFilterOptions, search, pagination, relatedModel },
@@ -48,9 +48,9 @@ export const PolarisAutoHasManyThroughInput = autoInput((props: AutoRelationship
           <Combobox.TextField
             onChange={search.set}
             value={search.value}
-            label={props.label ?? metadata.name}
+            label={label ?? metadata.name}
+            placeholder={placeholder}
             name={path}
-            placeholder="Search"
             autoComplete="off"
             verticalContent={getSelectedRelatedRecordTags({
               selectedRecords,

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasOneInput.tsx
@@ -23,7 +23,7 @@ import { RelatedModelOptions } from "./RelatedModelOptions.js";
  * @returns The hasOne field input component
  */
 export const PolarisAutoHasOneInput = autoInput((props: AutoRelationshipInputProps) => {
-  const { field } = props;
+  const { field, label, placeholder } = props;
   const {
     fieldMetadata: { path, metadata },
     relatedModelOptions: { options, searchFilterOptions, search, pagination, relatedModel },
@@ -51,9 +51,9 @@ export const PolarisAutoHasOneInput = autoInput((props: AutoRelationshipInputPro
           <Combobox.TextField
             onChange={search.set}
             value={search.value}
-            label={props.label ?? metadata.name}
+            label={label ?? metadata.name}
+            placeholder={placeholder}
             name={path}
-            placeholder="Search"
             autoComplete="off"
             verticalContent={selectedRecordTag}
           />

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisListMessages.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisListMessages.tsx
@@ -28,6 +28,6 @@ export const ListMessage = (props: { message: string }) => (
   </div>
 );
 
-export const NoRecordsMessage = () => <ListMessage message="No records found" />;
+export const NoRecordsMessage = () => <ListMessage message="No results" />;
 
 export { getErrorMessage };

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoComboInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoComboInput.tsx
@@ -81,7 +81,7 @@ export const makeShadcnAutoComboInput = ({
                 props.onChange?.(value);
               }}
               onFocus={() => setOpen(true)}
-              placeholder={"Search"}
+              placeholder={props.placeholder}
               className="ml-2 bg-transparent outline-none placeholder:text-muted-foreground flex-1"
             />
             {open && (
@@ -101,7 +101,7 @@ export const makeShadcnAutoComboInput = ({
                   searchValue={inputValue}
                   setSearchValue={setInputValue}
                   formatOptionText={props.formatOptionText}
-                  emptyMessage={props.emptyMessage ? `${props.emptyMessage} "${inputValue}"` : undefined}
+                  emptyMessage={props.emptyMessage}
                   canLoadMore={props.willLoadMoreOptions}
                   onLoadMore={props.onScrolledToBottom}
                 />

--- a/packages/react/src/auto/shadcn/inputs/ShadcnAutoEnumInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/ShadcnAutoEnumInput.tsx
@@ -34,7 +34,7 @@ export const makeShadcnAutoEnumInput = ({
   });
 
   function ShadcnAutoEnumInput(props: AutoEnumInputProps) {
-    const { label: labelProp } = props;
+    const { label: labelProp, placeholder } = props;
 
     const {
       allowMultiple,
@@ -103,6 +103,7 @@ export const makeShadcnAutoEnumInput = ({
         path={path}
         metadata={metadata}
         label={labelProp ?? label}
+        placeholder={placeholder}
         onChange={debouncedSearch}
         selectedRecordTag={selectedTagsElement}
         onSelect={(option) => {
@@ -122,7 +123,7 @@ export const makeShadcnAutoEnumInput = ({
           setSearchValue("");
         }}
         formatOptionText={formatOptionText}
-        emptyMessage={`No options found matching `}
+        emptyMessage={`No results`}
       />
     );
   }

--- a/packages/react/src/auto/shadcn/inputs/relationships/RelatedModelOption.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/RelatedModelOption.tsx
@@ -63,7 +63,7 @@ export const makeRelatedModelOption = (
     useDetectScrolledToBottom({ loadMoreRef, onLoadMore: props.onLoadMore });
 
     return (
-      <CommandList className="absolute top-full w-full bg-background border shadow-md rounded-b-md z-50">
+      <CommandList className="absolute top-full w-full bg-background border shadow-md rounded-md z-50">
         {isLoading && <CommandEmpty>Loading...</CommandEmpty>}
         {listBoxOptions.length > 0 ? <CommandGroup>{listBoxOptions}</CommandGroup> : null}
         {props.allowOther && props.searchValue && (

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoBelongsToInput.tsx
@@ -36,6 +36,8 @@ export const makeShadcnAutoBelongsToInput = ({
   });
 
   function ShadcnAutoBelongsToInput(props: AutoRelationshipInputProps) {
+    const { field, placeholder } = props;
+
     const {
       fieldMetadata: { path, metadata },
       relatedModelOptions: { options, searchFilterOptions, pagination, search, relatedModel },
@@ -47,7 +49,7 @@ export const makeShadcnAutoBelongsToInput = ({
       onRemoveRecord,
     } = useBelongsToInputController(props);
 
-    const optionLabel = useOptionLabelForField(props.field, props.optionLabel);
+    const optionLabel = useOptionLabelForField(field, props.optionLabel);
     const selectedOption = selectedRecord ? getRecordAsOption(selectedRecord, { primary: optionLabel }) : null;
 
     const selectedRecordTag =
@@ -92,6 +94,7 @@ export const makeShadcnAutoBelongsToInput = ({
         {...props}
         options={searchFilterOptions}
         path={path}
+        placeholder={placeholder}
         metadata={metadata}
         onChange={search.set}
         defaultValue={search.value}

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyInput.tsx
@@ -37,7 +37,7 @@ export const makeShadcnAutoHasManyInput = ({
   });
 
   function ShadcnAutoHasManyInput(props: AutoRelationshipInputProps) {
-    const { field } = props;
+    const { field, placeholder } = props;
 
     const {
       fieldMetadata: { path, metadata },
@@ -71,6 +71,7 @@ export const makeShadcnAutoHasManyInput = ({
         path={path}
         metadata={metadata}
         onChange={search.set}
+        placeholder={placeholder}
         selectedRecordTag={
           selectedRecords.length > 0 ? (
             <SelectedRecordTags selectedRecords={selectedRecords} optionLabel={optionLabel} onRemoveRecord={onRemoveRecord} />

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughInput.tsx
@@ -37,7 +37,7 @@ export const makeShadcnAutoHasManyThroughInput = ({
   });
 
   function ShadcnAutoHasManyThroughInput(props: AutoRelationshipInputProps) {
-    const { field } = props;
+    const { field, placeholder } = props;
     const {
       fieldMetadata: { path, metadata },
       relatedModelOptions: { options, searchFilterOptions, search, pagination, relatedModel },
@@ -77,6 +77,7 @@ export const makeShadcnAutoHasManyThroughInput = ({
           ) : null
         }
         onSelect={onSelectRecord}
+        placeholder={placeholder}
         checkSelected={(id) => {
           return selectedRecordIds.includes(id);
         }}

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneInput.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasOneInput.tsx
@@ -35,7 +35,7 @@ export const makeShadcnAutoHasOneInput = ({
   });
 
   function ShadcnAutoHasOneInput(props: AutoRelationshipInputProps) {
-    const { field } = props;
+    const { field, placeholder } = props;
     const {
       fieldMetadata: { path, metadata },
       relatedModelOptions: { options, searchFilterOptions, search, pagination, relatedModel },
@@ -73,6 +73,7 @@ export const makeShadcnAutoHasOneInput = ({
         {...props}
         options={searchFilterOptions}
         path={path}
+        placeholder={placeholder}
         metadata={metadata}
         onChange={search.set}
         defaultValue={search.value}

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnListMessages.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnListMessages.tsx
@@ -19,7 +19,7 @@ export const makeShadcnListMessages = ({
   Label,
 }: Pick<ShadcnElements, "CommandEmpty" | "CommandItem" | "Checkbox" | "Label">) => {
   function NoRecordsMessage(props: { message?: string }) {
-    const { message = "No records found" } = props;
+    const { message = "No results" } = props;
     return <CommandEmpty>{message}</CommandEmpty>;
   }
 

--- a/packages/react/src/auto/shared/AutoInputTypes.tsx
+++ b/packages/react/src/auto/shared/AutoInputTypes.tsx
@@ -71,6 +71,10 @@ export interface AutoEnumInputProps extends ControllableWithReactHookForm {
    * A callback function run after the input value changes
    */
   afterChange?: (...event: any[]) => void;
+  /**
+   * Optional placeholder for the input
+   */
+  placeholder?: string;
 }
 
 export interface AutoFileInputProps extends ControllableWithReactHookForm {
@@ -171,6 +175,10 @@ export interface AutoRolesInputProps extends ControllableWithReactHookForm {
    * The label of the Roles field
    */
   label?: InputLabel;
+  /**
+   * Optional placeholder for the input
+   */
+  placeholder?: string;
 }
 
 export interface AutoTextInputProps extends ControllableWithReactHookForm {


### PR DESCRIPTION
- Added optional `placeholder` prop to override the now blank default. Previously, the placeholder was always "Search"
  - Affected components
    - `AutoBelongsToInput`
    - `AutoHasOneInput`
    - `AutoHasManyInput`
    - `AutoHasManyThroughInput`
    - `AutoEnumInput`
    - `AutoRolesInput`
- Fixed issue with Polaris `AutoEmailInput`, `AutoStringInput`, and `AutoUrlInput` prop types where the props of the underlying components were not re-exported
