### PR TITLE
Fix pathing of validations on AutoHasManyThroughForm

### DIFF
--- a/packages/react/.changeset/fair-rabbits-lick.md
+++ b/packages/react/.changeset/fair-rabbits-lick.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+- Fixed a bug with AutoHasManyThroughForm where input validations were not working, causing type errors to occur on tha API for non-string fields

--- a/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
+++ b/packages/react/cypress/component/auto/form/AutoHasManyThroughForm.cy.tsx
@@ -76,6 +76,7 @@ describeForEachAutoAdapter(
             <AutoHasManyThroughJoinModelForm>
               <AutoInput field="effectiveFrom" />
               <AutoInput field="effectiveTo" />
+              <AutoInput field="attempt" />
             </AutoHasManyThroughJoinModelForm>
           </AutoHasManyThroughForm>
           <AutoSubmit id="submit" />
@@ -91,7 +92,9 @@ describeForEachAutoAdapter(
       cy.contains("Emma Williams").click();
       cy.contains("Add Students").click();
 
+      cy.wait(1000);
       cy.get('[id="deleteButton_students.0"]').click();
+      cy.wait(1000);
 
       expectUpdateActionSubmissionVariables({
         course: {
@@ -101,18 +104,41 @@ describeForEachAutoAdapter(
             // Updated second
             {
               update: {
-                effectiveFrom: "2025-02-18",
-                effectiveTo: "2025-02-22",
+                effectiveFrom: "2025-02-18T00:00:00.000Z",
+                effectiveTo: "2025-02-22T00:00:00.000Z",
                 id: "50",
-                student: { update: { firstName: "Benjamin", id: "43", lastName: "Martin" } },
+                attempt: 1,
+                student: {
+                  update: {
+                    department: null,
+                    firstName: "Benjamin",
+                    id: "43",
+                    lastName: "Martin",
+                    year: null,
+                  },
+                },
               },
             },
             // Created third
-            { create: { student: { _link: "10" } } },
+            {
+              create: {
+                effectiveFrom: null,
+                effectiveTo: null,
+                attempt: 2,
+                student: { _link: "10" },
+              },
+            },
           ],
         },
         id: "3",
       });
+
+      cy.get('[id="submit"]').click();
+      cy.contains("Attempt is required").should("exist"); // Validation for blank field
+
+      cy.get('[id="course.registrations.0.attempt"]').type("1");
+      cy.get('[id="course.registrations.1.attempt"]').type("2");
+
       cy.get('[id="submit"]').click();
       cy.wait("@updateCourse");
     });
@@ -128,6 +154,7 @@ describeForEachAutoAdapter(
           >
             <AutoInput field="firstName" />
             <AutoInput field="lastName" />
+            <AutoInput field="year" />
           </AutoHasManyThroughForm>
           <AutoSubmit id="submit" />
         </AutoForm>,
@@ -137,9 +164,13 @@ describeForEachAutoAdapter(
       cy.wait("@course");
       cy.wait("@students");
 
+      cy.wait(1000);
       cy.get('[id="deleteButton_students.0"]').click();
+      cy.wait(1000);
       cy.get('[name="course.registrations.0.student.firstName"]').click().type("- updated");
       cy.get('[name="course.registrations.0.student.lastName"]').click().type("- updated");
+      cy.get('[name="course.registrations.0.student.year"]').click().type("- updated");
+      cy.get('[name="course.registrations.0.student.year"]').click().type("1");
 
       expectUpdateActionSubmissionVariables({
         course: {
@@ -159,6 +190,7 @@ describeForEachAutoAdapter(
                     firstName: "Benjamin- updated",
                     id: "43",
                     lastName: "Martin- updated",
+                    year: 1,
                   },
                 },
               },
@@ -245,7 +277,7 @@ const RealUniversityCourseMetadata = {
               fieldType: "HasManyThrough",
               requiredArgumentForInput: false,
               sortable: false,
-              filterable: false,
+              filterable: true,
               __typename: "GadgetModelField",
               configuration: {
                 __typename: "GadgetHasManyThroughConfig",
@@ -285,7 +317,7 @@ const RealUniversityCourseMetadata = {
               fieldType: "HasManyThrough",
               requiredArgumentForInput: false,
               sortable: false,
-              filterable: false,
+              filterable: true,
               __typename: "GadgetModelField",
               configuration: {
                 __typename: "GadgetHasManyThroughConfig",
@@ -367,7 +399,7 @@ const RealUniversityCourseMetadata = {
               fieldType: "HasMany",
               requiredArgumentForInput: false,
               sortable: false,
-              filterable: false,
+              filterable: true,
               __typename: "GadgetModelField",
               configuration: {
                 __typename: "GadgetHasManyConfig",
@@ -393,7 +425,7 @@ const RealUniversityCourseMetadata = {
               fieldType: "HasMany",
               requiredArgumentForInput: false,
               sortable: false,
-              filterable: false,
+              filterable: true,
               __typename: "GadgetModelField",
               configuration: {
                 __typename: "GadgetHasManyConfig",
@@ -661,7 +693,7 @@ const RealUniversityCourseMetadata = {
               fieldType: "HasManyThrough",
               requiredArgumentForInput: false,
               sortable: false,
-              filterable: false,
+              filterable: true,
               __typename: "GadgetModelField",
               configuration: {
                 __typename: "GadgetHasManyThroughConfig",
@@ -743,7 +775,7 @@ const RealUniversityCourseMetadata = {
               fieldType: "HasMany",
               requiredArgumentForInput: false,
               sortable: false,
-              filterable: false,
+              filterable: true,
               __typename: "GadgetModelField",
               configuration: {
                 __typename: "GadgetHasManyConfig",
@@ -807,10 +839,25 @@ const RealUniversityCourseMetadata = {
               },
             },
             {
+              name: "Attempt",
+              apiIdentifier: "attempt",
+              fieldType: "Number",
+              requiredArgumentForInput: true,
+              sortable: true,
+              filterable: true,
+              __typename: "GadgetModelField",
+              configuration: {
+                __typename: "GadgetNumberConfig",
+                fieldType: "Number",
+                validations: [],
+                decimals: null,
+              },
+            },
+            {
               name: "Effective from",
               apiIdentifier: "effectiveFrom",
               fieldType: "DateTime",
-              requiredArgumentForInput: true,
+              requiredArgumentForInput: false,
               sortable: true,
               filterable: true,
               __typename: "GadgetModelField",
@@ -1064,7 +1111,7 @@ const RealUniversityCourseMetadata = {
               fieldType: "HasManyThrough",
               requiredArgumentForInput: false,
               sortable: false,
-              filterable: false,
+              filterable: true,
               __typename: "GadgetModelField",
               configuration: {
                 __typename: "GadgetHasManyThroughConfig",
@@ -1146,7 +1193,7 @@ const RealUniversityCourseMetadata = {
               fieldType: "HasMany",
               requiredArgumentForInput: false,
               sortable: false,
-              filterable: false,
+              filterable: true,
               __typename: "GadgetModelField",
               configuration: {
                 __typename: "GadgetHasManyConfig",
@@ -1236,7 +1283,7 @@ const RealUniversityCourseMetadata = {
                     fieldType: "HasMany",
                     requiredArgumentForInput: false,
                     sortable: false,
-                    filterable: false,
+                    filterable: true,
                     __typename: "GadgetModelField",
                     configuration: {
                       __typename: "GadgetHasManyConfig",
@@ -1262,7 +1309,7 @@ const RealUniversityCourseMetadata = {
                     fieldType: "HasManyThrough",
                     requiredArgumentForInput: false,
                     sortable: false,
-                    filterable: false,
+                    filterable: true,
                     __typename: "GadgetModelField",
                     configuration: {
                       __typename: "GadgetHasManyThroughConfig",
@@ -1302,7 +1349,7 @@ const RealUniversityCourseMetadata = {
                     fieldType: "HasMany",
                     requiredArgumentForInput: false,
                     sortable: false,
-                    filterable: false,
+                    filterable: true,
                     __typename: "GadgetModelField",
                     configuration: {
                       __typename: "GadgetHasManyConfig",
@@ -1328,7 +1375,7 @@ const RealUniversityCourseMetadata = {
                     fieldType: "HasManyThrough",
                     requiredArgumentForInput: false,
                     sortable: false,
-                    filterable: false,
+                    filterable: true,
                     __typename: "GadgetModelField",
                     configuration: {
                       __typename: "GadgetHasManyThroughConfig",

--- a/packages/react/spec/auto/storybook/form/AutoForm.stories.tsx
+++ b/packages/react/spec/auto/storybook/form/AutoForm.stories.tsx
@@ -2,13 +2,7 @@ import React, { useState } from "react";
 import { Provider } from "../../../../src/GadgetProvider.js";
 import { testApi as api } from "../../../apis.js";
 import { StorybookErrorBoundary } from "../StorybookErrorBoundary.js";
-import {
-  AutoHasManyThroughInput,
-  AutoInput,
-  AutoSubmit,
-  Button,
-  SelectableDesignSystemAutoFormStory,
-} from "./SelectableDesignSystemAutoFormStory.js";
+import { AutoInput, AutoSubmit, Button, SelectableDesignSystemAutoFormStory } from "./SelectableDesignSystemAutoFormStory.js";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
@@ -219,12 +213,5 @@ export const hasManyThrough: any = {
   name: "HasManyThrough fields",
   args: {
     action: api.hasManyThrough.baseModel.create,
-    children: (
-      <>
-        <AutoInput field="baseModelName" />
-        <AutoHasManyThroughInput field="baseModelHmtField" />
-        <AutoSubmit />
-      </>
-    ),
   },
 };

--- a/packages/react/spec/auto/storybook/form/AutoRelationshipForm.stories.tsx
+++ b/packages/react/spec/auto/storybook/form/AutoRelationshipForm.stories.tsx
@@ -174,6 +174,14 @@ export const UpdateWithHasManyThrough: any = {
   },
 };
 
+export const UpdateWithHasManyThroughSiblingFieldsOnly: any = {
+  render: (args: any) => <ExampleCourseHasManyThroughSiblingFieldsOnlyForm {...args} />,
+  args: {
+    action: api.university.course.update,
+    findBy: "3",
+  },
+};
+
 const ExampleCourseCreateRelatedForm = (props: any) => {
   return (
     <>
@@ -213,16 +221,11 @@ const ExampleCourseCreateRelatedForm = (props: any) => {
             }}
           >
             <InlineStack gap="300">
-              {/* Fields on the join model. The prefix is the model API id of the join model */}
-
               <AutoHasManyThroughJoinModelForm>
                 <AutoInput field="effectiveTo" />
                 <AutoInput field="effectiveFrom" />
+                <AutoInput field="attempt" />
               </AutoHasManyThroughJoinModelForm>
-
-              {/* Fields on the sibling model. No prefix */}
-              <AutoInput field="firstName" />
-              <AutoInput field="lastName" />
             </InlineStack>
           </AutoHasManyThroughForm>
         </Card>
@@ -236,6 +239,35 @@ const ExampleCourseCreateRelatedForm = (props: any) => {
             }}
           />
         </Card>
+        <AutoSubmit />
+      </SelectableDesignSystemAutoFormStory>
+    </>
+  );
+};
+
+const ExampleCourseHasManyThroughSiblingFieldsOnlyForm = (props: any) => {
+  return (
+    <>
+      <SelectableDesignSystemAutoFormStory {...props}>
+        <SubmitResultBanner />
+
+        <Card>
+          <AutoHasManyThroughForm
+            field="students"
+            recordLabel={{
+              primary: ["firstName", "lastName"],
+              secondary: "year",
+              tertiary: "department",
+            }}
+          >
+            <InlineStack gap="300">
+              <AutoInput field="firstName" />
+              <AutoInput field="lastName" />
+              <AutoInput field="year" />
+            </InlineStack>
+          </AutoHasManyThroughForm>
+        </Card>
+
         <AutoSubmit />
       </SelectableDesignSystemAutoFormStory>
     </>

--- a/packages/react/src/auto/hooks/useSelectedPathsFromRecordLabel.tsx
+++ b/packages/react/src/auto/hooks/useSelectedPathsFromRecordLabel.tsx
@@ -42,7 +42,7 @@ export const useSelectedPathsFromRecordLabel = (props: Pick<AutoRelationshipForm
     return Array.from(selectedPaths);
   }, [recordLabel, metadata]);
 
-  return selectedPaths;
+  return { selectedPaths, metadata };
 };
 
 export const getSelectedPathsFromOptionLabel = (optionLabel?: OptionLabel, getFieldsToSelectOnRecordLabelCallback?: () => string[]) => {

--- a/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/polaris/inputs/relationships/PolarisAutoHasManyThroughForm.tsx
@@ -135,7 +135,7 @@ export const PolarisAutoHasManyThroughForm = autoRelationshipForm((props: AutoHa
                           <RelationshipContext.Provider
                             value={{
                               transformPath: (path) => `${joinModelField}.${idx}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
-                              transformMetadataPath: (path) => `${metaDataPathPrefix}.${path}`,
+                              transformMetadataPath: (path) => `${joinModelField}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
                               fieldArray,
                               hasManyThrough: { joinModelApiIdentifier, inverseRelatedModelField },
                             }}

--- a/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
+++ b/packages/react/src/auto/shadcn/inputs/relationships/ShadcnAutoHasManyThroughForm.tsx
@@ -207,7 +207,7 @@ export const makeShadcnAutoHasManyThroughForm = ({
                         <RelationshipContext.Provider
                           value={{
                             transformPath: (path) => `${joinModelField}.${idx}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
-                            transformMetadataPath: (path) => `${metaDataPathPrefix}.${path}`,
+                            transformMetadataPath: (path) => `${joinModelField}.${path.replace(`${joinModelApiIdentifier}.`, "")}`,
                             fieldArray,
                             hasManyThrough: { joinModelApiIdentifier, inverseRelatedModelField },
                           }}

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -544,9 +544,6 @@ export const buildAutoFormFieldList = (
     subset = subset.filter(([_, field]) => !excludes.has(field.apiIdentifier));
   }
 
-  // Remove `hasMany` fields that emerge from `hasManyThrough` fields that are not actually model fields
-  subset = subset.filter(([_, field]) => !isJoinModelHasManyField(field));
-
   // Filter out fields that are not supported by the form
   const validFieldTypeSubset = subset.filter(([_, field]) =>
     options?.isUpsertAction ? isAcceptedUpsertFieldType(field) : isAcceptedFieldType(field)


### PR DESCRIPTION
- **UPDATE**
  - `AutoHasManyThroughForm` had a bug where the fields within were registered on paths that were different from their paths on the real form state
    - Fetching and submitting were always pathed based on the implicit join model hasMany field
      - Eg. Course hasMany students through registration - course.registrations.student.name, course.registration.startDate
    - The resulting nested action was also pathed based on this `implicit join model hasMany field` system.
    - The problem was that the metadata pathing was based on the actual HMT field instead of the implicit joinModelHasMany field. This mismatch of paths caused the following issues 
      - The path of the yupResolver did not agree with the form state path for AutoInputs within AutoHasManyThroughForm.
        - Validations were not run on those AutoInput fields, and bad validations did not block submission like other form contexts
        - The resolver is responsible for type transformations, and it would be impossible to user a number field in a AutoHasManyThrough field because the form state holds numbers a strings, and we relied on this resolver to transform them. This resulted in errors like `"123" is not assignable to type number`
        - `defaultValues` did not work for AutoHasManyThroughForm regardless of if the values were pathed based on the real HMT path or the implicitJoinHasMany path. Now the implicitJoinHasMany path works to set default values 