### PR TITLE
Export autocomponent types from the root file to ensure type portability

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -10,6 +10,16 @@
 
 ### Patch Changes
 
+- - Export `AutoHasManyThroughInputProps` to ensure portable TypeScript types.
+
+  This fixes a bug introduced in 0.20.2 where the `AutoHasManyThroughInputProps` type was used but not exported, causing errors like:
+
+  ```
+  The inferred type of 'AutoHasManyThroughForm' cannot be named without a reference to '../../node_modules/@gadgetinc/react/dist/esm/auto/interfaces/AutoRelationshipInputProps'. This is likely not portable. A type annotation is necessary
+  ```
+
+  from TypeScript. This release fixes that by exporting it.
+
 - - Fixed a bug with AutoHasManyThroughForm where input validations were not working, causing type errors to occur on tha API for non-string fields
 - - Added `allowMultipleSelections` prop to `AutoHasManyThroughForm` to control if sibling records can be linked multiple times through different join model records
 - Updated dependencies

--- a/packages/react/src/auto/shadcn/index.ts
+++ b/packages/react/src/auto/shadcn/index.ts
@@ -1,7 +1,11 @@
 export type { OptionsType } from "../../utils.js";
 export { type AutoInputComponent } from "../AutoInput.js";
 export type { AutoButtonProps } from "../hooks/useAutoButtonController.js";
-export type { AutoRelationshipFormProps, AutoRelationshipInputProps } from "../interfaces/AutoRelationshipInputProps.js";
+export type {
+  AutoHasManyThroughFormProps,
+  AutoRelationshipFormProps,
+  AutoRelationshipInputProps,
+} from "../interfaces/AutoRelationshipInputProps.js";
 export type {
   AutoBooleanInputProps,
   AutoDateTimeInputProps,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,28 @@ export * from "./auth/useAuth.js";
 export * from "./auth/useSession.js";
 export * from "./auth/useSignOut.js";
 export * from "./auth/useUser.js";
+export type { AutoButtonProps } from "./auto/hooks/useAutoButtonController.js";
+export type {
+  AutoHasManyThroughFormProps,
+  AutoRelationshipFormProps,
+  AutoRelationshipInputProps,
+} from "./auto/interfaces/AutoRelationshipInputProps.js";
+export type {
+  AutoBooleanInputProps,
+  AutoDateTimeInputProps,
+  AutoEncryptedStringInputProps,
+  AutoEnumInputProps,
+  AutoFileInputProps,
+  AutoHiddenInputProps,
+  AutoIdInputProps,
+  AutoInputProps,
+  AutoJSONInputProps,
+  AutoNumberInputProps,
+  AutoPasswordInputProps,
+  AutoRolesInputProps,
+  AutoTextInputProps,
+} from "./auto/shared/AutoInputTypes.js";
+export type { AutoRichTextInputProps } from "./auto/shared/AutoRichTextInputProps.js";
 export * from "./useAction.js";
 export * from "./useActionForm.js";
 export * from "./useBulkAction.js";


### PR DESCRIPTION
See changelog entry, that version hasnt actually been released yet so sneaking this into that one
