### PR TITLE
fix ShadcnAutoTableTextCell tooltip text color

### DIFF
--- a/packages/react/src/auto/shadcn/table/cells/ShadcnAutoTableTextCell.tsx
+++ b/packages/react/src/auto/shadcn/table/cells/ShadcnAutoTableTextCell.tsx
@@ -21,7 +21,7 @@ export const makeShadcnAutoTableTextCell = (elements: ShadcnAutoTableTextCellEle
         <TooltipProvider>
           <Tooltip>
             {isOverflowed && (
-              <TooltipContent className="max-w-[150px] max-h-[100px] overflow-y-auto overflow-x-hidden bg-background border border-neutral-300 shadow-md whitespace-normal break-words">
+              <TooltipContent className="max-w-[150px] max-h-[100px] overflow-y-auto overflow-x-hidden bg-background border border-neutral-300 shadow-md whitespace-normal break-words text-foreground">
                 {stringifiedValue}
               </TooltipContent>
             )}


### PR DESCRIPTION
- On truncated strings, the text color was not legible on the background color. Updated to explicitly set the color 