### PR TITLE
Changing the pr template so that it works with the changelog application

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,23 @@
 ... a description that explains what, why, and how ...
 
+## 🎩 Instructions
+
+<someone> please :tophat::
+
+1. ...
+2. ...
+3. ...
+
 ## PR Checklist
 
 - [ ] Important or complicated code is tested
-- [ ] Any user facing changes are documented in the Gadget-side changelog
-- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
-- [ ] Versions within this monorepo are matching and there's a valid upgrade path
+- [ ] Any user facing changes are documented (changelog section below)
+- [ ] Any app Problems are added to the problem finders
+- [ ] Any app data that needs a redeploy to take effect is listed in the `contentHash` functions
+- [ ] Important or complicated production behaviour has traces and logs added
+
+## Changelog
+
+If this PR will affect change user-facing behaviour, add detailed information about the change here to prompt an AI generated changelog entry.
+
+If no changelog is required, write `no-changelog-required` in square brackets `[]`.


### PR DESCRIPTION
... a description that explains what, why, and how ...

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
