### PR TITLE
Removed diff and code view from the AutoForm richText inputs

### DIFF
--- a/packages/react/src/auto/shared/AutoRichTextInput.tsx
+++ b/packages/react/src/auto/shared/AutoRichTextInput.tsx
@@ -2,8 +2,6 @@ import * as mdxModule from "@mdxeditor/editor";
 import "@mdxeditor/editor/style.css";
 import React, { useEffect, useRef } from "react";
 import { GadgetFieldType } from "../../internal/gql/graphql.js";
-import { useFormContext } from "../../useActionForm.js";
-import { get } from "../../utils.js";
 import { autoInput } from "../AutoInput.js";
 import { useStringInputController } from "../hooks/useStringInputController.js";
 import { assertFieldType, multiref } from "../hooks/utils.js";
@@ -21,16 +19,13 @@ const {
   thematicBreakPlugin,
   markdownShortcutPlugin,
   linkDialogPlugin,
-  diffSourcePlugin,
   toolbarPlugin,
-  DiffSourceToggleWrapper,
   UndoRedo,
   BlockTypeSelect,
   Separator,
 } = mdxModule;
 
 const AutoRichTextInput = autoInput<AutoRichTextInputProps>((props) => {
-  const { formState } = useFormContext();
   const { field, control, editorRef, ...rest } = props;
   const controller = useStringInputController({ field, control });
   assertFieldType({
@@ -56,14 +51,9 @@ const AutoRichTextInput = autoInput<AutoRichTextInputProps>((props) => {
         thematicBreakPlugin(),
         markdownShortcutPlugin(),
         linkDialogPlugin(),
-        diffSourcePlugin({
-          diffMarkdown: get(formState.defaultValues, field)?.markdown ?? "",
-          viewMode: "rich-text",
-          readOnlyDiff: true,
-        }),
         toolbarPlugin({
           toolbarContents: () => (
-            <DiffSourceToggleWrapper>
+            <>
               <UndoRedo />
               <BlockTypeSelect />
               <Separator />
@@ -71,7 +61,7 @@ const AutoRichTextInput = autoInput<AutoRichTextInputProps>((props) => {
               <ListsToggle />
               <CodeToggle />
               <CreateLink />
-            </DiffSourceToggleWrapper>
+            </>
           ),
         }),
       ]}


### PR DESCRIPTION
BEFORE
<img width="1304" height="282" alt="CleanShot 2025-07-29 at 15 13 38@2x" src="https://github.com/user-attachments/assets/602f0e6e-b59b-490e-9073-a9bdcaae6f6d" />


NOW
<img width="1066" height="272" alt="CleanShot 2025-07-29 at 15 13 04@2x" src="https://github.com/user-attachments/assets/6fec0c94-5fba-4688-99ca-fcc8941d06f0" />


- **UPDATE**
  - Antoine noticed that there were a lot of bugs and usability issues with the code and diff views in the AutoForm rich text input. 
  - This PR removes them since they are rarely used and provide a bad experience
    - Pain points
      - The diff view doesn't really make sense. You can edit the old and new, and the state resets if you change to the regular view and back
      - The code view is not usable. Every single keystroke blurs the input. 
