### PR TITLE
@gadgetinc/react-shopify-app-bridge : @shopify/app-bridge-react as a real dependency

### DIFF
--- a/packages/react-shopify-app-bridge/package.json
+++ b/packages/react-shopify-app-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/react-shopify-app-bridge",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "homepage": "https://github.com/gadget-inc/js-clients/tree/main/packages/react-shopify-app-bridge",
   "license": "MIT",
   "repository": "github:gadget-inc/js-clients",
@@ -28,13 +28,13 @@
   },
   "dependencies": {
     "@gadgetinc/react": "^0.25.1",
+    "@shopify/app-bridge-react": "^4.2.0",
     "crypto-js": "^4.2.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@gadgetinc/core": "workspace:*",
     "@gadgetinc/react": "workspace:*",
-    "@shopify/app-bridge-react": "^4.2.0",
     "@types/crypto-js": "^4.2.2",
     "@types/node": "^22.13.14",
     "@types/react": "^19.1.1",
@@ -46,7 +46,6 @@
   },
   "peerDependencies": {
     "@gadgetinc/core": ">=0.15.1",
-    "@shopify/app-bridge-react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,9 @@ importers:
       '@gadgetinc/react':
         specifier: workspace:*
         version: link:../react
+      '@shopify/app-bridge-react':
+        specifier: ^4.2.0
+        version: 4.2.2(react-dom@19.1.1)(react@19.1.1)
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
@@ -641,9 +644,6 @@ importers:
       '@gadgetinc/core':
         specifier: workspace:*
         version: link:../core
-      '@shopify/app-bridge-react':
-        specifier: ^4.2.0
-        version: 4.2.2(react-dom@19.1.1)(react@19.1.1)
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -7434,11 +7434,11 @@ packages:
       '@shopify/app-bridge-types': 0.3.0
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-    dev: true
+    dev: false
 
   /@shopify/app-bridge-types@0.3.0:
     resolution: {integrity: sha512-6LnQDfE5TP5RtlFFh/3S//9UmwS7rRsfDOHTPkZxvEZw5p+j0WfZcFnsq+ntr5Uc+xd3wZ0GZxt1GY1cm4/3bA==}
-    dev: true
+    dev: false
 
   /@shopify/app-bridge-types@0.5.3:
     resolution: {integrity: sha512-wj5pPqk4bQsFU6AQUo6SwyQ3zqBgodvxt7fWzRYakeHGG/YWeDv1uoNYjhSVm0jT80Wy18EObSMQTocUSgpqPA==}


### PR DESCRIPTION
in `@gadgetinc/react-shopify-app-bridge`, there is currently a peer/dev dependency on `"@shopify/app-bridge-react"`

This is a problem when trying to remove `"@shopify/app-bridge-react"` from default generated app templates because the missing peer dependency will make the frontend of the Gadget apps error. 

I want to remove `"@shopify/app-bridge-react"` from the default app templates to switch the app template to Polaris web components so that people use the web components based `<s-app-nav>` instead of the old app bridge appNav things from `"@shopify/app-bridge-react"`