### PR TITLE
add `loadingSkeleton` prop to AutoForm to match AutoTable

### DIFF
--- a/packages/react/.changeset/afraid-walls-fetch.md
+++ b/packages/react/.changeset/afraid-walls-fetch.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Added `loadingSkeleton` prop to AutoForm to override the default skeleton component.

--- a/packages/react/spec/auto/storybook/SelectableDesignSystemUtils.tsx
+++ b/packages/react/spec/auto/storybook/SelectableDesignSystemUtils.tsx
@@ -40,7 +40,7 @@ export const DesignSystemSelectionControl = ({ children }: { children: React.Rea
           </Button>
         </div>
 
-        <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+        <Suspense>{children}</Suspense>
       </AppProvider>
     </DesignSystemContext.Provider>
   );

--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -74,6 +74,8 @@ export type AutoFormProps<
   action: ActionFunc;
   /** What to show the user once the form has been submitted successfully */
   successContent?: ReactNode;
+  /** The loading skeleton to display when the form is loading */
+  loadingSkeleton?: ReactNode;
   /** An allowlist of fields to render within the form. Only these fields will be rendered as inputs. */
   include?: string[];
   /** A denylist of fields to render within the form. Every field except these fields will be rendered as inputs. */

--- a/packages/react/src/auto/polaris/PolarisAutoForm.tsx
+++ b/packages/react/src/auto/polaris/PolarisAutoForm.tsx
@@ -113,7 +113,7 @@ const PolarisAutoFormComponent = <
   if (fetchingMetadata) {
     return (
       <Form {...rest} onSubmit={submit}>
-        <PolarisAutoFormSkeleton />
+        {props.loadingSkeleton ?? <PolarisAutoFormSkeleton />}
       </Form>
     );
   }

--- a/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
+++ b/packages/react/src/auto/shadcn/ShadcnAutoForm.tsx
@@ -121,7 +121,7 @@ export const makeAutoForm = <Elements extends ShadcnElements>(elements: Elements
     if (fetchingMetadata) {
       return (
         <FormContainer {...rest} onSubmit={submit as any}>
-          <Skeleton />
+          {props.loadingSkeleton ?? <Skeleton />}
         </FormContainer>
       );
     }


### PR DESCRIPTION

Added `loadingSkeleton` prop to AutoForm to override the default skeleton component.
