### PR TITLE
Fix type error in AutoHasManyThroughForm to make children optional

### DIFF
--- a/packages/react/src/auto/AutoInput.tsx
+++ b/packages/react/src/auto/AutoInput.tsx
@@ -43,7 +43,9 @@ export function autoInput<P extends { field: string }>(Component: React.FC<P>): 
   return WrappedComponent as AutoInputComponent<P>;
 }
 
-export function autoRelationshipForm<P extends AutoRelationshipFormProps>(Component: React.FC<P>): AutoInputComponent<P> {
+export function autoRelationshipForm<P extends Pick<AutoRelationshipFormProps, "field" | "recordLabel">>(
+  Component: React.FC<P>
+): AutoInputComponent<P> {
   const WrappedComponent: React.FC<P> = (props) => {
     const { hasCustomFormChildren, registerFields, fieldSet } = useFieldsFromChildComponents();
 

--- a/packages/react/src/auto/hooks/useSelectedPathsFromRecordLabel.tsx
+++ b/packages/react/src/auto/hooks/useSelectedPathsFromRecordLabel.tsx
@@ -14,7 +14,7 @@ import {
 } from "../interfaces/AutoRelationshipInputProps.js";
 import { useMaybeFieldMetadata } from "./useFieldMetadata.js";
 
-export const useSelectedPathsFromRecordLabel = (props: AutoRelationshipFormProps) => {
+export const useSelectedPathsFromRecordLabel = (props: Pick<AutoRelationshipFormProps, "field" | "recordLabel">) => {
   const { field, recordLabel } = props;
   const { metadata } = useMaybeFieldMetadata(field);
 


### PR DESCRIPTION
- There was a type error here because the the `AutoRelationshipInput` wrapper erroneously extended the whole type relationship form props type with `children`  included 