### PR TITLE
Introduce new public auth mode for single shop tenant

### DIFF
--- a/packages/api-client-core/src/ClientOptions.ts
+++ b/packages/api-client-core/src/ClientOptions.ts
@@ -103,6 +103,10 @@ export interface AuthenticationModeOptions {
     getSessionId?: () => Promise<string | undefined>;
   };
 
+  publicShopTenant?: {
+    shopId: string;
+  };
+
   // @private Use a passed custom function for managing authentication. For some fancy integrations that the API client supports, like embedded Shopify apps, we use platform native features to authenticate with the Gadget backend.
   custom?: {
     processFetch(input: RequestInfo | URL, init: RequestInit): Promise<void>;

--- a/packages/api-client-core/src/GadgetConnection.ts
+++ b/packages/api-client-core/src/GadgetConnection.ts
@@ -74,6 +74,7 @@ export enum AuthenticationMode {
   InternalAuthToken = "internal-auth-token",
   Anonymous = "anonymous",
   Custom = "custom",
+  PublicShopTenant = "public-shop-tenant",
 }
 
 const objectForGlobals = typeof globalThis != "undefined" ? globalThis : typeof window != "undefined" ? window : undefined;
@@ -173,6 +174,8 @@ export class GadgetConnection {
         this.authenticationMode = AuthenticationMode.InternalAuthToken;
       } else if (options.apiKey) {
         this.authenticationMode = AuthenticationMode.APIKey;
+      } else if (options.publicShopTenant) {
+        this.authenticationMode = AuthenticationMode.PublicShopTenant;
       } else if (options.custom) {
         this.authenticationMode = AuthenticationMode.Custom;
       }
@@ -551,6 +554,11 @@ export class GadgetConnection {
       const val = this.sessionTokenStore!.getItem(this.sessionStorageKey);
       if (val) {
         headers.authorization = `Session ${val}`;
+      }
+    } else if (this.authenticationMode === AuthenticationMode.PublicShopTenant) {
+      const shopId = this.options.authenticationMode?.publicShopTenant?.shopId;
+      if (shopId) {
+        headers["x-gadget-public-shop-tenant"] = shopId;
       }
     }
 


### PR DESCRIPTION
This PR introduces a new authentication mode, `publicShopTenant`, that allows apps like Shopify theme app extensions to set up an unauthenticated role with a Shopify tenancy.

This allows use cases like fetching publicly accessible data for the specific shop without manually passing in the shop ID.

<details><summary>Click here to see an example usage</summary>

Example usage:
```liquid
<!-- In extensions/theme-extension/blocks/star_rating.liquid -->
<script src="https://shop-auth-mode--development.ggt.pub/api/client/web.min.js" defer="defer"></script>
<script>
document.addEventListener("DOMContentLoaded", function () {
  window.gadgetPublicClient = new Gadget({
    authenticationMode: {
      publicShopTenant: {
        shopId: {{ shop.id }},
      },
    },
  });
})
</script>
<script src="{{ 'getShopInfo.js' | asset_url }}" defer="defer"></script>
```

```js
// In extensions/theme-extension/assets/getShopInfo.js
const fetchCurrentShop = async () => {
  const shopInfoComponent = document.getElementById("shop-info");
  const shopInfo = await window.gadgetPublicClient.getCurrentShop();
  if (shopInfoComponent) {
    shopInfoComponent.innerHTML = JSON.stringify(shopInfo, null, 2);
  }
};

document.addEventListener("DOMContentLoaded", function() {
  fetchCurrentShop();
});
```

Then the `shopInfoComponent` should render the payload from the `getCurrentShop` global action.

</details> 

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented (changelog section below)
- [ ] Any app Problems are added to the problem finders
- [ ] Any app data that needs a redeploy to take effect is listed in the `contentHash` functions
- [ ] Important or complicated production behaviour has traces and logs added

## Changelog

If this PR will affect change user-facing behaviour, add detailed information about the change here to prompt an AI generated changelog entry.

If no changelog is required, write `no-changelog-required` in square brackets `[]`.
