### PR TITLE
Gracefully handle errors trying to get the shop installation data with missing scopes in mock embed mode

### DIFF
--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -107,10 +107,10 @@ const InnerGadgetProvider = memo(
 
     const [{ data: fetchOrInstallShopData, fetching: fetchingOrInstallingShop, error: fetchingOrInstallingShopError }, fetchOrInstallShop] =
       useMutation<{
-        shopifyConnection: { fetchOrInstallShop: { redirectToOauth: boolean; isAuthenticated: boolean; missingScopes: string[] } };
+        shopifyConnection?: { fetchOrInstallShop?: { redirectToOauth: boolean; isAuthenticated: boolean; missingScopes: string[] } };
       }>(FetchOrInstallShopMutation);
 
-    if (fetchOrInstallShopData) {
+    if (fetchOrInstallShopData?.shopifyConnection?.fetchOrInstallShop) {
       redirectToOauth = fetchOrInstallShopData.shopifyConnection.fetchOrInstallShop.redirectToOauth;
       isAuthenticated = fetchOrInstallShopData.shopifyConnection.fetchOrInstallShop.isAuthenticated;
       missingScopes = fetchOrInstallShopData.shopifyConnection.fetchOrInstallShop.missingScopes ?? [];

--- a/packages/react/.changeset/young-shoes-hear.md
+++ b/packages/react/.changeset/young-shoes-hear.md
@@ -1,0 +1,13 @@
+---
+"@gadgetinc/react-shopify-app-bridge": patch
+---
+
+Fix `<Provider/>` crash when booting in mock preview with out of date OAuth scopes
+
+Previously, the react `<Provider/>` would error on first render when rendering in a Shopify admin that met the following conditions:
+
+- using the Gadget Embed Preview feature to view the application within the Gadget editor
+- using Shopify Managed Installation mode where Shopify implements the OAuth scope granting process
+- on a shop that had previously installed the Gadget application, but with out of date scopes.
+
+Now, the provider correctly boots up, and the error from the missing scopes will be propagated using the normal mechanisms.


### PR DESCRIPTION
See changelog
