### PR TITLE
Add support for inline views and fix operation name on model namespaced views

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@gadget-client/app-with-no-user-model": "^1.10.0",
     "@gadget-client/bulk-actions-test": "^1.113.0",
     "@gadget-client/full-auth": "^1.9.0",
-    "@gadget-client/js-clients-test": "1.512.0-development.2591",
+    "@gadget-client/js-clients-test": "1.512.0-development.2601",
     "@gadget-client/kitchen-sink": "1.9.0-development.206",
     "@gadget-client/related-products-example": "^1.865.0",
     "@gadget-client/zxcv-deeply-nested": "^1.212.0",

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -87,6 +87,7 @@ export interface ViewFunctionWithoutVariables<ResultT> {
   (): Promise<ResultT>;
   type: "computedView";
   operationName: string;
+  gqlFieldName: string;
   namespace?: string | string[] | null;
   resultType: ResultT;
   plan(): GQLBuilderResult;
@@ -96,6 +97,7 @@ export interface ViewFunctionWithVariables<VariablesT, ResultT> {
   (variables: VariablesT): Promise<ResultT>;
   type: "computedView";
   operationName: string;
+  gqlFieldName: string;
   namespace?: string | string[] | null;
   variables: VariablesOptions;
   variablesType: VariablesT;

--- a/packages/api-client-core/src/GadgetFunctions.ts
+++ b/packages/api-client-core/src/GadgetFunctions.ts
@@ -89,6 +89,7 @@ export interface ViewFunctionWithoutVariables<ResultT> {
   operationName: string;
   gqlFieldName: string;
   namespace?: string | string[] | null;
+  referencedTypenames?: string[];
   resultType: ResultT;
   plan(): GQLBuilderResult;
 }
@@ -99,6 +100,7 @@ export interface ViewFunctionWithVariables<VariablesT, ResultT> {
   operationName: string;
   gqlFieldName: string;
   namespace?: string | string[] | null;
+  referencedTypenames?: string[];
   variables: VariablesOptions;
   variablesType: VariablesT;
   resultType: ResultT;

--- a/packages/react/.changeset/silent-starfishes-cough.md
+++ b/packages/react/.changeset/silent-starfishes-cough.md
@@ -1,5 +1,6 @@
 ---
 "@gadgetinc/react": minor
+"@gadgetinc/api-client-core": patch
 ---
 
 Add `useView` hook for executing computed views

--- a/packages/react/.changeset/silent-starfishes-cough.md
+++ b/packages/react/.changeset/silent-starfishes-cough.md
@@ -1,0 +1,7 @@
+---
+"@gadgetinc/react": minor
+---
+
+Add `useView` hook for executing computed views
+
+This adds a new React hook for invoking computed views defined using backend `.gelly` files.

--- a/packages/react/spec/auto/shadcn-defaults/__snapshots__/shadcnClassnameSafelist.spec.ts.snap
+++ b/packages/react/spec/auto/shadcn-defaults/__snapshots__/shadcnClassnameSafelist.spec.ts.snap
@@ -773,6 +773,10 @@ body {
   display: block;
 }
 
+.inline {
+  display: inline;
+}
+
 .flex {
   display: flex;
 }

--- a/packages/react/spec/auto/shadcn-defaults/shadcnClassnameSafelist.spec.ts
+++ b/packages/react/spec/auto/shadcn-defaults/shadcnClassnameSafelist.spec.ts
@@ -85,6 +85,7 @@ describe("Tailwind CSS Output Snapshot", () => {
         "h-9",
         "h-fit",
         "hidden",
+        "inline",
         "inline-flex",
         "inset-0",
         "items-center",

--- a/packages/react/spec/useView.spec.tsx
+++ b/packages/react/spec/useView.spec.tsx
@@ -116,6 +116,7 @@ describe("useView", () => {
     expect(result.current[0].error).toBeFalsy();
 
     expect(client.executeQuery).toHaveBeenCalledTimes(1);
+    expect(client.executeQuery.mock.calls[0][1].additionalTypenames).toEqual(["Widget"]);
 
     expect(query).toMatchInlineSnapshot(`
       "query totalInStock {

--- a/packages/react/src/auto/shadcn/GadgetShadcnTailwindSafelist.ts
+++ b/packages/react/src/auto/shadcn/GadgetShadcnTailwindSafelist.ts
@@ -74,6 +74,7 @@ export const GadgetShadcnTailwindSafelistFromTailwind = [
   "h-9",
   "h-fit",
   "hidden",
+  "inline",
   "inline-flex",
   "inset-0",
   "items-center",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -25,3 +25,4 @@ export * from "./useList.js";
 export * from "./useMaybeFindFirst.js";
 export * from "./useMaybeFindOne.js";
 export * from "./useTable.js";
+export * from "./useView.js";

--- a/packages/react/src/useView.ts
+++ b/packages/react/src/useView.ts
@@ -1,4 +1,10 @@
-import type { ViewFunction, ViewFunctionWithoutVariables, ViewFunctionWithVariables, ViewResult } from "@gadgetinc/api-client-core";
+import type {
+  GQLBuilderResult,
+  ViewFunction,
+  ViewFunctionWithoutVariables,
+  ViewFunctionWithVariables,
+  ViewResult,
+} from "@gadgetinc/api-client-core";
 import { get, namespaceDataPath } from "@gadgetinc/api-client-core";
 import { useMemo } from "react";
 import { useGadgetQuery } from "./useGadgetQuery.js";
@@ -9,7 +15,7 @@ import { ErrorWrapper, useQueryArgs } from "./utils.js";
 /**
  * React hook to fetch the result of a computed view from the backend. Returns a standard hook result set with a tuple of the result object with `data`, `fetching`, and `error` keys, and a `refetch` function. `data` will be the shape of the computed view's result.
  *
- * @param manager Gadget view function to run
+ * @param view Gadget view function to run, like `api.leaderboard` or `api.todos.summary`
  * @param options options for controlling client side execution
  *
  * @example
@@ -58,15 +64,45 @@ export function useView<F extends ViewFunctionWithVariables<any, any>>(
   variables: F["variablesType"],
   options?: Omit<ReadOperationOptions, "live">
 ): ReadHookResult<ViewResult<F>>;
+/**
+ * React hook to fetch the result of an inline computed view with variables from the backend. Returns a standard hook result set with a tuple of the result object with `data`, `fetching`, and `error` keys, and a `refetch` function. `data` will be the shape of the computed view's result.
+ *
+ * Does not know the type of the result from the input string -- for type safety, use a named view defined in a .gelly file in the backend.
+ *
+ * @param view Gelly query string to run, like `{ count(todos) }`
+ * @param variables variables to pass to the backend view
+ * @param options options for controlling client side execution
+ *
+ * @example
+ *
+ * ```
+ * export function Leaderboard() {
+ *   const [result, refresh] = useView("{ count(todos) }", {
+ *     first: 10,
+ *   });
+ *
+ *   if (result.error) return <>Error: {result.error.toString()}</>;
+ *   if (result.fetching && !result.data) return <>Fetching...</>;
+ *   if (!result.data) return <>No data found</>;
+ *
+ *   return <>{result.data.map((leaderboard) => <div>{leaderboard.name}: {leaderboard.score}</div>)}</>;
+ * }
+ * ```
+ */
+export function useView(
+  gellyQuery: string,
+  variables?: Record<string, unknown>,
+  options?: Omit<ReadOperationOptions, "live">
+): ReadHookResult<ViewResult<ViewFunction<unknown, unknown>>>;
 export function useView<VariablesT, F extends ViewFunction<VariablesT, any>>(
-  view: F,
+  view: F | string,
   variablesOrOptions?: VariablesT | Omit<ReadOperationOptions, "live">,
   maybeOptions?: Omit<ReadOperationOptions, "live">
 ): ReadHookResult<ViewResult<F>> {
   let variables: VariablesT | undefined;
   let options: Omit<ReadOperationOptions, "live"> | undefined;
 
-  if ("variables" in view) {
+  if (typeof view == "string" || "variables" in view) {
     variables = variablesOrOptions as VariablesT;
     options = maybeOptions;
   } else if (variablesOrOptions) {
@@ -75,17 +111,26 @@ export function useView<VariablesT, F extends ViewFunction<VariablesT, any>>(
 
   const memoizedVariables = useStructuralMemo(variables);
   const memoizedOptions = useStructuralMemo(options);
-  const plan = useMemo(() => view.plan((memoizedVariables ?? {}) as unknown as VariablesT), [view, memoizedVariables]);
+  const [plan, dataPath] = useMemo((): [plan: GQLBuilderResult, dataPath: string[]] => {
+    if (typeof view == "string") {
+      return [{ query: inlineViewQuery, variables: { query: view, variables: memoizedVariables } }, ["gellyView"]];
+    } else {
+      return [view.plan((memoizedVariables ?? {}) as unknown as VariablesT), namespaceDataPath([view.gqlFieldName], view.namespace)];
+    }
+  }, [view, memoizedVariables]);
 
   const [rawResult, refresh] = useGadgetQuery(useQueryArgs(plan, memoizedOptions));
 
   const result = useMemo(() => {
-    const dataPath = namespaceDataPath([view.operationName], view.namespace);
     const data = get(rawResult.data, dataPath);
     const error = ErrorWrapper.errorIfDataAbsent(rawResult, dataPath, options?.pause);
 
     return { ...rawResult, data, error };
-  }, [view, options?.pause, rawResult]);
+  }, [dataPath, options?.pause, rawResult]);
 
   return [result, refresh];
 }
+
+const inlineViewQuery = `query InlineView($query: String!, $variables: JSONObject) { 
+  gellyView(query: $query, variables: $variables) 
+}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@gadget-client/js-clients-test':
-        specifier: 1.512.0-development.2591
-        version: 1.512.0-development.2591
+        specifier: 1.512.0-development.2601
+        version: 1.512.0-development.2601
       '@gadget-client/kitchen-sink':
         specifier: 1.9.0-development.206
         version: 1.9.0-development.206
@@ -2919,8 +2919,8 @@ packages:
       '@gadgetinc/api-client-core': link:packages/api-client-core
     dev: true
 
-  /@gadget-client/js-clients-test@1.512.0-development.2591:
-    resolution: {integrity: sha1-G063g9VI1izQOSo+fXtuUu2a46w=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/16260}
+  /@gadget-client/js-clients-test@1.512.0-development.2601:
+    resolution: {integrity: sha1-aDC+taOpgqtTsp5365MZJEqLWmw=, tarball: https://registry.gadget.dev/npm/_/tarball/57882/114412/16441}
     dependencies:
       '@gadgetinc/api-client-core': link:packages/api-client-core
       tiny-graphql-query-compiler: link:packages/tiny-graphql-query-compiler


### PR DESCRIPTION
This adds support for inline views (views that are plain strings instead of .gelly files on the backed) and fixes support for named views mounted on models in the `useView` hook. See the tests!

[no-changelog-required]
