### PR TITLE
Update `useSession` to pause before SSR hydration completes

### DIFF
--- a/packages/react/spec/components/auth/SignedIn.spec.tsx
+++ b/packages/react/spec/components/auth/SignedIn.spec.tsx
@@ -20,7 +20,7 @@ describe("SignedIn", () => {
 
     rerender(component);
 
-    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1 style="">Hello, Jane!</h1></div>"`);
   });
 
   test("renders nothing when signed out", () => {
@@ -34,7 +34,7 @@ describe("SignedIn", () => {
 
     expectMockSignedOutUser();
     rerender(component);
-    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello</h1></div>"`);
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1 style="">Hello</h1></div>"`);
   });
 
   test("renders nothing when signed in but has no user on the session", () => {
@@ -48,6 +48,6 @@ describe("SignedIn", () => {
 
     expectMockDeletedUser();
     rerender(component);
-    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello</h1></div>"`);
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1 style="">Hello</h1></div>"`);
   });
 });

--- a/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
+++ b/packages/react/spec/components/auth/SignedInOrRedirect.spec.tsx
@@ -133,8 +133,8 @@ describe("SignedInOrRedirect", () => {
       expectMockSignedInUser();
       rerender(component);
 
-      expect(mockNavigate).not.toBeCalled();
-      expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
+      expect(mockNavigate).toBeCalledTimes(1);
+      expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1 style="">Hello, Jane!</h1></div>"`);
     });
   });
 });

--- a/packages/react/spec/components/auth/SignedOut.spec.tsx
+++ b/packages/react/spec/components/auth/SignedOut.spec.tsx
@@ -19,7 +19,7 @@ describe("SignedOut", () => {
     expectMockSignedOutUser();
 
     rerender(component);
-    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1 style="">Hello, Jane!</h1></div>"`);
   });
 
   test("renders children when there exists no associated user for the session", () => {
@@ -34,7 +34,7 @@ describe("SignedOut", () => {
     expectMockDeletedUser();
 
     rerender(component);
-    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello, Jane!</h1></div>"`);
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1 style="">Hello, Jane!</h1></div>"`);
   });
 
   test("renders nothing when signed in", () => {
@@ -49,6 +49,6 @@ describe("SignedOut", () => {
     expectMockSignedInUser();
 
     rerender(component);
-    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1>Hello</h1></div>"`);
+    expect(container.outerHTML).toMatchInlineSnapshot(`"<div><h1 style="">Hello</h1></div>"`);
   });
 });


### PR DESCRIPTION
- **UPDATE**
  - RRv7 apps have been getting bad hydration errors on the default Gadget web app template. This was caused by hooks that used `useSession` such as `useSignOut` being used before the hydration completes
  - This PR prevents those errors by pausing the session fetching until the hydration is complete. 


Prerelease 
```
"@gadgetinc/react": "https://codeload.github.com/gadget-inc/js-clients/tar.gz/@gadgetinc/react-v0.21.4-gitpkg-a041586f",
```

## 🎩 Instructions

<someone> please :tophat::

1. In an SSR app, go into authenticated areas and refresh repeatedly. Observe that there is sometimes a hydration error
2. Put this prerelease into your apps and go into authenticated areas. Refresh repeatedly to observe that there are not more hydration issues 
 