### PR TITLE
Update shadcn AutoTable search sizing to be wider and to compress as the page compresses

### DIFF
--- a/packages/react/spec/auto/shadcn-defaults/__snapshots__/shadcnClassnameSafelist.spec.ts.snap
+++ b/packages/react/spec/auto/shadcn-defaults/__snapshots__/shadcnClassnameSafelist.spec.ts.snap
@@ -878,16 +878,16 @@ body {
   width: 100%;
 }
 
-.min-w-\\[300px\\] {
-  min-width: 300px;
-}
-
 .max-w-\\[150px\\] {
   max-width: 150px;
 }
 
 .max-w-\\[200px\\] {
   max-width: 200px;
+}
+
+.max-w-\\[420px\\] {
+  max-width: 420px;
 }
 
 .max-w-full {

--- a/packages/react/src/auto/shadcn/GadgetShadcnTailwindSafelist.ts
+++ b/packages/react/src/auto/shadcn/GadgetShadcnTailwindSafelist.ts
@@ -4,6 +4,7 @@ const SpecialCaseClassNames = [
   "max-h-[100px]",
   "max-w-[150px]",
   "max-w-[200px]",
+  "max-w-[420px]",
   "border-b-[1px]",
   "border-t-[1px]",
   "border-x-[1px]",

--- a/packages/react/src/auto/shadcn/table/ShadcnAutoTableSearch.tsx
+++ b/packages/react/src/auto/shadcn/table/ShadcnAutoTableSearch.tsx
@@ -13,8 +13,8 @@ export const makeShadcnAutoTableSearch = (elements: ShadcnElements) => {
     const { clear, set, value } = props.search;
 
     return (
-      <div className="flex flex-row items-center gap-2">
-        <Input placeholder="Search" onChange={(e) => set(e.target.value)} value={value} className="min-w-[300px]"></Input>
+      <div className="flex flex-row items-center gap-2 w-full">
+        <Input placeholder="Search" onChange={(e) => set(e.target.value)} value={value} className="max-w-[420px]"></Input>
         {value.length > 0 && (
           <Button disabled={!value} onClick={clear} variant="ghost">
             Reset <X />


### PR DESCRIPTION
- UPDATE
  - Previously, the search bar was a fixed width and would spill out of the container on slim screens
  - Now, the search bar will shrink in size as the parent container shrinks 