### PR TITLE
Allow null in AutoForm `title` prop type

### DIFF
--- a/packages/react/src/auto/AutoForm.ts
+++ b/packages/react/src/auto/AutoForm.ts
@@ -41,7 +41,7 @@ type AutoFormPropsWithoutChildren = {
   children?: never;
 
   /** The title at the top of the form. False to omit */
-  title?: string | false;
+  title?: string | false | null;
 
   /** The label to use for the submit button at the bottom of the form */
   submitLabel?: ReactNode;


### PR DESCRIPTION
- Allow `null` as a valid type for the `title` prop in AutoForm to prevent the title from rendering 