### PR TITLE
adds the shopify install state hint to the standalone provider

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "files": [
     "README.md",
     "dist/**/*"

--- a/packages/react-shopify-app-bridge/src/Provider.tsx
+++ b/packages/react-shopify-app-bridge/src/Provider.tsx
@@ -229,12 +229,14 @@ const StandaloneInnerProvider = ({
   query,
   gadgetAppUrl,
   type,
+  shopifyInstallState,
 }: {
   isRootFrameRequest: boolean;
   children: ReactNode;
   query?: URLSearchParams;
   gadgetAppUrl: string;
   type: AppType;
+  shopifyInstallState?: ShopifyInstallState;
 }) => {
   // we still need to run the oauth process if we're in an install context so we should redirect to gadget
   const isInstallRequest = query?.has("hmac") && query?.has("shop");
@@ -262,7 +264,7 @@ const StandaloneInnerProvider = ({
   return (
     <GadgetAuthContext.Provider
       value={{
-        isAuthenticated: false,
+        isAuthenticated: shopifyInstallState?.isAuthenticated ?? false,
         isEmbedded: false,
         canAuth: false,
         loading: false,
@@ -389,7 +391,13 @@ export const Provider = ({
           {children}
         </InnerGadgetProvider>
       ) : (
-        <StandaloneInnerProvider isRootFrameRequest={isRootFrameRequest} query={query} type={coalescedType} gadgetAppUrl={gadgetAppUrl}>
+        <StandaloneInnerProvider
+          isRootFrameRequest={isRootFrameRequest}
+          query={query}
+          type={coalescedType}
+          gadgetAppUrl={gadgetAppUrl}
+          shopifyInstallState={shopifyInstallState}
+        >
           {children}
         </StandaloneInnerProvider>
       )}


### PR DESCRIPTION
This fixes the provider from `@gadgetinc/react-shopify-app-bridge` to be SSR compatible so that the `useGadget` hook will use the server-side shopify install state hint to power the `isAuthenticated`property

## PR Checklist

- [ ] Important or complicated code is tested
- [ ] Any user facing changes are documented in the Gadget-side changelog
- [ ] Any immediate changes are slated for release in Gadget via a generated package dependency bump
- [ ] Versions within this monorepo are matching and there's a valid upgrade path
