### PR TITLE
Updated AutoTable to clear sort state when the search value changes 

### DIFF
--- a/packages/react/.changeset/perfect-mayflies-sing.md
+++ b/packages/react/.changeset/perfect-mayflies-sing.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/react": patch
+---
+
+Updated AutoTable to clear sort state when the search value changes so that the order of results is ordered by search similarity instead


### PR DESCRIPTION
- **UPDATE**
  - Discord user reported that their AutoTable search results were not ordered based on search similarity, and that sort state was applied to the search results
    - https://discord.com/channels/836317518595096598/1344712127121985669
  - This happens because the API still applies the sort to the search results, which feels correct. It would be surprising to pass a `sort` param that gets ignored once you also add a search 
  - This problem is most apparent when you search by email address because the `@` character is a special elastic search char that acts kinda like an `OR`
    - Example
      - Search for `email_123@example.com` 
      - Elastic search interprets this as `(contains "email_123") OR (contains "example.com")`
      - A lot of extra results appear for anything that includes `example.com`
      - If there is an uncleared column based search that puts those other `example.com` records above the perfect  match `email_123@example.com`, it feels wrong

Previously this was happening
![CleanShot 2025-06-22 at 18 03 25](https://github.com/user-attachments/assets/ee40d1eb-14f4-43a1-8840-c9f559d97269)
