### PR TITLE
expose metadata hooks in react package

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ export type {
   AutoTextInputProps,
 } from "./auto/shared/AutoInputTypes.js";
 export type { AutoRichTextInputProps } from "./auto/shared/AutoRichTextInputProps.js";
+export { useActionMetadata, useModelMetadata } from "./metadata.js";
 export * from "./useAction.js";
 export * from "./useActionForm.js";
 export * from "./useBulkAction.js";

--- a/packages/react/src/metadata.tsx
+++ b/packages/react/src/metadata.tsx
@@ -351,7 +351,6 @@ const treeifyModelMetadata = <T extends { key: string; fields: FieldMetadata[]; 
 
 /**
  * Retrieve a given Gadget model's metadata from the backend
- * @internal
  */
 export const useModelMetadata = (
   apiIdentifier: string,
@@ -393,8 +392,7 @@ const getGlobalActionApiIdentifier = (api: AnyClient, fn: GlobalActionFunction<a
 };
 
 /**
- * Retrieve a given Gadget model action's metadata from the backend
- * @internal
+ * Retrieve a given Gadget action's metadata from the backend
  */
 export const useActionMetadata = (
   actionFunction: ActionFunction<any, any, any, any, any> | GlobalActionFunction<any>


### PR DESCRIPTION
- UPDATE
  - Exposing the metadata getter hooks that are used in auto comps from the react package 
  - Sometimes it could be useful to get that metadata in other contexts like getting the enum options to control a filter configuration 